### PR TITLE
Fix #269: heat_cool manual override blind spots (4 bugs)

### DIFF
--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -1482,6 +1482,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             ATTR_FAN_OVERRIDE_SINCE: self.automation_engine._fan_override_time,
             ATTR_FAN_RUNNING: fan_running,
             ATTR_HVAC_ACTION: hvac_action,
+            "hvac_mode": hvac_mode,
             ATTR_HVAC_RUNTIME_TODAY: hvac_runtime_today,
             ATTR_CONTACT_STATUS: self._compute_contact_status(),
             ATTR_AI_STATUS: self.claude_client.get_status()["status"] if self.claude_client else "disabled",
@@ -2258,10 +2259,14 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             and not self._is_recent_hvac_command()
             and not _is_expected_confirmation
             and self._current_classification
-            and new_state.state != self._current_classification.hvac_mode
+            and new_state.state
+            != (
+                self.automation_engine._last_commanded_hvac_mode
+                or (self._current_classification.hvac_mode if self._current_classification else None)
+            )
         ):
             # Mode changed outside of door/window pause to something
-            # different from what classification dictates — manual override
+            # different from what CA is actively controlling — manual override
             _LOGGER.info(
                 "Manual HVAC override detected: %s -> %s (classification wants %s)",
                 old_state.state,
@@ -2461,11 +2466,22 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                         )
 
         # Detect manual override: temperature changed but not by us
