### PR TITLE
Fix #264: economizer no longer overrides the #249 comfort band (fan-assist only)

### DIFF
--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -2588,26 +2588,24 @@ class AutomationEngine:
 
         # Comfort mode: two-phase strategy
         if indoor_temp is not None and indoor_temp > comfort_cool:
-            # Phase 1: cool-down — run AC, outdoor air assists efficiency
+            # Phase 1: cool-down. Issue #264: the #249 comfort band already holds comfort_cool, so the
+            # economizer no longer sets the HVAC mode/setpoint — doing so would flip the heat_cool band
+            # to single `cool` and fight the band (two controllers). It now only assists with the fan,
+            # pulling cool outdoor air through the open window to make the band's cooling more efficient.
             if self._economizer_phase != "cool-down":
                 self._economizer_phase = "cool-down"
-                await self._set_hvac_mode(
-                    "cool",
+                await self._activate_fan(
                     reason=(
-                        f"economizer cool-down — indoor {format_temp(indoor_temp, unit)}"
-                        f" > comfort {format_temp(comfort_cool, unit)},"
+                        f"economizer cool-down — fan assists the band's cooling: indoor"
+                        f" {format_temp(indoor_temp, unit)} > comfort {format_temp(comfort_cool, unit)},"
                         f" outdoor {format_temp(outdoor_temp, unit)} assisting"
-                    ),
-                )
-                await self._set_temperature(
-                    comfort_cool,
-                    reason=f"economizer cool-down — target comfort {format_temp(comfort_cool, unit)}",
+                    )
                 )
                 _LOGGER.info(
-                    "Economizer phase=cool-down: indoor=%s, target=%s, outdoor=%s",
+                    "Economizer phase=cool-down: indoor=%s, outdoor=%s — band holds comfort_cool=%s, fan assists",
                     format_temp(indoor_temp, unit),
-                    format_temp(comfort_cool, unit),
                     format_temp(outdoor_temp, unit),
+                    format_temp(comfort_cool, unit),
                 )
             return True
         else:

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -721,6 +721,25 @@ KNOWN_FIXES: dict[int, dict] = {
             "Single-setpoint mid-day edge re-selection — the band holds both edges via the device's shape",
         ],
     },
+    264: {
+        "issue": 264,
+        "title": "Economizer no longer overrides the #249 comfort band (fan-assist only)",
+        "version_fixed": "0.4.1",
+        "scope_covered": [
+            "check_window_cooling_opportunity() cool-down phase: removed _set_hvac_mode('cool') +"
+            " _set_temperature(comfort_cool) — the #249 band already holds comfort_cool, so the"
+            " economizer no longer flips the heat_cool band to single cool",
+            "Cool-down now only activates the fan to assist the band's cooling (pull cool outdoor air"
+            " through the open window); maintain phase unchanged (band stays armed, #249)",
+            "Thermostat stays in the stable heat_cool band on hot days — one controller, no mode flip",
+        ],
+        "scope_not_covered": [
+            "Full economizer retirement (its fan role overlaps natural ventilation) — deferred",
+            "No economizer on/off toggle added — it remains gated only by hot-day + window-open +"
+            " outdoor<=comfort_cool+delta + time-window eligibility",
+            "Restart re-evaluation (home sits paused after restart with an open contact) — tracked in #263",
+        ],
+    },
 }
 
 GITHUB_REPO = "gunkl/ClimateAdvisor"

