### PR TITLE
Feat #180: Restore GitHub issue submission modal + config flow step

### DIFF
--- a/custom_components/climate_advisor/api.py
+++ b/custom_components/climate_advisor/api.py
@@ -31,6 +31,7 @@ from .const import (
     API_RESUME_FROM_PAUSE,
     API_SEND_BRIEFING,
     API_STATUS,
+    API_SUBMIT_GITHUB_ISSUE,
     API_TOGGLE_AUTOMATION,
     ATTR_AUTOMATION_STATUS,
     ATTR_COMPLIANCE_SCORE,
@@ -48,6 +49,8 @@ from .const import (
     ATTR_TREND_MAGNITUDE,
     CONF_AI_ENABLED,
     CONF_AI_INVESTIGATOR_ENABLED,
+    CONF_GITHUB_REPO,
+    CONF_GITHUB_TOKEN,
     CONFIG_METADATA,
     DEFAULT_AI_ENABLED,
     DEFAULT_AI_INVESTIGATOR_ENABLED,
@@ -795,6 +798,73 @@ class ClimateAdvisorDeleteReportView(HomeAssistantView):
         return self.json({"success": True, "found": found})
 
 
+class ClimateAdvisorSubmitGithubIssueView(HomeAssistantView):
+    """POST /api/climate_advisor/submit_github_issue — create a GitHub issue from a report."""
+
+    url = API_SUBMIT_GITHUB_ISSUE
+    name = "api:climate_advisor:submit_github_issue"
+    requires_auth = True
+
+    async def post(self, request: web.Request) -> web.Response:
+        import aiohttp
+
+        hass = request.app["hass"]
+        coordinator = _get_coordinator(hass)
+        if not coordinator:
+            return self.json({"error": "Climate Advisor not loaded"}, status_code=503)
+
+        token = coordinator.config.get(CONF_GITHUB_TOKEN, "")
+        repo = coordinator.config.get(CONF_GITHUB_REPO, "")
+        if not token or not repo:
+            return self.json({"success": False, "error": "not_configured"})
+
+        try:
+            body = await request.json()
+        except Exception:
+            return self.json({"error": "invalid_json"}, status_code=400)
+
+        title = str(body.get("title", "")).strip()
+        issue_body = str(body.get("body", "")).strip()
+        labels = body.get("labels", ["bug"])
+
+        if not title:
+            return self.json({"error": "missing_title"}, status_code=400)
+        if not isinstance(labels, list):
+            labels = ["bug"]
+
+        from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+        session = async_get_clientsession(hass)
+        try:
+            resp = await session.post(
+                f"https://api.github.com/repos/{repo}/issues",
+                json={"title": title, "body": issue_body, "labels": labels},
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Accept": "application/vnd.github+json",
+                    "X-GitHub-Api-Version": "2022-11-28",
+                },
+                timeout=aiohttp.ClientTimeout(total=15),
+            )
+        except Exception:
+            _LOGGER.exception("GitHub issue submission: network error")
+            return self.json({"success": False, "error": "network_error"})
+
+        if resp.status == 201:
+            issue = await resp.json()
+            return self.json(
+                {
+                    "success": True,
+                    "issue_url": issue.get("html_url", ""),
+                    "issue_number": issue.get("number"),
+                }
+            )
+
+        # Never log the token — log only the HTTP status
+        _LOGGER.warning("GitHub issue submission: API returned status %d", resp.status)
+        return self.json({"success": False, "error": f"github_api_{resp.status}"})
+
+
 # All views to register
 API_VIEWS = [
     ClimateAdvisorStatusView,
@@ -816,6 +886,7 @@ API_VIEWS = [
     ClimateAdvisorInvestigateView,
     ClimateAdvisorInvestigationReportsView,
     ClimateAdvisorDeleteReportView,
+    ClimateAdvisorSubmitGithubIssueView,
     ClimateAdvisorEventLogView,
     ClimateAdvisorEnginesView,
 ]

--- a/custom_components/climate_advisor/config_flow.py
+++ b/custom_components/climate_advisor/config_flow.py
@@ -38,6 +38,8 @@ from .const import (
     CONF_FAN_ENTITY,
     CONF_FAN_MIN_RUNTIME_PER_HOUR,
     CONF_FAN_MODE,
+    CONF_GITHUB_REPO,
+    CONF_GITHUB_TOKEN,
     CONF_GUEST_TOGGLE,
     CONF_GUEST_TOGGLE_INVERT,
     CONF_HOME_TOGGLE,
@@ -127,6 +129,7 @@ OPTIONS_MENU_OPTIONS = [
     "notifications",
     "advanced",
     "ai_settings",
+    "github_settings",
     "save",
 ]
 
@@ -1306,6 +1309,59 @@ class ClimateAdvisorOptionsFlow(config_entries.OptionsFlow):
             data_schema=schema,
             errors=errors,
             description_placeholders={"key_status": key_status},
+        )
+
+    # ---- GitHub Integration ----
+
+    async def async_step_github_settings(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """GitHub Integration — token and repository for issue submission."""
+        errors: dict[str, str] = {}
+        current = self.config_entry.data
+
+        if user_input is not None:
+            new_token = user_input.get(CONF_GITHUB_TOKEN, "").strip()
+            repo = user_input.get(CONF_GITHUB_REPO, "").strip()
+
+            import re
+
+            if repo and not re.match(r"^[^/]+/[^/]+$", repo):
+                errors[CONF_GITHUB_REPO] = "github_repo_invalid"
+
+            if not errors:
+                merged: dict[str, Any] = {}
+                # Preserve existing token if field left blank
+                if new_token:
+                    merged[CONF_GITHUB_TOKEN] = new_token
+                elif current.get(CONF_GITHUB_TOKEN):
+                    merged[CONF_GITHUB_TOKEN] = current[CONF_GITHUB_TOKEN]
+                else:
+                    merged.pop(CONF_GITHUB_TOKEN, None)
+                merged[CONF_GITHUB_REPO] = repo
+                self._updates.update(merged)
+                return await self.async_step_init()
+
+        existing_token = current.get(CONF_GITHUB_TOKEN, "")
+        token_status = "configured" if existing_token else "not configured"
+
+        schema = vol.Schema(
+            {
+                vol.Optional(CONF_GITHUB_TOKEN, default=""): selector.TextSelector(
+                    selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
+                ),
+                vol.Optional(
+                    CONF_GITHUB_REPO,
+                    default=current.get(CONF_GITHUB_REPO, ""),
+                ): selector.TextSelector(selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT)),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="github_settings",
+            data_schema=schema,
+            errors=errors,
+            description_placeholders={"token_status": token_status},
         )
 
     # ---- Save & Close ----

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -331,6 +331,21 @@ KNOWN_FIXES: dict[int, dict] = {
             " will trigger grace — use _temp_command_pending guard to suppress if needed)",
         ],
     },
+    180: {
+        "version_fixed": "0.3.54",
+        "title": "GitHub issue submission modal — restored from uncommitted worktree code",
+        "scope_covered": [
+            "CONF_GITHUB_TOKEN / CONF_GITHUB_REPO constants added to const.py",
+            "ClimateAdvisorSubmitGithubIssueView — POST /api/climate_advisor/submit_github_issue",
+            "config_flow async_step_github_settings() — token + repo config fields",
+            "frontend modal — openGithubIssueModal, closeGithubIssueModal, submitGithubIssue",
+            "_formatCurrentReport() — formats current investigation report as issue body",
+        ],
+        "scope_not_covered": [
+            "API_REFINE_REPORT / investigation refinement — excluded from this PR",
+            "Annotation toolbar and rating buttons — excluded from this PR",
+        ],
+    },
 }
 
 GITHUB_REPO = "gunkl/ClimateAdvisor"
@@ -338,6 +353,10 @@ GITHUB_REPO_URL = "https://github.com/gunkl/ClimateAdvisor"
 GITHUB_API_BASE = "https://api.github.com"
 GITHUB_CONTEXT_TIMEOUT = 5.0  # seconds — skip if API is slow
 GITHUB_ISSUES_LIMIT = 15  # max issues to include in context
+
+CONF_GITHUB_TOKEN = "github_token"
+CONF_GITHUB_REPO = "github_repo"
+API_SUBMIT_GITHUB_ISSUE = "/api/climate_advisor/submit_github_issue"
 
 # Default setpoints (°F)
 DEFAULT_COMFORT_HEAT = 70

--- a/custom_components/climate_advisor/frontend/index.html
+++ b/custom_components/climate_advisor/frontend/index.html
@@ -705,6 +705,28 @@
       <button class="btn secondary" onclick="copyCurrentReport()" style="font-size:0.8rem;">Copy for Bug Report</button>
       <button class="btn secondary" onclick="downloadCurrentReport()" style="font-size:0.8rem;">&#x2B07; Download Report</button>
       <button class="btn secondary" onclick="downloadFullLogs()" style="font-size:0.8rem;">Download Full Logs</button>
+      <button class="btn secondary" id="github-issue-btn" onclick="window.openGithubIssueModal()" style="font-size:0.8rem;">&#x1F41B; Submit GitHub Issue</button>
+    </div>
+  </div>
+
+  <!-- GitHub Issue Modal -->
+  <div id="github-issue-modal" style="display:none;position:fixed;inset:0;z-index:10000;background:rgba(0,0,0,0.5);align-items:center;justify-content:center;">
+    <div style="background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:20px;width:min(560px,90vw);max-height:80vh;overflow-y:auto;box-shadow:0 4px 20px rgba(0,0,0,0.4);">
+      <h3 style="margin:0 0 12px;">Submit GitHub Issue</h3>
+      <div id="github-modal-not-configured" style="display:none;color:var(--warning);font-size:0.85rem;margin-bottom:10px;">
+        GitHub integration is not configured. Add your token and repository in HA Settings &#x2192; Devices &amp; Services &#x2192; Climate Advisor &#x2192; Configure &#x2192; GitHub Integration.
+      </div>
+      <label style="font-size:0.82rem;display:block;margin-bottom:4px;">Title</label>
+      <input id="github-issue-title" type="text" style="width:100%;box-sizing:border-box;padding:6px 8px;border-radius:4px;border:1px solid var(--border);background:var(--card-bg);color:var(--text);font-size:0.82rem;margin-bottom:10px;">
+      <label style="font-size:0.82rem;display:block;margin-bottom:4px;">Body</label>
+      <textarea id="github-issue-body" style="width:100%;box-sizing:border-box;padding:6px 8px;border-radius:4px;border:1px solid var(--border);background:var(--card-bg);color:var(--text);font-size:0.78rem;resize:vertical;min-height:140px;font-family:monospace;margin-bottom:10px;"></textarea>
+      <label style="font-size:0.82rem;display:block;margin-bottom:4px;">Labels (comma-separated)</label>
+      <input id="github-issue-labels" type="text" value="bug" style="width:100%;box-sizing:border-box;padding:6px 8px;border-radius:4px;border:1px solid var(--border);background:var(--card-bg);color:var(--text);font-size:0.82rem;margin-bottom:14px;">
+      <div id="github-issue-status" style="font-size:0.8rem;margin-bottom:10px;color:var(--text-secondary);"></div>
+      <div style="display:flex;gap:8px;justify-content:flex-end;">
+        <button class="btn secondary" onclick="window.closeGithubIssueModal()" style="font-size:0.8rem;">Cancel</button>
+        <button class="btn primary" id="github-submit-btn" onclick="window.submitGithubIssue()" style="font-size:0.8rem;">Submit Issue</button>
+      </div>
     </div>
   </div>
 
@@ -2913,6 +2935,72 @@
     return lines.join('\n');
   }
 
