### PR TITLE
Fix #266: dashboard shows band setpoints (dual-aware); Status card status-only

### DIFF
--- a/custom_components/climate_advisor/api.py
+++ b/custom_components/climate_advisor/api.py
@@ -88,10 +88,17 @@ class ClimateAdvisorStatusView(HomeAssistantView):
         climate_state = hass.states.get(coordinator.config.get("climate_entity", ""))
         hvac_mode = climate_state.state if climate_state else "unknown"
 
-        # Set point: only include when HVAC is actively running
+        # Set point(s): only include when HVAC is actively running. Single-setpoint modes
+        # (cool/heat) expose `temperature`; the heat_cool band (Issue #249/#266) exposes
+        # `target_temp_low`/`target_temp_high` instead. Attributes are already in the thermostat's
+        # display unit, so they are sent as-is (matching `current_setpoint`).
         setpoint = None
+        target_temp_low = None
+        target_temp_high = None
         if climate_state and hvac_mode != "off":
             setpoint = climate_state.attributes.get("temperature")
+            target_temp_low = climate_state.attributes.get("target_temp_low")
+            target_temp_high = climate_state.attributes.get("target_temp_high")
 
         indoor_temp = coordinator._get_indoor_temp()
         unit = coordinator.config.get("temp_unit", "fahrenheit")
@@ -108,6 +115,8 @@ class ClimateAdvisorStatusView(HomeAssistantView):
                 ATTR_HVAC_ACTION: data.get(ATTR_HVAC_ACTION, ""),
                 ATTR_HVAC_RUNTIME_TODAY: data.get(ATTR_HVAC_RUNTIME_TODAY, 0),
                 ATTR_CURRENT_SETPOINT: setpoint,
+                "target_temp_low": target_temp_low,
+                "target_temp_high": target_temp_high,
                 ATTR_INDOOR_TEMP: indoor_temp_display,
                 "unit": unit,
                 "automation_status": data.get(ATTR_AUTOMATION_STATUS, "unknown"),

--- a/custom_components/climate_advisor/frontend/index.html
+++ b/custom_components/climate_advisor/frontend/index.html
@@ -867,6 +867,17 @@
         : data.trend_direction === 'cooling' ? '\u2193' : '\u2192';
       const score = Math.round((data.compliance_score || 0) * 100);
 
