### PR TITLE
Fix #174: chart_log.get_entries() uses datetime.now(UTC) bypassing dt_util mock

### DIFF
--- a/custom_components/climate_advisor/chart_log.py
+++ b/custom_components/climate_advisor/chart_log.py
@@ -155,7 +155,7 @@ class ChartStateLog:
 
     def _maybe_prune(self) -> None:
         """Prune entries older than max_days, at most once per hour."""
-        now = datetime.now(UTC)
+        now = dt_util.now()
         if self._last_prune is not None and (now - self._last_prune) < timedelta(hours=1):
             return
         self._last_prune = now
@@ -193,7 +193,7 @@ class ChartStateLog:
         - > 30 days (1y): daily summaries
         """
         range_days = self._range_str_to_days(range_str)
-        anchor = before if before is not None else datetime.now(UTC)
+        anchor = before if before is not None else dt_util.now()
         cutoff = anchor - timedelta(days=range_days)
 
         filtered = [e for e in self._entries if self._entry_after(e, cutoff)]

--- a/tests/test_chart_historical_nav.py
+++ b/tests/test_chart_historical_nav.py
@@ -19,13 +19,15 @@ import types
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 # ── HA module stubs (must happen before importing climate_advisor) ──────────
 if "homeassistant" not in sys.modules:
     from conftest import _install_ha_stubs
 
     _install_ha_stubs()
 
-# Patch dt_util.now before importing coordinator modules
+# Patch dt_util stubs so coordinator imports resolve correctly.
 _FAKE_NOW = datetime(2026, 5, 20, 12, 0, 0, tzinfo=UTC)
 sys.modules["homeassistant.util.dt"].now = lambda: _FAKE_NOW
 sys.modules["homeassistant.util.dt"].parse_datetime = lambda s: datetime.fromisoformat(s) if s else None
@@ -90,6 +92,22 @@ class TestGetEntriesBeforeAnchor:
     FAILS before implementation because get_entries() has no before= param.
     """
 
+    @pytest.fixture(autouse=True)
+    def _freeze_chart_log_now(self):
+        """Freeze chart_log.dt_util.now() to _FAKE_NOW for all tests in this class.
+
+        chart_log.py binds dt_util via `from homeassistant.util import dt as dt_util`.
+        In full-suite runs, earlier test files can overwrite sys.modules["homeassistant.util"].dt.now
+        to return real wall-clock time, which breaks time-relative assertions here.
+        Patching the attribute on the already-bound module object ensures isolation.
+        """
+        from custom_components.climate_advisor import chart_log as _chart_log_mod
+
+        orig = _chart_log_mod.dt_util.now
+        _chart_log_mod.dt_util.now = lambda: _FAKE_NOW
+        yield
+        _chart_log_mod.dt_util.now = orig
+
     def test_get_entries_before_anchor_filters_past_window(self, tmp_path):
         """Entries after the anchor must be excluded.
 
@@ -145,6 +163,16 @@ class TestGetChartDataBeforeTs:
 
     FAILS before implementation because get_chart_data() has no before_ts param.
     """
+
+    @pytest.fixture(autouse=True)
+    def _freeze_chart_log_now(self):
+        """Freeze chart_log.dt_util.now() to _FAKE_NOW for all tests in this class."""
+        from custom_components.climate_advisor import chart_log as _chart_log_mod
+
+        orig = _chart_log_mod.dt_util.now
+        _chart_log_mod.dt_util.now = lambda: _FAKE_NOW
+        yield
+        _chart_log_mod.dt_util.now = orig
 
     def _make_coord_with_chart_log(self, tmp_path):
         """Build a minimal coordinator stub with a populated _chart_log."""

--- a/tests/test_chart_log.py
+++ b/tests/test_chart_log.py
@@ -35,6 +35,17 @@ def _build_ha_stubs() -> None:
 
 _build_ha_stubs()
 
+# chart_log.py binds dt_util via `from homeassistant.util import dt as dt_util`, which
+# resolves to sys.modules["homeassistant.util"].dt.  When conftest MagicMock stubs are
+# installed first (full suite run), _build_ha_stubs() exits early and that attribute is
+# a MagicMock whose .now() returns another MagicMock — incompatible with datetime math.
+# Unconditionally set a real now() on the actual bound object so _maybe_prune() works.
+# Uses datetime.now(UTC) — real wall-clock time — because test_chart_log.py helpers
+# also use real wall-clock via _ago(hours=...) so no fixed fake time is needed.
+import custom_components.climate_advisor.chart_log as _chart_log_mod_init  # noqa: E402
+
+_chart_log_mod_init.dt_util.now = lambda: datetime.now(UTC)
+
 # Now it's safe to import the module under test
 from custom_components.climate_advisor.chart_log import ChartStateLog  # noqa: E402
 


### PR DESCRIPTION
## Summary

`ChartStateLog._maybe_prune()` and `get_entries()` used `datetime.now(UTC)` directly instead of `dt_util.now()`. This bypassed the module-level `sys.modules` mock in `test_chart_historical_nav.py`, causing `test_get_entries_no_before_returns_all_in_range` to fail — entries were stored at fake-time dates (May 2026) but the anchor was real wall-clock time (May 28+), placing all entries outside the 3-day window.

## Root cause

`chart_log.py` binds `dt_util` via `from homeassistant.util import dt as dt_util`. In the conftest stub environment, `sys.modules["homeassistant.util"].dt` and `sys.modules["homeassistant.util.dt"]` are separate MagicMock instances. The test patched the latter, but chart_log used the former — so `datetime.now(UTC)` was the right call pattern but returned real time rather than the fake time.

## Fix

- Replace `datetime.now(UTC)` with `dt_util.now()` in both `_maybe_prune()` and `get_entries()`
- Add `autouse` fixtures to both test classes in `test_chart_historical_nav.py` that patch `dt_util.now` directly on the already-bound module object
- Add analogous patch in `test_chart_log.py` to prevent `MagicMock` math errors in `_maybe_prune()`

## Test results

- [x] `pytest tests/test_chart_historical_nav.py -v` — 4/4 pass (was 3/4)
- [x] `pytest tests/ -x -q` — 2229/2229 pass

Closes #174