### PR TITLE
Fix #295: pre-cool ceiling held all day — add _pre_condition_achieved gate

### DIFF
--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -153,6 +153,7 @@ def select_comfort_band(
     occupancy_mode: str,
     in_sleep_window: bool,
     aggressive_savings: bool,
+    pre_condition_achieved: bool = False,
 ) -> ComfortBand:
     """Compute the comfort band for the current plan — pure, no HA state access.
 
@@ -203,6 +204,7 @@ def select_comfort_band(
             classification.hvac_mode == "cool"
             and classification.pre_condition_target is not None
             and classification.pre_condition_target < 0
+            and not pre_condition_achieved
         ):
             ceiling += float(classification.pre_condition_target)  # pre-cool lowers the ceiling
         ctx = "comfort"
@@ -472,6 +474,12 @@ class AutomationEngine:
 
         # Occupancy mode — synced by coordinator (Issue #85)
         self._occupancy_mode: str = OCCUPANCY_HOME
+
+        # Pre-cool achievement gate (Issue #295) — once the home reaches the pre-cool
+        # target temperature for the day, revert to comfort_cool ceiling for the rest
+        # of the day rather than holding the lower pre-cool setpoint all afternoon.
+        self._pre_condition_achieved: bool = False
+        self._pre_condition_achieved_date: str | None = None
 
     async def _notify(self, message: str, title: str, notification_type: str) -> None:
         """Send a notification via configured channels, filtered by per-event preferences."""
@@ -883,6 +891,7 @@ class AutomationEngine:
         self,
         classification: DayClassification,
         predicted_indoor: list[dict] | None = None,
+        indoor_temp: float | None = None,
     ) -> None:
         """Apply a new day classification — adjust HVAC behavior accordingly.
 
@@ -895,6 +904,9 @@ class AutomationEngine:
                 (list of {"ts": ISO str, "temp": float} entries). When provided
                 and the model is calibrated, the ceiling guard evaluates whether
                 to pre-cool before comfort_cool is breached.