+  // ---- GitHub Issue Modal ----
+
+  function openGithubIssueModal() {
+    if (!_currentReport) return;
+    const modal = document.getElementById('github-issue-modal');
+    const result = _currentReport.result || {};
+    const data = result.data || {};
+    const rType = _currentReport.reportType === 'investigation' ? 'Investigative Analysis' : 'Activity Report';
+    const ts = _currentReport.timestamp ? new Date(_currentReport.timestamp).toLocaleString() : '';
+    const summary = (data.summary || '').replace(/\s+/g, ' ').trim().substring(0, 120);
+    document.getElementById('github-issue-title').value = summary
+      ? 'Climate Advisor: ' + summary.substring(0, 80)
+      : 'Climate Advisor: ' + rType + ' — ' + ts;
+    document.getElementById('github-issue-body').value = _formatCurrentReport();
+    document.getElementById('github-issue-labels').value = 'bug';
+    document.getElementById('github-issue-status').textContent = '';
+    document.getElementById('github-modal-not-configured').style.display = 'none';
+    document.getElementById('github-submit-btn').disabled = false;
+    modal.style.display = 'flex';
+  }
+
+  function closeGithubIssueModal() {
+    document.getElementById('github-issue-modal').style.display = 'none';
+  }
+
+  async function submitGithubIssue() {
+    const statusEl = document.getElementById('github-issue-status');
+    const submitBtn = document.getElementById('github-submit-btn');
+    const title = document.getElementById('github-issue-title').value.trim();
+    const body = document.getElementById('github-issue-body').value.trim();
+    const labelsRaw = document.getElementById('github-issue-labels').value;
+    const labels = labelsRaw.split(',').map(l => l.trim()).filter(Boolean);
+    if (!title) { statusEl.textContent = 'Title is required.'; return; }
+    statusEl.textContent = 'Submitting...';
+    submitBtn.disabled = true;
+    const token = await getAuthToken();
+    try {
+      const resp = await fetch('/api/climate_advisor/submit_github_issue', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + token },
+        body: JSON.stringify({ title, body, labels }),
+      });
+      const data = await resp.json();
+      if (data.success) {
+        statusEl.innerHTML = 'Issue created: <a href="' + escapeHtml(data.issue_url) + '" target="_blank" rel="noopener">#' + data.issue_number + '</a>';
+        submitBtn.disabled = true;
+        document.querySelector('#github-issue-modal .btn.secondary').textContent = 'Close';
+      } else if (data.error === 'not_configured') {
+        document.getElementById('github-modal-not-configured').style.display = 'block';
+        statusEl.textContent = '';
+        submitBtn.disabled = false;
+      } else {
+        statusEl.textContent = 'Failed: ' + (data.error || 'unknown error');
+        submitBtn.disabled = false;
+      }
+    } catch (e) {
+      statusEl.textContent = 'Network error: ' + e.message;
+      submitBtn.disabled = false;
+    }
+  }
+
+  // Close modal on backdrop click
+  document.getElementById('github-issue-modal').addEventListener('click', function(evt) {
+    if (evt.target === this) closeGithubIssueModal();
+  });
+
   // Expose AI tab functions to window for onclick handlers
   window.runReport = runReport;
   window.updateReportTypeUI = updateReportTypeUI;
