### PR TITLE
Fix #176: DailyRecord accumulated counters reset on HA restart mid-day

### DIFF
--- a/custom_components/climate_advisor/chart_log.py
+++ b/custom_components/climate_advisor/chart_log.py
@@ -155,7 +155,7 @@ class ChartStateLog:
 
     def _maybe_prune(self) -> None:
         """Prune entries older than max_days, at most once per hour."""
-        now = datetime.now(UTC)
+        now = dt_util.now()
         if self._last_prune is not None and (now - self._last_prune) < timedelta(hours=1):
             return
         self._last_prune = now
@@ -193,7 +193,7 @@ class ChartStateLog:
         - > 30 days (1y): daily summaries
         """
         range_days = self._range_str_to_days(range_str)
-        anchor = before if before is not None else datetime.now(UTC)
+        anchor = before if before is not None else dt_util.now()
         cutoff = anchor - timedelta(days=range_days)
 
         filtered = [e for e in self._entries if self._entry_after(e, cutoff)]

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -1915,9 +1915,12 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             predicted_indoor=self._last_predicted_indoor,
         )
 
-        # Initialize today's learning record
+        # Initialize today's learning record, preserving any counters already accumulated
+        # today (e.g. after an HA restart mid-day that fires briefing again).
+        _today_str = dt_util.now().strftime("%Y-%m-%d")
+        _prev = self._today_record if (self._today_record and self._today_record.date == _today_str) else None
         self._today_record = DailyRecord(
-            date=dt_util.now().strftime("%Y-%m-%d"),
+            date=_today_str,
             day_type=classification.day_type,
             trend_direction=classification.trend_direction,
             windows_recommended=classification.windows_recommended,
@@ -1926,6 +1929,14 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 classification.window_close_time.isoformat() if classification.window_close_time else None
             ),
             hvac_mode_recommended=classification.hvac_mode,
+            hvac_runtime_minutes=_prev.hvac_runtime_minutes if _prev else 0.0,
+            comfort_violations_minutes=_prev.comfort_violations_minutes if _prev else 0.0,
+            manual_overrides=_prev.manual_overrides if _prev else 0,
+            thermal_session_count=_prev.thermal_session_count if _prev else 0,
+            occupancy_away_minutes=_prev.occupancy_away_minutes if _prev else 0.0,
+            windows_opened=_prev.windows_opened if _prev else False,
+            window_open_actual_time=_prev.window_open_actual_time if _prev else None,
+            override_details=list(_prev.override_details) if _prev else [],
         )
 
         # Capture raw forecast high/low for weather bias learning
@@ -2256,6 +2267,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             for _hvac_ot in (OBS_TYPE_HVAC_HEAT, OBS_TYPE_HVAC_COOL):
                 self._end_hvac_active_phase(_hvac_ot)
             self._hvac_on_since = None
+            self.hass.async_create_task(self._async_save_state())
         elif was_running and is_running and old_action != new_action:
             # heat_cool mode: hvac_action switched heating↔cooling mid-session
             if old_action in running_actions and new_action in running_actions:

--- a/docs/08-COMPUTATION-REFERENCE.md
+++ b/docs/08-COMPUTATION-REFERENCE.md
@@ -29,6 +29,7 @@ The automation logic table and all threshold constants in this document are expr
 | How does comfort score accumulate and what triggers a suggestion? | `comfort_score = 1 − (total_violation_minutes / (days_recorded × 1440))`; more than 5 days with > 30 violation minutes triggers the `comfort_violations` suggestion. | [§Metric Definitions — Comfort Score](05-LEARNING-ENGINE-DESIGN.md#comfort-score-comfort_score) |
 | When does the ODE ceiling guard fire on a warm day and what activates AC? | The guard scans the predicted indoor curve on every 30-min cycle. When outdoor > indoor AND a breach above `comfort_cool` is predicted within the computed lead time (or 120-min fallback), the guard sets HVAC to cool at `comfort_cool`. Guard skips when no calibrated model, occupancy is away/vacation, or nat-vent can keep indoor below the ceiling. | [§6c. Warm-Day ODE Ceiling Guard](08-COMPUTATION-REFERENCE.md#6c-warm-day-ode-ceiling-guard-issue-136) |
 | How does MILD day window scheduling change when the ODE is available (Fix C, Issue #147)? | Before Fix C: MILD days used hardcoded `time(10, 0)` open / `time(17, 0)` close. After Fix C: constants `MILD_WINDOW_OPEN_HOUR = 10` and `MILD_WINDOW_CLOSE_HOUR = 17` are fallbacks; when the ODE is available, `nat_vent_cutoff` drives the close time — the same dynamic logic as warm days. | [§6d. MILD Day Dynamic Window Close Time](08-COMPUTATION-REFERENCE.md#6d-mild-day-dynamic-window-close-time-fix-c-issue-147) |
+| What invariant must `_async_send_briefing()` maintain when replacing `_today_record`? | It must copy all accumulated counters (`hvac_runtime_minutes`, `comfort_violations_minutes`, etc.) from the existing same-day record before constructing the new one. Creating a fresh `DailyRecord` unconditionally resets all counters to zero (Issue #176 bug). | [DailyRecord Persistence Invariant](08-COMPUTATION-REFERENCE.md#dailyrecord-persistence-invariant-issue-176) |
 
 ## 1. Day Classification
 
@@ -534,6 +535,34 @@ Fire paths emit `bedtime_setback` with `{mode, target_f, depth_f, adaptive, modi
 All five fields default to `None` at record creation. On a fire night, `setback_skipped_reason` stays `None`; on a skip night, all applied-value fields stay `None`. Accessible via `learning_db.py --daily` (see §Diagnostic Tools).
 
 **Test coverage:** `tests/test_occupancy_automation.py` — 18 tests covering all cells above; `tests/test_bedtime_setback.py` — full fire/skip/field coverage.
+
+---
+
+> **DailyRecord Persistence Invariant (Issue #176)**
+>
+> `DailyRecord` counters accumulate throughout the day and are persisted to
+> `climate_advisor_state.json`. When `_async_send_briefing()` creates an updated record
+> after classification (e.g., after HA restart), it **MUST preserve all already-accumulated
+> counters** from the existing same-day record before replacing it.
+>
+> Fields that must be preserved:
+> `hvac_runtime_minutes`, `comfort_violations_minutes`, `manual_overrides`,
+> `thermal_session_count`, `occupancy_away_minutes`, `windows_opened`,
+> `window_open_actual_time`, `override_details`.
+>
+> **Violation:** creating a fresh `DailyRecord(...)` unconditionally resets all counters to
+> zero, causing `hvac_runtime_today` to show `0.0` after a mid-day HA restart.
+>
+> **Fix pattern:** before constructing the new record, check whether `self._today_record`
+> already exists for today's date, and carry forward all accumulated counter fields into
+> the new `DailyRecord(...)` constructor call. Additionally, `_async_save_state()` must be
+> called on every HVAC on→off transition (after `_flush_hvac_runtime()`) so that state is
+> never more than one HVAC cycle stale at restart time.
+>
+> **Test coverage:** `tests/test_daily_record_accuracy.py` —
+> `test_daily_record_survives_briefing_after_restart`
+
+---
 
 ### 6b. Warm-Day Comfort-Floor Guard
 

--- a/tests/test_chart_historical_nav.py
+++ b/tests/test_chart_historical_nav.py
@@ -19,13 +19,15 @@ import types
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 # ── HA module stubs (must happen before importing climate_advisor) ──────────
 if "homeassistant" not in sys.modules:
     from conftest import _install_ha_stubs
 
     _install_ha_stubs()
 
-# Patch dt_util.now before importing coordinator modules
+# Patch dt_util stubs so coordinator imports resolve correctly.
 _FAKE_NOW = datetime(2026, 5, 20, 12, 0, 0, tzinfo=UTC)
 sys.modules["homeassistant.util.dt"].now = lambda: _FAKE_NOW
 sys.modules["homeassistant.util.dt"].parse_datetime = lambda s: datetime.fromisoformat(s) if s else None
@@ -90,6 +92,22 @@ class TestGetEntriesBeforeAnchor:
     FAILS before implementation because get_entries() has no before= param.
     """
 
