### PR TITLE
Fix #284: restore dual setpoints on door/window close and dashboard resume in heat_cool mode

### DIFF
--- a/custom_components/climate_advisor/ai_skills_investigator.py
+++ b/custom_components/climate_advisor/ai_skills_investigator.py
@@ -635,17 +635,23 @@ async def async_build_investigator_context(
         climate_entity_id: str = (coordinator.config or {}).get("climate_entity", "")
         hvac_mode = "unknown"
         current_temp = "unknown"
+        target_temp_low = "unknown"
+        target_temp_high = "unknown"
         if climate_entity_id:
             climate_state = hass.states.get(climate_entity_id)
             if climate_state is not None:
                 hvac_mode = climate_state.state
                 current_temp = climate_state.attributes.get("current_temperature", "unknown")
+                target_temp_low = climate_state.attributes.get("target_temp_low", "unknown")
+                target_temp_high = climate_state.attributes.get("target_temp_high", "unknown")
 
         lines += [
             "=== HVAC ENTITY ===",
-            f"  entity_id:     {climate_entity_id or 'not configured'}",
-            f"  hvac_mode:     {hvac_mode}",
-            f"  current_temp:  {current_temp}",
+            f"  entity_id:        {climate_entity_id or 'not configured'}",
+            f"  hvac_mode:        {hvac_mode}",
+            f"  current_temp:     {current_temp}",
+            f"  target_temp_low:  {target_temp_low}",
+            f"  target_temp_high: {target_temp_high}",
             "",
         ]
     except Exception:

--- a/custom_components/climate_advisor/api.py
+++ b/custom_components/climate_advisor/api.py
@@ -132,6 +132,8 @@ class ClimateAdvisorStatusView(HomeAssistantView):
                 "manual_override_active": ae._manual_override_active or ae._override_confirm_pending,
                 "fan_override_active": ae._fan_override_active,
                 "paused_by_door": ae.is_paused_by_door,
+                "ca_target_heat": coordinator.config.get("comfort_heat"),
+                "ca_target_cool": coordinator.config.get("comfort_cool"),
             }
         )
 

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -1362,6 +1362,13 @@ class AutomationEngine:
                 # Pre-cool: target is below comfort
                 target = target + c.pre_condition_target
                 reason = f"{reason} (pre-cool offset {format_temp_delta(abs(c.pre_condition_target), unit)})"
+        elif c.hvac_mode == "heat_cool":
+            await self._set_temperature_dual(
+                self.config["comfort_heat"],
+                self.config["comfort_cool"],
+                reason=reason,
+            )
+            return
         else:
             return
 

--- a/custom_components/climate_advisor/frontend/index.html
+++ b/custom_components/climate_advisor/frontend/index.html
@@ -871,9 +871,21 @@
       // target_temp_low/high (dual); cool/heat expose the single current_setpoint.
       let hvacTemps = '';
       if (data.hvac_mode === 'heat_cool' && (data.target_temp_low != null || data.target_temp_high != null)) {
-        const lo = data.target_temp_low != null ? data.target_temp_low + unitSym : '—';
-        const hi = data.target_temp_high != null ? data.target_temp_high + unitSym : '—';
-        hvacTemps = `Heat ${lo} · Cool ${hi}`;
+        const lo = data.target_temp_low != null ? Math.round(data.target_temp_low) + unitSym : '—';
+        const hi = data.target_temp_high != null ? Math.round(data.target_temp_high) + unitSym : '—';
+        const caTargetHeat = data.ca_target_heat;
+        const caTargetCool = data.ca_target_cool;
+        const diverged = caTargetHeat != null && caTargetCool != null
+            && data.target_temp_low != null && data.target_temp_high != null
+            && (Math.abs(data.target_temp_low - caTargetHeat) > 1
+                || Math.abs(data.target_temp_high - caTargetCool) > 1);
+        if (diverged) {
+          const caLo = Math.round(caTargetHeat) + unitSym;
+          const caHi = Math.round(caTargetCool) + unitSym;
+          hvacTemps = `Heat ${lo} · Cool ${hi} <span style="color:#888;font-size:0.85em">(CA: ${caLo}/${caHi})</span>`;
+        } else {
+          hvacTemps = `Heat ${lo} · Cool ${hi}`;
+        }
       } else if (data.current_setpoint != null) {
         hvacTemps = data.current_setpoint + unitSym;
       }