@@ -2925,6 +3013,9 @@
   window.deleteReport = deleteReport;
   window.downloadFullLogs = downloadFullLogs;
   window.downloadDebugLogs = downloadDebugLogs;
+  window.openGithubIssueModal = openGithubIssueModal;
+  window.closeGithubIssueModal = closeGithubIssueModal;
+  window.submitGithubIssue = submitGithubIssue;
 
   // --- Initial load (retry until auth token is available) ---
   function loadAll() {

--- a/custom_components/climate_advisor/strings.json
+++ b/custom_components/climate_advisor/strings.json
@@ -143,6 +143,7 @@
           "notifications": "Notifications",
           "advanced": "Learning & Behavior",
           "ai_settings": "AI Settings (Claude)",
+          "github_settings": "GitHub Integration",
           "save": "Save & Close"
         }
       },
@@ -351,6 +352,18 @@
           "ai_investigator_max_tokens": "Maximum token length for investigator reports (256-16384). 8192 recommended.",
           "ai_investigator_requests_per_day": "Maximum investigative analysis runs per day. Each investigation uses extended thinking. Resets at midnight."
         }
+      },
+      "github_settings": {
+        "title": "GitHub Integration",
+        "description": "Configure GitHub issue submission for investigation reports.\nCurrent token: {token_status}",
+        "data": {
+          "github_token": "GitHub Personal Access Token",
+          "github_repo": "GitHub Repository (owner/repo)"
+        },
+        "data_description": {
+          "github_token": "Token with issues:write scope. Leave blank to keep existing token.",
+          "github_repo": "Repository to submit issues to, e.g. gunkl/ClimateAdvisor."
+        }
       }
     },
     "error": {
@@ -362,7 +375,8 @@
       "ai_connection_failed": "Could not connect to Claude API. Check your API key and try again.",
       "ai_key_required": "API key is required when AI features are enabled.",
       "ai_temperature_out_of_range": "Temperature must be between 0.0 and 1.0.",
-      "ai_max_tokens_out_of_range": "Max tokens value is out of the allowed range for this field."
+      "ai_max_tokens_out_of_range": "Max tokens value is out of the allowed range for this field.",
+      "github_repo_invalid": "Repository must be in owner/repo format (e.g. myuser/MyRepo)."
     }
   },
   "issues": {

--- a/custom_components/climate_advisor/translations/en.json
+++ b/custom_components/climate_advisor/translations/en.json
@@ -143,6 +143,7 @@
           "notifications": "Notifications",
           "advanced": "Learning & Behavior",
           "ai_settings": "AI Settings (Claude)",
+          "github_settings": "GitHub Integration",
           "save": "Save & Close"
         }
       },