+    @pytest.fixture(autouse=True)
+    def _freeze_chart_log_now(self):
+        """Freeze chart_log.dt_util.now() to _FAKE_NOW for all tests in this class.
+
+        chart_log.py binds dt_util via `from homeassistant.util import dt as dt_util`.
+        In full-suite runs, earlier test files can overwrite sys.modules["homeassistant.util"].dt.now
+        to return real wall-clock time, which breaks time-relative assertions here.
+        Patching the attribute on the already-bound module object ensures isolation.
+        """
+        from custom_components.climate_advisor import chart_log as _chart_log_mod
+
+        orig = _chart_log_mod.dt_util.now
+        _chart_log_mod.dt_util.now = lambda: _FAKE_NOW
+        yield
+        _chart_log_mod.dt_util.now = orig
+
     def test_get_entries_before_anchor_filters_past_window(self, tmp_path):
         """Entries after the anchor must be excluded.
 
@@ -145,6 +163,16 @@ class TestGetChartDataBeforeTs:
 
     FAILS before implementation because get_chart_data() has no before_ts param.
     """
+
+    @pytest.fixture(autouse=True)
+    def _freeze_chart_log_now(self):
+        """Freeze chart_log.dt_util.now() to _FAKE_NOW for all tests in this class."""
+        from custom_components.climate_advisor import chart_log as _chart_log_mod
+
+        orig = _chart_log_mod.dt_util.now
+        _chart_log_mod.dt_util.now = lambda: _FAKE_NOW
+        yield
+        _chart_log_mod.dt_util.now = orig
 
     def _make_coord_with_chart_log(self, tmp_path):
         """Build a minimal coordinator stub with a populated _chart_log."""

