### PR TITLE
Feat #193: Activity report — add event log and per-override timeline detail

### DIFF
--- a/custom_components/climate_advisor/ai_skills_activity.py
+++ b/custom_components/climate_advisor/ai_skills_activity.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -38,7 +39,11 @@ Return your analysis with these exact section headers (use ## for headers):
 ## SUMMARY
 2-3 sentence overview of the current situation.
 ## TIMELINE
-Chronological summary of significant recent events and state changes.
+Chronological summary built from the EVENT LOG section. List each automation setpoint
+action, manual override (with setpoint values from MANUAL OVERRIDES TODAY), and contact
+sensor event in time order. For each override show: when it started, what setpoint was
+set, and how long it lasted (or "ongoing" if still active). If automation re-asserted
+after an override cleared, show that full sequence explicitly.
 ## DECISIONS
 Why each automation action was taken, with the logic explained.
 When fan_status is active while hvac_mode is off, explicitly trace the fan state to \
@@ -262,6 +267,111 @@ async def async_build_activity_context(
     except (ValueError, TypeError):
         pass
 
+    # --- Event log (last 12h, chronological) ---
+    event_log_lines: list[str] = []
+    event_log_count = 0
+    try:
+        cutoff = datetime.datetime.now(datetime.UTC) - datetime.timedelta(hours=12)
+        raw_log: list[Any] = getattr(coordinator, "_event_log", []) or []
+        recent_events: list[dict] = []
+        for entry in raw_log:
+            if not isinstance(entry, dict):
+                continue
+            raw_time = entry.get("time")
+            if raw_time is None:
+                recent_events.append(entry)
+                continue
+            if isinstance(raw_time, datetime.datetime):
+                event_dt = raw_time if raw_time.tzinfo else raw_time.replace(tzinfo=datetime.UTC)
+            else:
+                try:
+                    event_dt = datetime.datetime.fromisoformat(str(raw_time))
+                    if event_dt.tzinfo is None:
+                        event_dt = event_dt.replace(tzinfo=datetime.UTC)
+                except ValueError:
+                    recent_events.append(entry)
+                    continue
+            if event_dt >= cutoff:
+                recent_events.append(entry)
+
+        event_log_count = len(recent_events)
+        if event_log_count > 60:
+            omitted = event_log_count - 60
+            recent_events = recent_events[-60:]
+            event_log_lines.append(f"  (... {omitted} older events omitted)")
+
+        if recent_events:
+            for entry in recent_events:
+                raw_time = entry.get("time", "")
+                etype = entry.get("type", "unknown")
+                try:
+                    if isinstance(raw_time, datetime.datetime):
+                        local_dt = dt_util.as_local(raw_time) if raw_time.tzinfo else raw_time
+                    else:
+                        event_dt = datetime.datetime.fromisoformat(str(raw_time))
+                        local_dt = dt_util.as_local(event_dt) if event_dt.tzinfo else event_dt
+                    time_str = local_dt.strftime("%H:%M")
+                except Exception:
+                    time_str = str(raw_time)[:5]
+                extras = {k: v for k, v in entry.items() if k not in ("time", "type")}
+                extras_str = " ".join(f"{k}={v}" for k, v in extras.items())
+                if extras_str:
+                    event_log_lines.append(f"  {time_str} — {etype}: {extras_str}")
+                else:
+                    event_log_lines.append(f"  {time_str} — {etype}")
+        else:
+            event_log_lines.append("  (no events in last 12h)")
+    except Exception:
+        _LOGGER.warning("activity_report: failed to build event log section — skipping")
+        event_log_lines = ["  (unavailable)"]
+
+    # --- Manual overrides today ---
+    override_detail_lines: list[str] = []
+    try:
+        today_record = getattr(coordinator, "_today_record", None)
+        override_count = 0
+        override_details: list[dict] = []
+        if today_record is not None:
+            override_count = getattr(today_record, "manual_overrides", 0)
+            override_details = list(getattr(today_record, "override_details", []) or [])
+
+        override_detail_lines.append(f"  Count:             {override_count}")
+        if override_details:
+            for i, d in enumerate(override_details, 1):
+                t = d.get("time", "??:??")
+                old_t = d.get("old_temp", "?")
+                new_t = d.get("new_temp", "?")
+                direction = d.get("direction", "?")
+                magnitude = d.get("magnitude", "?")
+                sign = "+" if direction == "up" else "-"
+                override_detail_lines.append(f"  #{i}  {t}  {old_t}°F → {new_t}°F  ({sign}{magnitude}°F, {direction})")
+        else:
+            override_detail_lines.append("  (no setpoint overrides recorded today)")
+
+        ae = getattr(coordinator, "automation_engine", None)
+        if ae is not None and getattr(ae, "_manual_override_active", False):
+            override_time_str = getattr(ae, "_manual_override_time", None)
+            if override_time_str:
+                try:
+                    override_dt = datetime.datetime.fromisoformat(str(override_time_str))
+                    now_local = dt_util.now()
+                    duration_seconds = (now_local - override_dt).total_seconds()
+                    duration_min = max(0, round(duration_seconds / 60))
+                    local_start = dt_util.as_local(override_dt) if override_dt.tzinfo else override_dt
+                    override_detail_lines.append(
+                        f"  Current override:  active since {local_start.strftime('%H:%M')}, "
+                        f"duration {duration_min} min (ongoing)"
+                    )
+                except Exception:
+                    override_detail_lines.append("  Current override:  active (duration unknown)")
+            else:
+                override_detail_lines.append("  Current override:  active (start time unknown)")
+        else:
+            override_detail_lines.append("  Current override:  none active")
+    except Exception:
+        _LOGGER.warning("activity_report: failed to build override detail section — skipping")
+        override_detail_lines = ["  (unavailable)"]
+
     # --- Format context block ---
     lines = [
         "=== Climate Advisor Activity Report Context ===",
@@ -314,6 +424,12 @@ async def async_build_activity_context(
         "",
         "## ACTIVE PREDICTION ENGINES",
         *(engine_status_block.splitlines() if engine_status_block else ["  (unavailable)"]),
+        "",
+        f"## EVENT LOG (last 12h, {event_log_count} events)",
+        *event_log_lines,
+        "",
+        "## MANUAL OVERRIDES TODAY",
+        *override_detail_lines,
     ]
 
     return "\n".join(lines)

--- a/docs/ai-skills-spec.md
+++ b/docs/ai-skills-spec.md
@@ -166,7 +166,7 @@ Response persistence (history storage, timestamps) is the responsibility of `coo
 
 `async_build_activity_context(hass, coordinator, **kwargs) → str`
 
-Assembles nine labeled sections in fixed order. Data sources per section:
+Assembles eleven labeled sections in fixed order. Data sources per section:
 
 | Section label | Data source | Notes |
 |---|---|---|
@@ -180,6 +180,8 @@ Assembles nine labeled sections in fixed order. Data sources per section:
 | `CONFIGURATION` | `coordinator.config` | Comfort temps, setback temps, wake/sleep/briefing times |
 | `ACTIVE FEATURES` | `coordinator.config` | Boolean feature flags |
 | `ACTIVE PREDICTION ENGINES` | `coordinator.learning.get_engine_status()` formatted by `_format_engine_status_for_ai()` | See [Active Prediction Engines](#active-prediction-engines) |
+| `EVENT LOG` | `coordinator._event_log` filtered to last 12h | See [Event Log](#event-log) |
+| `MANUAL OVERRIDES TODAY` | `coordinator._today_record.override_details` + live `coordinator.automation_engine` state | See [Manual Overrides Today](#manual-overrides-today) |
 
 **Fresh HVAC runtime** is computed as `_today_record.hvac_runtime_minutes + session_elapsed_minutes` where `session_elapsed` is computed from `coordinator._hvac_on_since` at call time. This makes the runtime accurate regardless of coordinator.data staleness (up to 30 min between coordinator update cycles).
 
@@ -195,6 +197,48 @@ The `LEARNING` section includes only:
 - Confidence values or thresholds
 
 This enforces invariant 7 from `ai-integration.md`: suggestion text is not sent to Claude by this skill.
+
+### Event Log
+
+`coordinator._event_log` is a ring-buffer capped at `EVENT_LOG_CAP` entries. The activity report filters to events in the last 12 hours (cutoff = `datetime.now(UTC) - timedelta(hours=12)`). If more than 60 events match, the oldest are dropped and a `(... N older events omitted)` note is prepended. Each entry renders as:
+
+```
+  HH:MM — <event_type>: key=value key=value ...
+```
+
+Times are converted to HA local timezone for display. The list is chronological (oldest first within the window). Representative event types:
+- `apply_classification` — automation applied a day classification setpoint
+- `override_confirm_pending` — debounce window started for detected setpoint change
+- `override_confirmed` — override accepted after 10-min confirmation; includes `confirmed_after_seconds`
+- `manual_override_cleared` — override cleared; includes `was_mode` and `duration_seconds`
+- `grace_expired` — grace period ended, automation may resume
+- `sensor_opened` / `door_pause` — contact sensor events
+
+If the event log is empty or no events fall in the window, the section shows `(no events in last 12h)`. Any exception during log parsing is caught and logged at WARNING; the section shows `(unavailable)` rather than failing the context build.
+
+### Manual Overrides Today
+
+Provides a structured per-override record using two sources:
+
+**`coordinator._today_record.override_details`** — list of dicts appended each time a manual setpoint change is confirmed (distinct from automation commands). Each entry: `{time: "HH:MM", old_temp: float, new_temp: float, direction: "up"|"down", magnitude: float}`. This covers setpoint changes; for mode changes use the event log.
+
+**Current override state from `coordinator.automation_engine`:**
+- `_manual_override_active: bool` — is an override active right now?
+- `_manual_override_time: str | None` — ISO timestamp (HA local TZ) when the current override was confirmed
+
+Formatted output:
+```
+## MANUAL OVERRIDES TODAY
+  Count:             3
+  #1  17:02  72.0°F → 74.0°F  (+2.0°F, up)
+  #2  18:44  72.0°F → 75.0°F  (+3.0°F, up)
+  #3  21:10  72.0°F → 74.0°F  (+2.0°F, up)
+  Current override:  active since 21:10, duration 47 min (ongoing)
+```
+
+If `override_details` is empty: `(no setpoint overrides recorded today)`. If no override is currently active: `Current override: none active`. Duration is computed as `(dt_util.now() - override_dt).total_seconds() / 60` rounded to nearest minute. Any exception is caught and logged at WARNING.
+
+**12h window vs. full-day coverage:** The 12h EVENT LOG window may exclude early-morning events for late-afternoon reports. `override_details` is not window-filtered — it accumulates all day, so all setpoint override timestamps are always present in MANUAL OVERRIDES TODAY regardless of report time.
 
 ### Cross-Validation
 
@@ -238,7 +282,7 @@ engine_status["k_active_hvac"]["value"]["cool"]   # float | None
 
 `_SYSTEM_PROMPT` includes a `DEDUPLICATION RULE` requiring each section to be exclusive:
 - `SUMMARY`: current state only — no analysis, no decisions
-- `TIMELINE`: chronological events only — no "why" analysis
+- `TIMELINE`: chronological events built from the EVENT LOG — automation setpoint actions, manual overrides (with setpoint values from MANUAL OVERRIDES TODAY and durations), contact sensor events. Each override must state when it started, what setpoint was set, and how long it lasted ("ongoing" if still active). No "why" analysis.
 - `DECISIONS`: explain WHY each action was taken — do NOT re-describe Timeline content
 - `ANOMALIES`: deviations from expected behavior only — do NOT re-explain Decisions
 - `DIAGNOSTICS`: subsystem health only — do NOT repeat anomalies or decisions


### PR DESCRIPTION
## Summary

- Adds `EVENT LOG` section to activity report context: last 12h of coordinator events, chronological, one line per event, capped at 60 entries
- Adds `MANUAL OVERRIDES TODAY` section: each setpoint override with time, old→new temp, and current active override duration
- Updates system prompt to instruct Claude to build the TIMELINE from the event log with per-override durations ("ongoing" if still active)
- Updates `docs/ai-skills-spec.md` with new context sections and TIMELINE role description

## Problem

When multiple manual overrides occurred, the timeline showed only "17:05: automation set 72°F" and "post 17:05: grace period initiated." Subsequent overrides — their timestamps, setpoints, and durations — were invisible to Claude because the event log was never passed to the activity report skill.

## Root Cause

`async_build_activity_context()` passed only `ATTR_LAST_ACTION_TIME` and `ATTR_LAST_ACTION_REASON` (single snapshot). The event log (`coordinator._event_log`) already records `override_confirmed`, `manual_override_cleared` (with `duration_seconds`), etc. — but the activity report skill never read it.

## Test Plan

- [ ] 2234 tests pass, no regressions
- [ ] Run `climate_advisor.ai_activity_report` after multiple manual overrides; confirm Timeline lists each override with timestamp, setpoint change, and duration
- [ ] Run with zero overrides today — confirm graceful "0 overrides" and event log showing only automation actions

Closes #193