+            indoor_temp: Current indoor temperature in °F. When provided, used
+                to evaluate the pre-cool achievement gate (Issue #295). When
+                None the achievement check is skipped for this cycle.
         """
         self._current_classification = classification
 
@@ -958,6 +970,32 @@ class AutomationEngine:
                 classification.hvac_mode,
             )
 
+        # Issue #295: pre-cool achievement gate — daily reset + detection.
+        # Reset the flag at the start of each new calendar day so the pre-cool
+        # ceiling offset re-arms each morning.  Check whether the home has
+        # already reached the pre-cool target temperature; if so, set the flag
+        # so select_comfort_band() reverts to comfort_cool for the rest of the day.
+        _today = dt_util.now().strftime("%Y-%m-%d")
+        if self._pre_condition_achieved_date != _today:
+            self._pre_condition_achieved = False
+            self._pre_condition_achieved_date = _today
+
+        if (
+            not self._pre_condition_achieved
+            and classification.pre_condition
+            and classification.pre_condition_target is not None
+            and classification.pre_condition_target < 0
+            and indoor_temp is not None
+        ):
+            _absolute_target = float(self.config.get("comfort_cool", 75)) + float(classification.pre_condition_target)
+            if indoor_temp <= _absolute_target:
+                self._pre_condition_achieved = True
+                _LOGGER.info(
+                    "Pre-cool achieved (indoor=%.1f°F ≤ target=%.1f°F) — reverting to comfort ceiling for rest of day",
+                    indoor_temp,
+                    _absolute_target,
+                )
+
         # Arm the comfort band — the thermostat holds the house; no mode-specific dispatch needed.
         cls_reason = (
             f"daily classification — {classification.day_type} day,"
@@ -969,6 +1007,7 @@ class AutomationEngine:
             occupancy_mode=self._occupancy_mode,
             in_sleep_window=_in_sleep_window(dt_util.now(), self.config),
             aggressive_savings=bool(self.config.get("aggressive_savings", False)),
+            pre_condition_achieved=self._pre_condition_achieved,
         )
         await self._apply_comfort_band(_band, reason=cls_reason)
 
@@ -2906,15 +2945,20 @@ class AutomationEngine:
         self._grace_end_time = None
         self._grace_duration_seconds = None
         self._last_resume_source = None
+        # Issue #295: pre-cool achievement gate — restored so a restart mid-day after
+        # the home reached the pre-cool target does not re-arm the lower ceiling offset.
+        self._pre_condition_achieved = state.get("pre_condition_achieved", False)
+        self._pre_condition_achieved_date = state.get("pre_condition_achieved_date")
         _LOGGER.info(
             "Restored automation state: paused=%s, pre_pause_mode=%s, "
-            "last_action=%s, fan_active=%s, fan_override=%s "
+            "last_action=%s, fan_active=%s, fan_override=%s, precool_achieved=%s "
             "(override/grace state cleared — clean slate on restart)",
             self._paused_by_door,
             self._pre_pause_mode,
             self._last_action_reason,
             self._fan_active,
             self._fan_override_active,
+            self._pre_condition_achieved,
         )
 
     def get_serializable_state(self) -> dict[str, Any]:
@@ -2950,6 +2994,10 @@ class AutomationEngine:
                 if self._current_classification
                 else None
             ),
+            # Issue #295: pre-cool achievement gate — persisted so an HA restart after
+            # the home reached the pre-cool target does not re-arm the lower ceiling.
+            "pre_condition_achieved": self._pre_condition_achieved,
+            "pre_condition_achieved_date": self._pre_condition_achieved_date,
         }
 
     def cleanup(self) -> None:

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -1300,6 +1300,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             await self.automation_engine.apply_classification(
                 self._current_classification,
                 predicted_indoor=self._last_predicted_indoor,
+                indoor_temp=self._get_indoor_temp(),
             )
 
             # If the day type changed since the briefing was generated,
@@ -1964,6 +1965,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         await self.automation_engine.apply_classification(
             classification,
             predicted_indoor=self._last_predicted_indoor,
+            indoor_temp=self._get_indoor_temp(),
         )
 
         # Initialize today's learning record, preserving any counters already accumulated

--- a/tests/test_pre_condition_achieved.py
+++ b/tests/test_pre_condition_achieved.py
@@ -1,0 +1,351 @@
+"""Tests for Issue #295 — pre-cool achievement gate.
+
+Verifies that AutomationEngine sets _pre_condition_achieved=True once the home
+reaches the pre-cool target temperature, and that select_comfort_band() stops
+lowering the ceiling once the flag is set.
+
+Occupant experience: On a hot day (forecast 90°F, comfort_cool=75°F,
+pre_condition_target=-2°F), the AC pre-cools to 73°F. Once the home reaches
+73°F, the system should revert to 75°F as the ceiling — not keep holding 73°F
+all afternoon.  Without this fix the user pays extra energy all day to maintain
+73°F instead of their configured 75°F comfort ceiling.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from custom_components.climate_advisor.automation import AutomationEngine, select_comfort_band
+from custom_components.climate_advisor.classifier import DayClassification
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _consume_coroutine(coro):
+    """Close coroutine to prevent 'never awaited' warnings."""
+    coro.close()
+
+
+def _make_thermostat_state(mode: str = "cool") -> MagicMock:
+    """Return a mock thermostat state with heat+cool capabilities.
+
+    _apply_comfort_band reads attributes.hvac_modes + supported_features.
+    Without these attrs the band no-ops and _set_temperature is never reached.
+    """
+    s = MagicMock()
+    s.state = mode
+    s.attributes = {
+        "hvac_modes": ["off", "heat", "cool"],
+        "supported_features": 1,
+        "current_temperature": 76.0,  # default indoor temp injected via thermostat
+    }
+    return s
+
+
+def _make_engine(config_overrides: dict | None = None) -> AutomationEngine:
+    """Create an AutomationEngine with hot-day test config."""
+    hass = MagicMock()
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+    hass.async_create_task = MagicMock(side_effect=_consume_coroutine)
+    hass.states = MagicMock()
+    hass.states.get.return_value = _make_thermostat_state("cool")
+
+    config = {
+        "comfort_heat": 70,
+        "comfort_cool": 75,
+        "setback_heat": 60,
+        "setback_cool": 80,
+        "notify_service": "notify.notify",
+        "temp_unit": "fahrenheit",
+    }
+    if config_overrides:
+        config.update(config_overrides)
+
+    return AutomationEngine(
+        hass=hass,
+        climate_entity="climate.thermostat",
+        weather_entity="weather.forecast_home",
+        door_window_sensors=["binary_sensor.front_door"],
+        notify_service=config["notify_service"],
+        config=config,
+    )
+
+
+def _make_hot_classification(**kwargs) -> DayClassification:
+    """Create a hot-day DayClassification with pre_condition=True."""
+    obj = object.__new__(DayClassification)
+    obj.day_type = "hot"
+    obj.hvac_mode = "cool"
+    obj.trend_direction = "stable"
+    obj.trend_magnitude = 0
+    obj.today_high = kwargs.get("today_high", 90.0)
+    obj.today_low = kwargs.get("today_low", 65.0)
+    obj.tomorrow_high = kwargs.get("tomorrow_high", 88.0)
+    obj.tomorrow_low = kwargs.get("tomorrow_low", 65.0)
+    obj.pre_condition = kwargs.get("pre_condition", True)
+    obj.pre_condition_target = kwargs.get("pre_condition_target", -2.0)
+    obj.windows_recommended = kwargs.get("windows_recommended", False)
+    obj.window_open_time = None
+    obj.window_close_time = None
+    obj.setback_modifier = 0.0
+    obj.window_opportunity_morning = False
+    obj.window_opportunity_evening = False
+    obj.window_opportunity_morning_start = None
+    obj.window_opportunity_morning_end = None
+    obj.window_opportunity_evening_start = None
+    obj.window_opportunity_evening_end = None
+    return obj
+
+
+# ── Tests: initial state ──────────────────────────────────────────────────────
+
+
+class TestFlagInitialState:
+    def test_flag_starts_false(self):
+        """New AutomationEngine has _pre_condition_achieved = False."""
+        engine = _make_engine()
+        assert engine._pre_condition_achieved is False
+
+    def test_date_starts_none(self):
+        """New AutomationEngine has _pre_condition_achieved_date = None."""
+        engine = _make_engine()
+        assert engine._pre_condition_achieved_date is None
+
+
+# ── Tests: select_comfort_band — pure function ────────────────────────────────
+
+
+class TestSelectComfortBandPreCool:
+    """select_comfort_band ceiling-lowering guard with pre_condition_achieved parameter."""
+
+    def _band(self, pre_condition_achieved: bool, pre_condition_target: float = -2.0):
+        classification = _make_hot_classification(pre_condition_target=pre_condition_target)
+        config = {"comfort_heat": 70, "comfort_cool": 75}
+        return select_comfort_band(
+            classification,
+            config,
+            occupancy_mode="home",
+            in_sleep_window=False,
+            aggressive_savings=False,
+            pre_condition_achieved=pre_condition_achieved,
+        )
+
+    def test_ceiling_lowered_when_not_achieved(self):
+        """indoor_temp=76, comfort_cool=75, pre_condition_target=-2 → ceiling=73 (pre-cool active)."""
+        band = self._band(pre_condition_achieved=False)
+        assert band.ceiling == 73.0, (
+            f"Expected ceiling=73.0 (75 + -2) when pre-cool not yet achieved, got {band.ceiling}"
+        )
+
+    def test_ceiling_normal_when_achieved(self):
+        """When pre_condition_achieved=True, ceiling stays at comfort_cool (75), NOT 73."""
+        band = self._band(pre_condition_achieved=True)
+        assert band.ceiling == 75.0, f"Expected ceiling=75.0 (comfort_cool) when pre-cool achieved, got {band.ceiling}"
+
+    def test_ceiling_lowered_default_parameter(self):
+        """Default pre_condition_achieved=False still lowers ceiling (backward compat)."""
+        classification = _make_hot_classification()
+        config = {"comfort_heat": 70, "comfort_cool": 75}
+        band = select_comfort_band(
+            classification,
+            config,
+            occupancy_mode="home",
+            in_sleep_window=False,
+            aggressive_savings=False,
+            # pre_condition_achieved not passed — defaults to False
+        )
+        assert band.ceiling == 73.0
+
+
+# ── Tests: achievement detection via apply_classification ─────────────────────
+
+
+class TestAchievementDetection:
+    """apply_classification sets the achievement flag when indoor_temp reaches target."""
+
+    def _run_apply(
+        self,
+        engine: AutomationEngine,
+        classification: DayClassification,
+        indoor_temp: float | None,
+        today: str = "2026-06-13",
+    ) -> None:
+        """Run apply_classification in a patched date context, stubbing out HA calls."""
+        fixed_dt = datetime.fromisoformat(f"{today}T09:00:00")
+
+        async def _run():
+            with patch(
+                "custom_components.climate_advisor.automation.dt_util.now",
+                return_value=fixed_dt,
+            ):
+                await engine.apply_classification(
+                    classification,
+                    indoor_temp=indoor_temp,
+                )
+
+        asyncio.run(_run())
+
+    def test_flag_set_when_indoor_at_target(self):
+        """apply_classification with indoor_temp=73.0 (exactly at target 73) → flag becomes True."""
+        engine = _make_engine()
+        c = _make_hot_classification(pre_condition_target=-2.0)
+        # target = comfort_cool + pre_condition_target = 75 + (-2) = 73
+        self._run_apply(engine, c, indoor_temp=73.0)
+        assert engine._pre_condition_achieved is True, (
+            "Expected _pre_condition_achieved=True when indoor_temp=73.0 <= target=73.0"
+        )
+
+    def test_flag_set_when_indoor_below_target(self):
+        """apply_classification with indoor_temp=71.0 (below target 73) → flag becomes True."""
+        engine = _make_engine()
+        c = _make_hot_classification(pre_condition_target=-2.0)
+        self._run_apply(engine, c, indoor_temp=71.0)
+        assert engine._pre_condition_achieved is True, (
+            "Expected _pre_condition_achieved=True when indoor_temp=71.0 <= target=73.0"
+        )
+
+    def test_flag_not_set_when_indoor_above_target(self):
+        """apply_classification with indoor_temp=74.0 (above target 73) → flag stays False."""
+        engine = _make_engine()
+        c = _make_hot_classification(pre_condition_target=-2.0)
+        self._run_apply(engine, c, indoor_temp=74.0)
+        assert engine._pre_condition_achieved is False, (
+            "Expected _pre_condition_achieved=False when indoor_temp=74.0 > target=73.0"
+        )
+
+    def test_flag_not_set_when_indoor_temp_none(self):
+        """apply_classification with indoor_temp=None → flag stays False (can't evaluate)."""
+        engine = _make_engine()
+        c = _make_hot_classification(pre_condition_target=-2.0)
+        self._run_apply(engine, c, indoor_temp=None)
+        assert engine._pre_condition_achieved is False
+
+    def test_flag_not_set_when_pre_condition_false(self):
+        """apply_classification with pre_condition=False → flag stays False."""
+        engine = _make_engine()
+        c = _make_hot_classification(pre_condition=False, pre_condition_target=None)
+        self._run_apply(engine, c, indoor_temp=70.0)
+        assert engine._pre_condition_achieved is False
+
+    def test_flag_already_true_stays_true(self):
+        """Once flag=True, a subsequent call with indoor_temp above target doesn't reset it."""
+        engine = _make_engine()
+        c = _make_hot_classification(pre_condition_target=-2.0)
+        # First call: achieve the target
+        self._run_apply(engine, c, indoor_temp=73.0)
+        assert engine._pre_condition_achieved is True
+        # Second call: indoor drifted up to 74 (above target) — flag must stay True
+        self._run_apply(engine, c, indoor_temp=74.0)
+        assert engine._pre_condition_achieved is True, (
+            "Flag must remain True once set — drift above target must not clear it"
+        )
+
+
+# ── Tests: daily reset ────────────────────────────────────────────────────────
+
+
+class TestDailyReset:
+    def test_flag_resets_on_new_day(self):
+        """Flag set on 2026-06-13 resets to False when apply_classification called on 2026-06-14."""
+        engine = _make_engine()
+        c = _make_hot_classification(pre_condition_target=-2.0)
+
+        async def _run(today: str, indoor_temp: float | None):
+            fixed_dt = datetime.fromisoformat(f"{today}T09:00:00")
+            with patch(
+                "custom_components.climate_advisor.automation.dt_util.now",
+                return_value=fixed_dt,
+            ):
+                await engine.apply_classification(c, indoor_temp=indoor_temp)
+
+        # Day 1: set the flag
+        asyncio.run(_run("2026-06-13", 73.0))
+        assert engine._pre_condition_achieved is True
+        assert engine._pre_condition_achieved_date == "2026-06-13"
+
+        # Day 2: flag should reset before achievement check
+        asyncio.run(_run("2026-06-14", 74.0))  # 74 > target 73 — doesn't re-achieve
+        assert engine._pre_condition_achieved is False, "Flag must reset to False on a new calendar day"
+        assert engine._pre_condition_achieved_date == "2026-06-14"
+
+    def test_flag_persists_within_same_day(self):
+        """Flag set at 09:00 is still True when apply_classification called at 15:00 same day."""
+        engine = _make_engine()
+        c = _make_hot_classification(pre_condition_target=-2.0)
+
+        async def _run(hour: int, indoor_temp: float | None):
+            fixed_dt = datetime.fromisoformat(f"2026-06-13T{hour:02d}:00:00")
+            with patch(
+                "custom_components.climate_advisor.automation.dt_util.now",
+                return_value=fixed_dt,
+            ):
+                await engine.apply_classification(c, indoor_temp=indoor_temp)
+
+        # Morning: achieve
+        asyncio.run(_run(9, 73.0))
+        assert engine._pre_condition_achieved is True
+
+        # Afternoon: drift up but same day — flag stays True
+        asyncio.run(_run(15, 74.0))
+        assert engine._pre_condition_achieved is True
+
+
+# ── Tests: state persistence ──────────────────────────────────────────────────
+
+
+class TestStatePersistence:
+    def test_flag_in_serializable_state(self):
+        """get_serializable_state() includes pre_condition_achieved and pre_condition_achieved_date."""
+        engine = _make_engine()
+        engine._pre_condition_achieved = True
+        engine._pre_condition_achieved_date = "2026-06-13"
+
+        state = engine.get_serializable_state()
+
+        assert "pre_condition_achieved" in state, "pre_condition_achieved missing from serialized state"
+        assert "pre_condition_achieved_date" in state, "pre_condition_achieved_date missing from serialized state"
+        assert state["pre_condition_achieved"] is True
+        assert state["pre_condition_achieved_date"] == "2026-06-13"
+
+    def test_flag_false_in_serializable_state(self):
+        """get_serializable_state() correctly serializes False state."""
+        engine = _make_engine()
+        state = engine.get_serializable_state()
+        assert state["pre_condition_achieved"] is False
+        assert state["pre_condition_achieved_date"] is None
+
+    def test_restore_state_restores_flag(self):
+        """restore_state() restores pre_condition_achieved and pre_condition_achieved_date."""
+        engine = _make_engine()
+        engine.restore_state(
+            {
+                "pre_condition_achieved": True,
+                "pre_condition_achieved_date": "2026-06-13",
+            }
+        )
+        assert engine._pre_condition_achieved is True
+        assert engine._pre_condition_achieved_date == "2026-06-13"
+
+    def test_restore_state_defaults_flag_false(self):
+        """restore_state() with missing key defaults _pre_condition_achieved to False."""
+        engine = _make_engine()
+        engine.restore_state({})
+        assert engine._pre_condition_achieved is False
+        assert engine._pre_condition_achieved_date is None
+
+    def test_state_round_trip(self):
+        """get_serializable_state() + restore_state() round-trip preserves flag correctly."""
+        engine1 = _make_engine()
+        engine1._pre_condition_achieved = True
+        engine1._pre_condition_achieved_date = "2026-06-13"
+
+        serialized = engine1.get_serializable_state()
+
+        engine2 = _make_engine()
+        engine2.restore_state(serialized)
+
+        assert engine2._pre_condition_achieved is True
+        assert engine2._pre_condition_achieved_date == "2026-06-13"

--- a/tools/sim_harness/run_production.py
+++ b/tools/sim_harness/run_production.py
@@ -352,7 +352,19 @@ def _dispatch_event(
 
     elif etype == "classification":
         classification = _build_classification_from_event(event)
-        asyncio.run(engine.apply_classification(classification))
+        # Issue #295: pass the current injected indoor temp so apply_classification
+        # can evaluate the pre-cool achievement gate — mirrors coordinator behaviour
+        # where _get_indoor_temp() is always passed on each cycle.
+        _cls_indoor_f = None
+        _climate_st = fake_hass.states.get(climate_entity)
+        if _climate_st is not None:
+            _cls_indoor_f = _climate_st.attributes.get("current_temperature")
+            if _cls_indoor_f is not None:
+                try:
+                    _cls_indoor_f = float(_cls_indoor_f)
+                except (TypeError, ValueError):
+                    _cls_indoor_f = None
+        asyncio.run(engine.apply_classification(classification, indoor_temp=_cls_indoor_f))
 
     elif etype == "occupancy_away":
         engine.set_occupancy_mode("away")
@@ -465,7 +477,15 @@ def _handle_temp_update(
     # periodic ceiling-guard re-evaluation. Legacy ignores this field.
     predicted = event.get("predicted_indoor")
     if predicted and getattr(engine, "_current_classification", None) is not None:
-        asyncio.run(engine.apply_classification(engine._current_classification, predicted_indoor=predicted))
+        # Issue #295: pass current indoor temp so achievement gate is evaluated on cycle.
+        _tu_indoor_f = float(indoor_f) if indoor_f is not None else None
+        asyncio.run(
+            engine.apply_classification(
+                engine._current_classification,
+                predicted_indoor=predicted,
+                indoor_temp=_tu_indoor_f,
+            )
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -487,6 +507,8 @@ def _snapshot_engine_state(engine: Any) -> dict[str, Any]:
         "_occupancy_mode",
         "_override_confirm_pending",
         "_economizer_active",
+        "_pre_condition_achieved",  # Issue #295
+        "_pre_condition_achieved_date",  # Issue #295
     ):
         snap[attr] = getattr(engine, attr, None)
 

--- a/tools/simulations/pending/hot_day_precool_achieved_reverts_to_comfort.json
+++ b/tools/simulations/pending/hot_day_precool_achieved_reverts_to_comfort.json
@@ -1,0 +1,119 @@
+{
+  "name": "hot_day_precool_achieved_reverts_to_comfort",
+  "description": "Issue #295: On a hot day (forecast 90°F, comfort_cool=75°F, pre_condition_target=-2°F), the AC pre-cools the home toward 73°F. Once the home reaches 73°F the _pre_condition_achieved flag is set and select_comfort_band() reverts the ceiling to 75°F. A later cycle with indoor=74°F (above target) confirms the flag stays set and ceiling remains 75°F — the system does not re-arm the lower setpoint.",
+  "source": "synthetic",
+  "issue": 295,
+  "notes": [
+    "Three-exercise protocol (CLAUDE.md §10):",
+    "(a) Scenario effectiveness: deleting the 'and not pre_condition_achieved' guard in",
+    "    select_comfort_band() causes the t=60m assertion (expect_band ceiling=75) to FAIL —",
+    "    the ceiling would be 73 instead of 75 on every cycle after achievement.",
+    "(b) Docs↔production alignment: docs/08-COMPUTATION-REFERENCE.md §4 pre-conditioning",
+    "    table must document the exit condition before this scenario is promoted to golden.",
+    "    The scenario is the regression anchor that forces a doc update if the guard is removed.",
+    "(c) Occupant experience: if this scenario fails to catch a regression, occupants on a hot",
+    "    day pay extra energy to hold 73°F all afternoon instead of their configured 75°F",
+    "    comfort ceiling. The AC runs harder and longer than necessary from mid-morning onward."
+  ],
+  "config": {
+    "comfort_heat": 70,
+    "comfort_cool": 75,
+    "setback_heat": 60,
+    "setback_cool": 80,
+    "natural_vent_delta": 3.0
+  },
+  "events": [
+    {
+      "time": "2026-06-13T06:00:00",
+      "type": "temp_update",
+      "indoor_f": 76.0,
+      "outdoor_f": 80.0,
+      "note": "Morning: indoor=76°F (above comfort_cool=75), outdoor=80°F. Outdoor above indoor so no nat-vent."
+    },
+    {
+      "time": "2026-06-13T06:01:00",
+      "type": "classification",
+      "day_type": "hot",
+      "hvac_mode": "cool",
+      "pre_condition": true,
+      "pre_condition_target": -2.0,
+      "today_high": 90.0,
+      "today_low": 65.0,
+      "windows_recommended": false,
+      "note": "Hot day: hvac_mode=cool, pre_condition_target=-2. Absolute target=75+(-2)=73°F. Indoor=76 > 73 so flag not set yet. Band ceiling should be 73°F."
+    },
+    {
+      "time": "2026-06-13T06:30:00",
+      "type": "temp_update",
+      "indoor_f": 73.0,
+      "outdoor_f": 82.0,
+      "note": "30-min cycle: AC has cooled home to 73°F — exactly at the pre-cool target. Achievement should be detected."
+    },
+    {
+      "time": "2026-06-13T06:31:00",
+      "type": "classification",
+      "day_type": "hot",
+      "hvac_mode": "cool",
+      "pre_condition": true,
+      "pre_condition_target": -2.0,
+      "today_high": 90.0,
+      "today_low": 65.0,
+      "windows_recommended": false,
+      "note": "30-min coordinator cycle: same classification re-applied with indoor=73°F. Achievement gate fires. Band ceiling should now be 75°F (comfort_cool)."
+    },
+    {
+      "time": "2026-06-13T07:00:00",
+      "type": "temp_update",
+      "indoor_f": 74.0,
+      "outdoor_f": 84.0,
+      "note": "60-min cycle: indoor drifted up slightly to 74°F (above pre-cool target 73°F). Flag should remain True."
+    },
+    {
+      "time": "2026-06-13T07:01:00",
+      "type": "classification",
+      "day_type": "hot",
+      "hvac_mode": "cool",
+      "pre_condition": true,
+      "pre_condition_target": -2.0,
+      "today_high": 90.0,
+      "today_low": 65.0,
+      "windows_recommended": false,
+      "note": "60-min cycle: indoor=74°F (above 73 target but flag already True). Band ceiling must stay 75°F — flag must NOT be cleared by drift above target."
+    }
+  ],
+  "assertions": [
+    {
+      "at": "2026-06-13T06:01:00",
+      "expect": "expect_band",
+      "expect_band": {
+        "floor": 70,
+        "ceiling": 73
+      },
+      "reason": "At t=0 (indoor=76°F > target=73°F), pre-cool achievement not yet reached. select_comfort_band() lowers ceiling by pre_condition_target (-2°F): 75 + (-2) = 73°F. Floor stays at comfort_heat=70°F."
+    },
+    {
+      "at": "2026-06-13T06:31:00",
+      "expect": "expect_band",
+      "expect_band": {
+        "floor": 70,
+        "ceiling": 75
+      },
+      "reason": "At t=30m (indoor=73°F = target=73°F), _pre_condition_achieved is set True. select_comfort_band() skips the ceiling lowering. Ceiling reverts to comfort_cool=75°F. Occupant comfort ceiling is restored for the rest of the day."
+    },
+    {
+      "at": "2026-06-13T07:01:00",
+      "expect": "expect_band",
+      "expect_band": {
+        "floor": 70,
+        "ceiling": 75
+      },
+      "reason": "At t=60m (indoor=74°F, which is above target=73°F), the flag is already True and remains True — drift above target does not clear the achievement. Ceiling stays at 75°F. Without the fix the ceiling would re-arm at 73°F, causing the AC to over-cool all afternoon."
+    }
+  ],
+  "verdict": {
+    "type": "positive",
+    "summary": "Pre-cool achievement gate: ceiling lowers to 73°F until home reaches target, then reverts to comfort_cool=75°F for the rest of the day",
+    "observed_behavior": "Band ceiling=73 at t=0 → Band ceiling=75 at t=30m (achievement) → Band ceiling=75 at t=60m (flag persists through drift)",
+    "expected_behavior": "Occupant pre-cools home to 73°F on a hot day, then the system holds 75°F (their configured comfort setting) for the afternoon — not 73°F all day"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `_pre_condition_achieved` flag to `AutomationEngine` — set when `indoor_temp ≤ comfort_cool + pre_condition_target` (e.g. 73°F on a hot day with `comfort_cool=75`)
- `select_comfort_band()` receives `pre_condition_achieved` as a new keyword parameter; ceiling lowering is skipped once the flag is True
- Flag resets daily (date-keyed); persists through HA restarts (serialized to state)
- Both coordinator `apply_classification()` call sites now pass `indoor_temp=self._get_indoor_temp()`
- Harness (`run_production.py`) updated to forward indoor temp so simulation scenarios can assert the ceiling transition

## Why
The `-2°F` pre-cool offset was applied unconditionally every 30 minutes for the entire day on any hot day (today_high ≥ 85°F). Once the home reached 73°F, the system held it there all day — running more AC than the user's 75°F comfort setting requires. This is an original design gap from #249.

## Test plan
- [x] 18 new unit tests in `tests/test_pre_condition_achieved.py` — flag lifecycle, pure-function ceiling guard, daily reset, state persistence
- [x] Full test suite: 2569/2569 pass
- [x] New pending simulation scenario: `hot_day_precool_achieved_reverts_to_comfort` passes
- [x] Opus verification: APPROVE (no blocking issues)
- [ ] Post-deploy: `python tools/ha_logs.py --thermal` — confirm "Pre-cool achieved" log fires and no subsequent `set_temperature` calls to the pre-cool target appear in that day's cycles