--- a/tests/test_door_window.py
+++ b/tests/test_door_window.py
@@ -15,6 +15,7 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from custom_components.climate_advisor.automation import AutomationEngine
+from custom_components.climate_advisor.classifier import DayClassification
 from custom_components.climate_advisor.const import (
     CONF_AUTOMATION_GRACE_NOTIFY,
     CONF_AUTOMATION_GRACE_PERIOD,
@@ -1373,3 +1374,95 @@ class TestPhysicalWindowTrackingOnHotDay:
         self._simulate_debounce_expired(record, windows_recommended=False)
 
         assert record.window_physical_open_time == first_time
+
+
+# ---------------------------------------------------------------------------
+# Issue #284 — _set_temperature_for_mode heat_cool gap
+# ---------------------------------------------------------------------------
+
+
+def _make_classification_for_heat_cool() -> DayClassification:
+    """Create a heat_cool DayClassification without invoking __post_init__."""
+    obj = object.__new__(DayClassification)
+    obj.day_type = "mild"
+    obj.hvac_mode = "heat_cool"
+    obj.trend_direction = "stable"
+    obj.trend_magnitude = 1.0
+    obj.today_high = 72.0
+    obj.today_low = 55.0
+    obj.tomorrow_high = 73.0
+    obj.tomorrow_low = 56.0
+    obj.pre_condition = False
+    obj.pre_condition_target = None
+    obj.windows_recommended = False
+    obj.window_open_time = None
+    obj.window_close_time = None
+    obj.setback_modifier = 0.0
+    return obj
+
+
+class TestSetTemperatureForModeHeatCool:
+    """Issue #284: _set_temperature_for_mode must call _set_temperature_dual in heat_cool mode.
+
+    Before the fix the function had ``else: return`` which silently did nothing
+    for heat_cool classifications, leaving the thermostat on its Ecobee schedule
+    values after a door/window close or dashboard resume.
+    """
+
+    def test_door_window_close_calls_set_temperature_dual_in_heat_cool_mode(self):
+        """handle_all_doors_windows_closed in heat_cool mode calls _set_temperature_dual
+        with comfort_heat and comfort_cool (Issue #284).
+        """
+        engine = _make_automation_engine(
+            config_overrides={
+                "comfort_heat": 68,
+                "comfort_cool": 74,
+            }
+        )
+        engine._paused_by_door = True
+        engine._pre_pause_mode = "heat_cool"
+        engine._current_classification = _make_classification_for_heat_cool()
+
+        # Mock _set_temperature_dual so we can assert it is called
+        engine._set_temperature_dual = AsyncMock()
+
+        with patch(
+            "custom_components.climate_advisor.automation.async_call_later",
+            return_value=MagicMock(),
+        ):
+            asyncio.run(engine.handle_all_doors_windows_closed())
+
+        engine._set_temperature_dual.assert_awaited_once_with(
+            68,
+            74,
+            reason="door/window closed — restoring comfort",
+        )
+
+    def test_dashboard_resume_calls_set_temperature_dual_in_heat_cool_mode(self):
+        """resume_from_pause in heat_cool mode calls _set_temperature_dual with
+        comfort_heat and comfort_cool (Issue #284).
+        """
+        engine = _make_automation_engine(
+            config_overrides={
+                "comfort_heat": 68,
+                "comfort_cool": 74,
+            }
+        )
+        engine._paused_by_door = True
+        engine._current_classification = _make_classification_for_heat_cool()
+
+        # Mock _set_temperature_dual so we can assert it is called
+        engine._set_temperature_dual = AsyncMock()
+
+        _patch_call_later = "custom_components.climate_advisor.automation.async_call_later"
+        _patch_callback = "custom_components.climate_advisor.automation.callback"
+
+        with patch(_patch_call_later) as mock_call_later, patch(_patch_callback, side_effect=lambda f: f):
+            mock_call_later.return_value = MagicMock()
+            asyncio.run(engine.resume_from_pause())
+
+        engine._set_temperature_dual.assert_awaited_once_with(
+            68,
+            74,
+            reason="user resumed from door/window pause",
+        )


### PR DESCRIPTION
## Problem

CA dashboard shows 68/74 (CA's configured comfort band) while Ecobee shows 66/76. Root cause: \`_set_temperature_for_mode()\` silently returns without writing setpoints when \`c.hvac_mode == 'heat_cool'\` (the \`else: return\` fallthrough at line 1366).

This only affects **event-driven restore paths** — the 30-min coordinator cycle uses \`_apply_comfort_band()\` directly (correct). The gap causes the thermostat to hold the Ecobee's own schedule values for up to 30 minutes after:
- Door/window sensors close (\`automation.py:1668\`)
- User hits Resume on CA dashboard (\`automation.py:1988\`)

## Changes

### \`automation.py\` — Primary fix
Added \`heat_cool\` branch to \`_set_temperature_for_mode()\` calling \`_set_temperature_dual(comfort_heat, comfort_cool)\`. Both vulnerable call sites now write both setpoints instead of silently returning.

### \`ai_skills_investigator.py\` — Context enrichment
Added \`target_temp_low\` and \`target_temp_high\` to the HVAC entity section of the investigator context. Their absence made Issue #281 root cause analysis inconclusive.

### \`api.py\` + \`frontend/index.html\` — Display disambiguation
Status endpoint now returns \`ca_target_heat\` and \`ca_target_cool\` (CA's configured comfort band). Dashboard shows \`(CA: 68°F/74°F)\` in muted gray when live thermostat setpoints diverge from CA's target by >1°F. Disappears once CA successfully restores the setpoints.

## Test plan
- [x] New tests in \`test_door_window.py\` — door/window close in heat_cool mode calls \`_set_temperature_dual\` with comfort_heat/cool (fail-before/pass-after confirmed)
- [x] Full suite: 2515/2515 passed, ruff clean