### PR TITLE
Feat #293: v0.4.8 — heat_cool startup override fix, nat-vent dual-setpoint restore, AI setpoint context

### DIFF
--- a/custom_components/climate_advisor/ai_skills_activity.py
+++ b/custom_components/climate_advisor/ai_skills_activity.py
@@ -336,11 +336,17 @@ async def async_build_activity_context(
     climate_entity_id: str = options.get("climate_entity", "")
     hvac_mode = "unknown"
     current_temp = "unknown"
+    target_temp: float | None = None
+    target_temp_low: float | None = None
+    target_temp_high: float | None = None
     if climate_entity_id:
         climate_state = hass.states.get(climate_entity_id)
         if climate_state is not None:
             hvac_mode = climate_state.state
             current_temp = climate_state.attributes.get("current_temperature", "unknown")
+            target_temp = climate_state.attributes.get("temperature")
+            target_temp_low = climate_state.attributes.get("target_temp_low")
+            target_temp_high = climate_state.attributes.get("target_temp_high")
 
     # --- Automation state ---
     automation_status = data.get(ATTR_AUTOMATION_STATUS, "unknown")
@@ -505,6 +511,8 @@ async def async_build_activity_context(
         f"  HVAC action:       {hvac_action}",
         f"  HVAC runtime today:{hvac_runtime_today} min",
         f"  Indoor temp:       {current_temp}",
+        f"  Setpoint (single): {target_temp if target_temp is not None else 'N/A'}",
+        f"  Setpoint low/high: {target_temp_low if target_temp_low is not None else 'N/A'} / {target_temp_high if target_temp_high is not None else 'N/A'}",
         "",
         "## AUTOMATION STATE",
         f"  Status:            {automation_status}",

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -1464,14 +1464,27 @@ class AutomationEngine:
             return
 
         unit = self.config.get("temp_unit", "fahrenheit")
+        caps = self._get_thermostat_capabilities()
         if c.hvac_mode == "heat":
-            target = self.config["comfort_heat"]
+            floor_target = float(self.config["comfort_heat"])
+            if caps.supports_dual_setpoint:
+                ceil = float(self.config.get("comfort_cool", 76))
+                await self._set_temperature_dual(floor_target, ceil, reason=reason)
+            else:
+                await self._set_temperature(floor_target, reason=reason)
+            return
         elif c.hvac_mode == "cool":
-            target = self.config["comfort_cool"]
+            ceiling_target = float(self.config["comfort_cool"])
             if c.pre_condition and c.pre_condition_target and c.pre_condition_target < 0:
                 # Pre-cool: target is below comfort
-                target = target + c.pre_condition_target
+                ceiling_target = ceiling_target + c.pre_condition_target
                 reason = f"{reason} (pre-cool offset {format_temp_delta(abs(c.pre_condition_target), unit)})"
+            if caps.supports_dual_setpoint:
+                floor = float(self.config.get("comfort_heat", 68))
+                await self._set_temperature_dual(floor, ceiling_target, reason=reason)
+            else:
+                await self._set_temperature(ceiling_target, reason=reason)
+            return
         elif c.hvac_mode == "heat_cool":
             await self._set_temperature_dual(
                 self.config["comfort_heat"],
@@ -1481,8 +1494,6 @@ class AutomationEngine:
             return
         else:
             return
-
-        await self._set_temperature(target, reason=reason)
 
     async def _schedule_pre_condition(self, c: DayClassification) -> None:
         """Schedule pre-heating or pre-cooling based on trend.

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,25 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.4.7"
+VERSION = "0.4.8"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.4.8": [
+        "Fix #293: After every HA restart, CA no longer treats a heat_cool thermostat state as"
+        " a manual override. The startup check now recognises heat_cool as CA-compatible with"
+        " cool/heat classifier outputs, preventing a spurious 30-min grace period that blocked"
+        " automation each morning.",
+        "Fix #293: When natural ventilation ends (door/window sensors close), CA now uses the"
+        " dual-setpoint heat_cool command for capable thermostats instead of reverting to"
+        " single-setpoint cool mode. Ecobee users no longer see the band drop from [68/74] to"
+        " a single 72°F setpoint after every ventilation cycle.",
+        "Fix #293: AI activity investigator now includes active thermostat setpoints"
+        " (single-setpoint temperature and dual-setpoint low/high) in its context block so the"
+        " AI can explain pre-cool offsets and band boundaries in morning summaries.",
+        "Fix #293: GitHub issue titles generated from the dashboard no longer include a"
+        " redundant 'Climate Advisor: ' prefix; the full AI-generated summary is used up to"
+        " 100 characters.",
+    ],
     "0.4.7": [
         "Fix #290: Grace period expiry now immediately triggers a coordinator refresh so sensor"
         " entities reflect cleared override state without waiting up to 30 minutes.",
@@ -1014,6 +1030,36 @@ KNOWN_FIXES: dict[int, dict] = {
             "Startup bedtime recovery skipped when thermostat mode diverges from classification"
             " on restart — the mode-mismatch branch sets an override instead; this may be correct"
             " (real mode divergence is a legitimate override signal) but is untested",
+        ],
+    },
+    293: {
+        "version_fixed": "0.4.8",
+        "title": "heat_cool startup override false positive + nat-vent restore drops dual-setpoint mode",
+        "scope_covered": [
+            "coordinator.py _check_startup_override(): heat_cool thermostat state is now treated"
+            " as CA-compatible with cool/heat classifier outputs — no spurious override on restart",
+            "automation.py _set_temperature_for_mode(): checks _get_thermostat_capabilities();"
+            " for dual-setpoint thermostats emits _set_temperature_dual(floor, ceiling) on both"
+            " cool and heat paths, preserving heat_cool mode after nat-vent restore",
+            "ai_skills_activity.py async_build_activity_context(): reads temperature,"
+            " target_temp_low, target_temp_high from climate entity and includes them in context"
+            " block so AI can see and explain active setpoints",
+            "frontend/index.html openGithubIssueModal(): GitHub issue title no longer prefixed"
+            " with 'Climate Advisor:'; substring limit increased from 80 to 100 chars",
+            "tests/test_startup_override.py TestStartupHeatCoolCompatibility: three cases covering"
+            " heat_cool+cool→no override, heat_cool+heat→no override, cool+heat→override fires",
+            "tests/test_nat_vent_restore_dual_setpoint.py TestNatVentRestoreDualSetpoint:"
+            " dual-setpoint cool/pre-condition uses dual call, single-setpoint thermostat uses"
+            " single call, heat mode dual call",
+        ],
+        "scope_not_covered": [
+            "heat_cool startup state when the thermostat is in heat_cool but classification"
+            " is 'off' — treated as incompatible (legitimate override signal) and not changed",
+            "Nat-vent restore for thermostats that support heat_cool but currently in 'off' mode"
+            " — _set_temperature_for_mode() does not handle the off→heat_cool transition",
+            "pre_condition_target design question: 72°F ceiling persists all day on hot days by"
+            " design (thermal buffer); making it morning-only (cease offset once indoor ≤ target)"
+            " is out of scope for this fix",
         ],
     },
 }

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -1099,7 +1099,10 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
 
         current = climate_state.state
         recommended = classification.hvac_mode
-        if current != recommended:
+        # heat_cool is CA-compatible with both "cool" and "heat" classifier outputs:
+        # the thermostat autonomously defends both edges, so no mode mismatch exists.
+        _compatible = (current == recommended) or (current == "heat_cool" and recommended in ("cool", "heat"))
+        if not _compatible:
             _LOGGER.info(
                 "First run: HVAC is '%s' but classification recommends '%s' — treating as manual override",
                 current,

--- a/custom_components/climate_advisor/frontend/index.html
+++ b/custom_components/climate_advisor/frontend/index.html
@@ -3017,8 +3017,8 @@
     const ts = _currentReport.timestamp ? new Date(_currentReport.timestamp).toLocaleString() : '';
     const summary = (data.summary || '').replace(/\s+/g, ' ').trim().substring(0, 120);
     document.getElementById('github-issue-title').value = summary
-      ? 'Climate Advisor: ' + summary.substring(0, 80)
-      : 'Climate Advisor: ' + rType + ' — ' + ts;
+      ? summary.substring(0, 100)
+      : rType + ' — ' + ts;
     document.getElementById('github-issue-body').value = _formatCurrentReport();
     document.getElementById('github-issue-labels').value = 'bug';
     document.getElementById('github-issue-status').textContent = '';

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.4.7"
+  "version": "0.4.8"
 }

--- a/tests/test_activity_report.py
+++ b/tests/test_activity_report.py
@@ -769,3 +769,114 @@ class TestSetpointEventFieldClarity:
             "values in the Settings column for override_detected events.\n"
             f"Current _SYSTEM_PROMPT:\n{_SYSTEM_PROMPT}"
         )
+
+
+# ---------------------------------------------------------------------------
+# TestThermostatSetpointFields — Fix C (Issue #293)
+# ---------------------------------------------------------------------------
+
+
+def _make_hass_with_setpoints(
+    *,
+    temperature: float | None = None,
+    target_temp_low: float | None = None,
+    target_temp_high: float | None = None,
+) -> MagicMock:
+    """Return a hass mock with climate state carrying the given setpoint attributes."""
+    hass = MagicMock()
+    climate_state = MagicMock()
+    climate_state.state = "cool"
+    attrs: dict = {"current_temperature": 73.0}
+    if temperature is not None:
+        attrs["temperature"] = temperature
+    if target_temp_low is not None:
+        attrs["target_temp_low"] = target_temp_low
+    if target_temp_high is not None:
+        attrs["target_temp_high"] = target_temp_high
+    climate_state.attributes = attrs
+    hass.states.get.return_value = climate_state
+    return hass
+
+
+def _build_context_for_setpoint_test(hass: MagicMock) -> str:
+    """Call async_build_activity_context with the given hass mock."""
+    import asyncio
+
+    coord = _make_mock_coordinator_for_activity()
+    import custom_components.climate_advisor.ai_skills_activity as _act_mod
+
+    now = datetime.now(tz=UTC)
+    with patch.object(_act_mod.dt_util, "now", return_value=now):
+        return asyncio.run(async_build_activity_context(hass, coord, hours=24))
+
+
+class TestThermostatSetpointFields:
+    """Fix C (Issue #293): thermostat setpoint fields must appear in AI context.
+
+    When CA applies a pre-cool or setback offset, the AI investigator must see
+    the active thermostat setpoints so it can explain why the thermostat is set
+    to a temperature different from comfort_cool/comfort_heat.
+
+    All tests in this class MUST FAIL before the fix (fields absent) and
+    PASS after (fields present in context).
+    """
+
+    def test_single_setpoint_appears_in_context(self):
+        """climate.temperature=72.0 → '72.0' under Setpoint label in context.
+
+        Single-setpoint (cool or heat only) thermostats use the 'temperature'
+        attribute. The context must surface this value so the AI can compare
+        it to comfort_cool (76) and explain the 4°F pre-cool offset.
+        """
+        hass = _make_hass_with_setpoints(temperature=72.0)
+        context = _build_context_for_setpoint_test(hass)
+        assert "72.0" in context, (
+            "Fix C: climate.attributes['temperature']=72.0 must appear in the context "
+            "under the setpoint field.\n"
+            f"Context CLASSIFICATION section (first 1000 chars):\n{context[:1000]}"
+        )
+        assert "Setpoint" in context, (
+            f"Fix C: context must contain a 'Setpoint' label in the CLASSIFICATION section.\nContext:\n{context[:1000]}"
+        )
+
+    def test_dual_setpoint_low_appears_in_context(self):
+        """target_temp_low=68.0 → '68.0' appears in context under low/high label."""
+        hass = _make_hass_with_setpoints(target_temp_low=68.0, target_temp_high=74.0)
+        context = _build_context_for_setpoint_test(hass)
+        assert "68.0" in context, (
+            "Fix C: climate.attributes['target_temp_low']=68.0 must appear in context.\n"
+            f"Context (first 1000 chars):\n{context[:1000]}"
+        )
+
+    def test_dual_setpoint_high_appears_in_context(self):
+        """target_temp_high=74.0 → '74.0' appears in context under low/high label."""
+        hass = _make_hass_with_setpoints(target_temp_low=68.0, target_temp_high=74.0)
+        context = _build_context_for_setpoint_test(hass)
+        assert "74.0" in context, (
+            "Fix C: climate.attributes['target_temp_high']=74.0 must appear in context.\n"
+            f"Context (first 1000 chars):\n{context[:1000]}"
+        )
+
+    def test_na_shown_when_no_setpoints_present(self):
+        """No setpoint attributes → 'N/A' appears in context (not an exception).
+
+        Some thermostat integrations do not expose temperature/target_temp_low/high
+        (e.g., when in 'off' mode). The context must show 'N/A' gracefully.
+        """
+        hass = _make_hass_with_setpoints()  # no setpoint attrs
+        context = _build_context_for_setpoint_test(hass)
+        assert "N/A" in context, (
+            "Fix C: when no setpoint attributes are present, context must show 'N/A' "
+            "rather than omitting the field or raising an exception.\n"
+            f"Context (first 1000 chars):\n{context[:1000]}"
+        )
+
+    def test_single_setpoint_na_when_only_dual_set(self):
+        """target_temp_low/high set but 'temperature' absent → single-setpoint row shows N/A."""
+        hass = _make_hass_with_setpoints(target_temp_low=68.0, target_temp_high=74.0)
+        context = _build_context_for_setpoint_test(hass)
+        # Single-setpoint row must be present and show N/A for the absent 'temperature' attr
+        assert "N/A" in context, (
+            "Fix C: 'temperature' attribute absent → single-setpoint row must show N/A.\n"
+            f"Context (first 1000 chars):\n{context[:1000]}"
+        )

--- a/tests/test_nat_vent_restore_dual_setpoint.py
+++ b/tests/test_nat_vent_restore_dual_setpoint.py
@@ -1,0 +1,272 @@
+"""Tests for Fix B: _set_temperature_for_mode uses dual setpoint on capable thermostats.
+
+When natural ventilation ends and the engine restores comfort, it calls
+_set_temperature_for_mode(classification, reason=...).  For a dual-setpoint
+thermostat (heat_cool in hvac_modes + TARGET_TEMP_RANGE feature) this must
+emit a climate.set_temperature call with target_temp_low and target_temp_high
+instead of a single temperature value.
+
+Without this fix, the occupant on a dual-setpoint thermostat sees nat-vent
+restore push only one setpoint edge — leaving the thermostat partially armed
+and potentially drifting past the undefended edge (e.g. home cools below
+comfort_heat while only the cooling ceiling was set).
+
+See: GitHub Issue #293
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# ── HA module stubs — must run before any climate_advisor import ──
+if "homeassistant" not in sys.modules:
+    from conftest import install_ha_stubs
+
+    install_ha_stubs()
+
+from custom_components.climate_advisor.automation import AutomationEngine  # noqa: E402
+from custom_components.climate_advisor.const import (  # noqa: E402
+    CLIMATE_FEATURE_TARGET_TEMP_RANGE,
+)
+
+# ---------------------------------------------------------------------------
+# Minimal engine factory — mirrors test_grace_refresh_and_band_call.py
+# ---------------------------------------------------------------------------
+
+
+def _minimal_engine(comfort_heat: float = 68.0, comfort_cool: float = 74.0) -> AutomationEngine:
+    """Return an AutomationEngine with all HA interactions stubbed."""
+    hass = MagicMock()
+    hass.states.get.return_value = None
+    hass.services.async_call = AsyncMock()
+    hass.async_create_task = MagicMock(side_effect=lambda coro: coro.close())
+
+    engine = object.__new__(AutomationEngine)
+    engine.__dict__.update(
+        {
+            "hass": hass,
+            "climate_entity": "climate.thermostat",
+            "weather_entity": "weather.home",
+            "door_window_sensors": [],
+            "notify_service": "notify.test",
+            "config": {
+                "temp_unit": "fahrenheit",
+                "comfort_heat": comfort_heat,
+                "comfort_cool": comfort_cool,
+            },
+            "sensor_polarity_inverted": False,
+            "dry_run": False,
+            "_active_listeners": [],
+            "_current_classification": None,
+            "_paused_by_door": False,
+            "_pre_pause_mode": None,
+            "_manual_grace_cancel": None,
+            "_automation_grace_cancel": None,
+            "_grace_active": False,
+            "_last_resume_source": None,
+            "_grace_end_time": None,
+            "_grace_duration_seconds": 0,
+            "_manual_override_active": False,
+            "_manual_override_mode": None,
+            "_manual_override_time": None,
+            "_last_override_detected_time": None,
+            "_sensor_check_callback": None,
+            "_emit_event_callback": None,
+            "_request_refresh_callback": None,
+            "_revisit_callback": None,
+            "_revisit_cancel": None,
+            "_fan_active": False,
+            "_fan_override_active": False,
+            "_fan_override_time": None,
+            "_fan_command_pending": False,
+            "_fan_on_since": None,
+            "_pre_fan_hvac_mode": None,
+            "_hvac_command_pending": False,
+            "_temp_command_pending": False,
+            "_temp_command_time": None,
+            "_hvac_command_time": None,
+            "_fan_command_time": None,
+            "_last_commanded_hvac_mode": None,
+            "_last_commanded_hvac_time": None,
+            "_natural_vent_active": False,
+            "_economizer_active": False,
+            "_economizer_phase": "inactive",
+            "_last_action_time": None,
+            "_last_action_reason": None,
+            "_nat_vent_outdoor_exit_time": None,
+            "_override_confirm_pending": False,
+            "_override_confirm_cancel": None,
+            "_override_confirm_time": None,
+            "_override_confirm_mode": None,
+            "_override_confirm_source": None,
+            "_fan_min_runtime_active": False,
+            "_fan_min_cycle_cancel": None,
+            "_today_record": None,
+            "_last_classification_applied": None,
+            "_resumed_from_pause": False,
+            "_last_welcome_home_notified": None,
+            "_thermal_model": {},
+            "_hourly_forecast_temps": [],
+            "_occupancy_mode": "home",
+        }
+    )
+    return engine
+
+
+def _make_classification(hvac_mode: str = "cool", pre_condition: bool = False, pre_condition_target=None):
+    """Build a minimal classification stub with only the fields _set_temperature_for_mode reads."""
+    c = MagicMock()
+    c.hvac_mode = hvac_mode
+    c.pre_condition = pre_condition
+    c.pre_condition_target = pre_condition_target
+    return c
+
+
+def _dual_setpoint_state():
+    """Return a mock HA state for a thermostat that supports heat_cool + TARGET_TEMP_RANGE."""
+    state = MagicMock()
+    state.state = "cool"
+    state.attributes = {
+        "hvac_modes": ["off", "heat", "cool", "heat_cool"],
+        "supported_features": CLIMATE_FEATURE_TARGET_TEMP_RANGE | 1,
+    }
+    return state
+
+
+def _single_setpoint_state():
+    """Return a mock HA state for a thermostat that supports only heat/cool (no heat_cool)."""
+    state = MagicMock()
+    state.state = "cool"
+    state.attributes = {
+        "hvac_modes": ["off", "heat", "cool"],
+        "supported_features": 1,  # no TARGET_TEMP_RANGE
+    }
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestNatVentRestoreDualSetpoint:
+    """_set_temperature_for_mode must use dual setpoints on capable thermostats."""
+
+    def test_dual_setpoint_thermostat_uses_dual_call(self):
+        """Dual-setpoint thermostat on cool/pre-condition day → target_temp_low + target_temp_high.
+
+        Occupant impact: without this fix, nat-vent restore only sets the cooling
+        ceiling (target_temp_high) and ignores the heating floor — leaving the
+        thermostat unbalanced.  The home can drift below comfort_heat overnight.
+        """
+        engine = _minimal_engine(comfort_heat=68.0, comfort_cool=74.0)
+        engine.hass.states.get.return_value = _dual_setpoint_state()
+
+        classification = _make_classification(
+            hvac_mode="cool",
+            pre_condition=True,
+            pre_condition_target=-2.0,
+        )
+
+        with patch("custom_components.climate_advisor.automation.async_call_later"):
+            asyncio.run(engine._set_temperature_for_mode(classification, reason="nat vent restore"))
+
+        calls = engine.hass.services.async_call.call_args_list
+        climate_calls = [c for c in calls if c.args[0] == "climate" and c.args[1] == "set_temperature"]
+        assert len(climate_calls) == 1, f"Expected 1 set_temperature call, got {len(climate_calls)}"
+
+        payload = climate_calls[0].args[2]
+        # Dual path: must carry both setpoints
+        assert "target_temp_high" in payload, f"Expected target_temp_high in payload, got {payload}"
+        assert "target_temp_low" in payload, f"Expected target_temp_low in payload, got {payload}"
+        # Ceiling: comfort_cool (74) + pre_condition_target (-2) = 72°F
+        assert abs(payload["target_temp_high"] - 72.0) < 0.1, (
+            f"Expected target_temp_high=72.0, got {payload['target_temp_high']}"
+        )
+        # Floor: comfort_heat = 68°F
+        assert abs(payload["target_temp_low"] - 68.0) < 0.1, (
+            f"Expected target_temp_low=68.0, got {payload['target_temp_low']}"
+        )
+        # Single-setpoint key must NOT be present
+        assert "temperature" not in payload, (
+            f"Single-setpoint 'temperature' key must not appear in dual payload: {payload}"
+        )
+
+    def test_single_setpoint_thermostat_uses_single_call(self):
+        """Single-setpoint thermostat on cool/pre-condition day → single temperature value.
+
+        Occupant impact: a cool-only thermostat cannot accept target_temp_low/high;
+        sending dual setpoints would be silently rejected, leaving no active setpoint.
+        The function must fall back to the single temperature path for these devices.
+        """
+        engine = _minimal_engine(comfort_heat=68.0, comfort_cool=74.0)
+        engine.hass.states.get.return_value = _single_setpoint_state()
+
+        classification = _make_classification(
+            hvac_mode="cool",
+            pre_condition=True,
+            pre_condition_target=-2.0,
+        )
+
+        with patch("custom_components.climate_advisor.automation.async_call_later"):
+            asyncio.run(engine._set_temperature_for_mode(classification, reason="nat vent restore"))
+
+        calls = engine.hass.services.async_call.call_args_list
+        climate_calls = [c for c in calls if c.args[0] == "climate" and c.args[1] == "set_temperature"]
+        assert len(climate_calls) == 1, f"Expected 1 set_temperature call, got {len(climate_calls)}"
+
+        payload = climate_calls[0].args[2]
+        # Single path: must carry only temperature
+        assert "temperature" in payload, f"Expected 'temperature' in single-setpoint payload, got {payload}"
+        assert abs(payload["temperature"] - 72.0) < 0.1, (
+            f"Expected temperature=72.0 (74 + -2), got {payload['temperature']}"
+        )
+        # Dual keys must NOT be present
+        assert "target_temp_high" not in payload, (
+            f"Dual 'target_temp_high' must not appear in single-setpoint payload: {payload}"
+        )
+
+    def test_heat_mode_dual_setpoint(self):
+        """Heat classification on dual-setpoint thermostat → dual call with floor=comfort_heat.
+
+        Occupant impact: on a cold day, nat-vent restore with a dual-setpoint thermostat
+        must arm BOTH edges so the thermostat prevents over-cooling (floor) and over-heating
+        (ceiling).  Sending only the floor leaves the ceiling undefended.
+        """
+        engine = _minimal_engine(comfort_heat=70.0, comfort_cool=76.0)
+
+        # Thermostat currently in heat mode
+        state = MagicMock()
+        state.state = "heat"
+        state.attributes = {
+            "hvac_modes": ["off", "heat", "cool", "heat_cool"],
+            "supported_features": CLIMATE_FEATURE_TARGET_TEMP_RANGE | 1,
+        }
+        engine.hass.states.get.return_value = state
+
+        classification = _make_classification(hvac_mode="heat")
+
+        with patch("custom_components.climate_advisor.automation.async_call_later"):
+            asyncio.run(engine._set_temperature_for_mode(classification, reason="nat vent restore heat"))
+
+        calls = engine.hass.services.async_call.call_args_list
+        climate_calls = [c for c in calls if c.args[0] == "climate" and c.args[1] == "set_temperature"]
+        assert len(climate_calls) == 1, f"Expected 1 set_temperature call, got {len(climate_calls)}"
+
+        payload = climate_calls[0].args[2]
+        # Dual path: must carry both setpoints
+        assert "target_temp_low" in payload, f"Expected target_temp_low in dual payload, got {payload}"
+        assert "target_temp_high" in payload, f"Expected target_temp_high in dual payload, got {payload}"
+        # Floor: comfort_heat = 70°F
+        assert abs(payload["target_temp_low"] - 70.0) < 0.1, (
+            f"Expected target_temp_low=70.0, got {payload['target_temp_low']}"
+        )
+        # Ceiling: comfort_cool = 76°F
+        assert abs(payload["target_temp_high"] - 76.0) < 0.1, (
+            f"Expected target_temp_high=76.0, got {payload['target_temp_high']}"
+        )
+        assert "temperature" not in payload, (
+            f"Single-setpoint 'temperature' key must not appear in dual payload: {payload}"
+        )

--- a/tests/test_reason_logging.py
+++ b/tests/test_reason_logging.py
@@ -232,7 +232,9 @@ class TestDoorWindowLogging:
 
         messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
         mode_msgs = [m for m in messages if "Set HVAC mode" in m]
-        temp_msgs = [m for m in messages if "Set temperature" in m]
+        # Match both single-setpoint ("Set temperature") and dual-setpoint ("Set dual temperature")
+        # log variants; "Action recorded" lines use "temp" (not "temperature") so are excluded.
+        temp_msgs = [m for m in messages if "temperature" in m]
         assert len(mode_msgs) >= 1
         assert "door/window closed" in mode_msgs[0]
         assert "restoring heat mode" in mode_msgs[0]
@@ -330,7 +332,9 @@ class TestOccupancyLogging:
             asyncio.run(engine.handle_occupancy_home())
 
         messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
-        temp_msgs = [m for m in messages if "Set temperature" in m]
+        # Match both single-setpoint ("Set temperature") and dual-setpoint ("Set dual temperature")
+        # log variants; "Action recorded" lines use "temp" (not "temperature") so are excluded.
+        temp_msgs = [m for m in messages if "temperature" in m]
         assert len(temp_msgs) == 1
         assert "occupancy home" in temp_msgs[0]
         assert "heat comfort" in temp_msgs[0]

--- a/tests/test_startup_override.py
+++ b/tests/test_startup_override.py
@@ -263,6 +263,7 @@ class TestStartupBedtimeRecovery:
 
         assert result is False
         coord.hass.async_create_task.assert_not_called()
+        assert coord.automation_engine._manual_override_active is False
 
     def test_startup_bedtime_not_applied_when_override_active(self):
         """No bedtime recovery when a manual override is already active.
@@ -288,3 +289,58 @@ class TestStartupBedtimeRecovery:
 
         assert result is False
         coord.hass.async_create_task.assert_not_called()
+
+
+class TestStartupHeatCoolCompatibility:
+    """heat_cool thermostat state is CA-compatible with 'cool' or 'heat' recommendations.
+
+    Occupant impact: without this fix, every restart on a heat_cool thermostat
+    triggers a false manual-override flag — CA stops managing the home until the
+    user explicitly clears the override, letting temperature drift unchecked.
+    """
+
+    def test_heat_cool_state_cool_recommended_no_override(self):
+        """heat_cool state + 'cool' recommended → compatible, no override set.
+
+        A dual-setpoint thermostat is already defending both comfort edges; CA
+        is not in conflict with the classifier recommendation.
+        """
+        coord = _make_coordinator()
+        classification = _make_classification(day_type="hot", hvac_mode="cool")
+        climate_state = _make_climate_state("heat_cool")
+
+        result = coord._check_startup_override(climate_state, classification)
+
+        assert result is False
+        assert coord.automation_engine._manual_override_active is False
+
+    def test_heat_cool_state_heat_recommended_no_override(self):
+        """heat_cool state + 'heat' recommended → compatible, no override set.
+
+        On a cold day the classifier recommends 'heat'; a heat_cool thermostat
+        satisfies this by defending the floor — no override needed.
+        """
+        coord = _make_coordinator()
+        classification = _make_classification(day_type="cold", hvac_mode="heat")
+        climate_state = _make_climate_state("heat_cool")
+
+        result = coord._check_startup_override(climate_state, classification)
+
+        assert result is False
+        assert coord.automation_engine._manual_override_active is False
+
+    def test_cool_state_heat_recommended_still_sets_override(self):
+        """'cool' state + 'heat' recommended → still incompatible, override set.
+
+        The fix must not suppress legitimate overrides: a thermostat running AC
+        when the classifier recommends heat is a genuine conflict.
+        """
+        coord = _make_coordinator()
+        classification = _make_classification(day_type="cold", hvac_mode="heat")
+        climate_state = _make_climate_state("cool")
+
+        result = coord._check_startup_override(climate_state, classification)
+
+        assert result is True
+        assert coord.automation_engine._manual_override_active is True
+        assert coord.automation_engine._manual_override_mode == "cool"

--- a/tools/simulations/pending/nat_vent_restore_uses_dual_setpoint.json
+++ b/tools/simulations/pending/nat_vent_restore_uses_dual_setpoint.json
@@ -1,0 +1,87 @@
+{
+  "name": "nat_vent_restore_uses_dual_setpoint",
+  "description": "Issue #293 Fix B: when natural ventilation ends on a dual-setpoint thermostat (heat_cool mode + TARGET_TEMP_RANGE), the engine's restore call must arm both setpoints (target_temp_low + target_temp_high) rather than a single temperature. Without this fix, only one edge is commanded — leaving the thermostat partially armed and the undefended edge (e.g. the heat floor) subject to drift.",
+  "source": "synthetic",
+  "issue": 293,
+  "notes": [
+    "Three-exercise protocol (CLAUDE.md):",
+    "(a) Scenario effectiveness: if _set_temperature_for_mode reverts to always calling",
+    "    _set_temperature (single setpoint) on a cool classification, the dual_setback_applied",
+    "    assertion fails — target_temp_low is missing from the action_log, and the thermostat",
+    "    receives only a ceiling setpoint while the floor drifts.",
+    "(b) Docs↔production alignment: docs/08-COMPUTATION-REFERENCE.md should document that",
+    "    _set_temperature_for_mode is capability-aware after Issue #293.  The scenario is the",
+    "    regression anchor that forces a doc update if the dual path is removed.",
+    "(c) Occupant experience: if this scenario fails to catch a regression, occupants on a",
+    "    dual-setpoint thermostat see nat-vent restore arm only the AC ceiling — the heat floor",
+    "    is undefended.  On a warm day with cool nights, indoor temps can fall below comfort_heat",
+    "    after nat-vent closes, requiring manual intervention to warm the home.",
+    "Regression proof: change _set_temperature_for_mode to always call _set_temperature() on a",
+    "cool classification → dual_setback_applied fails (target_temp_low absent from action_log).",
+    "The thermostat must enter heat_cool mode with dual setpoints."
+  ],
+  "config": {
+    "comfort_heat": 68,
+    "comfort_cool": 74,
+    "setback_heat": 60,
+    "setback_cool": 80,
+    "natural_vent_delta": 3.0
+  },
+  "events": [
+    {
+      "time": "2026-07-20T08:00:00",
+      "type": "temp_update",
+      "indoor_f": 72.0,
+      "outdoor_f": 65.0,
+      "note": "Morning: indoor 72F (within band), outdoor 65F — nat-vent conditions met (outdoor < indoor, delta >= 3F)"
+    },
+    {
+      "time": "2026-07-20T08:01:00",
+      "type": "classification",
+      "day_type": "hot",
+      "hvac_mode": "cool",
+      "pre_condition": true,
+      "pre_condition_target": -2.0,
+      "windows_recommended": true,
+      "note": "Hot day: pre-cool target is comfort_cool + (-2) = 72F. Windows recommended."
+    },
+    {
+      "time": "2026-07-20T09:00:00",
+      "type": "sensor_open",
+      "entity": "binary_sensor.living_room_window",
+      "note": "Window opens — nat-vent activates (indoor 72F, outdoor 65F, delta 7F >= 3F)"
+    },
+    {
+      "time": "2026-07-20T11:00:00",
+      "type": "sensor_close",
+      "entity": "binary_sensor.living_room_window",
+      "note": "Window closes — nat-vent ends; _set_temperature_for_mode restores comfort (dual setpoint path for heat_cool thermostat)"
+    }
+  ],
+  "assertions": [
+    {
+      "at": "2026-07-20T09:00:00",
+      "expect": "natural_ventilation",
+      "reason": "sensor_open with outdoor (65F) below indoor (72F) and delta >= natural_vent_delta — nat-vent activates",
+      "track": "logic"
+    },
+    {
+      "at": "2026-07-20T11:00:00",
+      "expect": "resumed",
+      "reason": "sensor_close — all sensors closed, nat-vent ends and engine restores comfort mode",
+      "track": "logic"
+    },
+    {
+      "at": "2026-07-20T11:00:00",
+      "expect": "dual_setback_applied",
+      "reason": "Fix B (#293): _set_temperature_for_mode on a dual-setpoint thermostat must issue climate.set_temperature with target_temp_low=68F (comfort_heat) and target_temp_high=72F (comfort_cool + pre_condition_target -2). A single-edge command leaves the floor undefended — occupant wakes to a home cooler than comfort_heat.",
+      "track": "logic"
+    }
+  ],
+  "verdict": {
+    "type": "positive",
+    "summary": "Nat-vent restore on a dual-setpoint thermostat arms both setpoints [68F / 72F] — thermostat defends both comfort edges autonomously after windows close",
+    "observed_behavior": "natural_ventilation on sensor_open; resumed on sensor_close; dual set_temperature [target_temp_low=68, target_temp_high=72] emitted",
+    "expected_behavior": "Occupant closes window after cooling the house with outside air; thermostat immediately holds both comfort_heat floor and pre-cooled ceiling without requiring manual mode change"
+  }
+}


### PR DESCRIPTION
## Occupant Experience

After every HA restart, CA was silently treating a `heat_cool` thermostat state as a manual override (because the classifier never emits `heat_cool`), blocking automation for 30 minutes. Additionally, every nat-vent close event would drop the Ecobee from `heat_cool [68/74]` to single-setpoint `cool 72°F`, and the AI investigator had no visibility into which setpoint was actually active.

## Changes

### Fix A — Startup override false positive (`coordinator.py`)

`_check_startup_override()` now treats `heat_cool` as CA-compatible with `cool`/`heat` classifier outputs. A `_compatible` boolean replaced `current != recommended` — real mismatches (e.g., user switched to `fan_only` or `off`) still fire the override correctly.

### Fix B — Nat-vent restore drops heat_cool mode (`automation.py`)

`_set_temperature_for_mode()` now checks `_get_thermostat_capabilities()` and calls `_set_temperature_dual(floor, ceiling)` for dual-setpoint thermostats on both cool and heat classification paths. Occupancy-redirect paths (away/vacation) still return early before the caps check.

### Fix C — AI context missing active setpoints (`ai_skills_activity.py`)

Added `temperature`, `target_temp_low`, `target_temp_high` reads from the climate entity state. Two new lines in the context block (`Setpoint (single)` / `Setpoint low/high`) let the AI explain pre-cool offsets and band boundaries in morning summaries.

### Fix D — GitHub issue title prefix (`frontend/index.html`)

Removed hardcoded `'Climate Advisor: '` prefix from issue title generation. Substring limit increased from 80 to 100 chars.

## Tests

| File | Tests |
|---|---|
| `tests/test_startup_override.py` | `TestStartupHeatCoolCompatibility` (3 cases: heat_cool+cool→no override, heat_cool+heat→no override, cool+heat→override fires) |
| `tests/test_nat_vent_restore_dual_setpoint.py` (new) | dual thermostat cool path uses dual call, single thermostat uses single call, heat mode dual call |
| `tests/test_activity_report.py` | `TestThermostatSetpointFields` (5 cases: single-setpoint, dual low, dual high, all-N/A, mixed) |
| `tests/test_reason_logging.py` | Updated filter to match both `"Set temperature"` and `"Set dual temperature"` log strings |

**Results:** 2550/2550 pass, 0 warnings, lint clean. 46/46 golden simulation scenarios pass.

## Pending Scenario

`tools/simulations/pending/nat_vent_restore_uses_dual_setpoint.json` — validates that nat-vent close on a dual-setpoint thermostat with pre-condition emits `dual_setback_applied` (not single-setpoint). Promote to golden after user validates in production.

## Version

Bumped to **v0.4.8**. `RELEASE_NOTES["0.4.8"]` and `KNOWN_FIXES[293]` added to `const.py`.

## Closes

Closes #293