-        new_temp = new_state.attributes.get("temperature")
-        old_temp = old_state.attributes.get("temperature")
+        # In heat_cool mode the thermostat exposes target_temp_high/target_temp_low, not temperature.
+        if new_state.state == "heat_cool":
+            _new_high = new_state.attributes.get("target_temp_high")
+            _old_high = old_state.attributes.get("target_temp_high")
+            _new_low = new_state.attributes.get("target_temp_low")
+            _old_low = old_state.attributes.get("target_temp_low")
+            _setpoint_changed = (_new_high != _old_high) or (_new_low != _old_low)
+            # Use the cooling (high) setpoint as the representative value for override_details
+            new_temp, old_temp = _new_high, _old_high
+        else:
+            new_temp = new_state.attributes.get("temperature")
+            old_temp = old_state.attributes.get("temperature")
+            _setpoint_changed = new_temp != old_temp
 
         if (
-            new_temp != old_temp
+            _setpoint_changed
             and self._today_record
             and not self.automation_engine._temp_command_pending
             and not self.automation_engine._hvac_command_pending
@@ -2490,17 +2506,21 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 pass  # Non-numeric temps, skip detail recording
             _LOGGER.debug("Possible manual override detected: %s -> %s", old_temp, new_temp)
             await self._async_save_state()
-            # Setpoint-only override: mode matches classification but user moved the setpoint.
-            # Trigger the same override confirmation + grace mechanism as a mode change.
+            # Setpoint-only override: mode matches what CA is actively controlling.
+            # Use _last_commanded_hvac_mode so heat_cool mode is handled (classification.hvac_mode
+            # is always "cool"/"heat"/"off" — never "heat_cool" — so the old check missed heat_cool).
             ae = self.automation_engine
+            _ca_active_mode = ae._last_commanded_hvac_mode or (
+                self._current_classification.hvac_mode if self._current_classification else None
+            )
             if (
                 not ae._manual_override_active
                 and not ae._override_confirm_pending
                 and self._current_classification is not None
-                and new_state.state == self._current_classification.hvac_mode
+                and new_state.state == _ca_active_mode
             ):
                 _LOGGER.info(
-                    "Setpoint-only manual override detected: %s -> %s (mode=%s matches classification)",
+                    "Setpoint-only manual override detected: %s -> %s (mode=%s matches CA active mode)",
                     old_temp,
                     new_temp,
                     new_state.state,
@@ -2509,7 +2529,9 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                     source="setpoint",
                     old_mode=old_state.state,
                     new_mode=new_state.state,
-                    classification_mode=self._current_classification.hvac_mode,
+                    classification_mode=(
+                        self._current_classification.hvac_mode if self._current_classification else None
+                    ),
                 )
 
         # Detect manual fan_mode attribute changes on thermostat (Issue #37)
@@ -2523,6 +2545,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             and not self.automation_engine._fan_override_active
             and not self.automation_engine._hvac_command_pending
             and not self._is_recent_hvac_command(threshold_seconds=30.0)
+            and not _is_expected_confirmation
         ):
             _LOGGER.info(
                 "Manual HVAC fan_mode change detected: %s -> %s",

--- a/docs/08-COMPUTATION-REFERENCE.md
+++ b/docs/08-COMPUTATION-REFERENCE.md
@@ -31,6 +31,9 @@ The automation logic table and all threshold constants in this document are expr
 | How does MILD day window scheduling change when the ODE is available (Fix C, Issue #147)? | Before Fix C: MILD days used hardcoded `time(10, 0)` open / `time(17, 0)` close. After Fix C: constants `MILD_WINDOW_OPEN_HOUR = 10` and `MILD_WINDOW_CLOSE_HOUR = 17` are fallbacks; when the ODE is available, `nat_vent_cutoff` drives the close time — the same dynamic logic as warm days. | [§6d. MILD Day Dynamic Window Close Time](08-COMPUTATION-REFERENCE.md#6d-mild-day-dynamic-window-close-time-fix-c-issue-147) |
 | What invariant must `_async_send_briefing()` maintain when replacing `_today_record`? | It must copy all accumulated counters (`hvac_runtime_minutes`, `comfort_violations_minutes`, etc.) from the existing same-day record before constructing the new one. Creating a fresh `DailyRecord` unconditionally resets all counters to zero (Issue #176 bug). | [DailyRecord Persistence Invariant](08-COMPUTATION-REFERENCE.md#dailyrecord-persistence-invariant-issue-176) |
 | Why must `_async_thermostat_changed()` check all three command-pending flags, not just `_hvac_command_pending`? | Automation sequences (e.g., nat vent exit) call `_deactivate_fan()` before `_set_hvac_mode()`. The fan command sets `_fan_command_pending` but leaves `_hvac_command_pending` False. Checking only `_hvac_command_pending` bypasses the override-detection guard during that window. | [§9b Compound command-pending guard](08-COMPUTATION-REFERENCE.md#compound-command-pending-guard-in-_async_thermostat_changed-issue-205206) |
+| Why was a manual mode override not detected on dual-setpoint (`heat_cool`) thermostats? | CA commands `heat_cool` mode but the old code compared the thermostat's `hvac_mode` against `classification.hvac_mode` (e.g., `"cool"`). A user switching from `heat_cool` to `cool` evaluated as equal and was ignored. Fix: compare against `_last_commanded_hvac_mode` first. | [§9b Mode Override Detection — `_last_commanded_hvac_mode`](08-COMPUTATION-REFERENCE.md#mode-override-detection--_last_commanded_hvac_mode-issue-269-bug-c) |
+| Why was a manual setpoint change not detected on dual-setpoint (`heat_cool`) thermostats? | In `heat_cool` mode the `temperature` attribute is `None`; only `target_temp_low`/`target_temp_high` are populated. The setpoint override check now reads those attributes when mode is `heat_cool`. | [§9b Dual Setpoint Override Detection](08-COMPUTATION-REFERENCE.md#dual-setpoint-override-detection--heat_cool-mode-issue-269-bug-d) |
+| Why do cloud thermostats (Nest, Ecobee) falsely trigger fan overrides after HVAC mode changes? | Cloud polling echoes `fan_mode` attribute changes as delayed side-effects 30–120 s after the command, outside the 30 s `_is_recent_hvac_command` window. The `_is_expected_confirmation` flag extends suppression to 120 s for the `fan_mode` path. | [§9b `_is_expected_confirmation`](08-COMPUTATION-REFERENCE.md#_is_expected_confirmation-issue-269-bug-a) |
 | What is the comfort-band programming model introduced in Issue #249? | CA programs a floor+ceiling band every 30 min via one `select_comfort_band` decision and one `_apply_comfort_band` actuation; the thermostat's own deadband holds the house inside the band continuously — no more off+supervisor pattern. | [§6e Comfort-Band Programming](08-COMPUTATION-REFERENCE.md#6e-comfort-band-programming-issue-249) |
 | What command shape does `_apply_comfort_band` emit per thermostat capability? | Dual-capable: `heat_cool` mode + `set_temperature(target_temp_low=floor, target_temp_high=ceiling)`. Cool-only (active=ceiling): `cool` + `set_temperature(ceiling)`. Heat-only (active=floor): `heat` + `set_temperature(floor)`. | [§6e — `_apply_comfort_band` command shapes](08-COMPUTATION-REFERENCE.md#_apply_comfort_band-command-shapes) |
 | Why does nat-vent no longer set HVAC off when windows open (Issue #249)? | The band stays armed when nat-vent activates; the thermostat self-arbitrates — free cooling is free, AC kicks in only if the breeze can't hold the ceiling. Turning HVAC off also disarmed the floor, making cold-snap escalation impossible. | [§6e — Nat-vent and economizer with the band armed](08-COMPUTATION-REFERENCE.md#nat-vent-and-economizer-with-the-band-armed) |
@@ -994,10 +997,40 @@ The fix (Issue #206) expands the guard at both the pause-path and normal-path de
 
 **`_is_recent_hvac_command(threshold_seconds=3.0)`** is a secondary guard that inspects `_hvac_command_time` to catch race conditions where the flag was already cleared before the listener fired. It does not replace the flag check — it is an additional fallback for sub-second timing races.
 
-| Guard | Type | Purpose |
-|---|---|---|
-| `_hvac_command_pending OR _fan_command_pending OR _temp_command_pending` | Flag check (synchronous) | Primary: suppresses both pause-path and normal-path override detection during any automation-issued command sequence |
-| `_is_recent_hvac_command(threshold_seconds=3.0)` | Timestamp check | Secondary fallback: catches races where the command flag was cleared before the HA state-change event arrived |
+**`_is_expected_confirmation` (Issue #269 Bug A):** A third suppression layer for the `fan_mode` attribute-change path specifically. Cloud thermostats (e.g., Nest, Ecobee via cloud polling) sometimes echo a `fan_mode` attribute change as a delayed side-effect of an HVAC mode transition, arriving 30–120 seconds after the original command — outside the 30-second `_is_recent_hvac_command` window. When `_is_expected_confirmation` is `True`, the `fan_mode` change guard suppresses false override detection for up to 120 seconds after the last HVAC command. The three guards are evaluated in order: flag check → `_is_recent_hvac_command(30s)` → `_is_expected_confirmation(120s)`.
+
+| Guard | Type | Window | Purpose |
+|---|---|---|---|
+| `_hvac_command_pending OR _fan_command_pending OR _temp_command_pending` | Flag check (synchronous) | Until flag cleared | Primary: suppresses both pause-path and normal-path override detection during any automation-issued command sequence |
+| `_is_recent_hvac_command(threshold_seconds=30.0)` | Timestamp check | 30 s | Secondary fallback: catches races where the command flag was cleared before the HA state-change event arrived |
+| `_is_expected_confirmation` | Boolean flag | 120 s | Tertiary: suppresses `fan_mode` attribute changes that arrive as delayed side-effects of HVAC mode transitions on cloud thermostats |
+
+#### Mode Override Detection — `_last_commanded_hvac_mode` (Issue #269 Bug C)
+
+The normal-path override detection in `_async_thermostat_changed()` compares the thermostat's reported `hvac_mode` against the expected mode. Prior to Issue #269, that comparison was always against `classification.hvac_mode`. For dual-setpoint thermostats, CA commands `heat_cool` mode (§6e), but `classification.hvac_mode` may be `"cool"` or `"heat"`. A user switching from `heat_cool` back to `cool` would evaluate as `"cool" != "cool"` = `False` and go undetected.
+
+The fix replaces the comparison target with `ae._last_commanded_hvac_mode or classification.hvac_mode`:
+- When CA has issued a mode command, `_last_commanded_hvac_mode` holds the actual mode sent to the thermostat (e.g., `"heat_cool"`).
+- If no command has been issued in this session, it falls back to `classification.hvac_mode`.
+
+This ensures mode overrides are correctly detected regardless of whether the thermostat is single- or dual-setpoint capable.
+
+#### Dual Setpoint Override Detection — `heat_cool` Mode (Issue #269 Bug D)
+
+Setpoint override detection reads the thermostat's temperature attributes to determine whether the user has manually changed a setpoint. When the thermostat is in `heat_cool` mode, `temperature` (the single-setpoint attribute) is `None` — only `target_temp_low` and `target_temp_high` are populated.
+
+The fix gates attribute selection on the current thermostat mode:
+
+| Thermostat mode | Attribute read for setpoint check |
+|---|---|
+| `heat_cool` | `target_temp_low` and `target_temp_high` |
+| `heat`, `cool`, `off`, other | `temperature` (single-setpoint attribute) |
+
+The grace-period trigger in the same block also now compares against `ae._last_commanded_hvac_mode` rather than `classification.hvac_mode`, consistent with the Bug C fix above.
+
+#### `hvac_mode` in Coordinator Data (Issue #269 Bug B)
+
+`hvac_mode` — the thermostat's current operating mode string (`"heat_cool"`, `"cool"`, `"heat"`, `"off"`) — is now included in the coordinator's data dict returned by `_async_update_data()`. `_detect_and_emit_incidents()` reads it from `coordinator.data` to populate incident records with the actual thermostat mode at detection time, rather than deriving it indirectly from other attributes.
 
 **Test coverage:** `tests/test_override_automation_boundary.py` — compound guard invariant.
 
@@ -1705,4 +1738,4 @@ Issue #125 adds a `thermal_pipeline` key to the debug-state API response. This k
 
 ---
 
-_Last Updated: 2026-06-08_
+_Last Updated: 2026-06-11_

--- a/tests/test_heat_cool_override.py
+++ b/tests/test_heat_cool_override.py
@@ -340,10 +340,7 @@ class TestBugBHvacModeInData:
         import ast
         import pathlib
 
-        coordinator_path = pathlib.Path(
-            "c:/Users/David/Documents/VSCode Projects/ClimateAdvisor-issue-269"
-            "/custom_components/climate_advisor/coordinator.py"
-        )
+        coordinator_path = pathlib.Path(__file__).parent.parent / "custom_components/climate_advisor/coordinator.py"
         source = coordinator_path.read_text(encoding="utf-8")
         tree = ast.parse(source)
 
@@ -371,10 +368,7 @@ class TestBugBHvacModeInData:
         import ast
         import pathlib
 
-        coordinator_path = pathlib.Path(
-            "c:/Users/David/Documents/VSCode Projects/ClimateAdvisor-issue-269"
-            "/custom_components/climate_advisor/coordinator.py"
-        )
+        coordinator_path = pathlib.Path(__file__).parent.parent / "custom_components/climate_advisor/coordinator.py"
         source = coordinator_path.read_text(encoding="utf-8")
         tree = ast.parse(source)
 

--- a/tests/test_heat_cool_override.py
+++ b/tests/test_heat_cool_override.py
@@ -1,0 +1,690 @@
+"""Regression tests for Issue #269 — four heat_cool override visibility bugs.
+
+Bug A: Fan mode change suppression window too short (30s) for cloud thermostats.
+       Fix: also guard on _is_expected_confirmation (120s window).
+
+Bug B: hvac_mode missing from coordinator.data dict.
+       Fix: add "hvac_mode": hvac_mode entry to the result dict in _async_update_data.
+
+Bug C: heat_cool → cool mode switch not detected as manual override.
+       Fix: compare against _last_commanded_hvac_mode instead of classification.hvac_mode.
+
+Bug D: Dual setpoint changes (target_temp_high/low) invisible in heat_cool mode.
+       Fix: detect target_temp_high/low changes when state == "heat_cool".
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+import types
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# ── HA module stubs ──────────────────────────────────────────────────────────
+if "homeassistant" not in sys.modules:
+    from conftest import _install_ha_stubs
+
+    _install_ha_stubs()
+
+# Provide a stable dt_util.now so isoformat() calls work
+_NOW_BASE = datetime(2026, 6, 11, 14, 0, 0, tzinfo=UTC)
+sys.modules["homeassistant.util.dt"].now = lambda: _NOW_BASE
+
+from custom_components.climate_advisor.classifier import DayClassification  # noqa: E402
+from custom_components.climate_advisor.learning import DailyRecord  # noqa: E402
+
+# ── Constants ────────────────────────────────────────────────────────────────
+
+_THERMOSTAT_ID = "climate.thermostat"
+_PATCH_CALLBACK = "custom_components.climate_advisor.coordinator.callback"
+_PATCH_DT_UTIL = "custom_components.climate_advisor.coordinator.dt_util"
+
+
+# ── Shared helpers ────────────────────────────────────────────────────────────
+
+
+def _consume_coroutine(coro):
+    """Close a coroutine to prevent 'never awaited' RuntimeWarning."""
+    if asyncio.iscoroutine(coro):
+        coro.close()
+
+
+def _get_coordinator_class():
+    """Return the current ClimateAdvisorCoordinator class (fresh import each call)."""
+    mod = importlib.import_module("custom_components.climate_advisor.coordinator")
+    return mod.ClimateAdvisorCoordinator
+
+
+def _make_classification(**overrides):
+    """Build a DayClassification bypassing __post_init__ validation."""
+    c = object.__new__(DayClassification)
+    defaults = {
+        "day_type": "hot",
+        "trend_direction": "stable",
+        "trend_magnitude": 0,
+        "today_high": 96,
+        "today_low": 72,
+        "tomorrow_high": 94,
+        "tomorrow_low": 70,
+        "hvac_mode": "cool",
+        "pre_condition": False,
+        "pre_condition_target": None,
+        "windows_recommended": False,
+        "window_open_time": None,
+        "window_close_time": None,
+        "setback_modifier": 0.0,
+        "window_opportunity_morning": False,
+        "window_opportunity_evening": False,
+    }
+    defaults.update(overrides)
+    c.__dict__.update(defaults)
+    return c
+
+
+def _make_coordinator_stub(
+    *,
+    # Automation engine flags
+    hvac_command_pending: bool = False,
+    temp_command_pending: bool = False,
+    fan_command_pending: bool = False,
+    fan_override_active: bool = False,
+    manual_override_active: bool = False,
+    override_confirm_pending: bool = False,
+    # _last_commanded_hvac_mode / time (for _is_expected_confirmation and Bug C/D)
+    last_commanded_hvac_mode: str | None = None,
+    last_commanded_hvac_time: datetime | None = None,
+    # Classification
+    classification: DayClassification | None = None,
+    # _is_recent_hvac_command behaviour
+    hvac_command_age_seconds: float | None = None,
+):
+    """Build a minimal coordinator-like object for testing _async_thermostat_changed."""
+    hass = MagicMock()
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+    hass.async_create_task = MagicMock(side_effect=_consume_coroutine)
+
+    ClimateAdvisorCoordinator = _get_coordinator_class()
+    coord = object.__new__(ClimateAdvisorCoordinator)
+    coord.hass = hass
+    coord.config = {
+        "climate_entity": _THERMOSTAT_ID,
+        "weather_entity": "weather.forecast_home",
+        "comfort_heat": 70,
+        "comfort_cool": 75,
+    }
+
+    # Automation engine — MagicMock (NOT AsyncMock) per project convention
+    ae = MagicMock()
+    ae.is_paused_by_door = False
+    ae._hvac_command_pending = hvac_command_pending
+    ae._manual_override_active = manual_override_active
+    ae._override_confirm_pending = override_confirm_pending
+    ae._pause_active = False
+    ae._fan_command_pending = fan_command_pending
+    ae._fan_override_active = fan_override_active
+    ae._temp_command_pending = temp_command_pending
+    ae._temp_command_time = None
+    ae._fan_active = False
+    ae._natural_vent_active = False
+    # Bug A / C / D — explicit values (not truthy MagicMock defaults)
+    ae._last_commanded_hvac_mode = last_commanded_hvac_mode
+    ae._last_commanded_hvac_time = last_commanded_hvac_time
+    ae.handle_manual_override_during_pause = AsyncMock()
+    ae.handle_manual_override = MagicMock()
+    ae.handle_fan_manual_override = MagicMock()
+    coord.automation_engine = ae
+
+    coord._current_classification = classification if classification is not None else _make_classification()
+    coord._today_record = DailyRecord(date="2026-06-11", day_type="hot", trend_direction="stable")
+    coord._async_save_state = AsyncMock()
+
+    coord._is_recent_temp_command = MagicMock(return_value=False)
+
+    if hvac_command_age_seconds is None:
+        coord._is_recent_hvac_command = MagicMock(return_value=False)
+    else:
+
+        def _is_recent(threshold_seconds: float = 3.0) -> bool:
+            return hvac_command_age_seconds < threshold_seconds
+
+        coord._is_recent_hvac_command = _is_recent
+
+    coord._emit_event = MagicMock()
+    coord._hvac_on_since = None
+    coord._pending_thermal_event = None
+    coord._pre_heat_sample_buffer = []
+    coord._flush_hvac_runtime = MagicMock()
+    coord._start_hvac_observation = AsyncMock()
+    # _end_hvac_active_phase and _abandon_observation are sync calls (not awaited)
+    coord._end_hvac_active_phase = MagicMock()
+    coord._abandon_observation = MagicMock()
+    coord._get_indoor_temp = MagicMock(return_value=76.0)
+    coord._get_outdoor_temp = MagicMock(return_value=96.0)
+    coord._chart_log = MagicMock()
+    # Suppress chart helpers — wrapped in contextlib.suppress in coordinator anyway
+    coord._read_chart_hvac_action = MagicMock(return_value="cool")
+    coord._fan_is_running = MagicMock(return_value=False)
+    coord._any_sensor_open = MagicMock(return_value=False)
+
+    # Bind the real method under test
+    coord._async_thermostat_changed = types.MethodType(ClimateAdvisorCoordinator._async_thermostat_changed, coord)
+
+    return coord
+
+
+def _make_event(
+    old_hvac_mode: str = "heat_cool",
+    new_hvac_mode: str = "heat_cool",
+    old_temp: float | None = None,
+    new_temp: float | None = None,
+    old_target_high: float | None = None,
+    new_target_high: float | None = None,
+    old_target_low: float | None = None,
+    new_target_low: float | None = None,
+    old_fan_mode: str | None = None,
+    new_fan_mode: str | None = None,
+):
+    """Build a minimal HA state-change event for thermostat changes."""
+    old_attrs: dict = {"hvac_action": ""}
+    new_attrs: dict = {"hvac_action": ""}
+
+    if old_temp is not None:
+        old_attrs["temperature"] = old_temp
+    if new_temp is not None:
+        new_attrs["temperature"] = new_temp
+    if old_target_high is not None:
+        old_attrs["target_temp_high"] = old_target_high
+    if new_target_high is not None:
+        new_attrs["target_temp_high"] = new_target_high
+    if old_target_low is not None:
+        old_attrs["target_temp_low"] = old_target_low
+    if new_target_low is not None:
+        new_attrs["target_temp_low"] = new_target_low
+    if old_fan_mode is not None:
+        old_attrs["fan_mode"] = old_fan_mode
+    if new_fan_mode is not None:
+        new_attrs["fan_mode"] = new_fan_mode
+
+    old_state = MagicMock()
+    old_state.state = old_hvac_mode
+    old_state.attributes = old_attrs
+
+    new_state = MagicMock()
+    new_state.state = new_hvac_mode
+    new_state.attributes = new_attrs
+
+    event = MagicMock()
+    event.data = {"old_state": old_state, "new_state": new_state}
+    return event
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Bug A — Fan mode change suppression window (120s expected-confirmation guard)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestBugAFanOverrideSuppression:
+    """Fan mode changes arriving within 120s of CA's HVAC command are CA side-effects,
+    not user overrides. Changes arriving after 120s are genuine user overrides.
+
+    Without the fix, a cloud thermostat's fan_mode side-effect arriving at 35–90s
+    (after the 30s _is_recent_hvac_command window) incorrectly fires handle_fan_manual_override.
+    The fix adds `and not _is_expected_confirmation` to the fan_mode guard.
+    """
+
+    def test_fan_mode_change_within_120s_of_hvac_command_suppressed(self):
+        """Fan mode change arriving 60s after CA HVAC command → NOT a manual override.
+
+        _is_expected_confirmation is True (new_state.state == last_commanded_mode,
+        within 120s), so handle_fan_manual_override must NOT be called.
+        """
+        # HVAC command 60s ago; dt_util.now() patched so time math works
+        cmd_time = _NOW_BASE - timedelta(seconds=60)
+        coord = _make_coordinator_stub(
+            last_commanded_hvac_mode="heat_cool",
+            last_commanded_hvac_time=cmd_time,
+            hvac_command_age_seconds=60.0,  # past 30s _is_recent_hvac_command window
+        )
+
+        event = _make_event(
+            old_hvac_mode="heat_cool",
+            new_hvac_mode="heat_cool",  # matches last_commanded → _is_expected_confirmation True
+            old_fan_mode="auto",
+            new_fan_mode="on",
+        )
+
+        mock_dt = MagicMock()
+        mock_dt.now.return_value = _NOW_BASE
+        with patch(_PATCH_CALLBACK, side_effect=lambda fn: fn), patch(_PATCH_DT_UTIL, mock_dt):
+            asyncio.run(coord._async_thermostat_changed(event))
+
+        assert coord.automation_engine.handle_fan_manual_override.call_count == 0, (
+            "handle_fan_manual_override() must NOT be called when the fan_mode change "
+            "arrives within 120s of a CA HVAC command (cloud thermostat side-effect). "
+            "Bug A fix: add `and not _is_expected_confirmation` to the fan guard."
+        )
+
+    def test_fan_mode_change_after_120s_is_genuine_override(self):
+        """Fan mode change arriving 130s after CA HVAC command → IS a manual override.
+
+        _is_expected_confirmation is False (>120s), handle_fan_manual_override must fire.
+        """
+        cmd_time = _NOW_BASE - timedelta(seconds=130)
+        coord = _make_coordinator_stub(
+            last_commanded_hvac_mode="heat_cool",
+            last_commanded_hvac_time=cmd_time,
+            hvac_command_age_seconds=130.0,  # also past _is_recent_hvac_command 30s window
+        )
+
+        event = _make_event(
+            old_hvac_mode="heat_cool",
+            new_hvac_mode="heat_cool",
+            old_fan_mode="auto",
+            new_fan_mode="on",
+        )
+
+        mock_dt = MagicMock()
+        mock_dt.now.return_value = _NOW_BASE
+        with patch(_PATCH_CALLBACK, side_effect=lambda fn: fn), patch(_PATCH_DT_UTIL, mock_dt):
+            asyncio.run(coord._async_thermostat_changed(event))
+
+        assert coord.automation_engine.handle_fan_manual_override.call_count == 1, (
+            "handle_fan_manual_override() SHOULD be called when fan_mode changes 130s "
+            "after a CA HVAC command (past the 120s _is_expected_confirmation window). "
+            "Bug A fix must not suppress genuine overrides outside the window."
+        )
+
+    def test_fan_mode_change_with_no_prior_command_fires_override(self):
+        """Fan mode change with no prior CA command at all → genuine override fires."""
+        coord = _make_coordinator_stub(
+            last_commanded_hvac_mode=None,
+            last_commanded_hvac_time=None,
+        )
+
+        event = _make_event(
+            old_hvac_mode="cool",
+            new_hvac_mode="cool",
+            old_fan_mode="auto",
+            new_fan_mode="on",
+        )
+
+        with patch(_PATCH_CALLBACK, side_effect=lambda fn: fn):
+            asyncio.run(coord._async_thermostat_changed(event))
+
+        assert coord.automation_engine.handle_fan_manual_override.call_count == 1, (
+            "handle_fan_manual_override() must fire when there is no prior CA command "
+            "and no recent HVAC command (pure manual fan override)."
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Bug B — hvac_mode in coordinator.data
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestBugBHvacModeInData:
+    """hvac_mode must appear in coordinator.data after _async_update_data.
+
+    Without the fix, _detect_and_emit_incidents() reads current_data.get("hvac_mode") → None,
+    making HVAC mode incidents invisible.
+    """
+
+    def test_hvac_mode_key_present_in_result_dict(self):
+        """The result dict built in _async_update_data must include 'hvac_mode'."""
+        # We test this by reading the coordinator.py source and confirming the key is set,
+        # and by building a minimal result dict replica to verify key presence.
+        # (Full coordinator instantiation requires live HA; we use source inspection instead.)
+        import ast
+        import pathlib
+
+        coordinator_path = pathlib.Path(
+            "c:/Users/David/Documents/VSCode Projects/ClimateAdvisor-issue-269"
+            "/custom_components/climate_advisor/coordinator.py"
+        )
+        source = coordinator_path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+
+        # Walk the AST looking for the result dict assignment
+        found = False
+        for node in ast.walk(tree):
+            # Look for: result = { ..., "hvac_mode": hvac_mode, ... }
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name) and target.id == "result" and isinstance(node.value, ast.Dict):
+                        for key in node.value.keys:
+                            if isinstance(key, ast.Constant) and key.value == "hvac_mode":
+                                found = True
+        assert found, (
+            "The 'result' dict in _async_update_data must include the key 'hvac_mode'. "
+            'Bug B fix: add `"hvac_mode": hvac_mode` between ATTR_HVAC_ACTION and '
+            "ATTR_HVAC_RUNTIME_TODAY entries."
+        )
+
+    def test_hvac_mode_key_is_string_not_attr_constant(self):
+        """The hvac_mode key must be the literal string 'hvac_mode', not a module constant.
+
+        _detect_and_emit_incidents() reads current_data.get('hvac_mode') by string key.
+        """
+        import ast
+        import pathlib
+
+        coordinator_path = pathlib.Path(
+            "c:/Users/David/Documents/VSCode Projects/ClimateAdvisor-issue-269"
+            "/custom_components/climate_advisor/coordinator.py"
+        )
+        source = coordinator_path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name) and target.id == "result" and isinstance(node.value, ast.Dict):
+                        for key in node.value.keys:
+                            if isinstance(key, ast.Constant) and key.value == "hvac_mode":
+                                return  # found string literal key — pass
+        # If we reach here without finding it as a string literal:
+        raise AssertionError(
+            "The key 'hvac_mode' in the result dict must be a plain string literal "
+            "so that current_data.get('hvac_mode') works in _detect_and_emit_incidents()."
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Bug C — heat_cool → cool mode switch detected as override
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestBugCHeatCoolModeSwitchDetection:
+    """heat_cool → cool transition must be detected as a manual override.
+
+    Without the fix: new_state.state ("cool") != classification.hvac_mode ("cool") = False
+    → no override.
+
+    With the fix: compare against _last_commanded_hvac_mode ("heat_cool"),
+    so "cool" != "heat_cool" = True → override fires.
+    """
+
+    def test_heat_cool_to_cool_fires_override_when_ca_commanded_heat_cool(self):
+        """User switches heat_cool → cool while CA last commanded heat_cool.
+
+        Occupant experience: housemate turns off the heating band on a 96°F day
+        and CA must recognize this as an intentional override.
+        """
+        cmd_time = _NOW_BASE - timedelta(minutes=10)  # outside 120s window
+        coord = _make_coordinator_stub(
+            last_commanded_hvac_mode="heat_cool",
+            last_commanded_hvac_time=cmd_time,
+            classification=_make_classification(hvac_mode="cool"),
+        )
+        # The mode change is old enough that _is_expected_confirmation is False
+        # (new_state.state == "cool" != "heat_cool" == last_commanded_mode)
+        coord._is_recent_hvac_command = MagicMock(return_value=False)
+
+        event = _make_event(
+            old_hvac_mode="heat_cool",
+            new_hvac_mode="cool",
+        )
+
+        mock_dt = MagicMock()
+        mock_dt.now.return_value = _NOW_BASE
+        with patch(_PATCH_CALLBACK, side_effect=lambda fn: fn), patch(_PATCH_DT_UTIL, mock_dt):
+            asyncio.run(coord._async_thermostat_changed(event))
+
+        assert coord.automation_engine.handle_manual_override.call_count == 1, (
+            "handle_manual_override() must fire when the thermostat switches from "
+            "heat_cool to cool while CA last commanded heat_cool. "
+            "Bug C fix: compare against _last_commanded_hvac_mode, not classification.hvac_mode. "
+            "Without the fix, 'cool' == classification.hvac_mode ('cool') → no override detected."
+        )
+
+    def test_heat_cool_to_cool_no_prior_command_uses_classification_fallback(self):
+        """When no prior CA command exists, fall back to classification.hvac_mode for comparison.
+
+        If classification says 'cool' and thermostat switches to 'cool', no override
+        (the thermostat is doing what CA would want). This verifies the fallback logic.
+        """
+        coord = _make_coordinator_stub(
+            last_commanded_hvac_mode=None,
+            last_commanded_hvac_time=None,
+            classification=_make_classification(hvac_mode="cool"),
+        )
+        coord._is_recent_hvac_command = MagicMock(return_value=False)
+
+        event = _make_event(
+            old_hvac_mode="heat_cool",
+            new_hvac_mode="cool",  # matches classification fallback "cool"
+        )
+
+        # _last_cmd_mode is None → _is_expected_confirmation short-circuits, no now() call needed
+        with patch(_PATCH_CALLBACK, side_effect=lambda fn: fn):
+            asyncio.run(coord._async_thermostat_changed(event))
+
+        # new_state.state "cool" == classification.hvac_mode "cool" → no override
+        assert coord.automation_engine.handle_manual_override.call_count == 0, (
+            "When no prior CA command exists and thermostat switches to the mode "
+            "classification already wants ('cool'), no override should be detected. "
+            "The fallback to classification.hvac_mode must work correctly."
+        )
+
+    def test_cool_to_off_fires_override_when_ca_commanded_heat_cool(self):
+        """User turns thermostat off while CA last commanded heat_cool → override."""
+        cmd_time = _NOW_BASE - timedelta(minutes=10)
+        coord = _make_coordinator_stub(
+            last_commanded_hvac_mode="heat_cool",
+            last_commanded_hvac_time=cmd_time,
+            classification=_make_classification(hvac_mode="cool"),
+        )
+        coord._is_recent_hvac_command = MagicMock(return_value=False)
+
+        event = _make_event(
+            old_hvac_mode="cool",
+            new_hvac_mode="off",
+        )
+
+        mock_dt = MagicMock()
+        mock_dt.now.return_value = _NOW_BASE
+        with patch(_PATCH_CALLBACK, side_effect=lambda fn: fn), patch(_PATCH_DT_UTIL, mock_dt):
+            asyncio.run(coord._async_thermostat_changed(event))
+
+        assert coord.automation_engine.handle_manual_override.call_count == 1, (
+            "Turning thermostat off while CA commanded heat_cool must register as override."
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Bug D — Dual setpoint changes visible in heat_cool mode
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestBugDHeatCoolSetpointDetection:
+    """target_temp_high / target_temp_low changes in heat_cool mode must be detected.
+
+    Without the fix, the guard reads attributes.get("temperature") which is None
+    in heat_cool mode → None != None = False → no override detected.
+
+    The occupant experience: a housemate on a 96°F day raises the cooling setpoint
+    from 72 to 74, and CA never notices — no grace period, no learning signal.
+    """
+
+    def test_target_temp_high_change_increments_override_count(self):
+        """target_temp_high 72 → 74 in heat_cool mode → manual_overrides incremented."""
+        cmd_time = _NOW_BASE - timedelta(minutes=5)
+        coord = _make_coordinator_stub(
+            last_commanded_hvac_mode="heat_cool",
+            last_commanded_hvac_time=cmd_time,
+        )
+        initial = coord._today_record.manual_overrides
+
+        event = _make_event(
+            old_hvac_mode="heat_cool",
+            new_hvac_mode="heat_cool",
+            old_target_high=72.0,
+            new_target_high=74.0,
+            old_target_low=68.0,
+            new_target_low=68.0,
+        )
+
+        mock_dt = MagicMock()
+        mock_dt.now.return_value = _NOW_BASE
+        with patch(_PATCH_CALLBACK, side_effect=lambda fn: fn), patch(_PATCH_DT_UTIL, mock_dt):
+            asyncio.run(coord._async_thermostat_changed(event))
+
+        assert coord._today_record.manual_overrides == initial + 1, (
+            f"Expected manual_overrides={initial + 1}, got {coord._today_record.manual_overrides}. "
+            "Bug D fix: detect target_temp_high changes when state == 'heat_cool'. "
+            "Without the fix, the guard reads 'temperature' (None in heat_cool) → no override."
+        )
+
+    def test_target_temp_low_change_increments_override_count(self):
+        """target_temp_low 68 → 66 in heat_cool mode → manual_overrides incremented."""
+        cmd_time = _NOW_BASE - timedelta(minutes=5)
+        coord = _make_coordinator_stub(
+            last_commanded_hvac_mode="heat_cool",
+            last_commanded_hvac_time=cmd_time,
+        )
+        initial = coord._today_record.manual_overrides
+
+        event = _make_event(
+            old_hvac_mode="heat_cool",
+            new_hvac_mode="heat_cool",
+            old_target_high=72.0,
+            new_target_high=72.0,
+            old_target_low=68.0,
+            new_target_low=66.0,
+        )
+
+        mock_dt = MagicMock()
+        mock_dt.now.return_value = _NOW_BASE
+        with patch(_PATCH_CALLBACK, side_effect=lambda fn: fn), patch(_PATCH_DT_UTIL, mock_dt):
+            asyncio.run(coord._async_thermostat_changed(event))
+
+        assert coord._today_record.manual_overrides == initial + 1, (
+            f"Expected manual_overrides={initial + 1}, got {coord._today_record.manual_overrides}. "
+            "target_temp_low change in heat_cool mode must also be detected."
+        )
+
+    def test_heat_cool_setpoint_fires_handle_manual_override(self):
+        """target_temp_high change in heat_cool mode → handle_manual_override(source='setpoint') called.
+
+        CA last commanded 'heat_cool', no override active, no pending flags.
+        """
+        cmd_time = _NOW_BASE - timedelta(minutes=5)
+        coord = _make_coordinator_stub(
+            last_commanded_hvac_mode="heat_cool",
+            last_commanded_hvac_time=cmd_time,
+            classification=_make_classification(hvac_mode="cool"),
+        )
+
+        event = _make_event(
+            old_hvac_mode="heat_cool",
+            new_hvac_mode="heat_cool",
+            old_target_high=72.0,
+            new_target_high=74.0,
+            old_target_low=68.0,
+            new_target_low=68.0,
+        )
+
+        mock_dt = MagicMock()
+        mock_dt.now.return_value = _NOW_BASE
+        with patch(_PATCH_CALLBACK, side_effect=lambda fn: fn), patch(_PATCH_DT_UTIL, mock_dt):
+            asyncio.run(coord._async_thermostat_changed(event))
+
+        ae = coord.automation_engine
+        assert ae.handle_manual_override.call_count == 1, (
+            "handle_manual_override() must be called when target_temp_high changes in "
+            "heat_cool mode and CA is actively controlling heat_cool. "
+            "Bug D fix: use _last_commanded_hvac_mode for the mode comparison guard."
+        )
+        call_kwargs = ae.handle_manual_override.call_args
+        assert call_kwargs is not None
+        kwargs = call_kwargs.kwargs if call_kwargs.kwargs else {}
+        assert kwargs.get("source") == "setpoint", (
+            f"Expected source='setpoint', got: {kwargs}. "
+            "The override must be tagged as a setpoint change, not a mode change."
+        )
+
+    def test_heat_cool_setpoint_no_change_not_counted(self):
+        """target_temp_high and target_temp_low both unchanged → no override."""
+        cmd_time = _NOW_BASE - timedelta(minutes=5)
+        coord = _make_coordinator_stub(
+            last_commanded_hvac_mode="heat_cool",
+            last_commanded_hvac_time=cmd_time,
+        )
+        initial = coord._today_record.manual_overrides
+
+        event = _make_event(
+            old_hvac_mode="heat_cool",
+            new_hvac_mode="heat_cool",
+            old_target_high=72.0,
+            new_target_high=72.0,  # unchanged
+            old_target_low=68.0,
+            new_target_low=68.0,  # unchanged
+        )
+
+        mock_dt = MagicMock()
+        mock_dt.now.return_value = _NOW_BASE
+        with patch(_PATCH_CALLBACK, side_effect=lambda fn: fn), patch(_PATCH_DT_UTIL, mock_dt):
+            asyncio.run(coord._async_thermostat_changed(event))
+
+        assert coord._today_record.manual_overrides == initial, (
+            "No setpoint change → manual_overrides must not be incremented."
+        )
+
+    def test_non_heat_cool_mode_uses_temperature_attribute(self):
+        """In 'cool' mode (not heat_cool), the guard uses 'temperature' attribute as before."""
+        cmd_time = _NOW_BASE - timedelta(minutes=5)
+        coord = _make_coordinator_stub(
+            last_commanded_hvac_mode="cool",
+            last_commanded_hvac_time=cmd_time,
+            classification=_make_classification(hvac_mode="cool"),
+        )
+        initial = coord._today_record.manual_overrides
+
+        event = _make_event(
+            old_hvac_mode="cool",
+            new_hvac_mode="cool",
+            old_temp=72.0,
+            new_temp=74.0,
+        )
+
+        mock_dt = MagicMock()
+        mock_dt.now.return_value = _NOW_BASE
+        with patch(_PATCH_CALLBACK, side_effect=lambda fn: fn), patch(_PATCH_DT_UTIL, mock_dt):
+            asyncio.run(coord._async_thermostat_changed(event))
+
+        assert coord._today_record.manual_overrides == initial + 1, (
+            "In non-heat_cool mode, 'temperature' attribute change must still be detected. "
+            "The Bug D fix must not break single-setpoint thermostat detection."
+        )
+
+    def test_heat_cool_setpoint_suppressed_when_temp_command_pending(self):
+        """target_temp_high change when _temp_command_pending=True → not counted (CA did it)."""
+        cmd_time = _NOW_BASE - timedelta(minutes=5)
+        coord = _make_coordinator_stub(
+            last_commanded_hvac_mode="heat_cool",
+            last_commanded_hvac_time=cmd_time,
+            temp_command_pending=True,
+        )
+        initial = coord._today_record.manual_overrides
+
+        event = _make_event(
+            old_hvac_mode="heat_cool",
+            new_hvac_mode="heat_cool",
+            old_target_high=72.0,
+            new_target_high=74.0,
+            old_target_low=68.0,
+            new_target_low=68.0,
+        )
+
+        mock_dt = MagicMock()
+        mock_dt.now.return_value = _NOW_BASE
+        with patch(_PATCH_CALLBACK, side_effect=lambda fn: fn), patch(_PATCH_DT_UTIL, mock_dt):
+            asyncio.run(coord._async_thermostat_changed(event))
+
+        assert coord._today_record.manual_overrides == initial, (
+            "Setpoint change when _temp_command_pending=True must NOT be counted "
+            "(CA issued the setpoint command itself)."
+        )

--- a/tests/test_temp_command_guard.py
+++ b/tests/test_temp_command_guard.py
@@ -97,6 +97,10 @@ def _make_coord(*, temp_command_time: datetime | None = None):
     ae._hvac_command_time = None
     ae._manual_override_active = False
     ae._override_confirm_pending = False
+    # Must be explicitly None (not truthy MagicMock) so Bug C/D _ca_active_mode
+    # falls back to classification.hvac_mode correctly.
+    ae._last_commanded_hvac_mode = None
+    ae._last_commanded_hvac_time = None
     ae.handle_manual_override_during_pause = AsyncMock()
     ae.handle_manual_override = MagicMock()
     ae.handle_fan_manual_override = MagicMock()


### PR DESCRIPTION
## Summary

Four independent bugs made manual overrides invisible when the thermostat was in `heat_cool` mode (dual setpoint, Issue #249). On a 96°F day, the housemate tried to adjust the thermostat but CA silently reverted every attempt.

## Bugs fixed

**Bug A — False fan_manual_override from cloud thermostat echo**
CA's `heat_cool` mode command causes the thermostat's `fan_mode` attribute to change as a side effect. Ecobee-class cloud devices report this back in 30-120s — after the 30s guard had expired. CA called `handle_fan_manual_override()` for its own action, starting a spurious 90-min grace period at the worst time (hot day morning pre-cool window).

Fix: add `and not _is_expected_confirmation` to the fan_mode detection guard — a 120s tertiary layer (same window as the existing HVAC mode-change suppression). The 30s inner guard is unchanged.

**Bug B — `hvac_mode=null` in incident records**
`hvac_mode` was computed in `_async_update_data()` but never stored in `coordinator.data`. Every `incident_detected` event captured `hvac_mode=null`. Fix: one line added to the result dict.

**Bug C — `heat_cool → cool` mode switch not detected as override**
Override detection compared `new_state.state != classification.hvac_mode`. Classification emits `"cool"` for hot days; CA commands `"heat_cool"` for dual-setpoint thermostats. So `"cool" != "cool"` = False → no override detected, no grace period, CA re-armed `heat_cool` silently every 30 min.

Fix: compare against `_last_commanded_hvac_mode or classification.hvac_mode` — the mode CA actually commanded, not the abstract classification.

**Bug D — Dual setpoint changes completely invisible**
Setpoint detection read `attributes.get("temperature")` = None in heat_cool mode (thermostats expose `target_temp_high`/`target_temp_low`). Even if not None, the grace trigger required `state == classification.hvac_mode` → `heat_cool != cool`. Two-layer blindness.

Fix: gate on `state == "heat_cool"` to read the correct attributes; use `_last_commanded_hvac_mode` for the grace trigger comparison.

## Test plan

- [ ] 14 new regression tests in `tests/test_heat_cool_override.py`; 7 confirmed to fail without the fixes
- [ ] Full suite: 2455/2455 passing, zero warnings-as-errors
- [ ] Opus verification: correctness, security, logging all PASS

Closes #268
Closes #269