### PR TITLE
Fix #239: add _fan_command_time race guard for fan activation echoes

### DIFF
--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -413,6 +413,7 @@ class AutomationEngine:
         self._temp_command_pending: bool = False  # transient: distinguishes integration vs manual temp changes
         self._temp_command_time: datetime | None = None  # last system-initiated temp setpoint command timestamp
         self._hvac_command_time: datetime | None = None  # last system-initiated HVAC command timestamp
+        self._fan_command_time: datetime | None = None  # last system-initiated fan command timestamp (race guard)
         self._last_commanded_hvac_mode: str | None = None  # expected-state tracking: last mode automation commanded
         self._last_commanded_hvac_time: datetime | None = None  # expected-state tracking: when it was commanded
 
@@ -2450,6 +2451,7 @@ class AutomationEngine:
             _LOGGER.info("[DRY RUN] Would activate fan — %s", reason)
             return
 
+        self._fan_command_time = dt_util.now()
         self._fan_command_pending = True
         try:
             if fan_mode in (FAN_MODE_WHOLE_HOUSE, FAN_MODE_BOTH):
@@ -2495,6 +2497,7 @@ class AutomationEngine:
             _LOGGER.info("[DRY RUN] Would deactivate fan — %s", reason)
             return
 
+        self._fan_command_time = dt_util.now()
         self._fan_command_pending = True
         try:
             if fan_mode in (FAN_MODE_WHOLE_HOUSE, FAN_MODE_BOTH):

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -1050,6 +1050,13 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             return False
         return (dt_util.now() - cmd_time).total_seconds() < threshold_seconds
 
+    def _is_recent_fan_command(self, threshold_seconds: float = 30.0) -> bool:
+        """Check if a fan command was issued recently (race guard)."""
+        cmd_time = self.automation_engine._fan_command_time
+        if cmd_time is None:
+            return False
+        return (dt_util.now() - cmd_time).total_seconds() < threshold_seconds
+
     def _any_sensor_open(self) -> bool:
         """Return True if any monitored contact sensor is currently open."""
         return any(self._is_sensor_open(s) for s in self._resolved_sensors)
@@ -2546,6 +2553,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             and not self.automation_engine._hvac_command_pending
             and not self._is_recent_hvac_command(threshold_seconds=30.0)
             and not _is_expected_confirmation
