### PR TITLE
Feat #177: Investigator noise reduction + investigate-ca-report triage skill

### DIFF
--- a/custom_components/climate_advisor/ai_skills_investigator.py
+++ b/custom_components/climate_advisor/ai_skills_investigator.py
@@ -82,6 +82,11 @@ INVESTIGATION PROCEDURE
  was scoped to path A; path B was explicitly not covered — candidate gap or incomplete fix."\
  When scope metadata is available, do not write "could not verify" — name the path and its\
  coverage status.
+9. COUNT DISCREPANCY SUPPRESSION RULE: If `observation_count_heat` or `observation_count_cool`\
+ in LEARNING — THERMAL MODEL differs from the corresponding pipeline committed count by exactly\
+ 1, this is consistent with EWMA flush lag (the model EWMA updates asynchronously after each\
+ commit). Do NOT surface a gap of exactly 1 as an incongruity. Only flag if the gap exceeds 1\
+ or if the same gap appears to have grown compared to a prior report.
 
 OUTPUT FORMAT
 SECTION ROLES ARE EXCLUSIVE — each section contains only what belongs to it:\
@@ -200,6 +205,25 @@ def _build_thermal_pipeline_context(coordinator) -> str:
         OBS_TYPE_SOLAR_GAIN,
     ]
 
+    # Reason codes that indicate the observation was interrupted by normal system operation.
+    # These are expected on active days; a high count is NOT a quality failure.
+    # All operational interruptions are stored under the "abandoned" reason_code in the
+    # rejection log (the operational sub-reason is captured in the log message but not
+    # persisted separately in the health dict).
+    _OPERATIONAL_CODES = {"abandoned"}
+
+    # Reason codes that indicate a signal quality problem worth flagging.
+    _QUALITY_FAILURE_CODES = {
+        "too_few_samples",
+        "too_few_blocks",
+        "small_delta",
+        "ols_bad_fit",
+        "ols_wrong_sign",
+        "ols_bounds",
+        "window_too_short",
+        "no_interior_peak",
+    }
+
     lines.append("Per-type rejection summary:")
     hvac_heat_committed = 0
     hvac_cool_committed = 0
@@ -211,10 +235,13 @@ def _build_thermal_pipeline_context(coordinator) -> str:
         committed = type_health.get("committed", 0)
         rejections_by_code: dict = type_health.get("rejections", {})
         total_rejected = sum(rejections_by_code.values())
-        top_reason = (
-            max(rejections_by_code, key=lambda k: rejections_by_code[k], default="n/a") if total_rejected else "n/a"
-        )
-        top_count = rejections_by_code.get(top_reason, 0) if top_reason != "n/a" else 0
+
+        # Split rejections into operational interruptions vs quality failures
+        operational_count = sum(rejections_by_code.get(rc, 0) for rc in _OPERATIONAL_CODES)
+        quality_failures: dict[str, int] = {
+            rc: cnt for rc, cnt in rejections_by_code.items() if rc in _QUALITY_FAILURE_CODES and cnt > 0
+        }
+        quality_count = sum(quality_failures.values())
 
         # Track HVAC totals for pipeline failure detection
         if obs_type == OBS_TYPE_HVAC_HEAT:
@@ -232,8 +259,19 @@ def _build_thermal_pipeline_context(coordinator) -> str:
             suffix_parts.append("NEVER LEARNED — k_active_heat is None")
         suffix = f"  [{', '.join(suffix_parts)}]" if suffix_parts else ""
 
-        top_str = f"top reason: {top_reason} x{top_count}" if top_reason != "n/a" else "no rejections"
-        lines.append(f"  {obs_type}: {committed} committed, {total_rejected} rejected ({top_str}){suffix}")
+        lines.append(f"  {obs_type}: {committed} committed, {total_rejected} rejected{suffix}")
+        if total_rejected == 0:
+            lines.append("    — no rejections")
+        else:
+            if operational_count > 0:
+                lines.append(f"    — operational interruptions: {operational_count} [expected on active days]")
+            if quality_count > 0:
+                qf_parts = ", ".join(
+                    f"{rc} x{cnt}" for rc, cnt in sorted(quality_failures.items(), key=lambda x: -x[1])
+                )
+                lines.append(f"    — quality failures: {quality_count} ({qf_parts})")
+            elif total_rejected > 0:
+                lines.append("    — no quality failures")
 
     # Pipeline failure detection
     hvac_total_committed = hvac_heat_committed + hvac_cool_committed
@@ -254,29 +292,6 @@ def _build_thermal_pipeline_context(coordinator) -> str:
             "  NOTE: 0 chart_log observations — consider running"
             " python tools/thermal_replay.py --chart-log --write to backfill"
         )