--- a/tests/test_chart_log.py
+++ b/tests/test_chart_log.py
@@ -35,6 +35,17 @@ def _build_ha_stubs() -> None:
 
 _build_ha_stubs()
 
+# chart_log.py binds dt_util via `from homeassistant.util import dt as dt_util`, which
+# resolves to sys.modules["homeassistant.util"].dt.  When conftest MagicMock stubs are
+# installed first (full suite run), _build_ha_stubs() exits early and that attribute is
+# a MagicMock whose .now() returns another MagicMock — incompatible with datetime math.
+# Unconditionally set a real now() on the actual bound object so _maybe_prune() works.
+# Uses datetime.now(UTC) — real wall-clock time — because test_chart_log.py helpers
+# also use real wall-clock via _ago(hours=...) so no fixed fake time is needed.
+import custom_components.climate_advisor.chart_log as _chart_log_mod_init  # noqa: E402
+
+_chart_log_mod_init.dt_util.now = lambda: datetime.now(UTC)
+
 # Now it's safe to import the module under test
 from custom_components.climate_advisor.chart_log import ChartStateLog  # noqa: E402
 

--- a/tests/test_daily_record_accuracy.py
+++ b/tests/test_daily_record_accuracy.py
@@ -407,3 +407,170 @@ class TestManualOverridesTracking:
         asyncio.run(coord._async_thermostat_changed(event))
 
         assert coord._today_record.override_details == []
