### PR TITLE
Feat #186: Add window_compliance denominator to AI investigator context

### DIFF
--- a/custom_components/climate_advisor/ai_skills_investigator.py
+++ b/custom_components/climate_advisor/ai_skills_investigator.py
@@ -161,6 +161,22 @@ Scientific, evidence-based, methodical. Prefer "no evidence of X" over "X is fin
 """
 
 
+def _fmt_window_compliance(compliance: dict) -> str:
+    """Format window_compliance with its denominator for unambiguous AI interpretation.
+
+    Produces e.g. "0.6667 (2 of 3 windows-recommended days)" so the AI cannot
+    mistake the denominator for the total recording window.
+    """
+    val = compliance.get("window_compliance")
+    denom = compliance.get("window_compliance_denominator", 0)
+    if val is None:
+        return "none (no windows-recommended days in window)"
+    if denom == 0:
+        return f"{val} (denominator=0)"
+    numerator = round(val * denom)
+    return f"{val:.4f} ({numerator} of {denom} windows-recommended days)"
+
+
 def _build_thermal_pipeline_context(coordinator) -> str:
     """Build THERMAL OBSERVATION PIPELINE section for the investigator context.
 
@@ -488,7 +504,7 @@ async def async_build_investigator_context(
                 compliance: dict[str, Any] = learning.get_compliance_summary() or {}
                 lines += [
                     "=== LEARNING — COMPLIANCE SUMMARY ===",
-                    f"  window_compliance:              {compliance.get('window_compliance', 'unknown')}",
+                    f"  window_compliance:              {_fmt_window_compliance(compliance)}",
                     f"  avg_daily_hvac_runtime_minutes: {compliance.get('avg_daily_hvac_runtime_minutes', 'unknown')}",
                     f"  comfort_score:                  {compliance.get('comfort_score', 'unknown')}",
                     f"  total_manual_overrides:         {compliance.get('total_manual_overrides', 'unknown')}",

--- a/custom_components/climate_advisor/learning.py
+++ b/custom_components/climate_advisor/learning.py
@@ -1954,6 +1954,7 @@ class LearningEngine:
             "status": "active",
             "days_recorded": len(records),
             "window_compliance": window_compliance,
+            "window_compliance_denominator": len(window_days),
             "avg_daily_hvac_runtime_minutes": avg_runtime,
             "comfort_score": comfort_score,
             "total_manual_overrides": sum(r.get("manual_overrides", 0) for r in recent),


### PR DESCRIPTION
## Summary

The AI investigator misread `window_compliance = 0.6667` as mathematically irreconcilable with a 14-day recording window (investigation #183). The actual denominator is `window_compliance_denominator` — the count of days where windows were actually **recommended**, not total days in the window.

## Changes

- `learning.py` — `get_compliance_summary()` now returns `window_compliance_denominator` (count of windows-recommended days in the recent window)
- `ai_skills_investigator.py` — new `_fmt_window_compliance()` helper formats the value as `0.6667 (2 of 3 windows-recommended days)` so the AI cannot mistake the denominator for total recording days

## Before / After

**Before**: `window_compliance: 0.6667`
**After**: `window_compliance: 0.6667 (2 of 3 windows-recommended days)`

## Tests

- [x] `pytest tests/ -x -q` — 2234/2234 pass
- [x] `ruff check` clean

Closes #186