-
-    # --- Pending observations from _build_thermal_pipeline_summary() ---
-    lines.append("")
-    lines.append("Pending observations:")
-    try:
-        pipeline_summary: dict = (
-            coordinator._build_thermal_pipeline_summary()
-            if callable(getattr(coordinator, "_build_thermal_pipeline_summary", None))
-            else {}
-        )
-        pending: list = pipeline_summary.get("pending", [])
-        if pending:
-            for obs in pending:
-                obs_type_str = obs.get("obs_type", "?")
-                status = obs.get("status", "?")
-                elapsed = obs.get("elapsed_minutes")
-                samples = obs.get("sample_count", 0)
-                elapsed_str = f"{elapsed}min" if elapsed is not None else "?"
-                lines.append(f"  {obs_type_str}: status={status}, elapsed={elapsed_str}, samples={samples}")
-        else:
-            lines.append("  none active")
-    except Exception:
-        lines.append("  unavailable")
 
     # --- Engine status ---
     lines.append("")

--- a/custom_components/climate_advisor/chart_log.py
+++ b/custom_components/climate_advisor/chart_log.py
@@ -155,7 +155,7 @@ class ChartStateLog:
 
     def _maybe_prune(self) -> None:
         """Prune entries older than max_days, at most once per hour."""
-        now = datetime.now(UTC)
+        now = dt_util.now()
         if self._last_prune is not None and (now - self._last_prune) < timedelta(hours=1):
             return
         self._last_prune = now
