### PR TITLE
Fix #247: ceiling guard escalates to AC when outdoor stays below indoor

### DIFF
--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -18,6 +18,7 @@ from homeassistant.util import dt as dt_util
 from .classifier import DayClassification
 from .const import (
     CEILING_BRIDGE_TOLERANCE_F,
+    CEILING_ESCALATION_SAVINGS_MARGIN_F,
     CEILING_PRECOOL_FALLBACK_MIN,
     CONF_ADAPTIVE_PREHEAT,
     CONF_ADAPTIVE_SETBACK,
@@ -917,18 +918,35 @@ class AutomationEngine:
                 _k_via_bridge,
             )
 
+            # Issue #247: dormancy is THREE conditions (the change #218 specified but its commit
+            # omitted — only the escalation-on-fire half landed). Defer to free cooling ONLY when
+            # outdoor is cooler AND nat-vent is actually running AND indoor is still within band.
+            # If indoor has breached the ceiling (free cooling losing to solar/internal gains), or
+            # nat-vent is not actually running (sensors closed / fan override — #215), the guard must
+            # evaluate and escalate to AC even though outdoor <= indoor. aggressive_savings widens the
+            # in-band threshold so savings homes tolerate a small overshoot before paying for cooling.
+            _aggressive = bool(self.config.get("aggressive_savings", False))
+            _ceiling_threshold = (
+                _comfort_cool_cg + CEILING_ESCALATION_SAVINGS_MARGIN_F
+                if (_aggressive and _comfort_cool_cg is not None)
+                else _comfort_cool_cg
+            )
             if not _model_eligible:
                 _LOGGER.debug("ODE ceiling guard: skipped — k_passive=%s, conf=%s", _k_passive, _conf)
             elif _outdoor is None or _indoor_cg is None:
                 _LOGGER.debug("ODE ceiling guard: skipped — missing outdoor/indoor temps")
-            elif _outdoor <= _indoor_cg:
+            elif _outdoor <= _indoor_cg and self._natural_vent_active and _indoor_cg <= _ceiling_threshold:
                 _LOGGER.debug(
-                    "ODE ceiling guard: dormant — outdoor %.1f <= indoor %.1f (nat-vent eligible)",
+                    "ODE ceiling guard: dormant — outdoor %.1f <= indoor %.1f, nat-vent running,"
+                    " indoor <= ceiling threshold %.1f (free cooling viable)",
                     _outdoor,
                     _indoor_cg,
+                    _ceiling_threshold,
                 )
             else:
-                # Nat-vent unavailable; scan predicted curve for ceiling breach.
+                # Dormancy lifted (outdoor rose above indoor, OR nat-vent is not running, OR indoor
+                # breached the ceiling under active nat-vent — Issue #247). Scan the predicted curve
+                # for a ceiling breach.
                 # Inline equivalent of _find_ceiling_breach_time() — avoids circular import.
                 _breach_ts: datetime | None = None
                 _threshold = _comfort_cool_cg + _tolerance
@@ -964,11 +982,13 @@ class AutomationEngine:
                     _lead_min = max(30.0, min(240.0, _lead_min))
 
                     _LOGGER.info(
-                        "ODE ceiling guard: breach predicted at %s (%.1fh away), outdoor=%.1f > indoor=%.1f",
+                        "ODE ceiling guard: breach predicted at %s (%.1fh away), outdoor=%.1f, indoor=%.1f,"
+                        " nat_vent=%s",
                         _breach_ts.strftime("%H:%M"),
                         _hours_to_breach,
                         _outdoor,
                         _indoor_cg,
+                        self._natural_vent_active,
                     )
 
                     if _hours_to_breach <= _lead_min / 60:
@@ -1589,9 +1609,12 @@ class AutomationEngine:
             comfort_heat = float(self.config.get("comfort_heat", 70))
             indoor = self._get_indoor_temp_f()
             if self._natural_vent_active and indoor is not None and comfort_cool is not None and indoor > comfort_cool:
-                _LOGGER.warning(
+                # Issue #247: the ODE ceiling guard now ESCALATES to AC on the classification cycle
+                # when indoor breaches the ceiling under active nat-vent (its three-condition dormancy
+                # lifts), so this is an informational heads-up, not a stuck state.
+                _LOGGER.info(
                     "Nat-vent active but indoor %.1fF > comfort_cool %.1fF --"
-                    " ceiling guard will evaluate on next classification cycle",
+                    " ceiling guard will escalate to AC this classification cycle",
                     indoor,
                     comfort_cool,
                 )

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -659,6 +659,30 @@ KNOWN_FIXES: dict[int, dict] = {
             "Vacation mode ceiling exit (vacation setback is higher; same principle applies but not yet implemented)",
         ],
     },
+    247: {
+        "issue": 247,
+        "title": "Ceiling guard never escalated to AC when outdoor stayed below indoor"
+        " (re-occurrence of #218's incomplete fix)",
+        "version_fixed": "0.3.57",
+        "scope_covered": [
+            "apply_classification() ceiling-guard dormancy changed from 1 condition (outdoor<=indoor) to 3",
+            " (outdoor<=indoor AND _natural_vent_active AND indoor<=ceiling threshold)",
+            "Guard now evaluates+fires when indoor exceeds the ceiling even though outdoor<indoor"
+            " (solar/internal gains out-pace ventilation) — the #247 reactive case",
+            "Guard evaluates+fires when nat-vent is NOT running (windows closed / fan override) — the #215 case",
+            "Escalation-on-fire (deactivate fan, clear _natural_vent_active, emit nat_vent_ceiling_escalation)"
+            " from #218 part 2 is now reachable because the dormancy correctly lifts",
+            "aggressive_savings widens the escalation threshold to"
+            " comfort_cool + CEILING_ESCALATION_SAVINGS_MARGIN_F (2.0F)",
+            "Warning-only no-op in check_natural_vent_conditions() replaced with an INFO log"
+            " noting the guard will escalate",
+        ],
+        "scope_not_covered": [
+            "Predictive pre-emption (firing before indoor crosses the ceiling based on the ODE curve under nat-vent)"
+            " — deferred; the fix is reactive once indoor breaches the ceiling threshold",
+            "Coordinator cadence (re-evaluation still every 30 min + 5-min revisit) — unchanged",
+        ],
+    },
 }
 
 GITHUB_REPO = "gunkl/ClimateAdvisor"
@@ -1549,6 +1573,10 @@ THERMAL_OBS_CAP = 200  # max observations in LearningState
 # ---------------------------------------------------------------------------
 CEILING_PRECOOL_FALLBACK_MIN: int = 120  # fallback lead time when k_active_cool not learned
 CEILING_BRIDGE_TOLERANCE_F: float = 1.0  # bridge homes: require breach > comfort_cool + this
+# Issue #247: in aggressive_savings mode, tolerate this much overshoot above comfort_cool before
+# the ceiling guard escalates nat-vent -> AC (savings homes accept a small overshoot before paying
+# for cooling; normal mode escalates at comfort_cool).
+CEILING_ESCALATION_SAVINGS_MARGIN_F: float = 2.0
 
 ATTR_THERMAL_HEATING_RATE = "thermal_heating_rate"
 ATTR_THERMAL_COOLING_RATE = "thermal_cooling_rate"