+
+
+# ---------------------------------------------------------------------------
+# TestDailyRecordBriefingPreservation — Issue #176
+# ---------------------------------------------------------------------------
+
+
+class TestDailyRecordBriefingPreservation:
+    """Accumulated DailyRecord counters must survive _async_send_briefing() re-firing.
+
+    Regression for Issue #176: after an HA restart mid-day, async_restore_state()
+    correctly restores _today_record, but _async_send_briefing() then unconditionally
+    created a fresh DailyRecord with all counters at zero. The fix preserves same-day
+    accumulated fields when the record's date matches today.
+    """
+
+    def test_daily_record_survives_briefing_after_restart(self):
+        """Counters accumulated before restart are preserved when briefing fires again.
+
+        Scenario: HA restarts with hvac_runtime_minutes=19.8 already in _today_record.
+        _async_send_briefing() fires on the same calendar day. The new record must
+        keep the accumulated counters rather than resetting to zero.
+        """
+        ClimateAdvisorCoordinator = _get_coordinator_class()
+        coord = object.__new__(ClimateAdvisorCoordinator)
+
+        hass = MagicMock()
+        hass.services = MagicMock()
+        hass.services.async_call = AsyncMock()
+        hass.async_create_task = MagicMock(side_effect=_consume_coroutine)
+        coord.hass = hass
+
+        # Pre-restart accumulated record — date matches patched dt_util.now() "2026-04-05"
+        coord._today_record = _make_today_record(
+            date="2026-04-05",
+            hvac_runtime_minutes=19.8,
+            manual_overrides=3,
+            comfort_violations_minutes=12.0,
+        )
+
+        # Coordinator state
+        coord._briefing_sent_today = False
+        coord._automation_enabled = False  # exits early after DailyRecord creation
+        coord._current_classification = None
+        coord._occupancy_mode = "home"
+        coord._last_predicted_indoor = []
+        coord._last_briefing = ""
+        coord._last_briefing_short = ""
+        coord._briefing_day_type = None
+        coord._solar_phase_offset = 0.0
+        coord.config = {
+            "learning_enabled": False,
+            "push_briefing": False,
+            "email_briefing": False,
+            "notify_service": "notify.test",
+        }
+
+        ae = MagicMock()
+        ae.apply_classification = AsyncMock()
+        ae._thermal_model = {}
+        ae._natural_vent_active = False
+        ae._fan_override_active = False
+        coord.automation_engine = ae
+
+        learning = MagicMock()
+        learning.get_thermal_model = MagicMock(return_value={})
+        learning.generate_suggestions = MagicMock(return_value=[])
+        learning.get_last_suggestion_keys = MagicMock(return_value=[])
+        coord.learning = learning
+
+        coord._get_forecast = AsyncMock(return_value=MagicMock(current_outdoor_temp=65.0))
+        coord._get_hourly_forecast_data = AsyncMock(return_value=[])
+        coord._apply_outdoor_windows_gate = MagicMock()
+        coord._build_briefing_text = MagicMock(return_value=("briefing text", "short"))
+        coord._build_learning_health = MagicMock(return_value={})
+        coord._get_indoor_temp = MagicMock(return_value=72.0)
+        coord._async_save_state = AsyncMock()
+
+        cls = _make_classification()
+        send_briefing = types.MethodType(ClimateAdvisorCoordinator._async_send_briefing, coord)
+        _fake_now = datetime(2026, 4, 5, 10, 0, 0)
+
+        with (
+            patch("custom_components.climate_advisor.coordinator.classify_day", return_value=cls),
+            patch("custom_components.climate_advisor.coordinator._build_predicted_indoor_future", return_value=[]),
+            patch("custom_components.climate_advisor.coordinator.dt_util") as mock_dt_util,
+        ):
+            mock_dt_util.now.return_value = _fake_now
+            asyncio.run(send_briefing(_fake_now))
+
+        assert coord._today_record.hvac_runtime_minutes == 19.8, (
+            f"hvac_runtime_minutes was reset to {coord._today_record.hvac_runtime_minutes} "
+            "(expected 19.8 — DailyRecord not preserving accumulated counters after restart)"
+        )
+        assert coord._today_record.manual_overrides == 3
+        assert coord._today_record.comfort_violations_minutes == 12.0
+
+    def test_briefing_starts_fresh_on_new_day(self):
+        """When _today_record.date != today, counters are NOT carried over (next-day reset)."""
+        ClimateAdvisorCoordinator = _get_coordinator_class()
+        coord = object.__new__(ClimateAdvisorCoordinator)
+
+        hass = MagicMock()
+        hass.services = MagicMock()
+        hass.services.async_call = AsyncMock()
+        hass.async_create_task = MagicMock(side_effect=_consume_coroutine)
+        coord.hass = hass
+
+        # Yesterday's record — different date
+        coord._today_record = _make_today_record(
+            date="2026-04-04",  # yesterday; dt_util.now() returns 2026-04-05
+            hvac_runtime_minutes=95.0,
+            manual_overrides=5,
+        )
+
+        coord._briefing_sent_today = False
+        coord._automation_enabled = False
+        coord._current_classification = None
+        coord._occupancy_mode = "home"
+        coord._last_predicted_indoor = []
+        coord._last_briefing = ""
+        coord._last_briefing_short = ""
+        coord._briefing_day_type = None
+        coord._solar_phase_offset = 0.0
+        coord.config = {
+            "learning_enabled": False,
+            "push_briefing": False,
+            "email_briefing": False,
+            "notify_service": "notify.test",
+        }
+
+        ae = MagicMock()
+        ae.apply_classification = AsyncMock()
+        ae._thermal_model = {}
+        ae._natural_vent_active = False
+        ae._fan_override_active = False
+        coord.automation_engine = ae
+
+        learning = MagicMock()
+        learning.get_thermal_model = MagicMock(return_value={})
+        learning.generate_suggestions = MagicMock(return_value=[])
+        learning.get_last_suggestion_keys = MagicMock(return_value=[])
+        coord.learning = learning
+
+        coord._get_forecast = AsyncMock(return_value=MagicMock(current_outdoor_temp=65.0))
+        coord._get_hourly_forecast_data = AsyncMock(return_value=[])
+        coord._apply_outdoor_windows_gate = MagicMock()
+        coord._build_briefing_text = MagicMock(return_value=("briefing text", "short"))
+        coord._build_learning_health = MagicMock(return_value={})
+        coord._get_indoor_temp = MagicMock(return_value=72.0)
+        coord._async_save_state = AsyncMock()
+
+        cls = _make_classification()
+        send_briefing = types.MethodType(ClimateAdvisorCoordinator._async_send_briefing, coord)
+        _fake_now = datetime(2026, 4, 5, 10, 0, 0)
+
+        with (
+            patch("custom_components.climate_advisor.coordinator.classify_day", return_value=cls),
+            patch("custom_components.climate_advisor.coordinator._build_predicted_indoor_future", return_value=[]),
+            patch("custom_components.climate_advisor.coordinator.dt_util") as mock_dt_util,
+        ):
+            mock_dt_util.now.return_value = _fake_now
+            asyncio.run(send_briefing(_fake_now))
+
+        # Yesterday's counters must NOT carry over — fresh day
+        assert coord._today_record.hvac_runtime_minutes == 0.0
+        assert coord._today_record.manual_overrides == 0