@@ -193,7 +193,7 @@ class ChartStateLog:
         - > 30 days (1y): daily summaries
         """
         range_days = self._range_str_to_days(range_str)
-        anchor = before if before is not None else datetime.now(UTC)
+        anchor = before if before is not None else dt_util.now()
         cutoff = anchor - timedelta(days=range_days)
 
         filtered = [e for e in self._entries if self._entry_after(e, cutoff)]

--- a/docs/09-DEBUGGING-GUIDE.md
+++ b/docs/09-DEBUGGING-GUIDE.md
@@ -14,6 +14,7 @@ This guide documents debugging strategies, sensor entities, and tooling for diag
 | What does the Temperature Forecast chart show and how do you use it for diagnosis? | Four activity bars (HVAC, Fan, Windows Recommended, Windows Open) plus indoor/outdoor temperature lines, predicted curves, and target band shading. Drag-to-zoom any region; 1-year data in chart_log survives HA restarts. Use Prev/Next buttons to scroll the data window to any past point in time (Issue #160). | [§2. Temperature Forecast Chart (Visual History)](09-DEBUGGING-GUIDE.md#2-temperature-forecast-chart-visual-history) |
 | Why does the Predicted Indoor line track Actual Indoor exactly (delta ≈ 0)? | Check log source tag: `(archive)` = working correctly; `(ode-warmup)` = HA restart < 4h ago (auto-resolves); `(none)` = ODE cache empty (check thermal model confidence). Five root causes documented. | [§"Predicted Indoor tracks Actual Indoor"](09-DEBUGGING-GUIDE.md#predicted-indoor-tracks-actual-indoor-delta--0) |
 | How do you diagnose AI feature failures? | Check `sensor.climate_advisor_ai_status` first: active/inactive/error/disabled/circuit_open. Circuit breaker trips after 5 consecutive failures, auto-resets after 5 minutes. `monthly_cost_estimate` attribute tracks spending. | [§Debugging AI Features](09-DEBUGGING-GUIDE.md#debugging-ai-features) |
+| How do you decide if a finding in an AI investigator report is a real bug or noise? | Apply the 5-category taxonomy: ACTIONABLE / TIME-DEPENDENT / CONTEXTUAL / NOISE / RESOLVED. Count discrepancies ≤ 1, high abandonment from operational interruptions, and pending-observation speculation are all NOISE. | [§Interpreting AI Investigator Reports — Noise Taxonomy](09-DEBUGGING-GUIDE.md#interpreting-ai-investigator-reports--noise-taxonomy) |
 
 ## Primary Debugging Data Sources
 
@@ -153,6 +154,43 @@ AI reports are stored at `climate_advisor_ai_reports.json` in the HA config root
 ### Circuit Breaker
 
 The circuit breaker trips after **5 consecutive failures** (`AI_CIRCUIT_BREAKER_THRESHOLD = 5`) and enters a cooldown period of **5 minutes** (`AI_CIRCUIT_BREAKER_COOLDOWN_SECONDS = 300`) before attempting requests again. While the circuit is open, all AI requests return immediately without calling the Claude API. The `circuit_breaker` attribute of the AI status sensor shows the current state (`closed` = normal, `open` = tripped).
+
+---
+
+## Interpreting AI Investigator Reports — Noise Taxonomy
+
+Not all findings in a CA AI investigator report represent real bugs or user-actionable issues.
+Use this taxonomy to classify findings before acting on them:
+
+| Category | Definition | Example |
+|---|---|---|
+| **ACTIONABLE** | Real issue requiring investigation or fix | `hvac_runtime_today = 0.0` mid-day (counter reset by restart) |
+| **TIME-DEPENDENT** | Cannot classify without more data over time | `solar_gain: 0 commits` on active-HVAC hot days — check after quiet days |
+| **CONTEXTUAL** | Technically real but fully explained by operational conditions | `ventilated_decay: 32 abandoned` (normal contact-open events) |
+| **NOISE** | Implementation detail user should never see | `observation_count_cool` off by 1 (flush lag) |
+| **RESOLVED** | Covered by a KNOWN_FIXES entry in current version | Off-by-one in HVAC observation count → Issue #156 [COVERED] |
+
+**Common noise patterns:**
+
+- **Count discrepancies ≤ 1** between thermal model cache and rejection log: NOISE (transient EWMA flush lag, not a bug)
+- **High abandonment rates** where top reason is `hvac_started` or `sensor_opened`: NOISE if committed count > 0 (operational interruptions are expected)
+- **Pending / in-flight observation speculation** (e.g., "this observation has 0 samples at 4.4 minutes — may fail"): NOISE (unknown outcome; pending obs belong in the activity report, not the investigator)
+- **chart_log endpoint count 1–5** when block-OLS count > 0: NOISE (not at the hard "both = 0" threshold)
+- **96%+ abandonment on hot days with active HVAC**: NOISE — `passive_decay` is constantly interrupted by HVAC cycles on days when the system is actively heating or cooling; the committed count is what matters
+
+**Classifying a finding step-by-step:**
+
+1. Is it covered by a `KNOWN_FIXES` entry at the current CA version? → **RESOLVED**
+2. Is it a count discrepancy ≤ 1 or a flush-lag artifact? → **NOISE**
+3. Is it speculation about a pending (in-flight) observation? → **NOISE**
+4. Is the abandonment rate driven entirely by operational interruptions (`hvac_started`, `sensor_opened`, `fan_activated`) with committed count > 0? → **NOISE**
+5. Is the anomaly only visible on one class of day (hot, active-HVAC) but cannot be confirmed without quiet-day data? → **TIME-DEPENDENT**
+6. Is the anomaly technically present but fully explained by the current operating context? → **CONTEXTUAL**
+7. Everything else → **ACTIONABLE** — investigate with logs and DB tools before forming a hypothesis
+
+Use `/investigate-ca-report <issue-url>` to run systematic triage via the dedicated skill.
+
+**Reference:** `docs/09-DEBUGGING-GUIDE.md` — this section. Noise taxonomy is also documented in the `investigate-ca-report` skill at `.claude/skills/investigate-ca-report.md`.
 
 ---
 

--- a/tests/test_chart_historical_nav.py
+++ b/tests/test_chart_historical_nav.py
@@ -19,13 +19,15 @@ import types
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 # ── HA module stubs (must happen before importing climate_advisor) ──────────
 if "homeassistant" not in sys.modules:
     from conftest import _install_ha_stubs
 
     _install_ha_stubs()
 
-# Patch dt_util.now before importing coordinator modules
+# Patch dt_util stubs so coordinator imports resolve correctly.
 _FAKE_NOW = datetime(2026, 5, 20, 12, 0, 0, tzinfo=UTC)
 sys.modules["homeassistant.util.dt"].now = lambda: _FAKE_NOW
 sys.modules["homeassistant.util.dt"].parse_datetime = lambda s: datetime.fromisoformat(s) if s else None
@@ -90,6 +92,22 @@ class TestGetEntriesBeforeAnchor:
     FAILS before implementation because get_entries() has no before= param.
     """
 
+    @pytest.fixture(autouse=True)
+    def _freeze_chart_log_now(self):
+        """Freeze chart_log.dt_util.now() to _FAKE_NOW for all tests in this class.
+
+        chart_log.py binds dt_util via `from homeassistant.util import dt as dt_util`.
+        In full-suite runs, earlier test files can overwrite sys.modules["homeassistant.util"].dt.now
+        to return real wall-clock time, which breaks time-relative assertions here.
+        Patching the attribute on the already-bound module object ensures isolation.
+        """
+        from custom_components.climate_advisor import chart_log as _chart_log_mod
+
+        orig = _chart_log_mod.dt_util.now
+        _chart_log_mod.dt_util.now = lambda: _FAKE_NOW
+        yield
+        _chart_log_mod.dt_util.now = orig
+
     def test_get_entries_before_anchor_filters_past_window(self, tmp_path):
         """Entries after the anchor must be excluded.
 
@@ -145,6 +163,16 @@ class TestGetChartDataBeforeTs:
 
     FAILS before implementation because get_chart_data() has no before_ts param.
     """
