### PR TITLE
Fix #230: Grace expiry converges to scheduled automation state

### DIFF
--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -1834,6 +1834,9 @@ class AutomationEngine:
                     )
                 )
 
+            # Converge to correct scheduled state (bedtime setback or current classification)
+            self.hass.async_create_task(self._apply_current_scheduled_state())
+
         cancel = async_call_later(self.hass, duration, _grace_expired)
         if source == "manual":
             self._manual_grace_cancel = cancel
@@ -1911,6 +1914,49 @@ class AutomationEngine:
         elif state and state.state == "off":
             # HVAC already off, just set the pause flag
             self._paused_by_door = True
+
+    async def _apply_current_scheduled_state(self, reason: str = "grace_expired") -> None:
+        """After override clears, converge to the scheduled automation state.
+
+        Determines what state automation would be in right now if no manual override
+        had occurred, and applies it. Ensures automation always converges back to the
+        correct state after a grace period expires.
+        """
+        from homeassistant.util import dt as dt_util  # noqa: PLC0415
+
+        now = dt_util.now()
+
+        # Determine if we're in a bedtime window (after sleep_time OR before wake_time)
+        sleep_time = self.config.get("sleep_time")  # e.g. "22:30"
+        wake_time = self.config.get("wake_time")  # e.g. "07:00"
+
+        if sleep_time and wake_time:
+            try:
+                from datetime import time as dt_time  # noqa: PLC0415
+
+                sleep_h, sleep_m = map(int, sleep_time.split(":"))
+                wake_h, wake_m = map(int, wake_time.split(":"))
+                now_time = now.time().replace(second=0, microsecond=0)
+                sleep_t = dt_time(sleep_h, sleep_m)
+                wake_t = dt_time(wake_h, wake_m)
+
+                # Bedtime window: after sleep_time OR before wake_time
+                in_bedtime_window = now_time >= sleep_t or now_time < wake_t
+                if in_bedtime_window:
+                    _LOGGER.info(
+                        "Grace expired: in bedtime window (%s–%s) — applying bedtime setback",
+                        sleep_time,
+                        wake_time,
+                    )
+                    await self.handle_bedtime()
+                    return
+            except (ValueError, AttributeError):
+                pass  # malformed config — fall through to classification
+
+        # Otherwise apply current classification
+        if self._current_classification:
+            _LOGGER.info("Grace expired: applying current classification")
+            await self.apply_classification(self._current_classification)
 
     async def handle_occupancy_away(self) -> None:
         """Handle everyone leaving — apply setback."""

--- a/tests/test_door_window.py
+++ b/tests/test_door_window.py
@@ -762,8 +762,13 @@ class TestGracePeriodExpiry:
         # Fire the expiry callback
         grace_callback(None)
 
-        # Should NOT have scheduled a notification task
-        engine.hass.async_create_task.assert_not_called()
+        # Should NOT have scheduled a notification task (convergence task is expected but not notify)
+        notify_calls = [
+            call
+            for call in engine.hass.async_create_task.call_args_list
+            if hasattr(call.args[0], "__qualname__") and "_notify" in call.args[0].__qualname__
+        ]
+        assert notify_calls == [], f"No notification task should be scheduled, got: {notify_calls}"
 
     def test_door_open_during_grace_is_blocked(self):
         """Opening a door during active grace period does not pause HVAC."""

