### PR TITLE
Fix #190: forecast date uses local now + raw entry date (UTC rollover)

### DIFF
--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -54,6 +54,11 @@ RELEASE_NOTES: dict[str, list[str]] = {
         "Fix #149: Activity report section deduplication rule added to system prompt",
         "Fix #149: HVAC peak indoor temp now captured at exact HVAC-off moment (not only at poll cycles)",
     ],
+    "0.3.55": [
+        "Fix #190: _get_forecast() switches to local date + raw forecast date —"
+        " tomorrow's forecast no longer shows day-after-tomorrow in evening hours"
+        " (UTC rollover bug in negative UTC offset timezones)",
+    ],
     "0.3.44": [
         "Fix #143: _get_forecast() date-keyed dict replaces blind-index fallback"
         " — briefing tomorrow-high now always reads the correct forecast entry"
@@ -143,6 +148,20 @@ KNOWN_FIXES: dict[int, dict] = {
         "scope_not_covered": [
             "Thermal mass / phase lag — ODE is still first-order, solar peak timing not addressed",
             "In-memory consecutive-pair OLS on 5-min samples — still structurally limited by 1°F quantization",
+        ],
+    },
+    190: {
+        "version_fixed": "0.3.55",
+        "title": "_get_forecast() evening UTC rollover — tomorrow shows day-after-tomorrow after 5pm PDT",
+        "scope_covered": [
+            "coordinator._get_forecast() — reference date now uses dt_util.now().date() (local)"
+            " instead of dt_util.utcnow().date() (UTC)",
+            "forecast entry bucketing now uses fc_obj.date() (raw) instead of astimezone(UTC).date()"
+            " — API's intended date is preserved without timezone conversion",
+            "briefing tomorrow-high — correct at all hours in all timezones",
+        ],
+        "scope_not_covered": [
+            "_get_hourly_forecast_data() — hourly entries use per-hour timestamps and were not affected by this bug",
         ],
     },
     143: {

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -1681,14 +1681,15 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         today_fc = None
         tomorrow_fc = None
         if forecast:
-            # Use UTC calendar date for matching. Daily forecast entries from
-            # HA weather integrations are often timestamped at UTC midnight
-            # (e.g. 2026-05-16T00:00:00+00:00). Converting to local time shifts
-            # that to 5pm PDT on 2026-05-15 — making tomorrow's entry appear to
-            # be today's. Matching on UTC date keeps the API's intended calendar
-            # day regardless of local timezone offset.
-            now_utc = dt_util.utcnow()
-            now_date = now_utc.date()
+            # Use local calendar date for "today" and extract the raw date from
+            # each forecast entry without timezone conversion. Weather APIs that
+            # use UTC midnight timestamps (e.g. 2026-05-31T00:00:00Z) intend
+            # the date portion (2026-05-31) as the forecast date — comparing
+            # that raw date against the local calendar date is correct at all
+            # hours. Using UTC for "now" breaks in the evening when UTC has
+            # rolled to the next calendar day but local time hasn't (Issue #190).
+            now_local = dt_util.now()
+            now_date = now_local.date()
             tomorrow_date = now_date + timedelta(days=1)
             _LOGGER.debug(
                 "_get_forecast raw datetimes (first 5): %s",
@@ -1699,7 +1700,8 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 fc_dt = entry.get("datetime", "")
                 try:
                     fc_obj = datetime.fromisoformat(fc_dt)
-                    fc_date = fc_obj.astimezone(UTC).date() if fc_obj.tzinfo else fc_obj.date()
+                    # Raw date: no tz conversion. API date intent, compared against local now_date.
+                    fc_date = fc_obj.date()
                     forecast_by_date.setdefault(fc_date, entry)
                 except (ValueError, TypeError):
                     continue
@@ -1708,13 +1710,13 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             available_dates = sorted(forecast_by_date.keys())
             if today_fc is None and available_dates:
                 _LOGGER.warning(
-                    "_get_forecast: no entry for today (%s UTC); available dates: %s",
+                    "_get_forecast: no entry for today (%s local); available dates: %s",
                     now_date,
                     available_dates,
                 )
             if tomorrow_fc is None and available_dates:
                 _LOGGER.warning(
-                    "_get_forecast: no entry for tomorrow (%s UTC); available dates: %s",
+                    "_get_forecast: no entry for tomorrow (%s local); available dates: %s",
                     tomorrow_date,
                     available_dates,
                 )

--- a/docs/forecast-pipeline-spec.md
+++ b/docs/forecast-pipeline-spec.md
@@ -34,16 +34,16 @@ date-keyed dict approach (see below) handles all variants correctly.
 ## Date-Keyed Matching
 
 `_get_forecast()` builds a `forecast_by_date: dict` using `setdefault()` — the first entry
-for each UTC date wins — then looks up today and tomorrow by UTC calendar date:
+for each raw date wins — then looks up today and tomorrow by local calendar date:
 
 ```python
 today_fc = forecast_by_date.get(now_date)
 tomorrow_fc = forecast_by_date.get(tomorrow_date)
 ```
 
-`now_date = dt_util.utcnow().date()` (UTC calendar date).
+`now_date = dt_util.now().date()` (local calendar date).
 `tomorrow_date = now_date + timedelta(days=1)`.
-Each entry's key: `fc_obj.astimezone(UTC).date()`.
+Each entry's key: `fc_obj.date()` — raw date, no timezone conversion (see [§ Timezone Strategy](#timezone-strategy)).
 
 If either lookup returns `None`, the corresponding temperature defaults to `current_outdoor`
 (the value obtained from the live thermostat reading). The existing `if today_fc:` / `if
@@ -53,10 +53,10 @@ No blind-index fallback exists. Array position carries no semantic meaning.
 
 ## Missing Today Handling
 
-When `today_fc is None` after the dict build, a WARNING log records the available UTC dates:
+When `today_fc is None` after the dict build, a WARNING log records the available local dates:
 
 ```
-_get_forecast: no entry for today (2026-05-15 UTC); available dates: [2026-05-16, 2026-05-17, ...]
+_get_forecast: no entry for today (2026-05-15 local); available dates: [2026-05-16, 2026-05-17, ...]
 ```
 
 This is normal for weather providers that exclude the current day from the daily forecast
@@ -93,25 +93,31 @@ observed temperature history guard (`_outdoor_temp_history` max/min override).
 
 ## Timezone Strategy
 
-All date comparisons use **UTC calendar date**, not local date:
+Date comparisons use **local calendar date for "now"** and **raw date from the forecast
+datetime string (no timezone conversion) for each entry**:
 
-- `dt_util.utcnow().date()` — UTC calendar today
-- `fc_obj.astimezone(UTC).date()` — forecast entry converted to UTC date before comparison
-- Local timezone is never used for day-boundary decisions in the forecast dict
+- `dt_util.now().date()` — local calendar today (HA configured timezone)
+- `fc_obj.date()` — raw date extracted from the API datetime string, no `astimezone()` conversion
 
-**Why UTC, not local?** HA weather integrations frequently timestamp daily forecast entries
-at UTC midnight (e.g., `2026-05-16T00:00:00+00:00`). In a UTC-7 timezone (PDT), converting
-that to local time gives `2026-05-15T17:00-07:00` — local date 2026-05-15 (yesterday). The
-entry the API intends as "tomorrow" (2026-05-16) would be bucketed as "today," causing a
-one-day off-by-one across the entire forecast. UTC date matching avoids this entirely: the
-UTC midnight entry for 2026-05-16 has UTC date 2026-05-16 and correctly maps to tomorrow.
+**Why raw date, not local-converted or UTC-converted?**
 
-This applies regardless of the user's local timezone. An API entry for calendar day N
-will always have a UTC timestamp that falls on UTC date N (midnight, noon, or any intra-day
-time), making UTC the stable matching key.
+Weather APIs that use UTC midnight timestamps (e.g. `2026-05-16T00:00:00+00:00`) intend the
+date portion (`2026-05-16`) as the forecast date for calendar day May 16. Comparing that raw
+date against the local calendar date is correct at all hours in all timezones.
 
-This strategy was confirmed as correct by production diagnosis in v0.3.44 — the preceding
-`dt_util.as_local()` approach (Fix #107, v0.3.22) introduced this shift for UTC midnight APIs.
+Two problematic alternatives and why they fail:
+
+1. **Local conversion** (`dt_util.as_local()`): `2026-05-16T00:00:00+00:00` → `2026-05-15T17:00-07:00`
+   (PDT). Local date = May 15. The API's May 16 entry would be bucketed as today when the local
+   date is May 15, producing an off-by-one (the pre-v0.3.44 bug).
+
+2. **UTC calendar date for "now"** (`dt_util.utcnow().date()`): At 5pm PDT (= midnight UTC),
+   UTC has already rolled to the next day. UTC "today" = local tomorrow. The API's local-tomorrow
+   entry is labeled "today" and local day-after-tomorrow is labeled "tomorrow" (Issue #190 — the
+   evening rollover bug introduced in v0.3.44).
+
+The raw-date approach sidesteps both problems: the API's intended date is preserved exactly,
+and "now" uses the local calendar date the user actually experiences.
 
 ## Known History
 
@@ -119,6 +125,7 @@ This strategy was confirmed as correct by production diagnosis in v0.3.44 — th
 |---|---|
 | v0.3.22 (Fix #107) | Changed forecast key from `'time'` to `'datetime'`; added `dt_util.as_local()` for timezone-aware parsing. Blind-index fallback retained. |
 | v0.3.44 (Fix #143) | Replaced loop + fallback block with UTC-date-keyed dict. Removed all blind index assumptions. Switched from `dt_util.as_local()` to `astimezone(UTC)` for entry date extraction — fixes one-day off-by-one for UTC midnight forecast timestamps. Added WARNING logging for missing dates and INFO for matched raw temps. |
+| v0.3.55 (Fix #190) | Replaced UTC-date approach with raw-date + local-now. `dt_util.utcnow()` → `dt_util.now()` for the reference date; `fc_obj.astimezone(UTC).date()` → `fc_obj.date()` for entry bucketing. Fixes evening UTC rollover: in UTC-7 timezones after 5pm, UTC had already rolled to the next day causing tomorrow's forecast to appear as today. |
 
 ### Why the fallback was wrong (Fix #143)
 

--- a/tests/test_forecast_pipeline.py
+++ b/tests/test_forecast_pipeline.py
@@ -1,12 +1,14 @@
-"""Tests for _get_forecast() date-keyed dict matching (Issue #143).
+"""Tests for _get_forecast() date-keyed dict matching (Issues #143, #190).
 
 Covers:
 1. API starts from tomorrow — forecast array has no today entry
 2. Normal full forecast — both today and tomorrow present
 3. Core regression guard — today_high != tomorrow_high when API starts from tomorrow
 4. Empty forecast — all temperatures fall back to current_outdoor
-5. UTC midnight datetimes — entries timestamped at UTC midnight are matched by UTC
-   calendar date, not shifted to the previous local day (the production root cause)
+5. UTC midnight datetimes — entries timestamped at UTC midnight matched by raw date
+   against local today (not UTC date, not local-converted date) — fixes #190
+6. Evening UTC rollover — 7pm PDT where UTC date is already tomorrow; tomorrow's
+   forecast must still show local tomorrow, not day-after-tomorrow
 """
 
 from __future__ import annotations
@@ -14,7 +16,7 @@ from __future__ import annotations
 import asyncio
 import sys
 import types
-from datetime import UTC, date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -31,18 +33,26 @@ _TODAY = date(2026, 5, 15)
 _TOMORROW = _TODAY + timedelta(days=1)
 _CURRENT_OUTDOOR = 65.0
 
-# dt_util.utcnow() mock — 06:00 UTC on today (= 11pm PDT prev day, but UTC date = today)
-_NOW_UTC = datetime(2026, 5, 15, 13, 0, 0, tzinfo=UTC)  # 1pm UTC = 6am PDT
+# PDT = UTC-7
+_PDT = timezone(-timedelta(hours=7))
+
+# dt_util.now() mock — 6am PDT on today (UTC date == local date, no rollover)
+_NOW_LOCAL = datetime(2026, 5, 15, 6, 0, 0, tzinfo=_PDT)
+
+# dt_util.now() mock for the evening rollover scenario — 7pm PDT May 15
+# UTC equivalent: 2am May 16 — UTC date is already May 16, but local date is still May 15
+_NOW_LOCAL_EVENING = datetime(2026, 5, 15, 19, 0, 0, tzinfo=_PDT)
 
 
 def _make_entry(d: date, temp: float, *, utc_midnight: bool = False) -> dict:
     """Forecast entry for the given date.
 
     utc_midnight=True: timestamps at UTC midnight (e.g. 2026-05-16T00:00:00+00:00).
-    In PDT (UTC-7) this shifts to 5pm the previous local day — the production case.
+    The raw date portion is the API's intended forecast date. In PDT (UTC-7) this
+    shifts to 5pm the previous local day if converted — which is why we use raw date.
 
     utc_midnight=False (default): timestamps at local noon with -07:00 offset.
-    UTC date == local date in this case.
+    Raw date == local date in this case.
     """
     dt_str = f"{d.isoformat()}T00:00:00+00:00" if utc_midnight else f"{d.isoformat()}T12:00:00-07:00"
     return {
@@ -95,13 +105,13 @@ def _make_coordinator_stub(forecast_data: list) -> MagicMock:
     return coord
 
 
-def _run_get_forecast(coord) -> object:
-    """Run _get_forecast() with dt_util.utcnow patched to _NOW_UTC."""
+def _run_get_forecast(coord, *, now_local: datetime = _NOW_LOCAL) -> object:
+    """Run _get_forecast() with dt_util.now patched to the given local datetime."""
 
     async def run():
         with patch(
-            "custom_components.climate_advisor.coordinator.dt_util.utcnow",
-            return_value=_NOW_UTC,
+            "custom_components.climate_advisor.coordinator.dt_util.now",
+            return_value=now_local,
         ):
             return await coord._get_forecast()
 
@@ -167,21 +177,18 @@ class TestForecastDateMatching:
         assert result.today_high == pytest.approx(_CURRENT_OUTDOOR)
         assert result.tomorrow_high == pytest.approx(_CURRENT_OUTDOOR)
 
-    def test_utc_midnight_entries_matched_by_utc_calendar_date(self, tmp_path: Path):
-        """UTC midnight timestamps must match by UTC date, not local date.
+    def test_utc_midnight_entries_matched_by_raw_date(self, tmp_path: Path):
+        """UTC midnight timestamps are matched by their raw date, not local-converted date.
 
-        Production root cause: weather APIs like Open-Meteo and some HA integrations
-        return daily forecast entries timestamped at UTC midnight. In PDT (UTC-7),
-        2026-05-16T00:00:00+00:00 converts to 2026-05-15T17:00-07:00 (local), which
-        has local date 2026-05-15 (TODAY). Using local date would bucket tomorrow's
-        entry as today and day+2 as tomorrow — same off-by-one as the original bug.
+        Weather APIs like Open-Meteo return entries at UTC midnight. The raw date
+        portion (2026-05-16 in 2026-05-16T00:00:00+00:00) is the API's intended
+        forecast date. This is compared directly against the local calendar date.
 
-        Using UTC date: 2026-05-16T00:00:00+00:00 has UTC date 2026-05-16 → tomorrow. ✓
+        If we converted to local PDT first: 2026-05-16T00:00:00Z → 2026-05-15T17:00 PDT
+        → local date 2026-05-15 (today) — wrong, this is tomorrow's forecast.
+
+        Raw date: 2026-05-16 compared against local today 2026-05-15 → tomorrow. ✓
         """
-        # Entries timestamped at UTC midnight — the production problematic format.
-        # _TODAY = 2026-05-15, _TOMORROW = 2026-05-16
-        # UTC midnight for _TODAY  → UTC date 2026-05-15 → should be today_fc
-        # UTC midnight for _TOMORROW → UTC date 2026-05-16 → should be tomorrow_fc
         forecast = [
             _make_entry(_TODAY, 72.0, utc_midnight=True),
             _make_entry(_TOMORROW, 79.0, utc_midnight=True),
@@ -191,9 +198,34 @@ class TestForecastDateMatching:
         result = _run_get_forecast(coord)
 
         assert result is not None
-        assert result.today_high == pytest.approx(72.0), (
-            "UTC midnight today entry must match today, not be shifted to yesterday"
-        )
+        assert result.today_high == pytest.approx(72.0), "UTC midnight today entry must match today via raw date"
         assert result.tomorrow_high == pytest.approx(79.0), (
-            "UTC midnight tomorrow entry must match tomorrow, not be shifted to today"
+            "UTC midnight tomorrow entry must match tomorrow via raw date"
+        )
+
+    def test_evening_utc_rollover_no_off_by_one(self, tmp_path: Path):
+        """Evening scenario: 7pm PDT May 15 — UTC has rolled to May 16 but local is still May 15.
+
+        Issue #190: using dt_util.utcnow() at this time returns date May 16, causing
+        the May 16 forecast entry (local tomorrow) to be labeled 'today' and the
+        May 17 entry (local day-after-tomorrow) to be labeled 'tomorrow'.
+
+        Fix: dt_util.now().date() = May 15 (local). Raw date May 16 = local tomorrow. ✓
+        """
+        # UTC midnight entries: the production format
+        forecast = [
+            _make_entry(_TODAY, 72.0, utc_midnight=True),  # May 15 — local today
+            _make_entry(_TOMORROW, 91.0, utc_midnight=True),  # May 16 — local tomorrow
+            _make_entry(_TOMORROW + timedelta(days=1), 68.0, utc_midnight=True),  # May 17
+        ]
+        coord = _make_coordinator_stub(forecast)
+        # Simulate 7pm PDT May 15 (UTC = 2am May 16 — UTC date already rolled over)
+        result = _run_get_forecast(coord, now_local=_NOW_LOCAL_EVENING)
+
+        assert result is not None
+        assert result.today_high == pytest.approx(72.0), (
+            "REGRESSION #190: today_high should be May 15 entry (72°F), not May 16 (91°F)"
+        )
+        assert result.tomorrow_high == pytest.approx(91.0), (
+            "REGRESSION #190: tomorrow_high should be May 16 entry (91°F), not May 17 (68°F)"
         )


### PR DESCRIPTION
## Problem

In UTC-7 (PDT) after 5pm, `dt_util.utcnow().date()` returns the next calendar day (UTC has already rolled over). This caused:
- The forecast entry for local **tomorrow** to be labeled **today**
- The forecast entry for local **day-after-tomorrow** to be labeled **tomorrow**

The briefing and dashboard showed the wrong temperature for "tomorrow" every evening.

## Root cause

Issue #143 fixed a different bug by switching to UTC date matching. That fix was correct for UTC midnight API timestamps but introduced this evening rollover regression: UTC "today" = local tomorrow after ~5pm PDT.

## Fix

Two-line change in `_get_forecast()`:
- `dt_util.utcnow().date()` → `dt_util.now().date()` (local calendar date for reference)
- `fc_obj.astimezone(UTC).date()` → `fc_obj.date()` (raw date from API string — no conversion)

Weather APIs that use UTC midnight timestamps intend the date portion as the forecast date. Comparing raw date against local today/tomorrow is correct at all hours in all timezones.

## Tests

- Updated `test_utc_midnight_entries_matched_by_raw_date` (renamed from UTC variant)
- Added `test_evening_utc_rollover_no_off_by_one` — simulates 7pm PDT with UTC already on next day
- All 2235 tests pass