@@ -351,6 +352,18 @@
           "ai_investigator_max_tokens": "Maximum token length for investigator reports (256-16384). 8192 recommended.",
           "ai_investigator_requests_per_day": "Maximum investigative analysis runs per day. Each investigation uses extended thinking. Resets at midnight."
         }
+      },
+      "github_settings": {
+        "title": "GitHub Integration",
+        "description": "Configure GitHub issue submission for investigation reports.\nCurrent token: {token_status}",
+        "data": {
+          "github_token": "GitHub Personal Access Token",
+          "github_repo": "GitHub Repository (owner/repo)"
+        },
+        "data_description": {
+          "github_token": "Token with issues:write scope. Leave blank to keep existing token.",
+          "github_repo": "Repository to submit issues to, e.g. gunkl/ClimateAdvisor."
+        }
       }
     },
     "error": {
@@ -362,7 +375,8 @@
       "ai_connection_failed": "Could not connect to Claude API. Check your API key and try again.",
       "ai_key_required": "API key is required when AI features are enabled.",
       "ai_temperature_out_of_range": "Temperature must be between 0.0 and 1.0.",
-      "ai_max_tokens_out_of_range": "Max tokens value is out of the allowed range for this field."
+      "ai_max_tokens_out_of_range": "Max tokens value is out of the allowed range for this field.",
+      "github_repo_invalid": "Repository must be in owner/repo format (e.g. myuser/MyRepo)."
     }
   },
   "issues": {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -105,7 +105,7 @@ class TestAPIViewList:
     """Test the API_VIEWS registry."""
 
     def test_correct_count(self):
-        assert len(API_VIEWS) == 21
+        assert len(API_VIEWS) == 22
 
     def test_all_are_callable(self):
         for view_cls in API_VIEWS:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1643,6 +1643,7 @@ class TestOptionsFlowMenu:
             "notifications",
             "advanced",
             "ai_settings",
+            "github_settings",
             "save",
         ]
         assert expected == OPTIONS_MENU_OPTIONS