+      // Issue #266: show the thermostat's setpoint(s) under the mode. The heat_cool band exposes
+      // target_temp_low/high (dual); cool/heat expose the single current_setpoint.
+      let hvacTemps = '';
+      if (data.hvac_mode === 'heat_cool' && (data.target_temp_low != null || data.target_temp_high != null)) {
+        const lo = data.target_temp_low != null ? data.target_temp_low + unitSym : '—';
+        const hi = data.target_temp_high != null ? data.target_temp_high + unitSym : '—';
+        hvacTemps = `Heat ${lo} · Cool ${hi}`;
+      } else if (data.current_setpoint != null) {
+        hvacTemps = data.current_setpoint + unitSym;
+      }
+
       grid.innerHTML = `
         <div class="status-item">
           <div class="label">Day Type</div>
@@ -878,11 +889,15 @@
         </div>
         <div class="status-item">
           <div class="label">HVAC Mode</div>
-          <div class="value">${data.hvac_mode || 'unknown'}${data.current_setpoint != null ? ' @ ' + data.current_setpoint + unitSym : ''}</div>
+          <div class="value">${data.hvac_mode || 'unknown'}${hvacTemps ? `<br><span style="font-size:0.8rem;opacity:0.85">${hvacTemps}</span>` : ''}</div>
         </div>
         <div class="status-item">
           <div class="label">Status</div>
-          <div class="value">${data.automation_status || 'unknown'}${data.indoor_temp != null ? ' | ' + data.indoor_temp.toFixed(1) + unitSym : ''}</div>
+          <div class="value">${data.automation_status || 'unknown'}</div>
+        </div>
+        <div class="status-item">
+          <div class="label">Indoor</div>
+          <div class="value">${data.indoor_temp != null ? data.indoor_temp.toFixed(1) + unitSym : '—'}</div>
         </div>
         <div class="status-item">
           <div class="label">Occupancy</div>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -278,6 +278,8 @@ def _simulate_status_get(coordinator):
         "hvac_mode": "off",
         "indoor_temp": indoor_temp_display,
         "current_setpoint": None,
+        "target_temp_low": None,
+        "target_temp_high": None,
         "automation_status": data.get("automation_status", "unknown"),
         "compliance_score": data.get("compliance_score", 1.0),
         "next_action": data.get(ATTR_NEXT_ACTION, ""),
@@ -310,6 +312,45 @@ def _simulate_learning_get(coordinator):
         "comfort_range_high": round(from_fahrenheit(coordinator.config.get("comfort_cool", 75), unit), 1),
         "unit": unit,
     }
+
+
+def _extract_setpoints(climate_state, hvac_mode):
+    """Replicate the api.py status setpoint extraction (Issue #266).
+
+    Single-setpoint modes (cool/heat) expose `temperature`; the heat_cool band exposes
+    `target_temp_low`/`target_temp_high`. Nothing is exposed when HVAC is off.
+    """
+    setpoint = target_temp_low = target_temp_high = None
+    if climate_state and hvac_mode != "off":
+        setpoint = climate_state.attributes.get("temperature")
+        target_temp_low = climate_state.attributes.get("target_temp_low")
+        target_temp_high = climate_state.attributes.get("target_temp_high")
+    return setpoint, target_temp_low, target_temp_high
+
+
+class TestStatusSetpointExtraction:
+    """Issue #266: the status endpoint must expose the dual band setpoints in heat_cool mode."""
+
+    def test_heat_cool_band_exposes_dual_setpoints(self):
+        state = MagicMock()
+        state.attributes = {"temperature": None, "target_temp_low": 64, "target_temp_high": 72}
+        setpoint, low, high = _extract_setpoints(state, "heat_cool")
+        assert setpoint is None  # single setpoint is absent in the heat_cool band
+        assert low == 64
+        assert high == 72
+
+    def test_cool_mode_exposes_single_setpoint(self):
+        state = MagicMock()
+        state.attributes = {"temperature": 74, "target_temp_low": None, "target_temp_high": None}
+        setpoint, low, high = _extract_setpoints(state, "cool")
+        assert setpoint == 74
+        assert low is None and high is None
+
+    def test_off_mode_exposes_no_setpoints(self):
+        state = MagicMock()
+        state.attributes = {"temperature": 74, "target_temp_low": 64, "target_temp_high": 72}
+        setpoint, low, high = _extract_setpoints(state, "off")
+        assert setpoint is None and low is None and high is None
 
 
 class TestStatusViewCelsiusUnit:


### PR DESCRIPTION
Closes #266.

## Occupant impact
On the Status tab, when the thermostat is in the #249 `heat_cool` band, the **HVAC Mode** card showed just "heat_cool" with **no temperatures** — the API only sent the single `temperature` attribute, which is `None` in heat_cool mode (the real values are `target_temp_low`/`target_temp_high`). You couldn't see the band the system was holding.

## Changes
- **`api.py`** status endpoint: also sends `target_temp_low`/`target_temp_high`, alongside `current_setpoint`.
- **`frontend/index.html`** `loadStatus()`:
  - **HVAC Mode** card → mode with its setpoint(s) on the line under it: `Heat <low>° · Cool <high>°` for `heat_cool`, the single setpoint for `cool`/`heat`.
  - **Status** card → status only (temperature removed).
  - New **Indoor** card → current indoor temp (preserved, separate concern).
- **tests**: `_simulate_status_get` gains the two keys; new `TestStatusSetpointExtraction` covers the setpoint extraction (dual for heat_cool, single for cool, none when off).

## Verification
Full suite **2441 passed**; ruff clean; `validate.py` clean.