### PR TITLE
Feat #166: AI Investigation Analysis — feedback loop, unified view, GitHub integration

### DIFF
--- a/custom_components/climate_advisor/ai_skills_investigator.py
+++ b/custom_components/climate_advisor/ai_skills_investigator.py
@@ -380,6 +380,10 @@ async def async_build_investigator_context(
     """
     lines: list[str] = ["=== Climate Advisor Investigator Context ===", ""]
 
+    # Time window — controls event log cutoff and daily records lookback
+    hours: int = min(max(int(kwargs.get("hours", 168)), 1), 720)
+    daily_records_days: int = min((hours + 23) // 24 + 1, 30)
+
     # Focus question (optional caller override)
     focus: str = kwargs.get("focus", "")
     if focus:
@@ -538,16 +542,16 @@ async def async_build_investigator_context(
                 _LOGGER.warning("investigator: generate_suggestions() failed")
                 lines += ["=== LEARNING — ACTIVE SUGGESTIONS ===", "  unavailable", ""]
 
-            # Last 14 daily records
+            # Daily records — window determined by caller's hours parameter
             try:
                 state_obj = getattr(learning, "_state", None)
                 records: list[Any] = []
                 if state_obj is not None:
                     raw_records = getattr(state_obj, "records", None)
                     if isinstance(raw_records, list):
-                        records = raw_records[-14:]
+                        records = raw_records[-daily_records_days:]
 
-                lines.append("=== LEARNING — LAST 14 DAILY RECORDS ===")
+                lines.append(f"=== LEARNING — LAST {daily_records_days} DAILY RECORDS ===")
                 if records:
                     for rec in records:
                         if isinstance(rec, dict):
@@ -566,7 +570,7 @@ async def async_build_investigator_context(
                 lines.append("")
             except Exception:
                 _LOGGER.warning("investigator: failed to read daily records")
-                lines += ["=== LEARNING — LAST 14 DAILY RECORDS ===", "  unavailable", ""]
+                lines += [f"=== LEARNING — LAST {daily_records_days} DAILY RECORDS ===", "  unavailable", ""]
         else:
             lines += ["=== LEARNING ===", "  learning engine not available", ""]
     except Exception:
@@ -586,7 +590,6 @@ async def async_build_investigator_context(
     # 4. Event log
     # ------------------------------------------------------------------
     try:
-        hours: int = int(kwargs.get("hours", 48))
         cutoff = datetime.datetime.now(datetime.UTC) - datetime.timedelta(hours=hours)
         event_log: list[Any] = getattr(coordinator, "_event_log", []) or []
         recent_events: list[Any] = []
@@ -871,7 +874,7 @@ def investigation_fallback(coordinator: Any, **kwargs: Any) -> dict[str, Any]:
                 if state_obj is not None:
                     raw_records = getattr(state_obj, "records", None)
                     if isinstance(raw_records, list):
-                        for rec in raw_records[-14:]:
+                        for rec in raw_records[-30:]:
                             if not isinstance(rec, dict):
                                 continue
                             date_val = rec.get("date", "?")

--- a/custom_components/climate_advisor/api.py
+++ b/custom_components/climate_advisor/api.py
@@ -652,9 +652,9 @@ class ClimateAdvisorInvestigateView(HomeAssistantView):
 
         focus: str = str(body.get("focus", ""))
         try:
-            hours: int = max(1, min(int(body.get("hours", 48)), 168))
+            hours: int = max(1, min(int(body.get("hours", 168)), 720))
         except (ValueError, TypeError):
-            hours = 48
+            hours = 168
 
         if not coordinator.config.get(CONF_AI_ENABLED, DEFAULT_AI_ENABLED):
             return self.json_message("AI features are not enabled", status_code=403)

--- a/custom_components/climate_advisor/api.py
+++ b/custom_components/climate_advisor/api.py
@@ -21,6 +21,7 @@ from .const import (
     API_CANCEL_OVERRIDE,
     API_CHART_DATA,
     API_CONFIG,
+    API_DELETE_REPORT,
     API_ENGINES,
     API_EVENT_LOG,
     API_FORCE_RECLASSIFY,
@@ -757,6 +758,43 @@ class ClimateAdvisorEnginesView(HomeAssistantView):
         return self.json(status)
 
 
+class ClimateAdvisorDeleteReportView(HomeAssistantView):
+    """POST /api/climate_advisor/delete_report — delete a report by type + timestamp."""
+
+    url = API_DELETE_REPORT
+    name = "api:climate_advisor:delete_report"
+    requires_auth = True
+
+    async def post(self, request: web.Request) -> web.Response:
+        hass = request.app["hass"]
+        coordinator = _get_coordinator(hass)
+        if not coordinator:
+            return self.json({"error": "Climate Advisor not loaded"}, status_code=503)
+
+        try:
+            body = await request.json()
+        except Exception:
+            return self.json({"error": "invalid_json"}, status_code=400)
+
+        report_type = body.get("report_type", "")
+        timestamp = body.get("timestamp", "")
+        if not timestamp:
+            return self.json({"error": "missing_timestamp"}, status_code=400)
+
+        if report_type == "activity":
+            found = coordinator.delete_ai_report(timestamp)
+            if found:
+                await hass.async_add_executor_job(coordinator._save_ai_reports)
+        elif report_type == "investigation":
+            found = coordinator.delete_investigation_report(timestamp)
+            if found:
+                await hass.async_add_executor_job(coordinator._save_investigation_reports)
+        else:
+            return self.json({"error": "invalid_type"}, status_code=400)
+
+        return self.json({"success": True, "found": found})
+
+
 # All views to register
 API_VIEWS = [
     ClimateAdvisorStatusView,
@@ -777,6 +815,7 @@ API_VIEWS = [
     ClimateAdvisorAIReportsView,
     ClimateAdvisorInvestigateView,
     ClimateAdvisorInvestigationReportsView,
+    ClimateAdvisorDeleteReportView,
     ClimateAdvisorEventLogView,
     ClimateAdvisorEnginesView,
 ]

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -1203,11 +1203,11 @@ AI_RETRY_BASE_DELAY_SECONDS = 1.0  # exponential backoff: 1s, 2s, 4s
 AI_REQUEST_HISTORY_CAP = 50
 
 # Persisted report history
-AI_REPORT_HISTORY_CAP = 10
+AI_REPORT_HISTORY_CAP = 60
 AI_REPORTS_FILE = "climate_advisor_ai_reports.json"
 
 # Investigation report history (Issue #82)
-INVESTIGATION_REPORT_HISTORY_CAP = 20
+INVESTIGATION_REPORT_HISTORY_CAP = 60
 INVESTIGATION_REPORTS_FILE = "climate_advisor_investigation_reports.json"
 
 # Sensor attributes for AI status
@@ -1219,3 +1219,4 @@ API_AI_ACTIVITY = f"{API_BASE}/ai_activity"
 API_AI_REPORTS = f"{API_BASE}/ai_reports"
 API_AI_INVESTIGATE = f"{API_BASE}/ai_investigate"
 API_INVESTIGATION_REPORTS = f"{API_BASE}/investigation_reports"
+API_DELETE_REPORT = f"{API_BASE}/delete_report"

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -664,6 +664,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
 
         report_entry = {
             "timestamp": dt_util.now().isoformat(),
+            "report_type": "activity",
             "result": result,
         }
         self._ai_report_history.append(report_entry)
@@ -700,7 +701,9 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             with open(filepath, encoding="utf-8") as f:
                 data = json.load(f)
             if isinstance(data, list):
-                self._ai_report_history = data[-AI_REPORT_HISTORY_CAP:]
+                cutoff = (datetime.now(UTC) - timedelta(days=30)).isoformat()
+                recent = [e for e in data if isinstance(e, dict) and e.get("timestamp", "") >= cutoff]
+                self._ai_report_history = recent[-AI_REPORT_HISTORY_CAP:]
                 _LOGGER.debug("Loaded %d AI reports from disk", len(self._ai_report_history))
             else:
                 _LOGGER.warning("AI reports file has unexpected format, starting fresh")
@@ -715,11 +718,18 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         """Return the AI report history for dashboard display."""
         return list(self._ai_report_history)
 
+    def delete_ai_report(self, timestamp: str) -> bool:
+        """Remove an activity report by timestamp. Returns True if removed."""
+        before = len(self._ai_report_history)
+        self._ai_report_history = [e for e in self._ai_report_history if e.get("timestamp") != timestamp]
+        return len(self._ai_report_history) < before
+
     async def async_store_investigation_report(self, result: dict) -> None:
         """Store an investigation report result in history and persist to disk."""
 
         entry = {
             "timestamp": dt_util.now().isoformat(),
+            "report_type": "investigation",
             "result": result,
         }
         self._investigation_report_history.append(entry)
@@ -730,6 +740,14 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
     def get_investigation_report_history(self) -> list[dict]:
         """Return a copy of the investigation report history."""
         return list(self._investigation_report_history)
+
+    def delete_investigation_report(self, timestamp: str) -> bool:
+        """Remove an investigation report by timestamp. Returns True if removed."""
+        before = len(self._investigation_report_history)
+        self._investigation_report_history = [
+            e for e in self._investigation_report_history if e.get("timestamp") != timestamp
+        ]
+        return len(self._investigation_report_history) < before
 
     def _save_investigation_reports(self) -> None:
         """Save investigation report history to disk (atomic write)."""
@@ -761,7 +779,9 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             with open(filepath, encoding="utf-8") as f:
                 data = json.load(f)
             if isinstance(data, list):
-                self._investigation_report_history = data[-INVESTIGATION_REPORT_HISTORY_CAP:]
+                cutoff = (datetime.now(UTC) - timedelta(days=30)).isoformat()
+                recent = [e for e in data if isinstance(e, dict) and e.get("timestamp", "") >= cutoff]
+                self._investigation_report_history = recent[-INVESTIGATION_REPORT_HISTORY_CAP:]
                 _LOGGER.debug(
                     "Loaded %d investigation reports from disk",
                     len(self._investigation_report_history),

--- a/custom_components/climate_advisor/frontend/index.html
+++ b/custom_components/climate_advisor/frontend/index.html
@@ -654,75 +654,74 @@
     </div>
   </div>
 
-  <!-- Activity Report Card -->
+  <!-- Panel A — Controls -->
   <div class="card">
-    <h2>Activity Report</h2>
-    <div style="display:flex;gap:12px;align-items:center;margin-bottom:12px;flex-wrap:wrap">
-      <label style="font-size:0.85rem;color:var(--text-secondary)">Time window:</label>
-      <select id="ai-hours" style="padding:4px 8px;border-radius:4px;border:1px solid var(--border);background:var(--card-bg);color:var(--text)">
+    <h2>Generate Report</h2>
+    <div style="display:flex;gap:12px;align-items:center;margin-bottom:10px;flex-wrap:wrap;">
+      <label style="font-size:0.85rem;color:var(--text-secondary);">Report type:</label>
+      <select id="report-type" onchange="updateReportTypeUI()" style="padding:4px 8px;border-radius:4px;border:1px solid var(--border);background:var(--card-bg);color:var(--text);">
+        <option value="activity">Activity Report</option>
+        <option value="investigation">Investigative Analysis</option>
+      </select>
+    </div>
+    <div style="display:flex;gap:12px;align-items:center;margin-bottom:10px;flex-wrap:wrap;">
+      <label style="font-size:0.85rem;color:var(--text-secondary);">Time window:</label>
+      <select id="report-time-window" style="padding:4px 8px;border-radius:4px;border:1px solid var(--border);background:var(--card-bg);color:var(--text);">
         <option value="6">Last 6 hours</option>
         <option value="12">Last 12 hours</option>
         <option value="24" selected>Last 24 hours</option>
         <option value="48">Last 48 hours</option>
         <option value="168">Last 7 days</option>
       </select>
-      <label style="font-size:0.85rem;color:var(--text-secondary)">Detail:</label>
-      <select id="ai-detail" style="padding:4px 8px;border-radius:4px;border:1px solid var(--border);background:var(--card-bg);color:var(--text)">
-        <option value="full" selected>Full</option>
-        <option value="brief">Brief</option>
-      </select>
-      <button class="btn" id="ai-run-report" onclick="runAIReport()">Run Report</button>
+      <span id="activity-detail-controls" style="display:flex;gap:8px;align-items:center;">
+        <label style="font-size:0.85rem;color:var(--text-secondary);">Detail:</label>
+        <select id="ai-detail" style="padding:4px 8px;border-radius:4px;border:1px solid var(--border);background:var(--card-bg);color:var(--text);">
+          <option value="full" selected>Full</option>
+          <option value="brief">Brief</option>
+        </select>
+      </span>
     </div>
-    <div id="ai-report-loading" class="loading" style="display:none">Generating report... this may take 15-30 seconds.</div>
-    <div id="ai-report-content" style="display:none"></div>
-    <div id="ai-report-actions" style="display:none;margin-top:12px;gap:8px;flex-wrap:wrap">
-      <button class="btn secondary" onclick="copyAIReport()" style="font-size:0.8rem">Copy for Bug Report</button>
-      <button class="btn secondary" onclick="downloadFullLogs()" style="font-size:0.8rem">Download Full Logs</button>
-    </div>
-  </div>
-
-  <!-- Report History Card -->
-  <div class="card">
-    <h2>Report History</h2>
-    <div id="ai-history-loading" class="loading">Loading...</div>
-    <div id="ai-history-content" style="display:none"></div>
-  </div>
-
-  <!-- Investigative Analysis Card -->
-  <div class="card">
-    <h2>🔬 Investigative Analysis</h2>
-    <p style="color: var(--text-secondary); font-size: 0.85rem; margin-bottom: 1rem;">
-      Scientific cross-source analysis to find incongruities, data issues, and system errors.
-      Requires AI and Investigative Agent to be enabled in settings.
-    </p>
-    <div style="display:flex;gap:12px;align-items:center;margin-bottom:0.5rem;flex-wrap:wrap;">
-      <label style="font-size:0.85rem;">Time window:</label>
-      <select id="investigation-range" style="font-size:0.85rem;padding:4px 8px;border-radius:4px;border:1px solid var(--border);background:var(--bg);color:var(--text);">
-        <option value="24">Last 1 day</option>
-        <option value="168" selected>Last 7 days</option>
-        <option value="720">Last 30 days</option>
-      </select>
-    </div>
-    <div style="margin-bottom: 0.75rem;">
+    <div id="investigation-focus-controls" style="display:none;margin-bottom:10px;">
       <textarea id="investigation-focus"
         placeholder="Optional: describe what you'd like investigated (e.g. 'why is window compliance 0%')..."
-        style="width:100%; min-height:60px; padding:0.5rem; border-radius:6px;
-               border:1px solid var(--border); background:var(--bg);
-               color:var(--text); font-size:0.85rem; resize:vertical; box-sizing:border-box;"></textarea>
+        style="width:100%;min-height:60px;padding:0.5rem;border-radius:6px;border:1px solid var(--border);background:var(--bg);color:var(--text);font-size:0.85rem;resize:vertical;box-sizing:border-box;"></textarea>
     </div>
-    <div style="display:flex; gap:0.5rem; align-items:center; flex-wrap:wrap;">
-      <button class="btn" onclick="runInvestigation()" id="investigate-btn">🔍 Run Investigation</button>
-      <button class="btn secondary" onclick="downloadInvestigationReport()" id="investigate-download-btn" style="display:none;">⬇ Download Report</button>
-      <span id="investigation-status" style="font-size:0.8rem; color:var(--text-secondary);"></span>
+    <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
+      <button class="btn" id="run-report-btn" onclick="runReport()">Run Report</button>
+      <span id="report-run-status" style="font-size:0.8rem;color:var(--text-secondary);"></span>
     </div>
-    <div id="investigation-result" style="display:none; margin-top:1rem;"></div>
+    <div id="report-run-loading" class="loading" style="display:none;">Generating report&#x2026; this may take 15&#x2013;30 seconds.</div>
   </div>
 
-  <!-- Investigation History Card -->
+  <!-- Panel B — Preview Pane -->
+  <div class="card" id="report-preview-card">
+    <div id="report-preview-header" style="display:flex;align-items:center;gap:8px;margin-bottom:10px;flex-wrap:wrap;">
+      <h2 style="margin:0;">Report Preview</h2>
+    </div>
+    <div id="report-preview-content">
+      <p style="color:var(--text-secondary);font-size:0.85rem;">No report loaded. Select a type above and click Run Report.</p>
+    </div>
+    <div id="report-preview-actions" style="display:none;margin-top:12px;gap:8px;flex-wrap:wrap;">
+      <button class="btn secondary" onclick="copyCurrentReport()" style="font-size:0.8rem;">Copy for Bug Report</button>
+      <button class="btn secondary" onclick="downloadCurrentReport()" style="font-size:0.8rem;">&#x2B07; Download Report</button>
+      <button class="btn secondary" onclick="downloadFullLogs()" style="font-size:0.8rem;">Download Full Logs</button>
+    </div>
+  </div>
+
+  <!-- Panel C — History -->
   <div class="card">
-    <h2>📋 Investigation History</h2>
-    <div id="investigation-history-list">
-      <p style="color:var(--text-secondary); font-size:0.85rem;">No investigations run yet.</p>
+    <h2>Report History</h2>
+    <div style="display:flex;gap:6px;align-items:center;flex-wrap:wrap;margin-bottom:10px;">
+      <button class="btn secondary" id="hist-filter-all" onclick="setHistoryFilter('all')" style="font-size:0.8rem;">All</button>
+      <button class="btn secondary" id="hist-filter-activity" onclick="setHistoryFilter('activity')" style="font-size:0.8rem;opacity:0.55;">Activity</button>
+      <button class="btn secondary" id="hist-filter-investigation" onclick="setHistoryFilter('investigation')" style="font-size:0.8rem;opacity:0.55;">Investigation</button>
+      <input type="date" id="hist-from-date" onchange="window.renderHistory()" oninput="window.renderHistory()" style="padding:3px 6px;border-radius:4px;border:1px solid var(--border);background:var(--card-bg);color:var(--text);font-size:0.8rem;" title="From date">
+      <span style="font-size:0.8rem;color:var(--text-secondary);">to</span>
+      <input type="date" id="hist-to-date" onchange="window.renderHistory()" oninput="window.renderHistory()" style="padding:3px 6px;border-radius:4px;border:1px solid var(--border);background:var(--card-bg);color:var(--text);font-size:0.8rem;" title="To date">
+      <button class="btn secondary" onclick="document.getElementById('hist-from-date').value='';document.getElementById('hist-to-date').value='';window.renderHistory();" style="font-size:0.8rem;" title="Clear date range">&#x2715;</button>
+    </div>
+    <div id="unified-history-list">
+      <p style="color:var(--text-secondary);font-size:0.85rem;">Loading history&#x2026;</p>
     </div>
   </div>
 
@@ -2385,13 +2384,16 @@
   }
 
   // --- AI Tab Functions ---
-  let _currentAIReport = null;
+  let _currentReport = null;
+  let _allHistoryEntries = [];
+  let _filteredHistoryEntries = [];
+  let _historyTypeFilter = 'all';
+  let _historyShowing = 5;
 
   async function loadAIData() {
     loadAIStatus();
-    loadAIHistory();
     loadSuggestions();
-    loadInvestigationHistory();
+    loadUnifiedHistory();
   }
 
   async function loadAIStatus() {
@@ -2428,29 +2430,54 @@
     }
   }
 
-  async function runAIReport() {
-    const hours = parseInt(document.getElementById('ai-hours').value);
+  function updateReportTypeUI() {
+    const type = document.getElementById('report-type').value;
+    const twSelect = document.getElementById('report-time-window');
+    const detailControls = document.getElementById('activity-detail-controls');
+    const focusControls = document.getElementById('investigation-focus-controls');
+    if (type === 'activity') {
+      twSelect.innerHTML = '<option value="6">Last 6 hours</option>'
+        + '<option value="12">Last 12 hours</option>'
+        + '<option value="24" selected>Last 24 hours</option>'
+        + '<option value="48">Last 48 hours</option>'
+        + '<option value="168">Last 7 days</option>';
+      detailControls.style.display = 'flex';
+      focusControls.style.display = 'none';
+    } else {
+      twSelect.innerHTML = '<option value="24">Last 1 day</option>'
+        + '<option value="168" selected>Last 7 days</option>'
+        + '<option value="720">Last 30 days</option>';
+      detailControls.style.display = 'none';
+      focusControls.style.display = 'block';
+    }
+  }
+
+  async function runReport() {
+    const type = document.getElementById('report-type').value;
+    if (type === 'activity') {
+      await _runActivityReport();
+    } else {
+      await _runInvestigation();
+    }
+  }
+
+  async function _runActivityReport() {
+    const hours = parseInt(document.getElementById('report-time-window').value, 10) || 24;
     const detail = document.getElementById('ai-detail').value;
-    const btn = document.getElementById('ai-run-report');
-    const loading = document.getElementById('ai-report-loading');
-    const content = document.getElementById('ai-report-content');
-    const actions = document.getElementById('ai-report-actions');
-
+    const btn = document.getElementById('run-report-btn');
+    const loading = document.getElementById('report-run-loading');
+    const status = document.getElementById('report-run-status');
     btn.disabled = true;
-    btn.textContent = 'Running...';
+    btn.textContent = 'Running\u2026';
     loading.style.display = 'block';
-    content.style.display = 'none';
-    actions.style.display = 'none';
-
+    status.textContent = '';
     try {
       const result = await apiPost('ai_activity', { hours, detail_level: detail });
-      _currentAIReport = result;
-      renderAIReport(result);
-      // Refresh history after new report
-      loadAIHistory();
+      _currentReport = { reportType: 'activity', timestamp: new Date().toISOString(), result };
+      renderReportInPreview(_currentReport);
+      loadUnifiedHistory();
     } catch (e) {
-      content.style.display = 'block';
-      content.innerHTML = `<p style="color:var(--danger)">Failed to generate report: ${e.message}</p>`;
+      status.textContent = 'Error: ' + e.message;
     } finally {
       btn.disabled = false;
       btn.textContent = 'Run Report';
@@ -2458,43 +2485,117 @@
     }
   }
 
-  function renderAIReport(result) {
-    const content = document.getElementById('ai-report-content');
-    const actions = document.getElementById('ai-report-actions');
-    content.style.display = 'block';
+  async function _runInvestigation() {
+    const btn = document.getElementById('run-report-btn');
+    const loading = document.getElementById('report-run-loading');
+    const status = document.getElementById('report-run-status');
+    const focus = document.getElementById('investigation-focus').value.trim();
+    const hours = parseInt(document.getElementById('report-time-window').value, 10) || 168;
+    btn.disabled = true;
+    btn.textContent = 'Running\u2026';
+    loading.style.display = 'block';
+    status.textContent = '';
+    const _stages = [
+      'Collecting HVAC state and sensor readings\u2026',
+      'Reading thermal model and weather patterns\u2026',
+      'Scanning event log for anomalies\u2026',
+      'Reviewing recent AI report history\u2026',
+      'Fetching release notes and GitHub issues\u2026',
+      'Applying scientific method to data\u2026',
+      'Formulating hypotheses (this may take a moment)\u2026',
+      'Writing investigation report\u2026',
+    ];
+    let _stageIdx = 0;
+    status.textContent = _stages[0];
+    const _stageTimer = setInterval(() => {
+      _stageIdx = (_stageIdx + 1) % _stages.length;
+      status.textContent = _stages[_stageIdx];
+    }, 2500);
+    try {
+      const body = { hours };
+      if (focus) body.focus = focus;
+      const result = await apiFetch('ai_investigate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      _currentReport = { reportType: 'investigation', timestamp: new Date().toISOString(), result, focus };
+      renderReportInPreview(_currentReport);
+      status.textContent = 'Completed at ' + new Date().toLocaleTimeString() + ' (source: ' + (result.source || 'unknown') + ')';
+      loadUnifiedHistory();
+    } catch (err) {
+      const hint = err.message.toLowerCase().includes('not enabled')
+        ? ' \u2014 enable it in Home Assistant \u2192 Settings \u2192 Integrations \u2192 Climate Advisor \u2192 Configure \u2192 AI Settings'
+        : '';
+      status.textContent = 'Error: ' + err.message + hint;
+    } finally {
+      clearInterval(_stageTimer);
+      btn.disabled = false;
+      btn.textContent = 'Run Report';
+      loading.style.display = 'none';
+    }
+  }
 
-    if (!result || !result.success) {
-      const err = result ? result.error : 'Unknown error';
-      const source = result ? result.source : 'error';
-      content.innerHTML = `<p style="color:var(--danger)">Report failed (${source}): ${err}</p>`;
+  function renderReportInPreview(entry) {
+    const header = document.getElementById('report-preview-header');
+    const content = document.getElementById('report-preview-content');
+    const actions = document.getElementById('report-preview-actions');
+    const typeLabel = entry.reportType === 'investigation' ? '\ud83d\udd2c Investigative Analysis' : 'Activity Report';
+    const ts = entry.timestamp ? new Date(entry.timestamp).toLocaleString() : '';
+    const isRefined = entry.result && entry.result.is_refined;
+    const refinedBadge = isRefined
+      ? ' <span style="background:var(--primary);color:#fff;font-size:0.7rem;padding:1px 6px;border-radius:10px;vertical-align:middle;">refined</span>'
+      : '';
+    header.innerHTML = '<h2 style="margin:0;">' + escapeHtml(typeLabel) + '</h2>'
+      + (ts ? '<span style="color:var(--text-secondary);font-size:0.85rem;">' + escapeHtml(ts) + '</span>' : '')
+      + refinedBadge;
+    const result = entry.result || {};
+    if (!result.success) {
+      const err = result.error || 'Unknown error';
+      const src = result.source || 'error';
+      content.innerHTML = '<p style="color:var(--danger)">Report failed (' + escapeHtml(src) + '): ' + escapeHtml(err) + '</p>';
+      actions.style.display = 'none';
       return;
     }
-
     const data = result.data || {};
-    const source = result.source === 'fallback'
+    const sourceLabel = result.source === 'fallback'
       ? '<span style="color:var(--warning);font-size:0.8rem">(fallback \u2014 AI unavailable)</span>'
       : '<span style="color:var(--success);font-size:0.8rem">(AI-generated)</span>';
-
-    const sections = ['summary', 'timeline', 'decisions', 'anomalies', 'diagnostics'];
-    const sectionLabels = {
-      summary: 'Summary',
-      timeline: 'Timeline',
-      decisions: 'Decisions',
-      anomalies: 'Anomalies',
-      diagnostics: 'Diagnostics',
-    };
-
-    let html = `<div style="margin-bottom:8px">${source}</div>`;
-    sections.forEach(key => {
-      const text = data[key] || '';
-      if (!text) return;
-      html += `
-        <div style="margin-bottom:12px">
-          <h3 style="font-size:0.9rem;margin-bottom:4px;color:var(--primary)">${sectionLabels[key]}</h3>
-          <div style="font-size:0.85rem;white-space:pre-wrap;line-height:1.5">${escapeHtml(text)}</div>
-        </div>`;
-    });
-
+    let html = '<div style="margin-bottom:8px">' + sourceLabel + '</div>';
+    if (entry.reportType === 'activity') {
+      const sections = ['summary', 'timeline', 'decisions', 'anomalies', 'diagnostics'];
+      const sectionLabels = { summary: 'Summary', timeline: 'Timeline', decisions: 'Decisions', anomalies: 'Anomalies', diagnostics: 'Diagnostics' };
+      sections.forEach(key => {
+        const text = data[key] || '';
+        if (!text) return;
+        html += '<div style="margin-bottom:12px"><h3 style="font-size:0.9rem;margin-bottom:4px;color:var(--primary)">'
+          + sectionLabels[key] + '</h3>'
+          + '<div style="font-size:0.85rem;white-space:pre-wrap;line-height:1.5">' + escapeHtml(text) + '</div></div>';
+      });
+    } else {
+      const sections = [
+        { key: 'summary', label: '\ud83d\udcca Summary' },
+        { key: 'incongruities', label: '\u26a0\ufe0f Incongruities Found' },
+        { key: 'data_quality', label: '\ud83d\udd22 Data Quality Issues' },
+        { key: 'errors_warnings', label: '\ud83d\udea8 System Errors / Warnings' },
+        { key: 'hypotheses', label: '\ud83d\udd2c Hypotheses' },
+        { key: 'recommended_actions', label: '\u2705 Recommended Actions' },
+        { key: 'assumptions', label: '\ud83d\udcdd Assumptions & Confidence' },
+      ];
+      let hasSection = false;
+      for (const { key, label } of sections) {
+        const text = data[key] || '';
+        if (!text) continue;
+        hasSection = true;
+        html += '<details open style="margin-bottom:0.5rem;">'
+          + '<summary style="cursor:pointer;font-weight:600;padding:0.25rem 0;">' + escapeHtml(label) + '</summary>'
+          + '<pre style="white-space:pre-wrap;font-size:0.8rem;margin:0.5rem 0 0;padding:0.5rem;background:var(--bg);border-radius:4px;">'
+          + escapeHtml(text) + '</pre></details>';
+      }
+      if (!hasSection && result.raw_response) {
+        html += '<pre style="white-space:pre-wrap;font-size:0.8rem;">' + escapeHtml(result.raw_response) + '</pre>';
+      }
+    }
     content.innerHTML = html;
     actions.style.display = 'flex';
   }
@@ -2505,34 +2606,16 @@
     return div.innerHTML;
   }
 
-  function copyAIReport() {
-    if (!_currentAIReport) return;
-    const data = _currentAIReport.data || {};
-    const lines = [
-      '=== Climate Advisor AI Activity Report ===',
-      'Generated: ' + new Date().toISOString(),
-      'Source: ' + (_currentAIReport.source || 'unknown'),
-      '',
-    ];
-    ['summary', 'timeline', 'decisions', 'anomalies', 'diagnostics'].forEach(key => {
-      if (data[key]) {
-        lines.push('--- ' + key.toUpperCase() + ' ---');
-        lines.push(data[key]);
-        lines.push('');
-      }
-    });
-    const text = lines.join('\n');
-    const btn = document.querySelector('#ai-report-actions .btn');
-    const orig = btn.textContent;
+  function copyCurrentReport() {
+    if (!_currentReport) return;
+    const text = _formatCurrentReport();
+    const btn = document.querySelector('#report-preview-actions .btn');
+    const orig = btn ? btn.textContent : 'Copy for Bug Report';
     function showCopied() {
-      btn.textContent = 'Copied!';
-      setTimeout(() => { btn.textContent = orig; }, 2000);
+      if (btn) { btn.textContent = 'Copied!'; setTimeout(() => { btn.textContent = orig; }, 2000); }
     }
     if (navigator.clipboard && navigator.clipboard.writeText) {
-      navigator.clipboard.writeText(text).then(showCopied).catch(() => {
-        fallbackCopy(text);
-        showCopied();
-      });
+      navigator.clipboard.writeText(text).then(showCopied).catch(() => { fallbackCopy(text); showCopied(); });
     } else {
       fallbackCopy(text);
       showCopied();
@@ -2551,9 +2634,9 @@
   }
 
   async function downloadFullLogs() {
-    const hoursEl = document.getElementById('ai-hours');
+    const hoursEl = document.getElementById('report-time-window');
     const hours = hoursEl ? parseInt(hoursEl.value, 10) || 24 : 24;
-    const btn = document.querySelector('#ai-report-actions .btn:last-child');
+    const btn = document.querySelector('#report-preview-actions .btn:last-child');
     const orig = btn ? btn.textContent : '';
     if (btn) { btn.textContent = 'Downloading...'; btn.disabled = true; }
     try {
@@ -2622,200 +2705,110 @@
     }
   }
 
-  async function loadAIHistory() {
+  async function loadUnifiedHistory() {
     try {
-      const data = await apiFetch('ai_reports');
-      const loading = document.getElementById('ai-history-loading');
-      const content = document.getElementById('ai-history-content');
-      loading.style.display = 'none';
-      content.style.display = 'block';
-
-      const reports = data.reports || [];
-      if (reports.length === 0) {
-        content.innerHTML = '<p style="color:var(--text-secondary);font-size:0.85rem">No reports yet. Run an activity report above.</p>';
-        return;
-      }
-
-      let html = '<div style="display:flex;flex-direction:column;gap:8px">';
-      reports.slice().reverse().forEach((entry, i) => {
-        const ts = entry.timestamp ? new Date(entry.timestamp).toLocaleString() : 'Unknown time';
-        const r = entry.result || {};
-        const source = r.source || 'unknown';
-        const success = r.success ? 'success' : 'failed';
-        const summary = (r.data && r.data.summary) ? r.data.summary.substring(0, 120) + '...' : 'No summary';
-        html += `
-          <div class="setting-row" style="cursor:pointer" onclick="showHistoryReport(${reports.length - 1 - i})">
-            <div class="setting-info">
-              <div class="setting-label" style="font-size:0.85rem">${ts}</div>
-              <div class="setting-description">${escapeHtml(summary)}</div>
-            </div>
-            <div class="setting-value" style="font-size:0.75rem;color:${success === 'success' ? 'var(--success)' : 'var(--danger)'}">${source} / ${success}</div>
-          </div>`;
-      });
-      html += '</div>';
-      content.innerHTML = html;
-    } catch (e) {
-      document.getElementById('ai-history-loading').textContent = 'Failed to load history: ' + e.message;
+      const [activityData, investigationData] = await Promise.allSettled([
+        apiFetch('ai_reports'),
+        apiFetch('investigation_reports'),
+      ]);
+      const activityReports = (activityData.status === 'fulfilled' && activityData.value && activityData.value.reports)
+        ? activityData.value.reports.map(e => Object.assign({}, e, { report_type: e.report_type || 'activity' }))
+        : [];
+      const investigationReports = (investigationData.status === 'fulfilled' && Array.isArray(investigationData.value))
+        ? investigationData.value.map(e => Object.assign({}, e, { report_type: e.report_type || 'investigation' }))
+        : [];
+      _allHistoryEntries = activityReports.concat(investigationReports)
+        .sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+      renderHistory();
+    } catch (_e) {
+      const container = document.getElementById('unified-history-list');
+      if (container) container.innerHTML = '<p style="color:var(--text-secondary);font-size:0.85rem;">Failed to load history.</p>';
     }
   }
 
-  async function showHistoryReport(index) {
-    try {
-      const data = await apiFetch('ai_reports');
-      const reports = data.reports || [];
-      if (index >= 0 && index < reports.length) {
-        const entry = reports[index];
-        _currentAIReport = entry.result;
-        renderAIReport(entry.result);
-        // Scroll to report
-        document.getElementById('ai-report-content').scrollIntoView({ behavior: 'smooth' });
-      }
-    } catch (e) {
-      console.error('Failed to load history report:', e);
-    }
-  }
-
-
-  let _lastInvestigationResult = null;
-  let _cachedInvestigationReports = [];
-
-  async function runInvestigation() {
-    const btn = document.getElementById('investigate-btn');
-    const dlBtn = document.getElementById('investigate-download-btn');
-    const status = document.getElementById('investigation-status');
-    const resultDiv = document.getElementById('investigation-result');
-    const focus = document.getElementById('investigation-focus').value.trim();
-
-    btn.disabled = true;
-    dlBtn.style.display = 'none';
-    resultDiv.style.display = 'none';
-
-    const _stages = [
-      'Collecting HVAC state and sensor readings\u2026',
-      'Reading thermal model and weather patterns\u2026',
-      'Scanning 48h event log for anomalies\u2026',
-      'Reviewing recent AI report history\u2026',
-      'Fetching release notes and GitHub issues\u2026',
-      'Applying scientific method to data\u2026',
-      'Formulating hypotheses (this may take a moment)\u2026',
-      'Writing investigation report\u2026',
-    ];
-    let _stageIdx = 0;
-    status.textContent = _stages[0];
-    const _stageTimer = setInterval(() => {
-      _stageIdx = (_stageIdx + 1) % _stages.length;
-      status.textContent = _stages[_stageIdx];
-    }, 2500);
-
-    try {
-      const hours = parseInt(document.getElementById('investigation-range').value, 10) || 168;
-      const body = { hours };
-      if (focus) body.focus = focus;
-      const result = await apiFetch('ai_investigate', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
-
-      _lastInvestigationResult = { timestamp: new Date().toISOString(), result, focus };
-
-      const data = result.data || {};
-      const source = result.source || 'unknown';
-      const ts = new Date().toLocaleTimeString();
-      status.textContent = 'Completed at ' + ts + ' (source: ' + source + ')';
-      dlBtn.style.display = '';
-
-      // Build structured output
-      const sections = [
-        { key: 'summary', label: '📊 Summary' },
-        { key: 'incongruities', label: '⚠️ Incongruities Found' },
-        { key: 'data_quality', label: '🔢 Data Quality Issues' },
-        { key: 'errors_warnings', label: '🚨 System Errors / Warnings' },
-        { key: 'hypotheses', label: '🔬 Hypotheses' },
-        { key: 'recommended_actions', label: '✅ Recommended Actions' },
-        { key: 'assumptions', label: '📝 Assumptions & Confidence' },
-      ];
-
-      let html = '';
-      for (const { key, label } of sections) {
-        const content = data[key] || '';
-        if (!content) continue;
-        html += '<details open style="margin-bottom:0.5rem;">'
-          + '<summary style="cursor:pointer; font-weight:600; padding:0.25rem 0;">' + escapeHtml(label) + '</summary>'
-          + '<pre style="white-space:pre-wrap; font-size:0.8rem; margin:0.5rem 0 0; padding:0.5rem;'
-          + ' background:var(--bg); border-radius:4px;">' + escapeHtml(content) + '</pre>'
-          + '</details>';
-      }
-
-      if (!html) {
-        html = '<pre style="white-space:pre-wrap; font-size:0.8rem;">' + escapeHtml(result.raw_response || JSON.stringify(result, null, 2)) + '</pre>';
-      }
-
-      resultDiv.innerHTML = html;
-      resultDiv.style.display = 'block';
-
-      // Refresh history
-      loadInvestigationHistory();
-    } catch (err) {
-      const hint = err.message.toLowerCase().includes('not enabled')
-        ? ' — enable it in Home Assistant → Settings → Integrations → Climate Advisor → Configure → AI Settings'
-        : '';
-      status.textContent = 'Error: ' + err.message + hint;
-    } finally {
-      clearInterval(_stageTimer);
-      btn.disabled = false;
-    }
-  }
-
-  async function loadInvestigationHistory() {
-    const container = document.getElementById('investigation-history-list');
+  function renderHistory() {
+    const container = document.getElementById('unified-history-list');
     if (!container) return;
-    try {
-      const reports = await apiFetch('investigation_reports');
-      if (!Array.isArray(reports) || reports.length === 0) {
-        container.innerHTML = '<p style="color:var(--text-secondary); font-size:0.85rem;">No investigations run yet.</p>';
-        return;
-      }
-      // Show most recent first
-      const sorted = [...reports].reverse();
-      _cachedInvestigationReports = sorted;
-      container.innerHTML = sorted.map((entry, idx) => {
-        const ts = new Date(entry.timestamp).toLocaleString();
-        const source = (entry.result && entry.result.source) ? entry.result.source : 'unknown';
-        const data = (entry.result && entry.result.data) ? entry.result.data : {};
-        const invSections = [
-          { key: 'summary',             label: 'Investigation Summary' },
-          { key: 'incongruities',       label: 'Incongruities Found' },
-          { key: 'data_quality',        label: 'Data Quality Issues' },
-          { key: 'errors_warnings',     label: 'System Errors / Warnings' },
-          { key: 'hypotheses',          label: 'Hypotheses' },
-          { key: 'recommended_actions', label: 'Recommended Actions' },
-          { key: 'assumptions',         label: 'Assumptions & Confidence' },
-        ];
-        const sectionsHtml = invSections.map(({ key, label }) => {
-          const content = (data[key] || '').trim();
-          if (!content) return '';
-          return '<div style="margin-top:0.75rem;">'
-            + '<div style="font-size:0.75rem; font-weight:600; color:var(--text-primary);'
-            + ' text-transform:uppercase; letter-spacing:0.05em; margin-bottom:0.25rem;">'
-            + escapeHtml(label) + '</div>'
-            + '<p style="font-size:0.8rem; margin:0; color:var(--text-secondary);'
-            + ' white-space:pre-wrap; line-height:1.5;">' + escapeHtml(content) + '</p>'
-            + '</div>';
-        }).join('');
-        const bodyHtml = sectionsHtml
-          || (entry.result && entry.result.error
-            ? '<p style="font-size:0.8rem; margin:0.5rem 0 0; color:var(--text-secondary);">' + escapeHtml(entry.result.error) + '</p>'
-            : '<p style="font-size:0.8rem; margin:0.5rem 0 0; color:var(--text-secondary);">No report data available.</p>');
-        return '<details style="margin-bottom:0.5rem;">'
-          + '<summary style="cursor:pointer; font-size:0.85rem; padding:0.25rem 0; display:flex; align-items:center; gap:0.5rem;">'
-          + '<span><strong>' + escapeHtml(ts) + '</strong>'
-          + ' <span style="color:var(--text-secondary);">(' + escapeHtml(source) + ')</span></span>'
-          + '<button class="btn secondary" style="font-size:0.75rem; padding:0.15rem 0.5rem; margin-left:auto;" '
-          + 'onclick="event.stopPropagation(); downloadInvestigationReportByIndex(' + idx + ')">⬇ Download</button>'
-          + '</summary>'
-          + '<div style="padding:0 0.25rem 0.5rem;">' + bodyHtml + '</div>'
-          + '</details>';
-      }).join('');
-    } catch (_err) {
-      container.innerHTML = '<p style="color:var(--text-secondary); font-size:0.85rem;">Failed to load history.</p>';
+    const fromVal = document.getElementById('hist-from-date').value;
+    const toVal = document.getElementById('hist-to-date').value;
+    const fromDate = fromVal ? new Date(fromVal) : null;
+    const toDate = toVal ? new Date(toVal + 'T23:59:59') : null;
+    _filteredHistoryEntries = _allHistoryEntries.filter(e => {
+      if (_historyTypeFilter !== 'all' && (e.report_type || 'activity') !== _historyTypeFilter) return false;
+      const ts = new Date(e.timestamp);
+      if (fromDate && ts < fromDate) return false;
+      if (toDate && ts > toDate) return false;
+      return true;
+    });
+    if (_filteredHistoryEntries.length === 0) {
+      container.innerHTML = '<p style="color:var(--text-secondary);font-size:0.85rem;">No reports match the current filter.</p>';
+      return;
     }
+    const showing = Math.min(_historyShowing, _filteredHistoryEntries.length);
+    const displayed = _filteredHistoryEntries.slice(0, showing);
+    let html = '<div style="display:flex;flex-direction:column;gap:4px;">';
+    displayed.forEach((entry, idx) => {
+      const ts = entry.timestamp ? new Date(entry.timestamp).toLocaleString() : 'Unknown time';
+      const rType = entry.report_type || 'activity';
+      const typeBadge = rType === 'investigation'
+        ? '<span style="background:var(--primary);color:#fff;font-size:0.7rem;padding:1px 6px;border-radius:10px;">Investigation</span>'
+        : '<span style="background:var(--success);color:#fff;font-size:0.7rem;padding:1px 6px;border-radius:10px;">Activity</span>';
+      const result = entry.result || {};
+      const source = result.source || 'unknown';
+      const summary = (result.data && result.data.summary)
+        ? result.data.summary.replace(/\s+/g, ' ').trim().substring(0, 110) + (result.data.summary.length > 110 ? '…' : '')
+        : '';
+      const isActive = _currentReport && _currentReport.timestamp === entry.timestamp;
+      const activeBorder = isActive ? 'border:1px solid var(--primary);border-radius:6px;' : '';
+      html += '<div class="setting-row" style="cursor:pointer;' + activeBorder + ';align-items:flex-start;" onclick="showHistoryReport(' + idx + ')">'
+        + '<div class="setting-info" style="min-width:0;flex:1;">'
+        + '<div style="display:flex;gap:6px;align-items:center;flex-wrap:wrap;">'
+        + '<span style="font-size:0.82rem;font-weight:500;">' + escapeHtml(ts) + '</span>'
+        + typeBadge
+        + '<span style="font-size:0.75rem;color:var(--text-secondary);">' + escapeHtml(source) + '</span>'
+        + '</div>'
+        + (summary ? '<div style="font-size:0.78rem;color:var(--text-secondary);margin-top:3px;line-height:1.4;">' + escapeHtml(summary) + '</div>' : '')
+        + '</div>'
+        + '<button onclick="event.stopPropagation();deleteReport(' + idx + ')" title="Delete report"'
+        + ' style="background:none;border:none;cursor:pointer;color:var(--text-secondary);font-size:1rem;padding:2px 4px;flex-shrink:0;line-height:1;">🗑</button>'
+        + '</div>';
+    });
+    html += '</div>';
+    if (_filteredHistoryEntries.length > showing) {
+      html += '<button class="btn secondary" onclick="showMoreHistory()" style="margin-top:8px;font-size:0.8rem;width:100%;">Show more ('
+        + (_filteredHistoryEntries.length - showing) + ' remaining)</button>';
+    }
+    container.innerHTML = html;
+  }
+
+  function setHistoryFilter(type) {
+    _historyTypeFilter = type;
+    _historyShowing = 5;
+    ['all', 'activity', 'investigation'].forEach(t => {
+      const btn = document.getElementById('hist-filter-' + t);
+      if (btn) btn.style.opacity = t === type ? '1' : '0.55';
+    });
+    renderHistory();
+  }
+
+  function showMoreHistory() {
+    _historyShowing = 20;
+    renderHistory();
+  }
+
+  function showHistoryReport(idx) {
+    const entry = _filteredHistoryEntries[idx];
+    if (!entry) return;
+    _currentReport = {
+      reportType: entry.report_type || 'activity',
+      timestamp: entry.timestamp,
+      result: entry.result,
+      focus: entry.focus,
+    };
+    renderReportInPreview(_currentReport);
+    renderHistory();
+    const card = document.getElementById('report-preview-card');
+    if (card) card.scrollIntoView({ behavior: 'smooth' });
   }
 
   function _formatInvestigationReport(entry) {
@@ -2863,35 +2856,75 @@
     URL.revokeObjectURL(url);
   }
 
-  function downloadInvestigationReport() {
-    if (!_lastInvestigationResult) return;
-    const date = new Date(_lastInvestigationResult.timestamp).toISOString().slice(0, 10);
-    _triggerTextDownload(
-      _formatInvestigationReport(_lastInvestigationResult),
-      'climate-advisor-investigation-' + date + '.md'
-    );
+  async function deleteReport(idx) {
+    const entry = _filteredHistoryEntries[idx];
+    if (!entry) return;
+    try {
+      await apiFetch('delete_report', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ report_type: entry.report_type || 'activity', timestamp: entry.timestamp }),
+      });
+      // If the deleted report is currently displayed, clear the preview
+      if (_currentReport && _currentReport.timestamp === entry.timestamp) {
+        _currentReport = null;
+        document.getElementById('report-preview-header').innerHTML = '<h2 style="margin:0;">Report Preview</h2>';
+        document.getElementById('report-preview-content').innerHTML = '<p style="color:var(--text-secondary);font-size:0.85rem;">No report loaded. Select a type above and click Run Report.</p>';
+        document.getElementById('report-preview-actions').style.display = 'none';
+      }
+      await loadUnifiedHistory();
+    } catch (e) {
+      alert('Failed to delete report: ' + e.message);
+    }
   }
 
-  function downloadInvestigationReportByIndex(idx) {
-    const entry = _cachedInvestigationReports[idx];
-    if (!entry) return;
-    const date = new Date(entry.timestamp).toISOString().slice(0, 10);
-    _triggerTextDownload(
-      _formatInvestigationReport(entry),
-      'climate-advisor-investigation-' + date + '.md'
-    );
+  function downloadCurrentReport() {
+    if (!_currentReport) return;
+    const date = new Date(_currentReport.timestamp).toISOString().slice(0, 10);
+    const rType = _currentReport.reportType;
+    const filename = 'climate-advisor-' + (rType === 'investigation' ? 'investigation' : 'activity') + '-' + date + '.md';
+    _triggerTextDownload(_formatCurrentReport(), filename);
+  }
+
+  function _formatCurrentReport() {
+    if (!_currentReport) return '';
+    if (_currentReport.reportType === 'investigation') {
+      return _formatInvestigationReport({ timestamp: _currentReport.timestamp, result: _currentReport.result, focus: _currentReport.focus });
+    }
+    const ts = _currentReport.timestamp ? new Date(_currentReport.timestamp).toLocaleString() : '';
+    const result = _currentReport.result || {};
+    const data = result.data || {};
+    const lines = [
+      '# Climate Advisor — Activity Report', '',
+      '| Field | Value |', '|---|---|',
+      '| **Date** | ' + ts + ' |',
+      '| **Source** | ' + (result.source || 'unknown') + ' |',
+      '', '---', '',
+    ];
+    ['summary', 'timeline', 'decisions', 'anomalies', 'diagnostics'].forEach(key => {
+      if (data[key]) {
+        lines.push('## ' + key.charAt(0).toUpperCase() + key.slice(1));
+        lines.push('');
+        lines.push(data[key]);
+        lines.push('');
+      }
+    });
+    lines.push('---', '', '*Generated by Climate Advisor — Home Assistant Integration*');
+    return lines.join('\n');
   }
 
   // Expose AI tab functions to window for onclick handlers
-  window.runAIReport = runAIReport;
-  window.copyAIReport = copyAIReport;
+  window.runReport = runReport;
+  window.updateReportTypeUI = updateReportTypeUI;
+  window.renderHistory = renderHistory;
+  window.setHistoryFilter = setHistoryFilter;
+  window.showMoreHistory = showMoreHistory;
+  window.showHistoryReport = showHistoryReport;
+  window.copyCurrentReport = copyCurrentReport;
+  window.downloadCurrentReport = downloadCurrentReport;
+  window.deleteReport = deleteReport;
   window.downloadFullLogs = downloadFullLogs;
   window.downloadDebugLogs = downloadDebugLogs;
-  window.showHistoryReport = showHistoryReport;
-  window.runInvestigation = runInvestigation;
-  window.loadInvestigationHistory = loadInvestigationHistory;
-  window.downloadInvestigationReport = downloadInvestigationReport;
-  window.downloadInvestigationReportByIndex = downloadInvestigationReportByIndex;
 
   // --- Initial load (retry until auth token is available) ---
   function loadAll() {

--- a/custom_components/climate_advisor/frontend/index.html
+++ b/custom_components/climate_advisor/frontend/index.html
@@ -695,6 +695,14 @@
       Scientific cross-source analysis to find incongruities, data issues, and system errors.
       Requires AI and Investigative Agent to be enabled in settings.
     </p>
+    <div style="display:flex;gap:12px;align-items:center;margin-bottom:0.5rem;flex-wrap:wrap;">
+      <label style="font-size:0.85rem;">Time window:</label>
+      <select id="investigation-range" style="font-size:0.85rem;padding:4px 8px;border-radius:4px;border:1px solid var(--border);background:var(--bg);color:var(--text);">
+        <option value="24">Last 1 day</option>
+        <option value="168" selected>Last 7 days</option>
+        <option value="720">Last 30 days</option>
+      </select>
+    </div>
     <div style="margin-bottom: 0.75rem;">
       <textarea id="investigation-focus"
         placeholder="Optional: describe what you'd like investigated (e.g. 'why is window compliance 0%')..."
@@ -2700,7 +2708,8 @@
     }, 2500);
 
     try {
-      const body = { hours: 48 };
+      const hours = parseInt(document.getElementById('investigation-range').value, 10) || 168;
+      const body = { hours };
       if (focus) body.focus = focus;
       const result = await apiFetch('ai_investigate', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -105,7 +105,7 @@ class TestAPIViewList:
     """Test the API_VIEWS registry."""
 
     def test_correct_count(self):
-        assert len(API_VIEWS) == 20
+        assert len(API_VIEWS) == 21
 
     def test_all_are_callable(self):
         for view_cls in API_VIEWS:


### PR DESCRIPTION
## Summary

- **Iteration 1 — Investigation time window**: Investigation requests now accept 1d / 7d / 30d window; `daily_records_days` is derived from `hours` so 30-day investigations pull 30 days of daily records instead of the hardcoded 14.
- **Iteration 2 — Unified AI tab**: Three-card layout replaced with unified Controls / Preview / History panel. Activity and investigation reports share one history list (interleaved, date-filterable, click-to-load). Report history caps raised to 60 with 30-day time-based pruning.
- **Iteration 3 — Text-selection feedback + refinement loop**: Highlight any text in a report → floating 👍/👎 toolbar → annotate → add overall comment → Submit & Refine → Claude refines only the text (no re-analysis). Refined reports stored with `is_refined=True` and show a `(refined)` badge in history. Recent feedback injected into the investigator context to suppress re-flagging of dismissed findings (`climate_advisor_report_feedback.json`, cap 120, 30-day retention).
- **Iteration 4 — GitHub issue submission**: Optional `github_token` + `github_repo` config via HA options flow (`GitHub Integration` step). `POST /api/climate_advisor/submit_github_issue` creates a GitHub issue pre-filled from the current report. Token never logged — only HTTP status on failure. Submit button disables after success; Cancel changes to Close.

## Files changed

| Area | Files |
|---|---|
| Backend | `coordinator.py`, `api.py`, `ai_skills_investigator.py`, `config_flow.py`, `const.py` |
| Frontend | `frontend/index.html` |
| Config/i18n | `strings.json`, `translations/en.json`, `manifest.json` |
| Tests | `test_api.py`, `test_config_flow.py`, `test_config_metadata.py` |
| Docs | `docs/rest-api.md`, `docs/09-DEBUGGING-GUIDE.md` |

## Test plan

- [x] 2229 tests pass (`pytest tests/ -x -q`)
- [x] Ruff clean (`ruff check --fix` + `ruff format`)
- [x] Iteration 1 validated: 1d/7d/30d window selector works in browser
- [x] Iteration 2 validated: unified panel renders; history interleave + date filter + click-to-load works
- [x] Iteration 3 validated: highlight text → annotate → Submit & Refine → refined report appears with `(refined)` badge
- [x] Iteration 4 validated: GitHub issue modal pre-fills; issue created; submit disables + Cancel→Close on success
- [x] Version bumped to 0.3.53 in `const.py` and `manifest.json`
- [x] `KNOWN_FIXES[166]` entry added

Closes #166