### PR DESCRIPTION
## Summary

When HA restarts mid-day, `hvac_runtime_today` (and all other DailyRecord counters) drops to 0. Detected via AI investigator report #167: runtime went from 19.8 → 0.0 min within 43 minutes on the same day.

## Root Cause

`_async_send_briefing()` unconditionally creates `DailyRecord(...)` with all counters at zero, overwriting the record that `async_restore_state()` just restored from disk.

```
HA restart → async_restore_state() [restores hvac_runtime=19.8] → _async_send_briefing() → DailyRecord(...) [resets to 0.0] ✗
```

**All affected counters:** `hvac_runtime_minutes`, `comfort_violations_minutes`, `manual_overrides`, `thermal_session_count`, `occupancy_away_minutes`, `windows_opened`, `window_open_actual_time`, `override_details`

## Fix

1. **`coordinator.py` ~line 1919**: Before creating the new `DailyRecord`, capture the existing record if its date matches today. Pass all 8 accumulated fields through when constructing the new record.
2. **`coordinator.py` ~line 2270**: Add `async_create_task(_async_save_state())` after HVAC on→off transition so state is never more than one cycle stale.

## Tests

- `TestDailyRecordBriefingPreservation::test_daily_record_survives_briefing_after_restart` — 19.8 min survives briefing on same day ✓
- `TestDailyRecordBriefingPreservation::test_briefing_starts_fresh_on_new_day` — yesterday's counters don't carry over ✓

## Docs

`docs/08-COMPUTATION-REFERENCE.md` — DailyRecord Persistence Invariant documented.

Closes #176