+            and not self._is_recent_fan_command(threshold_seconds=30.0)
         ):
             _LOGGER.info(
                 "Manual HVAC fan_mode change detected: %s -> %s",
@@ -2570,6 +2578,10 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
 
         # Skip if fan override is already active
         if self.automation_engine._fan_override_active:
+            return
+
+        # Skip if a fan command was issued recently (cloud thermostat echo guard)
+        if self._is_recent_fan_command(threshold_seconds=30.0):
             return
 
         on_states = {"on"}

--- a/docs/08-COMPUTATION-REFERENCE.md
+++ b/docs/08-COMPUTATION-REFERENCE.md
@@ -965,10 +965,11 @@ The coordinator maintains five internal fields to manage fan state across activa
 | `_fan_override_active` | `bool` | Whether a user manual fan override is in effect |
 | `_fan_override_time` | `datetime \| None` | Timestamp of when the fan override was detected |
 | `_fan_command_pending` | `bool` | Set to `True` immediately before the integration issues a fan command; cleared immediately after |
+| `_fan_command_time` | `datetime \| None` | Timestamp recorded at the start of every `_activate_fan()` and `_deactivate_fan()` call; used by `_is_recent_fan_command()` as a timestamp-based secondary guard |
 
-**`_activate_fan()`** sets `_fan_command_pending = True`, issues the fan-on service call, then sets `_fan_active = True` and records `_fan_on_since`. If `_fan_override_active` is `True` at activation time, the call is skipped so the integration does not fight the user's manual setting.
+**`_activate_fan()`** sets `_fan_command_time = dt_util.now()` and `_fan_command_pending = True`, issues the fan-on service call, then sets `_fan_active = True` and records `_fan_on_since`. If `_fan_override_active` is `True` at activation time, the call is skipped so the integration does not fight the user's manual setting.
 
-**`_deactivate_fan()`** follows the same pattern in reverse: sets `_fan_command_pending = True`, issues the fan-off service call, then clears `_fan_active` and `_fan_on_since`. Override state is not checked on deactivation — the intent is always to stop the fan when the economizer or transition logic calls for it.
+**`_deactivate_fan()`** follows the same pattern in reverse: sets `_fan_command_time = dt_util.now()` and `_fan_command_pending = True`, issues the fan-off service call, then clears `_fan_active` and `_fan_on_since`. Override state is not checked on deactivation — the intent is always to stop the fan when the economizer or transition logic calls for it.
 
 ### 9b. Fan Override Detection
 
@@ -976,7 +977,9 @@ Fan override detection runs in two places:
 
 1. **`_async_fan_entity_changed()`** — a state-change listener registered on the `fan_entity` (for `fan_mode == whole_house_fan` or `both`). When the entity state changes, the listener checks whether `_fan_command_pending` is set. If the flag is clear, the state change was user-initiated, not integration-initiated, and a fan override is recorded: `_fan_override_active = True`, `_fan_override_time = utcnow()`.
 
-2. **`_async_thermostat_changed()`** — the existing thermostat state listener is extended to also inspect the thermostat's `fan_mode` attribute (for `fan_mode == hvac_fan` or `both`). If the fan_mode attribute changes while `_fan_command_pending` is clear, a fan override is recorded using the same fields.
+2. **`_async_thermostat_changed()`** — the existing thermostat state listener is extended to also inspect the thermostat's `fan_mode` attribute (for `fan_mode == hvac_fan` or `both`). If the fan_mode attribute changes while `_fan_command_pending` is clear **and** `_is_recent_fan_command(30.0)` returns `False`, a fan override is recorded using the same fields. The 30-second window is required because cloud-connected thermostats can echo the integration's own `climate.set_fan_mode` call seconds after `_fan_command_pending` has already been cleared (Issue #239).
+
+The same guard applies in **`_async_fan_entity_changed()`** (belt-and-suspenders): `_fan_command_pending` is checked first; `_is_recent_fan_command(30.0)` is checked as the fallback.
 
 #### Compound command-pending guard in `_async_thermostat_changed()` (Issue #205/206)
 
@@ -995,15 +998,18 @@ All three flags must be tested together. Testing only `_hvac_command_pending` is
 
 The fix (Issue #206) expands the guard at both the pause-path and normal-path detection sites to `_hvac_command_pending OR _fan_command_pending OR _temp_command_pending`. If **any** of the three flags is `True`, the state change is treated as automation-issued and suppressed.
 
-**`_is_recent_hvac_command(threshold_seconds=3.0)`** is a secondary guard that inspects `_hvac_command_time` to catch race conditions where the flag was already cleared before the listener fired. It does not replace the flag check — it is an additional fallback for sub-second timing races.
+**`_is_recent_hvac_command(threshold_seconds=3.0)`** is a secondary guard that inspects `_hvac_command_time` to catch race conditions where the HVAC flag was already cleared before the listener fired.
 
-**`_is_expected_confirmation` (Issue #269 Bug A):** A third suppression layer for the `fan_mode` attribute-change path specifically. Cloud thermostats (e.g., Nest, Ecobee via cloud polling) sometimes echo a `fan_mode` attribute change as a delayed side-effect of an HVAC mode transition, arriving 30–120 seconds after the original command — outside the 30-second `_is_recent_hvac_command` window. When `_is_expected_confirmation` is `True`, the `fan_mode` change guard suppresses false override detection for up to 120 seconds after the last HVAC command. The three guards are evaluated in order: flag check → `_is_recent_hvac_command(30s)` → `_is_expected_confirmation(120s)`.
+**`_is_expected_confirmation` (Issue #269 Bug A):** A third suppression layer for the `fan_mode` attribute-change path specifically. Cloud thermostats (e.g., Nest, Ecobee via cloud polling) sometimes echo a `fan_mode` attribute change as a delayed side-effect of an HVAC mode transition, arriving 30–120 seconds after the original command — outside the 30-second `_is_recent_hvac_command` window. When `_is_expected_confirmation` is `True`, the `fan_mode` change guard suppresses false override detection for up to 120 seconds after the last HVAC command.
 
-| Guard | Type | Window | Purpose |
-|---|---|---|---|
-| `_hvac_command_pending OR _fan_command_pending OR _temp_command_pending` | Flag check (synchronous) | Until flag cleared | Primary: suppresses both pause-path and normal-path override detection during any automation-issued command sequence |
-| `_is_recent_hvac_command(threshold_seconds=30.0)` | Timestamp check | 30 s | Secondary fallback: catches races where the command flag was cleared before the HA state-change event arrived |
-| `_is_expected_confirmation` | Boolean flag | 120 s | Tertiary: suppresses `fan_mode` attribute changes that arrive as delayed side-effects of HVAC mode transitions on cloud thermostats |
+**`_is_recent_fan_command(threshold_seconds=30.0)` (Issue #239):** A fourth suppression layer for direct fan service calls. `climate.set_fan_mode` calls do not update `_hvac_command_time`, so `_is_recent_hvac_command()` never fires for fan-mode echoes. This guard reads `_fan_command_time` (set at the start of `_activate_fan()` and `_deactivate_fan()`) and suppresses false overrides within 30 seconds of any fan command.
+
+| Guard | Type | Applies to | Window | Purpose |
+|---|---|---|---|---|
+| `_hvac_command_pending OR _fan_command_pending OR _temp_command_pending` | Flag check (synchronous) | All command types | Until cleared | Primary: suppresses both paths during any automation-issued command |
+| `_is_recent_hvac_command(threshold_seconds=30.0)` | Timestamp check | HVAC mode / setpoint changes | 30 s | Secondary: catches races where the HVAC flag cleared before the HA event arrived |
+| `_is_expected_confirmation` | Boolean flag | Fan_mode attribute changes from HVAC mode transitions | 120 s | Tertiary: suppresses delayed fan_mode echoes from HVAC mode changes on cloud thermostats |
+| `_is_recent_fan_command(threshold_seconds=30.0)` | Timestamp check | Fan mode changes (`climate.set_fan_mode`) | 30 s | Quaternary: suppresses fan echo races where `_fan_command_pending` cleared before the HA event arrived |
 
 #### Mode Override Detection — `_last_commanded_hvac_mode` (Issue #269 Bug C)
 
@@ -1254,6 +1260,7 @@ Complete list of all constants from `const.py` that affect runtime behavior.
 | `_fan_override_active` | `False` | Whether a user manual fan override is in effect |
 | `_fan_override_time` | `None` | UTC timestamp of when the fan override was detected |
 | `_fan_command_pending` | `False` | Set during integration-issued fan commands to suppress false override detection |
+| `_fan_command_time` | `None` | UTC timestamp of the most recent `_activate_fan()` / `_deactivate_fan()` call; read by `_is_recent_fan_command()` |
 
 ---
 

--- a/tests/test_fan_command_guard.py
+++ b/tests/test_fan_command_guard.py
@@ -1,0 +1,291 @@
+"""Regression tests for the _fan_command_time race guard (Issue #239).
+
+The guard prevents CA's own fan activation/deactivation from being falsely
+detected as a manual override when the cloud thermostat echo arrives after
+_fan_command_pending has already cleared.
+
+Three scenarios:
+1. Recent fan command (within 30 s) → thermostat echo (fan_mode "auto" → "on")
+   → handle_fan_manual_override NOT called (guard suppresses it).
+2. Stale fan command (45 s ago) → fan_mode changes → override correctly detected.
+3. Recent fan command (deactivation) → fan_mode changes "on" → "auto"
+   → NOT detected as override.
+
+Also tests the _async_fan_entity_changed path for belt-and-suspenders coverage.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+import types
+from contextlib import contextmanager
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# ── HA module stubs ──────────────────────────────────────────────────────────
+if "homeassistant" not in sys.modules:
+    from conftest import _install_ha_stubs
+
+    _install_ha_stubs()
+
+_NOW = datetime(2026, 6, 11, 14, 0, 0)
+
+
+@contextmanager
+def _fixed_now(when: datetime):
+    """Temporarily pin coordinator.dt_util.now() to a fixed datetime.
+
+    coordinator.py resolves dt_util as sys.modules["homeassistant.util"].dt
+    (the attribute on the parent MagicMock), NOT sys.modules["homeassistant.util.dt"].
+    We patch only the coordinator module's name so other modules (chart_log, etc.)
+    that share the same MagicMock are unaffected.
+    """
+    coordinator_mod = importlib.import_module("custom_components.climate_advisor.coordinator")
+    with patch.object(coordinator_mod.dt_util, "now", return_value=when):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_coordinator_class():
+    mod = importlib.import_module("custom_components.climate_advisor.coordinator")
+    return mod.ClimateAdvisorCoordinator
+
+
+def _consume_coroutine(coro):
+    coro.close()
+
+
+def _make_state(state_value: str, fan_mode: str = "auto") -> MagicMock:
+    s = MagicMock()
+    s.state = state_value
+    s.attributes = {
+        "hvac_action": "idle",
+        "temperature": 70.0,
+        "fan_mode": fan_mode,
+    }
+    return s
+
+
+def _make_thermostat_event(old_state: MagicMock, new_state: MagicMock) -> MagicMock:
+    event = MagicMock()
+    event.data = {"old_state": old_state, "new_state": new_state}
+    return event
+
+
+def _make_fan_entity_event(old_state_str: str, new_state_str: str) -> MagicMock:
+    old_s = MagicMock()
+    old_s.state = old_state_str
+    new_s = MagicMock()
+    new_s.state = new_state_str
+    event = MagicMock()
+    event.data = {"old_state": old_s, "new_state": new_s}
+    return event
+
+
+def _make_coord(*, fan_command_time=None):
+    """Coordinator stub with real _async_thermostat_changed / _async_fan_entity_changed bound."""
+    ClimateAdvisorCoordinator = _get_coordinator_class()
+    coord = object.__new__(ClimateAdvisorCoordinator)
+
+    hass = MagicMock()
+    hass.async_add_executor_job = AsyncMock(return_value=None)
+    hass.async_create_task = MagicMock(side_effect=_consume_coroutine)
+    coord.hass = hass
+
+    coord.config = {
+        "climate_entity": "climate.thermostat",
+        "weather_entity": "weather.test",
+        "comfort_heat": 70,
+        "comfort_cool": 75,
+    }
+
+    ae = MagicMock()
+    ae.is_paused_by_door = False
+    ae._hvac_command_pending = False
+    ae._manual_override_active = False
+    ae._fan_command_pending = False
+    ae._fan_override_active = False
+    ae._fan_active = False
+    ae._natural_vent_active = False
+    ae._fan_override_active = False
+    ae._temp_command_pending = False
+    ae._fan_command_time = fan_command_time
+    ae._hvac_command_time = None
+    ae._temp_command_time = None
+    ae.handle_manual_override_during_pause = AsyncMock()
+    ae.handle_manual_override = MagicMock()
+    ae.handle_fan_manual_override = MagicMock()
+    coord.automation_engine = ae
+
+    from custom_components.climate_advisor.classifier import DayClassification
+
+    c = object.__new__(DayClassification)
+    c.__dict__.update(
+        {
+            "day_type": "mild",
+            "trend_direction": "stable",
+            "trend_magnitude": 0,
+            "today_high": 72,
+            "today_low": 55,
+            "tomorrow_high": 73,
+            "tomorrow_low": 56,
+            "hvac_mode": "off",
+            "pre_condition": False,
+            "pre_condition_target": None,
+            "windows_recommended": False,
+            "window_open_time": None,
+            "window_close_time": None,
+            "setback_modifier": 0.0,
+            "window_opportunity_morning": False,
+            "window_opportunity_evening": False,
+        }
+    )
+    coord._current_classification = c
+
+    from custom_components.climate_advisor.learning import DailyRecord
+
+    coord._today_record = DailyRecord(date="2026-06-11", day_type="mild", trend_direction="stable")
+    coord._async_save_state = AsyncMock()
+    coord._emit_event = MagicMock()
+    coord._hvac_on_since = None
+    coord._pending_thermal_event = None
+    coord._pre_heat_sample_buffer = []
+    coord._flush_hvac_runtime = MagicMock()
+    coord._start_hvac_observation = AsyncMock()
+    coord._end_hvac_active_phase = MagicMock()
+    coord._abandon_observation = AsyncMock()
+    coord._get_indoor_temp = MagicMock(return_value=72.0)
+    coord._get_outdoor_temp = MagicMock(return_value=65.0)
+    coord._any_sensor_open = MagicMock(return_value=False)
+    coord._cancel_all_debounce_timers = MagicMock()
+    coord._chart_log = MagicMock()
+
+    coord._async_thermostat_changed = types.MethodType(ClimateAdvisorCoordinator._async_thermostat_changed, coord)
+    coord._async_fan_entity_changed = types.MethodType(ClimateAdvisorCoordinator._async_fan_entity_changed, coord)
+    coord._is_recent_hvac_command = types.MethodType(ClimateAdvisorCoordinator._is_recent_hvac_command, coord)
+    coord._is_recent_temp_command = types.MethodType(ClimateAdvisorCoordinator._is_recent_temp_command, coord)
+    coord._is_recent_fan_command = types.MethodType(ClimateAdvisorCoordinator._is_recent_fan_command, coord)
+    return coord
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestFanCommandGuard:
+    """_is_recent_fan_command suppresses false override on CA's own fan echo."""
+
+    def test_recent_fan_command_suppresses_thermostat_echo(self):
+        """fan_command_time=now → fan_mode echo auto→on → override NOT fired.
+
+        Occupant effect: without this guard, CA's own fan activation would
+        immediately cancel the fan (override detected → fan stopped), leaving
+        the occupant with no ventilation even though CA just turned the fan on.
+        """
+        coord = _make_coord(fan_command_time=_NOW)
+
+        old_state = _make_state("cool", fan_mode="auto")
+        new_state = _make_state("cool", fan_mode="on")
+        event = _make_thermostat_event(old_state, new_state)
+
+        with _fixed_now(_NOW):
+            asyncio.run(coord._async_thermostat_changed(event))
+
+        coord.automation_engine.handle_fan_manual_override.assert_not_called()
+
+    def test_stale_fan_command_allows_override_detection(self):
+        """fan_command_time=45 s ago → fan_mode changes → override correctly detected.
+
+        Occupant effect: a user who manually adjusts the thermostat fan 45 seconds
+        after CA last touched it should still have their preference respected.
+        """
+        stale_time = _NOW - timedelta(seconds=45)
+        coord = _make_coord(fan_command_time=stale_time)
+        coord.automation_engine._fan_override_active = False
+
+        old_state = _make_state("cool", fan_mode="auto")
+        new_state = _make_state("cool", fan_mode="on")
+        event = _make_thermostat_event(old_state, new_state)
+
+        with _fixed_now(_NOW):
+            asyncio.run(coord._async_thermostat_changed(event))
+
+        coord.automation_engine.handle_fan_manual_override.assert_called_once()
+
+    def test_none_fan_command_time_allows_override_detection(self):
+        """fan_command_time=None → override correctly detected (guard inactive at startup).
+
+        Occupant effect: on a fresh start where CA has never run the fan, a manual
+        fan change at the thermostat should always be respected.
+        """
+        coord = _make_coord(fan_command_time=None)
+
+        old_state = _make_state("cool", fan_mode="auto")
+        new_state = _make_state("cool", fan_mode="on")
+        event = _make_thermostat_event(old_state, new_state)
+
+        with _fixed_now(_NOW):
+            asyncio.run(coord._async_thermostat_changed(event))
+
+        coord.automation_engine.handle_fan_manual_override.assert_called_once()
+
+    def test_recent_deactivation_echo_not_detected_as_override(self):
+        """fan_command_time=now (deactivation) → fan_mode on→auto echo → NOT override.
+
+        Occupant effect: when CA turns the fan off at bedtime, the thermostat echo
+        (fan_mode "on" → "auto") should not re-trigger an override that would
+        re-enable the fan and prevent the occupant from sleeping quietly.
+        """
+        coord = _make_coord(fan_command_time=_NOW)
+        coord.automation_engine._fan_active = True  # CA had fan on
+
+        old_state = _make_state("cool", fan_mode="on")
+        new_state = _make_state("cool", fan_mode="auto")
+        event = _make_thermostat_event(old_state, new_state)
+
+        with _fixed_now(_NOW):
+            asyncio.run(coord._async_thermostat_changed(event))
+
+        coord.automation_engine.handle_fan_manual_override.assert_not_called()
+
+
+class TestFanEntityChangedGuard:
+    """_async_fan_entity_changed also respects _is_recent_fan_command (belt-and-suspenders)."""
+
+    def test_recent_fan_command_suppresses_fan_entity_echo(self):
+        """fan_command_time=now → fan entity state off→on → override NOT fired.
+
+        Occupant effect: the whole-house fan entity echo after CA activates it
+        must not be treated as a manual override.
+        """
+        coord = _make_coord(fan_command_time=_NOW)
+        coord.automation_engine._fan_active = False
+
+        event = _make_fan_entity_event("off", "on")
+        with _fixed_now(_NOW):
+            asyncio.run(coord._async_fan_entity_changed(event))
+
+        coord.automation_engine.handle_fan_manual_override.assert_not_called()
+
+    def test_stale_fan_command_fan_entity_override_detected(self):
+        """fan_command_time=45 s ago → fan entity on → override correctly detected.
+
+        Occupant effect: manual use of a whole-house fan switch 45 seconds after
+        CA last touched it should still be recorded as a user override.
+        """
+        stale_time = _NOW - timedelta(seconds=45)
+        coord = _make_coord(fan_command_time=stale_time)
+        coord.automation_engine._fan_active = False
+
+        event = _make_fan_entity_event("off", "on")
+        with _fixed_now(_NOW):
+            asyncio.run(coord._async_fan_entity_changed(event))
+
+        coord.automation_engine.handle_fan_manual_override.assert_called_once()

--- a/tests/test_heat_cool_override.py
+++ b/tests/test_heat_cool_override.py
@@ -127,6 +127,7 @@ def _make_coordinator_stub(
     ae._fan_override_active = fan_override_active
     ae._temp_command_pending = temp_command_pending
     ae._temp_command_time = None
+    ae._fan_command_time = None  # no recent fan command by default
     ae._fan_active = False
     ae._natural_vent_active = False
     # Bug A / C / D — explicit values (not truthy MagicMock defaults)
@@ -142,6 +143,7 @@ def _make_coordinator_stub(
     coord._async_save_state = AsyncMock()
 
     coord._is_recent_temp_command = MagicMock(return_value=False)
+    coord._is_recent_fan_command = MagicMock(return_value=False)
 
     if hvac_command_age_seconds is None:
         coord._is_recent_hvac_command = MagicMock(return_value=False)

--- a/tests/test_override_dedup.py
+++ b/tests/test_override_dedup.py
@@ -162,6 +162,8 @@ def _make_thermostat_coordinator_stub(
     ae._fan_override_active = fan_override_active
     ae._temp_command_pending = temp_command_pending
     ae._temp_command_time = None  # no recent temp command by default
+    ae._fan_command_time = None  # no recent fan command by default
+    ae._hvac_command_time = None  # no recent hvac command by default
     ae._fan_active = False
     ae._natural_vent_active = False
     ae.handle_manual_override_during_pause = AsyncMock()
@@ -175,6 +177,9 @@ def _make_thermostat_coordinator_stub(
 
     # _is_recent_temp_command: no recent temp command in these dedup tests
     coord._is_recent_temp_command = MagicMock(return_value=False)
+
+    # _is_recent_fan_command: no recent fan command in these dedup tests
+    coord._is_recent_fan_command = MagicMock(return_value=False)
 
     # Mock _is_recent_hvac_command based on hvac_command_age_seconds:
     # Returns True (within threshold) if age < threshold, else False.


### PR DESCRIPTION
## Root Cause

When CA activates the fan for natural ventilation, `_activate_fan()` sets `_fan_command_pending=True`, issues `climate.set_fan_mode`, then clears the flag in a `finally` block — all within a single coroutine frame, before the event loop delivers the thermostat state-change echo. When the echo arrives asynchronously, `_fan_command_pending` is already `False`. The only other guards are `_is_recent_hvac_command(30.0)` and `_is_expected_confirmation`, neither of which applies to a fan command that didn't touch the HVAC mode. All guards pass → `handle_fan_manual_override()` fires → spurious 90-min grace period.

This is the same race condition as fix #221/#225 (temperature setpoint command time guard).

## Fix

Three additions, parallel to the existing `_temp_command_time` / `_is_recent_temp_command` pattern:

- `automation.py`: add `_fan_command_time: datetime | None = None`; set it at the start of both `_activate_fan()` and `_deactivate_fan()` (before the service call)
- `coordinator.py`: add `_is_recent_fan_command(threshold_seconds=30.0)` method; add the guard to both `_async_thermostat_changed` (fan_mode block) and `_async_fan_entity_changed`

`_fan_command_time` is intentionally not serialized — it's a transient race guard that should reset on restart.

## Tests

6 new tests in `tests/test_fan_command_guard.py`:
- Recent command → fan_mode echo suppressed (not detected as override)
- Stale command (45s) → override correctly detected
- `None` timestamp (fresh start) → override correctly detected
- Deactivation echo suppressed when command is recent
- Fan entity change suppressed when command is recent
- Fan entity change detected when command is stale

Full suite: 2447/2447 passing, zero warnings-as-errors.

Closes #239