--- a/docs/08-COMPUTATION-REFERENCE.md
+++ b/docs/08-COMPUTATION-REFERENCE.md
@@ -27,7 +27,7 @@ The automation logic table and all threshold constants in this document are expr
 | How does the physics ODE predict future indoor temperature? | `T(t+dt) = T_outdoor + (T − T_outdoor) × exp(k_p × dt) + (Q/k_p) × (exp(k_p × dt) − 1)`, where Q switches between k_active_heat, k_active_cool, and 0 per schedule period. | [§5c. Predicted Temperature Graph — Physics Path](08-COMPUTATION-REFERENCE.md#5c-predicted-temperature-graph--physics-path) |
 | What is the dynamic target band and how does occupancy mode change it? | `_compute_target_band_schedule()` returns `[{ts, lower, upper}]` per forecast hour; away = setback today only, vacation = deep setback all days, home/guest = comfort with sleep/wake ramps. | [§5d. Dynamic Target Band](08-COMPUTATION-REFERENCE.md#5d-dynamic-target-band--_compute_target_band_schedule) |
 | How does comfort score accumulate and what triggers a suggestion? | `comfort_score = 1 − (total_violation_minutes / (days_recorded × 1440))`; more than 5 days with > 30 violation minutes triggers the `comfort_violations` suggestion. | [§Metric Definitions — Comfort Score](05-LEARNING-ENGINE-DESIGN.md#comfort-score-comfort_score) |
-| When does the ODE ceiling guard fire on a warm day and what activates AC? | The guard scans the predicted indoor curve on every 30-min cycle. When outdoor > indoor AND a breach above `comfort_cool` is predicted within the computed lead time (or 120-min fallback), the guard sets HVAC to cool at `comfort_cool`. Guard skips when no calibrated model, occupancy is away/vacation, or nat-vent can keep indoor below the ceiling. | [§6c. Warm-Day ODE Ceiling Guard](08-COMPUTATION-REFERENCE.md#6c-warm-day-ode-ceiling-guard-issue-136) |
+| When does the ODE ceiling guard fire on a warm day and what activates AC? | The guard scans the predicted indoor curve on every 30-min cycle and sets HVAC to cool at `comfort_cool` when a breach is predicted within the lead time (or 120-min fallback). It is **dormant only when all 3 hold**: outdoor <= indoor AND nat-vent is actually running AND indoor still <= ceiling. So it also fires when indoor already exceeds the ceiling (even if outdoor < indoor) or when nat-vent is not running — clearing nat-vent on escalation. Guard skips when no calibrated model or occupancy is away/vacation. | [§6c. Warm-Day ODE Ceiling Guard](08-COMPUTATION-REFERENCE.md#6c-warm-day-ode-ceiling-guard-issue-136) |
 | How does MILD day window scheduling change when the ODE is available (Fix C, Issue #147)? | Before Fix C: MILD days used hardcoded `time(10, 0)` open / `time(17, 0)` close. After Fix C: constants `MILD_WINDOW_OPEN_HOUR = 10` and `MILD_WINDOW_CLOSE_HOUR = 17` are fallbacks; when the ODE is available, `nat_vent_cutoff` drives the close time — the same dynamic logic as warm days. | [§6d. MILD Day Dynamic Window Close Time](08-COMPUTATION-REFERENCE.md#6d-mild-day-dynamic-window-close-time-fix-c-issue-147) |
 | What invariant must `_async_send_briefing()` maintain when replacing `_today_record`? | It must copy all accumulated counters (`hvac_runtime_minutes`, `comfort_violations_minutes`, etc.) from the existing same-day record before constructing the new one. Creating a fresh `DailyRecord` unconditionally resets all counters to zero (Issue #176 bug). | [DailyRecord Persistence Invariant](08-COMPUTATION-REFERENCE.md#dailyrecord-persistence-invariant-issue-176) |
 | Why must `_async_thermostat_changed()` check all three command-pending flags, not just `_hvac_command_pending`? | Automation sequences (e.g., nat vent exit) call `_deactivate_fan()` before `_set_hvac_mode()`. The fan command sets `_fan_command_pending` but leaves `_hvac_command_pending` False. Checking only `_hvac_command_pending` bypasses the override-detection guard during that window. | [§9b Compound command-pending guard](08-COMPUTATION-REFERENCE.md#compound-command-pending-guard-in-_async_thermostat_changed-issue-205206) |
@@ -604,7 +604,27 @@ When the day classification is `warm` or `mild` (HVAC mode = `off`) and the ther
 
 #### Purpose
 
-The guard closes the "read-render split" gap: `_build_predicted_indoor_future()` feeds the chart every 30 min with an accurate indoor forecast, but prior to Issue #136 that forecast was never routed into `apply_classification()`. The ceiling guard routes it: if the ODE curve predicts a `comfort_cool` breach and outdoor air is already warmer than indoor (nat-vent unavailable), the guard sets HVAC to `cool` at `comfort_cool` before the breach occurs.
+The guard closes the "read-render split" gap: `_build_predicted_indoor_future()` feeds the chart every 30 min with an accurate indoor forecast, but prior to Issue #136 that forecast was never routed into `apply_classification()`. The ceiling guard routes it: if the ODE curve predicts a `comfort_cool` breach and free cooling cannot keep up, the guard sets HVAC to `cool` at `comfort_cool` before (or as soon as) the breach occurs.
+
+#### Dormancy: when the guard defers to free cooling (3-condition — Issue #247)
+
+The guard goes **dormant** (defers to natural ventilation) only when **all three** of these hold:
+
+1. `outdoor <= indoor` — outdoor air can in principle cool the home, **and**
+2. `self._natural_vent_active` — windows are actually open and nat-vent is running (not merely *eligible*), **and**
+3. `indoor <= ceiling threshold` — indoor is still at/under the ceiling, so free cooling is keeping up.
+
+If any condition fails, the guard **evaluates** (and fires if the breach scan confirms a breach):
+
+- **indoor already exceeds the ceiling** — the #247 reactive case: solar/internal gains are out-pacing the breeze, so the guard escalates to AC **even though `outdoor < indoor`**. Free cooling stays the first remediation; AC fires only when ventilation is demonstrably losing.
+- **nat-vent is NOT running** (windows closed, fan override) — the #215 case: do not defer to a ventilation that is not happening.
+- **outdoor has risen above indoor** — the original #136/#218 path (airflow would add heat).
+
+> **Regression note:** Issue #218 specified this 3-condition dormancy *plus* the escalation-on-fire that clears nat-vent, but the committed fix (`676daa4`) landed only the escalation half. The dormancy stayed one-condition (`outdoor <= indoor`), so on a day where outdoor stayed below indoor the guard never woke and the escalation code was unreachable — the home sat above the ceiling for hours (re-filed as #247). The escalation-on-fire is now reachable because the dormancy correctly lifts.
+
+**`aggressive_savings` widens the ceiling threshold.** In normal mode the ceiling threshold is `comfort_cool`. In `aggressive_savings` mode it is `comfort_cool + CEILING_ESCALATION_SAVINGS_MARGIN_F` (2.0°F) — savings homes tolerate a small overshoot before paying for the compressor, but are still rescued from a real comfort failure once indoor exceeds that wider threshold.
+
+**On escalation the guard clears nat-vent** (Issue #218 part 2): if `_natural_vent_active` is true when the guard fires, it deactivates the fan, sets `_natural_vent_active = False`, and emits `nat_vent_ceiling_escalation` before switching to `cool` — so free cooling does not fight the compressor.
 
 #### Guard conditions
 
@@ -615,7 +635,7 @@ The guard closes the "read-render split" gap: `_build_predicted_indoor_future()`
 | Occupancy away or vacation | Skip — handled by upstream occupancy guards (§6a) |
 | `predicted_indoor` is empty or None | Skip — no ODE curve available (fresh install, no physics gate) |
 | Outdoor temp unavailable or missing | Skip |
-| `outdoor <= indoor` | Dormant — nat-vent is eligible; guard does not fire |
+| `outdoor <= indoor` **AND** `_natural_vent_active` **AND** `indoor <= ceiling threshold` | Dormant — free cooling is actually viable; guard defers to nat-vent (see 3-condition dormancy below) |
 | `_find_ceiling_breach_time()` returns None | Dormant — no breach predicted above threshold |
 | Bridge home (`k_passive_via_bridge=True`) | Apply `+CEILING_BRIDGE_TOLERANCE_F (1.0°F)` tolerance; guard fires at `comfort_cool + 1.0°F` |
 | `k_active_cool` not learned (None) | Guard fires with `CEILING_PRECOOL_FALLBACK_MIN = 120` min lead time |
@@ -676,14 +696,15 @@ Bridge homes use `k_vent_window` as a proxy for `k_passive`. The `k_passive_via_
 |---|---|---|
 | `CEILING_PRECOOL_FALLBACK_MIN` | `120` | Lead time (minutes) when `k_active_cool` is not learned |
 | `CEILING_BRIDGE_TOLERANCE_F` | `1.0` | Extra °F threshold for bridge homes |
+| `CEILING_ESCALATION_SAVINGS_MARGIN_F` | `2.0` | Overshoot tolerated above `comfort_cool` before escalating in `aggressive_savings` mode (Issue #247) |
 
-Both are defined in `const.py`.
+All three are defined in `const.py`.
 
 #### Interaction with §6b comfort-floor guard
 
 The ceiling guard runs **after** the comfort-floor guard in `apply_classification()`. The comfort-floor guard runs inside the `hvac_mode == "off"` branch; the ceiling guard is a separate block also gated by `classification.hvac_mode == "off"`, so it evaluates regardless of whether the floor guard fired.
 
-In practice the two guards do not conflict: if indoor is below `comfort_heat` (floor guard fires), outdoor is typically also cool (early morning), making `outdoor <= indoor` true and the ceiling guard dormant on that cycle. A home simultaneously below the comfort floor and predicted to breach the ceiling is a degenerate condition that resolves naturally — the floor guard heats, the next cycle re-evaluates both guards with updated temperatures.
+In practice the two guards do not conflict: if indoor is below `comfort_heat` (floor guard fires), indoor is well under `comfort_cool`, so `_find_ceiling_breach_time()` finds no breach above the ceiling and the ceiling guard is dormant via that row (regardless of the 3-condition dormancy). A home simultaneously below the comfort floor and predicted to breach the ceiling is a degenerate condition that resolves naturally — the floor guard heats, the next cycle re-evaluates both guards with updated temperatures.
 
 #### Emitted event
 

--- a/tests/test_warm_day_comfort_gap.py
+++ b/tests/test_warm_day_comfort_gap.py
@@ -405,11 +405,46 @@ class TestCeilingGuardSkips:
         hvac_calls = [c for c in calls if c.args[1] == "set_hvac_mode"]
         assert not any(c.args[2].get("hvac_mode") == "cool" for c in hvac_calls)
 
-    def test_skips_when_outdoor_below_indoor(self):
-        """Outdoor <= indoor → nat-vent available → guard dormant."""
+    def test_dormant_when_outdoor_below_natvent_running_in_band(self):
+        """Issue #247: dormant ONLY when outdoor<=indoor AND nat-vent running AND indoor in band.
+
+        This replaces the old `test_skips_when_outdoor_below_indoor`, which asserted "no AC whenever
+        outdoor <= indoor" UNCONDITIONALLY — even with indoor 76°F above comfort_cool 74°F. That
+        encoded the bug: it validated the one-condition dormancy that #218 was supposed to replace
+        (its 3-condition fix was specified but never committed). The correct behavior is: defer to
+        free cooling only while it is actually viable — outdoor cool, windows actually ventilating,
+        and indoor still within band.
+        """
         engine = _make_engine(config_overrides={"comfort_cool": 74.0})
-        _set_indoor_temp_via_climate(engine, 76.0)
-        engine._last_outdoor_temp = 72.0  # outdoor < indoor → nat-vent available
+        _set_indoor_temp_via_climate(engine, 73.0)  # IN band
+        engine._last_outdoor_temp = 70.0  # outdoor < indoor
+        engine._natural_vent_active = True  # windows actually ventilating
+        _set_thermal_model(engine, k_passive=-0.05, conf="medium")
+
+        now = datetime(2026, 5, 11, 10, 0, 0, tzinfo=UTC)
+        # Curve DOES breach later — proves dormancy holds on the indoor-in-band + nat-vent condition,
+        # not merely because nothing breaches (the breach scan is never reached while dormant).
+        curve = _make_predicted_indoor(start_hour_utc=10, temps=[73.0, 74.5, 75.0])
+
+        with patch("custom_components.climate_advisor.automation.dt_util") as mock_dt:
+            mock_dt.now.return_value = now
+            asyncio.run(engine.apply_classification(_make_warm_off_classification(), predicted_indoor=curve))
+
+        calls = engine.hass.services.async_call.call_args_list
+        cool_calls = [c for c in calls if c.args[1] == "set_hvac_mode" and c.args[2].get("hvac_mode") == "cool"]
+        assert len(cool_calls) == 0  # free cooling still viable → dormant
+
+    def test_fires_when_indoor_breaches_ceiling_despite_outdoor_below(self):
+        """Issue #247: nat-vent active, outdoor < indoor, indoor ABOVE comfort_cool → escalate to AC.
+
+        Solar/internal gains exceed ventilated cooling; free cooling is demonstrably losing. The
+        guard must fire even though outdoor < indoor (this is the exact #247 case the old test
+        wrongly asserted should be dormant).
+        """
+        engine = _make_engine(config_overrides={"comfort_cool": 74.0})
+        _set_indoor_temp_via_climate(engine, 76.0)  # OUT of band
+        engine._last_outdoor_temp = 70.0  # outdoor < indoor
+        engine._natural_vent_active = True
         _set_thermal_model(engine, k_passive=-0.05, conf="medium")
 
         now = datetime(2026, 5, 11, 10, 0, 0, tzinfo=UTC)
@@ -421,7 +456,48 @@ class TestCeilingGuardSkips:
 
         calls = engine.hass.services.async_call.call_args_list
         cool_calls = [c for c in calls if c.args[1] == "set_hvac_mode" and c.args[2].get("hvac_mode") == "cool"]
-        assert len(cool_calls) == 0
+        assert len(cool_calls) >= 1  # escalated to AC
+
+    def test_fires_when_natvent_not_running_and_indoor_above_ceiling(self):
+        """Issue #215/#247: nat-vent NOT running (sensors closed / fan override), indoor above ceiling,
+        outdoor below indoor → guard must fire (do not defer to a ventilation that is not happening)."""
+        engine = _make_engine(config_overrides={"comfort_cool": 74.0})
+        _set_indoor_temp_via_climate(engine, 76.0)
+        engine._last_outdoor_temp = 70.0  # outdoor < indoor
+        engine._natural_vent_active = False  # windows closed / fan off
+        _set_thermal_model(engine, k_passive=-0.05, conf="medium")
+
+        now = datetime(2026, 5, 11, 10, 0, 0, tzinfo=UTC)
+        curve = _make_predicted_indoor(start_hour_utc=10, temps=[76.0, 77.0, 78.0])
+
+        with patch("custom_components.climate_advisor.automation.dt_util") as mock_dt:
+            mock_dt.now.return_value = now
+            asyncio.run(engine.apply_classification(_make_warm_off_classification(), predicted_indoor=curve))
+
+        calls = engine.hass.services.async_call.call_args_list
+        cool_calls = [c for c in calls if c.args[1] == "set_hvac_mode" and c.args[2].get("hvac_mode") == "cool"]
+        assert len(cool_calls) >= 1
+
+    def test_aggressive_savings_widens_escalation_threshold(self):
+        """Issue #247: in aggressive_savings, tolerate a small overshoot (comfort_cool + margin) before
+        escalating — so a 75°F reading (within comfort_cool 74 + 2°F margin) stays dormant under
+        active nat-vent."""
+        engine = _make_engine(config_overrides={"comfort_cool": 74.0, "aggressive_savings": True})
+        _set_indoor_temp_via_climate(engine, 75.0)  # within 74 + 2°F savings margin
+        engine._last_outdoor_temp = 70.0
+        engine._natural_vent_active = True
+        _set_thermal_model(engine, k_passive=-0.05, conf="medium")
+
+        now = datetime(2026, 5, 11, 10, 0, 0, tzinfo=UTC)
+        curve = _make_predicted_indoor(start_hour_utc=10, temps=[75.0, 75.5, 75.8])
+
+        with patch("custom_components.climate_advisor.automation.dt_util") as mock_dt:
+            mock_dt.now.return_value = now
+            asyncio.run(engine.apply_classification(_make_warm_off_classification(), predicted_indoor=curve))
+
+        calls = engine.hass.services.async_call.call_args_list
+        cool_calls = [c for c in calls if c.args[1] == "set_hvac_mode" and c.args[2].get("hvac_mode") == "cool"]
+        assert len(cool_calls) == 0  # savings margin tolerates the small overshoot
 
     def test_skips_when_no_breach_in_curve(self):
         """All predicted temps below comfort_cool → guard dormant."""

--- a/tools/simulations/pending/ceiling_guard_fires_when_outdoor_stays_below_indoor.json
+++ b/tools/simulations/pending/ceiling_guard_fires_when_outdoor_stays_below_indoor.json
@@ -1,0 +1,97 @@
+{
+  "name": "ceiling_guard_fires_when_outdoor_stays_below_indoor",
+  "description": "Issue #247 regression: outdoor STAYS below indoor all afternoon, nat-vent is active and running, but solar/internal gains push indoor above comfort_cool. The ODE ceiling guard must escalate to AC (clearing nat-vent) even though outdoor < indoor — free cooling is demonstrably losing. This is the exact case #218's intended 3-condition dormancy was supposed to cover but the committed fix omitted (only the escalation-on-fire half landed, which is unreachable while the guard stays dormant on outdoor<=indoor).",
+  "source": "synthetic",
+  "issue": 247,
+  "notes": [
+    "Occupant experience this guards: on a mild/warm day CA opened the windows, the afternoon sun warmed the",
+    "house faster than the breeze cooled it, indoor sat at 76F (2F over the 74F ceiling) for hours, and the AC",
+    "never ran. This scenario fails on pre-fix code (ceiling guard goes dormant whenever outdoor<=indoor) and",
+    "passes once the dormancy requires outdoor<=indoor AND nat_vent_active AND indoor<=ceiling.",
+    "Distinct from warm_day_ceiling_breach_ac_defense (#136), where outdoor RISES above indoor and the guard",
+    "already fired correctly — that scenario masked the omission because its breach path crosses outdoor>indoor."
+  ],
+  "verdict": {
+    "type": "positive",
+    "summary": "With nat-vent active and outdoor staying below indoor, once indoor exceeds comfort_cool the ceiling guard escalates to AC and clears nat-vent",
+    "observed_behavior": "Live instance 2026-06-09: indoor 75-76F, outdoor 70F, nat_vent active, HVAC runtime 0 min — guard never fired",
+    "expected_behavior": "Ceiling guard fires AC at comfort_cool=74F and clears nat-vent because indoor breached the ceiling, despite outdoor (68F) < indoor (76F)"
+  },
+  "config": {
+    "comfort_heat": 70,
+    "comfort_cool": 74,
+    "setback_heat": 62,
+    "setback_cool": 80,
+    "natural_vent_delta": 3.0
+  },
+  "events": [
+    {
+      "time": "2026-07-10T14:00:00",
+      "type": "classification",
+      "day_type": "warm",
+      "hvac_mode": "off",
+      "windows_recommended": false,
+      "note": "Warm-day classification: HVAC off. Indoor will be checked for nat-vent eligibility on sensor open."
+    },
+    {
+      "time": "2026-07-10T14:01:00",
+      "type": "temp_update",
+      "indoor_f": 72.0,
+      "outdoor_f": 68.0,
+      "note": "Early afternoon: outdoor 68F below indoor 72F, indoor > comfort_heat 70F — nat-vent eligible."
+    },
+    {
+      "time": "2026-07-10T14:02:00",
+      "type": "sensor_open",
+      "entity": "binary_sensor.living_room_window",
+      "note": "User opens window per recommendation: outdoor 68F < indoor 72F, indoor > comfort_heat 70F, outdoor <= threshold 77F — nat-vent activates."
+    },
+    {
+      "time": "2026-07-10T15:30:00",
+      "type": "temp_update",
+      "indoor_f": 76.0,
+      "outdoor_f": 68.0,
+      "note": "90 min later: outdoor STILL 68F (below indoor) but solar/internal gains drove indoor to 76F — 2F above comfort_cool=74F. ODE predicts indoor stays above the ceiling under continued nat-vent. Free cooling is losing; guard must escalate to AC.",
+      "predicted_indoor": [
+        {
+          "ts": "2026-07-10T15:30:00",
+          "temp": 76.0
+        },
+        {
+          "ts": "2026-07-10T16:30:00",
+          "temp": 76.8
+        },
+        {
+          "ts": "2026-07-10T17:30:00",
+          "temp": 77.2
+        }
+      ]
+    }
+  ],
+  "assertions": [
+    {
+      "at": "2026-07-10T14:02:00",
+      "expect": "natural_ventilation",
+      "reason": "sensor_open: outdoor 68F < indoor 72F, indoor > comfort_heat 70F, outdoor 68F <= threshold 77F — nat-vent activates as the first/preferred remediation."
+    },
+    {
+      "at": "2026-07-10T15:30:00",
+      "expect": "ceiling_guard_fires_cool",
+      "expect_temp": 74.0,
+      "reason": "Issue #247: indoor 76F > comfort_cool 74F with nat-vent active and outdoor (68F) still below indoor. The 3-condition dormancy lifts (indoor > ceiling), the breach scan confirms indoor already above the ceiling, and the guard escalates to AC at comfort_cool=74F. Pre-fix code stayed dormant on outdoor<=indoor and never fired."
+    },
+    {
+      "at": "2026-07-10T15:30:00",
+      "expect": "nat_vent_not_active",
+      "reason": "Issue #218 part 2 (now reachable): when the ceiling guard escalates to AC it clears nat-vent (deactivates fan, _natural_vent_active=False) and emits nat_vent_ceiling_escalation, so free cooling does not fight the compressor."
+    }
+  ],
+  "thermal_model": {
+    "confidence": "high",
+    "confidence_k_passive": "high",
+    "confidence_k_hvac": "high",
+    "k_passive": -0.15,
+    "k_active_cool": -2.0,
+    "k_active_heat": 2.0
+  }
+}


### PR DESCRIPTION
## Occupant impact
On a warm/mild afternoon CA opened the windows (nat-vent), but the sun warmed the house faster than the breeze cooled it. Indoor sat at **76°F — 2°F over the comfort ceiling — for hours with the AC idle** (live instance 2026-06-09: indoor 75–76°F, outdoor 70°F, nat-vent active, **0 min HVAC runtime**). This fix makes the AC actually step in once free cooling is demonstrably losing.

## Root cause — why #218's fix didn't work
The ODE ceiling guard went **dormant on the single condition `outdoor <= indoor`**, so whenever outdoor stayed below indoor the guard never even scanned for a breach. #218 ("nat-vent → HVAC escalation missing", same June 2024 symptom) **specified a two-part fix**: (1) make the dormancy three conditions, and (2) clear nat-vent when the guard fires. **Commit `676daa4` landed only part 2** (+19/−0) — the escalation code — which is *unreachable* while the guard stays dormant on `outdoor <= indoor`. The #218 golden masked it because its breach path drives outdoor *above* indoor. Verified via `git merge-base` (676daa4 is an ancestor of both deployed `bf01e3e` and `origin/main`) and `git show 676daa4`.

## Fix — the 3-condition dormancy #218 specified
The guard is dormant **only when all three hold**: `outdoor <= indoor` **AND** `_natural_vent_active` **AND** `indoor <= ceiling threshold`. If any fails it evaluates and escalates to AC at `comfort_cool`:
- indoor already breached the ceiling though outdoor < indoor (solar/internal gains out-pace ventilation) — the **#247** case;
- nat-vent not actually running (windows closed / fan override) — the **#215** case;
- outdoor risen above indoor — the original **#136/#218** path (unchanged).

`aggressive_savings` widens the threshold to `comfort_cool + CEILING_ESCALATION_SAVINGS_MARGIN_F` (2.0°F). On escalation the guard clears nat-vent (deactivates fan, emits `nat_vent_ceiling_escalation`) — **#218 part 2, now reachable**.

> Recategorized as the **misprogramming backstop** under the broader *thermostat-is-the-controller* direction (separate research/design issue).

## Tests & verification
- **New scenario** `pending/ceiling_guard_fires_when_outdoor_stays_below_indoor.json` runs through the single production-engine harness and is **proven to catch the regression**: PASSES on the fix, FAILS (guard stays dormant → nat-vent continues) when the 1-condition dormancy is temporarily restored.
- Split `test_warm_day_comfort_gap.py::test_skips_when_outdoor_below_indoor` (it encoded the *omitted* behavior) into dormant-in-band / fires-when-breached / #215-nat-vent-off / aggressive-savings cases, with docstring justification.
- Golden suite 25/26 (1 skip = integration-track, unchanged); full suite **2395 passed**, lint clean, warnings-as-errors.
- Docs §6c + Anchors row + `KNOWN_FIXES[247]` updated.

## Base branch
Targets `feature/236-headless-single-engine` (PR #246) — the new scenario requires the single-engine harness. Merge after #246.

## Not in scope (deferred)
Predictive pre-emption while venting and the *thermostat-is-the-controller* codification are tracked separately. The golden scenario stays in `pending/` awaiting scenario-card sign-off before promotion + signing.