--- a/tests/test_grace_convergence.py
+++ b/tests/test_grace_convergence.py
@@ -1,0 +1,262 @@
+"""Tests for grace-expiry → scheduled-state convergence (Issue #230).
+
+When a grace period expires normally (sensors closed, not in a planned window),
+the engine must apply the correct scheduled state rather than leaving HVAC at
+the position set by the earlier manual override.
+
+Covers:
+- Grace expiry in bedtime window → handle_bedtime() called
+- Grace expiry outside bedtime window → apply_classification() called
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from custom_components.climate_advisor.automation import AutomationEngine
+from custom_components.climate_advisor.classifier import DayClassification
+from custom_components.climate_advisor.const import (
+    CONF_MANUAL_GRACE_NOTIFY,
+    CONF_MANUAL_GRACE_PERIOD,
+)
+
+# Provide a base dt_util.now — individual tests override this via patch
+sys.modules["homeassistant.util.dt"].now = lambda: datetime(2026, 3, 20, 23, 0, 0)
+
+# Patch targets
+_PATCH_CALL_LATER = "custom_components.climate_advisor.automation.async_call_later"
+_PATCH_CALLBACK = "custom_components.climate_advisor.automation.callback"
+_PATCH_DT_NOW = "custom_components.climate_advisor.automation.dt_util.now"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_automation_engine(config_overrides: dict | None = None) -> AutomationEngine:
+    """Create an AutomationEngine with mocked HA dependencies."""
+    hass = MagicMock()
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+
+    def _consume_coroutine(coro):
+        """Close coroutine to prevent 'never awaited' warnings."""
+        coro.close()
+
+    hass.async_create_task = MagicMock(side_effect=_consume_coroutine)
+    hass.states = MagicMock()
+
+    config = {
+        "comfort_heat": 70,
+        "comfort_cool": 75,
+        "setback_heat": 60,
+        "setback_cool": 80,
+        "notify_service": "notify.notify",
+        CONF_MANUAL_GRACE_PERIOD: 300,
+        CONF_MANUAL_GRACE_NOTIFY: False,
+    }
+    if config_overrides:
+        config.update(config_overrides)
+
+    return AutomationEngine(
+        hass=hass,
+        climate_entity="climate.thermostat",
+        weather_entity="weather.forecast_home",
+        door_window_sensors=["binary_sensor.front_door"],
+        notify_service=config["notify_service"],
+        config=config,
+    )
+
+
+def _make_classification(
+    day_type: str = "mild",
+    hvac_mode: str = "cool",
+    **kwargs,
+) -> DayClassification:
+    """Create a DayClassification bypassing __post_init__ validation."""
+    obj = object.__new__(DayClassification)
+    obj.day_type = day_type
+    obj.trend_direction = "stable"
+    obj.trend_magnitude = 2.0
+    obj.today_high = kwargs.get("today_high", 78.0)
+    obj.today_low = kwargs.get("today_low", 58.0)
+    obj.tomorrow_high = kwargs.get("tomorrow_high", 79.0)
+    obj.tomorrow_low = kwargs.get("tomorrow_low", 59.0)
+    obj.hvac_mode = hvac_mode
+    obj.pre_condition = False
+    obj.pre_condition_target = None
+    obj.windows_recommended = kwargs.get("windows_recommended", False)
+    obj.window_open_time = kwargs.get("window_open_time")
+    obj.window_close_time = kwargs.get("window_close_time")
+    obj.setback_modifier = kwargs.get("setback_modifier", 0.0)
+    return obj
+
+
+def _fire_grace_expiry(engine: AutomationEngine) -> None:
+    """Start a grace period and synchronously fire the expiry callback."""
+    with patch(_PATCH_CALL_LATER) as mock_call_later, patch(_PATCH_CALLBACK, side_effect=lambda f: f):
+        mock_call_later.return_value = MagicMock()
+        engine._start_grace_period("manual")
+        assert mock_call_later.call_count == 1
+        grace_callback = mock_call_later.call_args[0][2]
+
+    # Sensors are closed (no re-pause) and not within a planned window
+    engine._sensor_check_callback = None
+    engine._is_within_planned_window_period = MagicMock(return_value=False)
+
+    # Fire the expiry callback directly (it's a sync @callback that schedules async work)
+    grace_callback(None)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestGraceConvergence:
+    """Grace period expiry must apply the correct scheduled state."""
+
+    def test_grace_expiry_applies_bedtime_setback_in_bedtime_window(self):
+        """Grace expires at 23:00 — inside bedtime window (22:30–07:00) → handle_bedtime() called."""
+        engine = _make_automation_engine(
+            {
+                "sleep_time": "22:30",
+                "wake_time": "07:00",
+            }
+        )
+        engine._current_classification = _make_classification(hvac_mode="cool")
+
+        handle_bedtime_called = []
+
+        async def _fake_handle_bedtime():
+            handle_bedtime_called.append(True)
+
+        engine.handle_bedtime = _fake_handle_bedtime
+
+        apply_classification_called = []
+
+        async def _fake_apply_classification(c):
+            apply_classification_called.append(c)
+
+        engine.apply_classification = _fake_apply_classification
+
+        mock_now = datetime(2026, 3, 20, 23, 0, 0)  # 23:00 — inside bedtime window
+
+        with patch(_PATCH_DT_NOW, return_value=mock_now):
+            asyncio.run(engine._apply_current_scheduled_state())
+
+        assert handle_bedtime_called, "handle_bedtime() should have been called (in bedtime window)"
+        assert not apply_classification_called, "apply_classification() should NOT be called in bedtime window"
+
+    def test_grace_expiry_applies_classification_outside_bedtime_window(self):
+        """Grace expires at 14:00 — outside bedtime window → apply_classification() called."""
+        engine = _make_automation_engine(
+            {
+                "sleep_time": "22:30",
+                "wake_time": "07:00",
+            }
+        )
+        classification = _make_classification(hvac_mode="cool")
+        engine._current_classification = classification
+
+        handle_bedtime_called = []
+
+        async def _fake_handle_bedtime():
+            handle_bedtime_called.append(True)
+
+        engine.handle_bedtime = _fake_handle_bedtime
+
+        apply_classification_called = []
+
+        async def _fake_apply_classification(c):
+            apply_classification_called.append(c)
+
+        engine.apply_classification = _fake_apply_classification
+
+        mock_now = datetime(2026, 3, 20, 14, 0, 0)  # 14:00 — daytime, not in bedtime window
+
+        with patch(_PATCH_DT_NOW, return_value=mock_now):
+            asyncio.run(engine._apply_current_scheduled_state())
+
+        assert apply_classification_called, "apply_classification() should have been called outside bedtime window"
+        assert not handle_bedtime_called, "handle_bedtime() should NOT be called outside bedtime window"
+        assert apply_classification_called[0] is classification
+
+    def test_grace_expiry_no_classification_no_crash(self):
+        """_apply_current_scheduled_state does nothing gracefully when no classification set."""
+        engine = _make_automation_engine(
+            {
+                "sleep_time": "22:30",
+                "wake_time": "07:00",
+            }
+        )
+        engine._current_classification = None
+
+        handle_bedtime_called = []
+
+        async def _fake_handle_bedtime():
+            handle_bedtime_called.append(True)
+
+        engine.handle_bedtime = _fake_handle_bedtime
+
+        mock_now = datetime(2026, 3, 20, 14, 0, 0)  # outside bedtime window
+
+        with patch(_PATCH_DT_NOW, return_value=mock_now):
+            # Should not raise
+            asyncio.run(engine._apply_current_scheduled_state())
+
+        assert not handle_bedtime_called
+
+    def test_grace_expiry_no_sleep_wake_config_applies_classification(self):
+        """Without sleep_time/wake_time config, falls through to classification."""
+        engine = _make_automation_engine()  # no sleep_time or wake_time in config
+        classification = _make_classification(hvac_mode="heat")
+        engine._current_classification = classification
+
+        apply_classification_called = []
+
+        async def _fake_apply_classification(c):
+            apply_classification_called.append(c)
+
+        engine.apply_classification = _fake_apply_classification
+
+        mock_now = datetime(2026, 3, 20, 23, 0, 0)
+
+        with patch(_PATCH_DT_NOW, return_value=mock_now):
+            asyncio.run(engine._apply_current_scheduled_state())
+
+        assert apply_classification_called, "apply_classification() should be called when no sleep/wake config"
+        assert apply_classification_called[0] is classification
+
+    def test_grace_normal_expiry_schedules_convergence_task(self):
+        """Normal grace expiry (sensors closed) schedules _apply_current_scheduled_state via async_create_task."""
+        engine = _make_automation_engine(
+            {
+                "sleep_time": "22:30",
+                "wake_time": "07:00",
+            }
+        )
+        engine._current_classification = _make_classification(hvac_mode="cool")
+
+        scheduled_coros: list = []
+
+        def _capture_task(coro):
+            scheduled_coros.append(coro)
+            # We must close the coro to avoid 'never awaited' warnings
+            coro.close()
+
+        engine.hass.async_create_task = MagicMock(side_effect=_capture_task)
+
+        mock_now = datetime(2026, 3, 20, 23, 0, 0)
+
+        with patch(_PATCH_DT_NOW, return_value=mock_now):
+            _fire_grace_expiry(engine)
+
+        # At least one coroutine should have been submitted — the convergence task
+        assert len(scheduled_coros) >= 1, (
+            "async_create_task should have been called to schedule _apply_current_scheduled_state"
+        )


### PR DESCRIPTION
Fixes #230

After a manual override grace period expires, the system now applies whatever scheduled automation state should be active — bedtime setback if in the bedtime window, current classification otherwise. Previously, the bedtime setback fired during the grace window was permanently lost.