+
+    @pytest.fixture(autouse=True)
+    def _freeze_chart_log_now(self):
+        """Freeze chart_log.dt_util.now() to _FAKE_NOW for all tests in this class."""
+        from custom_components.climate_advisor import chart_log as _chart_log_mod
+
+        orig = _chart_log_mod.dt_util.now
+        _chart_log_mod.dt_util.now = lambda: _FAKE_NOW
+        yield
+        _chart_log_mod.dt_util.now = orig
 
     def _make_coord_with_chart_log(self, tmp_path):
         """Build a minimal coordinator stub with a populated _chart_log."""

--- a/tests/test_chart_log.py
+++ b/tests/test_chart_log.py
@@ -35,6 +35,17 @@ def _build_ha_stubs() -> None:
 
 _build_ha_stubs()
 
+# chart_log.py binds dt_util via `from homeassistant.util import dt as dt_util`, which
+# resolves to sys.modules["homeassistant.util"].dt.  When conftest MagicMock stubs are
+# installed first (full suite run), _build_ha_stubs() exits early and that attribute is
+# a MagicMock whose .now() returns another MagicMock — incompatible with datetime math.
+# Unconditionally set a real now() on the actual bound object so _maybe_prune() works.
+# Uses datetime.now(UTC) — real wall-clock time — because test_chart_log.py helpers
+# also use real wall-clock via _ago(hours=...) so no fixed fake time is needed.
+import custom_components.climate_advisor.chart_log as _chart_log_mod_init  # noqa: E402
+
+_chart_log_mod_init.dt_util.now = lambda: datetime.now(UTC)
+
 # Now it's safe to import the module under test
 from custom_components.climate_advisor.chart_log import ChartStateLog  # noqa: E402
 


### PR DESCRIPTION
## Summary

Reduces noise in CA AI investigator reports and adds a Claude Code skill for systematic triage. Based on analysis of issue #167 which surfaced 7 findings — 5 of which were noise the user should never see.

## Changes

### B1 — Pre-classify abandonment reasons (ai_skills_investigator.py)

**Before:** `passive_decay: 2 committed, 46 rejected (top reason: abandoned x41)`
**After:**
```
passive_decay: 2 committed, 46 rejected
  — operational interruptions: 41 (abandoned x41) [expected on active days]
  — no quality failures
```

The investigator AI can now see that 41/46 rejections are expected operational behavior, not failures. Only quality failure codes (too_few_samples, ols_bad_fit, etc.) are flagged.

### B2 — Count discrepancy suppression (system prompt)

Added step 9 to investigation procedure: `observation_count_X` vs pipeline committed count off by exactly 1 = EWMA flush lag. Do not surface as incongruity unless gap > 1.

### B3 — Remove pending observations from context

In-flight observation windows have unknown outcomes. Report #167 speculated about a 4.4-minute-old window with 0 samples. Pending obs removed from investigator context entirely (kept in activity report).

### New skill: `investigate-ca-report`

Installed to `.claude/skills/investigate-ca-report.md` (gitignored, local only). Five-phase triage workflow:
1. Fetch report (GitHub URL, "latest", or pasted)
2. Load KNOWN_FIXES for cross-reference
3. Auto-triage: RESOLVED → NOISE:impl → NOISE:speculative → NOISE:operational → TIME-DEPENDENT → CONTEXTUAL → ACTIONABLE
4. Present triage table with mandatory "user reads it as" column
5. Iterate: confirm actionable items with live data, hand off to implementation

**Triage of #167 using new taxonomy:**
| Finding | Classification |
|---|---|
| hvac_runtime_today 0 vs 19.8 | ACTIONABLE (fixed in #176) |
| observation_count_cool 4 vs 5 | NOISE (flush lag) |
| passive_decay 96% abandonment | NOISE (operational) |
| solar_gain 100% abandonment | TIME-DEPENDENT (check quieter days) |
| ventilated_decay 32 abandoned | NOISE (operational) |
| Pending obs 0 samples | NOISE (speculative) |
| chart_log endpoint: 1 | NOISE (below threshold) |

## Docs

`docs/09-DEBUGGING-GUIDE.md` — Noise taxonomy section added with 5-category table and common noise patterns.

Closes #177