### PR DESCRIPTION
## Summary

Restores the GitHub issue submission feature that was implemented in the issue-166 worktree working directory but never committed before cleanup. The feature was deployed and working, then lost when a staging deploy overwrote the HA instance.

## What was restored

| File | Change |
|---|---|
| `const.py` | `CONF_GITHUB_TOKEN`, `CONF_GITHUB_REPO`, `API_SUBMIT_GITHUB_ISSUE` constants |
| `api.py` | `ClimateAdvisorSubmitGithubIssueView` — POST `/api/climate_advisor/submit_github_issue` |
| `config_flow.py` | `async_step_github_settings()` — token + repo config step; added to options menu |
| `strings.json` + `translations/en.json` | GitHub Integration labels + `github_repo_invalid` error |
| `frontend/index.html` | GitHub issue modal HTML/JS — `openGithubIssueModal`, `closeGithubIssueModal` (Cancel→Close fix), `submitGithubIssue`, backdrop-click-to-close |

**Excluded** (separate features also in the worktree): `API_REFINE_REPORT`, annotation toolbar, rating buttons.

## Test results

- [x] `pytest tests/test_api.py tests/test_config_flow.py` — 132/132 pass
- [x] `pytest tests/ -x -q` — 2229/2229 pass
- [x] `ruff check` clean

## Verification

1. HA Settings → CA → Configure → "GitHub Integration" step shows token + repo fields
2. Dashboard: run investigation → "🐛 Submit GitHub Issue" button visible
3. Click button → modal with pre-filled title + body opens
4. Submit → POSTs to backend, success shows GitHub issue link
5. Cancel → modal closes without submitting

Closes #180