--- a/docs/08-COMPUTATION-REFERENCE.md
+++ b/docs/08-COMPUTATION-REFERENCE.md
@@ -857,7 +857,7 @@ Mode changes are issued only when the thermostat is not already in the target mo
 Natural ventilation and the economizer **no longer set `hvac_mode=off`** when they activate (Issue #249 Design §4). They manage only the fan; the comfort band remains armed throughout:
 
 - **Nat-vent active (windows open, outdoor cooler than indoor):** fan on, `_natural_vent_active = True`, band unchanged. The thermostat self-arbitrates: if the breeze keeps the home below the ceiling, the compressor idles for free. If the breeze fails and indoor rises above `comfort_cool`, the thermostat cools without waiting for the next CA 30-minute cycle.
-- **Economizer maintain phase:** fan on (or HVAC fan mode), band unchanged. The compressor is not needed as long as the open windows can hold the ceiling.
+- **Economizer (both phases):** fan on (or HVAC fan mode), band unchanged. The band holds `comfort_cool`, so the economizer never sets the HVAC mode/setpoint (Issue #264) — cool-down assists with the fan while the band cools; maintain holds it via ventilation.
 - **Escalation:** when the ODE ceiling guard (§6c) fires, nat-vent is cleared (`_natural_vent_active = False`) and a `nat_vent_ceiling_escalation` event is emitted — the band was already armed at the cool ceiling, so "escalation" means allowing the compressor to run rather than re-programming the setpoint.
 
 **Why no more HVAC off on nat-vent:** Turning HVAC off on nat-vent activation disarmed the floor. If outdoor conditions changed mid-night (cold snap), CA would not re-heat until the next 30-minute cycle noticed the floor breach — up to 30 minutes of the home sitting below the comfort floor. With the band always armed, the thermostat heats immediately.
@@ -911,7 +911,11 @@ Window advice is set by the classifier at classification time, based on `day_typ
 
 ## 8. Economizer (Window Cooling on Hot Days)
 
-The economizer is a two-phase strategy that uses open windows to reduce AC load on hot days.
+The economizer uses open windows on hot days to make the band's cooling cheaper. Under the #249 band
+model it is **fan-assist only**: the comfort band (§6e) holds `comfort_cool`, so the economizer no
+longer sets the HVAC mode or setpoint (Issue #264) — it runs the fan to pull cool outdoor air through
+the open window. It never overrides the band; there is no separate economizer on/off toggle (it is
+gated purely by the eligibility conditions below).
 
 ### Eligibility
 
@@ -928,17 +932,17 @@ All of the following must be true simultaneously:
 
 | Mode | aggressive_savings | Phase | Condition | Action |
 |---|---|---|---|---|
-| Normal | `False` | Phase 1: cool-down | `indoor_temp > comfort_cool` | Set HVAC to `cool`, target = `comfort_cool`; outdoor air assists efficiency |
-| Normal | `False` | Phase 2: maintain | `indoor_temp <= comfort_cool` | Set HVAC to `off`; activate fan for ventilation |
-| Savings | `True` | Maintain only (skip Phase 1) | Any eligible condition | Set HVAC to `off` immediately; activate fan; no AC assist |
+| Normal | `False` | Phase 1: cool-down | `indoor_temp > comfort_cool` | **Activate the fan only** — the #249 band already holds `comfort_cool`; the economizer pulls cool outdoor air through the open window to assist the band's cooling. It does **not** set the HVAC mode/setpoint (Issue #264 — that would flip the `heat_cool` band to single `cool`). |
+| Normal | `False` | Phase 2: maintain | `indoor_temp <= comfort_cool` | Activate the fan; the band stays armed (no `hvac_mode=off` — Issue #249) |
+| Savings | `True` | Maintain only (skip Phase 1) | Any eligible condition | Activate the fan; band stays armed; no AC assist (savings relies on ventilation) |
 
-When the economizer deactivates (conditions no longer met), the fan is turned off and HVAC resumes normal `cool` mode at `comfort_cool`.
+When the economizer deactivates (conditions no longer met), the fan is turned off; the comfort band continues to hold the thermostat — no HVAC mode change is issued (Issues #249/#264).
 
 ---
 
 ## 9. Fan Control
 
-Fans only activate during the economizer **maintain** phase (Phase 2 or savings-mode ventilation). Fan behavior is controlled by the `fan_mode` config setting.
+Fans activate during natural ventilation and during the economizer (both phases — cool-down assists the band's cooling, maintain holds it; Issue #264). Fan behavior is controlled by the `fan_mode` config setting.
 
 | fan_mode value | Activate action | Deactivate action |
 |---|---|---|

--- a/tests/test_economizer.py
+++ b/tests/test_economizer.py
@@ -1,8 +1,9 @@
 """Tests for the two-phase economizer (window cooling) feature (Issue #27).
 
 Tests cover:
-- Phase 1 (cool-down): AC runs to cool to set temp when indoor > comfort
-- Phase 2 (maintain): AC off when indoor <= comfort, ventilation holds
+- Phase 1 (cool-down): the #249 band holds comfort_cool; the economizer assists with the fan and
+  does not override the HVAC mode/setpoint (Issue #264)
+- Phase 2 (maintain): band stays armed when indoor <= comfort, ventilation holds (Issue #249)
 - Time-bounding: only morning (6-9) and evening (17-24)
 - aggressive_savings: skip AC, ventilation only
 - Guards: non-HOT days, windows closed, too warm outdoor, no classification
@@ -125,7 +126,8 @@ class TestEconomizerCoolDown:
     """Phase 1: AC runs when indoor > comfort and outdoor is favorable."""
 
     def test_cooldown_activates_ac_when_indoor_above_comfort(self):
-        """Indoor 80°F > comfort 75°F, outdoor 73°F → AC runs in cool mode."""
+        """Indoor 80°F > comfort 75°F, outdoor 73°F → cool-down phase; the #249 band holds
+        comfort_cool, so the economizer assists with the fan and does NOT override the HVAC mode (#264)."""
         engine = _make_automation_engine()
         engine._current_classification = _make_hot_classification()
 
@@ -141,11 +143,12 @@ class TestEconomizerCoolDown:
         assert result is True
         assert engine._economizer_active is True
         assert engine._economizer_phase == "cool-down"
-        # Should set HVAC to cool mode and set temperature to comfort
+        # Issue #264: the #249 comfort band already holds comfort_cool — the economizer no longer
+        # flips the HVAC mode/setpoint (that would fight the band). Cool-down now only assists with the fan.
         mode_calls = _get_hvac_mode_calls(engine)
-        assert any(c[0][2]["hvac_mode"] == "cool" for c in mode_calls)
+        assert not any(c[0][2]["hvac_mode"] == "cool" for c in mode_calls), "economizer must not override the band mode"
         temp_calls = _get_set_temp_calls(engine)
-        assert any(c[0][2]["temperature"] == 75 for c in temp_calls)
+        assert not any(c[0][2]["temperature"] == 75 for c in temp_calls), "economizer must not set the band's setpoint"
 
     def test_cooldown_no_repeat_calls_same_phase(self):
         """Calling again while still in cool-down doesn't re-issue commands."""
@@ -368,8 +371,9 @@ class TestEconomizerAggressiveSavings:
         # Should NOT have set cool mode (savings skips AC assist)
         assert not any(c[0][2]["hvac_mode"] == "cool" for c in mode_calls)
 
-    def test_comfort_mode_uses_ac_for_cooldown(self):
-        """With aggressive_savings=False (default), AC runs for cool-down."""
+    def test_comfort_mode_cooldown_assists_with_fan_not_ac_override(self):
+        """Issue #264: with aggressive_savings=False, cool-down assists with the fan; the #249 band
+        (not the economizer) holds comfort_cool, so the economizer no longer flips the HVAC mode."""
         engine = _make_automation_engine({"aggressive_savings": False})
         engine._current_classification = _make_hot_classification()
 
@@ -385,7 +389,7 @@ class TestEconomizerAggressiveSavings:
         assert result is True
         assert engine._economizer_phase == "cool-down"
         mode_calls = _get_hvac_mode_calls(engine)
-        assert any(c[0][2]["hvac_mode"] == "cool" for c in mode_calls)
+        assert not any(c[0][2]["hvac_mode"] == "cool" for c in mode_calls), "economizer must not override the band mode"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_window_hvac_interaction.py
+++ b/tests/test_window_hvac_interaction.py
@@ -158,21 +158,23 @@ class TestEconomizerNatVentGuard:
             assert call.args[0] != "cool", "Should not activate AC when nat-vent is active"
 
     def test_economizer_activates_normally_without_nat_vent(self):
-        """Returns True and calls _set_hvac_mode('cool') when nat-vent is NOT active."""
+        """Issue #264: cool-down activates (fan assist) without overriding the band. The #249 band
+        already holds comfort_cool, so the economizer no longer calls _set_hvac_mode('cool')."""
         ae = _make_ae_stub(_natural_vent_active=False, _economizer_active=False)
 
         result = asyncio.run(
             ae.check_window_cooling_opportunity(
                 outdoor_temp=70.0,
-                indoor_temp=78.0,  # indoor > comfort_cool (75) → Phase 1
+                indoor_temp=78.0,  # indoor > comfort_cool (75) → Phase 1 cool-down
                 windows_physically_open=True,
                 current_hour=19,
             )
         )
 
         assert result is True
-        ae._set_hvac_mode.assert_called_once()
-        assert ae._set_hvac_mode.call_args.args[0] == "cool"
+        assert ae._economizer_phase == "cool-down"
+        ae._set_hvac_mode.assert_not_called()  # #264: must not override the band's mode
+        ae._activate_fan.assert_called_once()  # assists with the fan instead
 
     def test_economizer_nat_vent_guard_does_not_deactivate_economizer(self):
         """When nat-vent is active and economizer was also running, deactivation is NOT triggered.


### PR DESCRIPTION
Closes #264. Found live on the 0.4.0 deploy.

## Occupant impact
On a hot evening with a window open, the #249 band correctly armed `heat_cool [comfort_heat, comfort_cool]` — then **the economizer immediately overrode it to single `cool`@comfort_cool**, flipping the thermostat out of the band. Same comfort outcome (74°F), but two controllers fighting and the "thermostat holds the band" principle broken.

## Root cause
The economizer (`check_window_cooling_opportunity`, Issue #27) predates #249. Its **cool-down** phase called `_set_hvac_mode("cool")` + `_set_temperature(comfort_cool)` — but the #249 band **already holds comfort_cool**, so that's redundant *and* it overrides the band's `heat_cool` mode. P3 reconciled the economizer's HVAC-*off* (maintain) but not its cool-mode *override* (cool-down). There is also **no economizer on/off toggle** — it's gated only by hot-day + window-open + outdoor≤comfort_cool+delta + morning/evening hours (`aggressive_savings` only switches its phase).

## Fix
Cool-down no longer sets the HVAC mode/setpoint — the band owns the ceiling. It now only **activates the fan** to assist the band's cooling (pull cool outdoor air through the open window). The thermostat stays in the stable `heat_cool` band on hot days — **one controller, no mode flip**, same comfort.

- `automation.py`: cool-down → fan-assist (dropped `_set_hvac_mode`/`_set_temperature`)
- tests: migrated `test_economizer` + `test_window_hvac_interaction` cool-down assertions (band owns cooling; economizer must not override the mode)
- docs §8/§9/§6e: economizer is fan-assist-only under #249; no on/off toggle (eligibility-gated)
- `KNOWN_FIXES[264]`

## Related / not in scope
- **#263** — the sibling bug from the same deploy: home sits **paused** after a restart with an open contact (didn't auto-recover to nat-vent/cooling). Tracked separately.
- Full economizer retirement (its fan role overlaps natural ventilation) — deferred.

## Verification
Full suite **2438 passed**; golden integrity OK (34); ruff clean.