### PR TITLE
Fix #299: Ecobee dual-setpoint desync — double-write bypass, hvac_mode conditional, setpoint confirmation check

### DIFF
--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -420,6 +420,7 @@ class AutomationEngine:
         self._pending_setpoint_low: float | None = None  # dual setpoint validation: commanded low (service units)
         self._pending_setpoint_high: float | None = None  # dual setpoint validation: commanded high (service units)
         self._pending_setpoint_single: float | None = None  # single setpoint validation: commanded temp (service units)
+        self._write_seq: int = 0  # monotonic counter: validation callbacks skip if a newer write has superseded them
         self._hvac_command_time: datetime | None = None  # last system-initiated HVAC command timestamp
         self._fan_command_time: datetime | None = None  # last system-initiated fan command timestamp (race guard)
         self._last_commanded_hvac_mode: str | None = None  # expected-state tracking: last mode automation commanded
@@ -1153,6 +1154,7 @@ class AutomationEngine:
                         await self._set_temperature(
                             _comfort_cool_cg,
                             reason="ODE ceiling guard — target comfort_cool",
+                            mode="cool",
                         )
                         if self._emit_event_callback:
                             self._emit_event_callback(
@@ -1217,12 +1219,12 @@ class AutomationEngine:
         elif band.active == "ceiling" and caps.supports_cool:
             if _current_mode != "cool":
                 await self._set_hvac_mode("cool", reason=f"{reason} [band: entering cool]")
-            await self._set_temperature(band.ceiling, reason=reason)
+            await self._set_temperature(band.ceiling, reason=reason, mode="cool")
             _cmd_shape = "cool"
         elif band.active == "floor" and caps.supports_heat:
             if _current_mode != "heat":
                 await self._set_hvac_mode("heat", reason=f"{reason} [band: entering heat]")
-            await self._set_temperature(band.floor, reason=reason)
+            await self._set_temperature(band.floor, reason=reason, mode="heat")
             _cmd_shape = "heat"
         else:
             # The thermostat advertises no mode that can defend the active edge (e.g. a heat-only
@@ -1290,12 +1292,16 @@ class AutomationEngine:
         finally:
             self._hvac_command_pending = False
 
-    async def _set_temperature(self, temperature: float, *, reason: str) -> None:
+    async def _set_temperature(self, temperature: float, *, reason: str, mode: str = "cool") -> None:
         """Set the thermostat target temperature.
 
         Args:
             temperature: Target temperature in internal Fahrenheit.
             reason: Human-readable reason for logging.
+            mode: "cool" (ceiling setpoint) or "heat" (floor setpoint).  Determines the
+                pre-write offset direction for HA deduplication bypass (Issue #299):
+                cool ceiling goes up by 1 (won't trigger cooling), heat floor goes down by 1
+                (won't trigger heating).
         """
         unit = self.config.get("temp_unit", "fahrenheit")
         # Convert internal °F to user's unit before sending to HA climate entity
@@ -1344,9 +1350,23 @@ class AutomationEngine:
                         "comfort_cool": self.config.get("comfort_cool", 76),
                     },
                 )
+        # Set state tracking to TARGET values before writes so the validation callback
+        # always compares against the intended final setpoint.
+        self._pending_setpoint_single = service_temp
+        self._write_seq += 1
+        _my_seq = self._write_seq
         self._temp_command_pending = True
         self._temp_command_time = dt_util.now()
         try:
+            # Pre-write: offset setpoint to bypass HA deduplication.  Direction is chosen
+            # so the temporary offset does not trigger unnecessary conditioning (Issue #299).
+            _pre_temp = service_temp + 1.0 if mode == "cool" else service_temp - 1.0
+            await self.hass.services.async_call(
+                "climate",
+                "set_temperature",
+                {"entity_id": self.climate_entity, "temperature": _pre_temp},
+            )
+            # Target write: correct setpoint.
             await self.hass.services.async_call(
                 "climate",
                 "set_temperature",
@@ -1354,9 +1374,10 @@ class AutomationEngine:
             )
         finally:
             self._temp_command_pending = False
-        self._pending_setpoint_single = service_temp
 
         async def _check_single_setpoint_accepted() -> None:
+            if self._write_seq != _my_seq:
+                return
             state = self.hass.states.get(self.climate_entity)
             if state is None:
                 return
@@ -1402,6 +1423,14 @@ class AutomationEngine:
 
         Uses the same flag/logging/record_action pattern as _set_temperature().
         low/high are internal Fahrenheit values; converted to user unit before service call.
+
+        Two-write strategy (Issue #299):
+        1. Pre-write: offset setpoints (low-1, high+1 in service units) to bypass HA's
+           Ecobee integration deduplication — without this, identical setpoints are silently
+           dropped when the HA entity already reports the same values (stale optimistic state).
+        2. Target write: correct setpoints WITHOUT hvac_mode (only included in pre-write if a
+           mode transition is needed) — omitting hvac_mode prevents the Ecobee from re-evaluating
+           its comfort program on every steady-state write.
         """
         unit = self.config.get("temp_unit", "fahrenheit")
         service_low = from_fahrenheit(low, unit)
@@ -1414,27 +1443,52 @@ class AutomationEngine:
                 reason,
             )
             return
+        # Set state tracking to TARGET values before any writes so the validation
+        # callback always compares against the intended final setpoints.
+        self._last_commanded_hvac_mode = "heat_cool"
+        self._last_commanded_hvac_time = dt_util.now()
+        self._pending_setpoint_low = service_low
+        self._pending_setpoint_high = service_high
+        self._write_seq += 1
+        _my_seq = self._write_seq
         self._temp_command_pending = True
         self._temp_command_time = dt_util.now()
         try:
+            # Determine whether a mode transition is needed.
+            _climate_state = self.hass.states.get(self.climate_entity)
+            _needs_mode_switch = _climate_state is None or _climate_state.state != "heat_cool"
+
+            # Pre-write: offset setpoints to guarantee HA sends a command even when entity
+            # state already matches the target (deduplication bypass).  The -1/+1 direction
+            # widens the band, so the thermostat will not trigger unnecessary conditioning.
+            _pre_data: dict = {
+                "entity_id": self.climate_entity,
+                "target_temp_low": service_low - 1.0,
+                "target_temp_high": service_high + 1.0,
+            }
+            if _needs_mode_switch:
+                _pre_data["hvac_mode"] = "heat_cool"
+            await self.hass.services.async_call("climate", "set_temperature", _pre_data)
+
+            # Target write: correct setpoints.  hvac_mode is intentionally omitted here —
+            # the mode was already set (or was already heat_cool) so including it would
+            # trigger the Ecobee to re-evaluate its comfort program instead of holding.
             await self.hass.services.async_call(
                 "climate",
                 "set_temperature",
                 {
                     "entity_id": self.climate_entity,
-                    "hvac_mode": "heat_cool",
                     "target_temp_low": service_low,
                     "target_temp_high": service_high,
                 },
             )
         finally:
             self._temp_command_pending = False
-        self._last_commanded_hvac_mode = "heat_cool"
-        self._last_commanded_hvac_time = dt_util.now()
-        self._pending_setpoint_low = service_low
-        self._pending_setpoint_high = service_high
 
         async def _check_dual_setpoint_accepted() -> None:
+            # Skip if a newer write has superseded this one.
+            if self._write_seq != _my_seq:
+                return
             state = self.hass.states.get(self.climate_entity)
             if state is None:
                 return
@@ -1507,10 +1561,10 @@ class AutomationEngine:
         if c.hvac_mode == "heat":
             floor_target = float(self.config["comfort_heat"])
             if caps.supports_dual_setpoint:
-                ceil = float(self.config.get("comfort_cool", 76))
+                ceil = float(self.config.get("comfort_cool", 75))
                 await self._set_temperature_dual(floor_target, ceil, reason=reason)
             else:
-                await self._set_temperature(floor_target, reason=reason)
+                await self._set_temperature(floor_target, reason=reason, mode="heat")
             return
         elif c.hvac_mode == "cool":
             ceiling_target = float(self.config["comfort_cool"])
@@ -1519,10 +1573,10 @@ class AutomationEngine:
                 ceiling_target = ceiling_target + c.pre_condition_target
                 reason = f"{reason} (pre-cool offset {format_temp_delta(abs(c.pre_condition_target), unit)})"
             if caps.supports_dual_setpoint:
-                floor = float(self.config.get("comfort_heat", 68))
+                floor = float(self.config.get("comfort_heat", 70))
                 await self._set_temperature_dual(floor, ceiling_target, reason=reason)
             else:
-                await self._set_temperature(ceiling_target, reason=reason)
+                await self._set_temperature(ceiling_target, reason=reason, mode="cool")
             return
         elif c.hvac_mode == "heat_cool":
             await self._set_temperature_dual(
@@ -2514,6 +2568,15 @@ class AutomationEngine:
 
     async def handle_bedtime(self) -> None:
         """Apply bedtime setback."""
+        # Issue #299: guard against double-write when this task is fired via async_create_task
+        # in _check_startup_override() while apply_classification() runs in the same coordinator
+        # cycle.  apply_classification() runs first (it is awaited), sets _temp_command_time, and
+        # clears _temp_command_pending in its finally block.  By the time handle_bedtime() runs,
+        # the flag is already clear — a time-based cooldown is required.
+        if self._temp_command_time is not None and (dt_util.now() - self._temp_command_time).total_seconds() < 30:
+            _LOGGER.debug("handle_bedtime: skipping — setpoint write within last 30s (startup dedup guard)")
+            return
+
         # Issue #85: vacation/away already has a setback — don't override it with sleep temps
         if self._occupancy_mode in (OCCUPANCY_VACATION, OCCUPANCY_AWAY):
             _LOGGER.info("Bedtime skipped — %s mode (setback already active)", self._occupancy_mode)

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,29 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.4.8"
+VERSION = "0.4.9"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.4.9": [
+        "Fix #299: CA setpoint writes to the Ecobee thermostat now bypass HA's deduplication"
+        " filter. Every setpoint command sends an intentionally-offset pre-write followed by the"
+        " exact target, guaranteeing the command reaches the physical thermostat even when HA's"
+        " optimistic state already matches the target.",
+        "Fix #299: Dual-setpoint (heat_cool) writes no longer include hvac_mode in every call."
+        " The mode switch is sent only when the thermostat is not already in heat_cool mode,"
+        " preventing the Ecobee from applying its comfort-program setpoints (65/75) instead of"
+        " CA's commanded values (e.g. 68/74).",
+        "Fix #299: CA now verifies that reported thermostat setpoints match its commanded values"
+        " within 1°F before treating a state change as a confirmation. When setpoints differ by"
+        " more than 1°F in heat_cool mode the event is treated as an Ecobee comfort-program"
+        " reassertion, not a confirmation, preventing false-positive override suppression.",
+        "Fix #299: handle_bedtime() now skips the setpoint write if another setpoint command was"
+        " issued within the last 30 seconds, eliminating a startup race where the coordinator's"
+        " initial classification cycle and the sleep-window bedtime handler both fired and"
+        " produced a double-write that triggered the Ecobee comfort-program reversion.",
+        "Fix #299: Fallback default temperatures in _set_temperature_for_mode() corrected from"
+        " 68°F/76°F to 70°F/75°F, matching the documented comfort defaults.",
+    ],
     "0.4.8": [
         "Fix #293: After every HA restart, CA no longer treats a heat_cool thermostat state as"
         " a manual override. The startup check now recognises heat_cool as CA-compatible with"
@@ -1060,6 +1080,41 @@ KNOWN_FIXES: dict[int, dict] = {
             "pre_condition_target design question: 72°F ceiling persists all day on hot days by"
             " design (thermal buffer); making it morning-only (cease offset once indoor ≤ target)"
             " is out of scope for this fix",
+        ],
+    },
+    299: {
+        "version_fixed": "0.4.9",
+        "title": "Ecobee dual-setpoint desync — double-write dedup bypass, hvac_mode conditional,"
+        " setpoint confirmation check, startup cooldown guard",
+        "scope_covered": [
+            "automation.py _set_temperature(): now issues two service calls — offset pre-write"
+            " (temp±1°F, direction chosen to never trigger conditioning) then exact target write;"
+            " accepts mode='cool'|'heat' parameter so offset direction is always safe",
+            "automation.py _set_temperature_dual(): same double-write pattern"
+            " (low-1/high+1 pre-write then exact target); hvac_mode='heat_cool' included in"
+            " pre-write only when thermostat is not already in heat_cool mode — omitted in"
+            " target write in all cases; _write_seq nonce prevents stale validation callbacks",
+            "automation.py _apply_comfort_band(): passes explicit mode='cool' or mode='heat'"
+            " to all _set_temperature() callsites so offset direction is correct for each path",
+            "automation.py _set_temperature_for_mode(): fallback defaults corrected to"
+            " comfort_heat=70°F and comfort_cool=75°F (were 68°F/76°F)",
+            "automation.py handle_bedtime(): 30-second cooldown guard skips the bedtime"
+            " setpoint write if _temp_command_time is within the last 30s — eliminates startup"
+            " race between coordinator's first classification cycle and the sleep-window handler",
+            "coordinator.py _async_thermostat_changed(): _is_expected_confirmation() now checks"
+            " that reported heat_cool setpoints are within 1°F of CA's pending setpoints;"
+            " setpoints outside this window are treated as an Ecobee comfort-program reassertion,"
+            " not a CA write confirmation",
+            "All caller test files updated: 11 test files revised to expect 2 service calls"
+            " per setpoint write (pre-write + target) and verify values at the correct call index",
+        ],
+        "scope_not_covered": [
+            "Two-step mode transition (set_hvac_mode then set_temperature with delay) — not"
+            " needed after hold-type change to 'hold until I change again' on the Ecobee device",
+            "Celsius homes: pre-write offset is ±1°C (≈1.8°F); functionally identical dedup"
+            " bypass behavior, no additional change needed",
+            "Ecobee comfort-program reversion triggered by Ecobee app or physical thermostat"
+            " control — CA will detect and re-apply on the next 30-min coordinator cycle",
         ],
     },
 }

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -2193,11 +2193,27 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         # the state-change event arrives (e.g. 3–30s for Ecobee/Nest cloud round-trips).
         _last_cmd_mode = self.automation_engine._last_commanded_hvac_mode
         _last_cmd_time = self.automation_engine._last_commanded_hvac_time
+        # Fix P3 (Issue #299): also verify setpoints match when in heat_cool mode.
+        # If mode matches but setpoints differ by >1°F, the Ecobee applied its own
+        # comfort program instead of holding CA's commanded values — not a confirmation.
+        _pending_low = getattr(self.automation_engine, "_pending_setpoint_low", None)
+        _pending_high = getattr(self.automation_engine, "_pending_setpoint_high", None)
+        _reported_low = new_state.attributes.get("target_temp_low")
+        _reported_high = new_state.attributes.get("target_temp_high")
+        _setpoints_match = (
+            _last_cmd_mode != "heat_cool"
+            or _pending_low is None
+            or _pending_high is None
+            or _reported_low is None
+            or _reported_high is None
+            or (abs(float(_reported_low) - _pending_low) <= 1.0 and abs(float(_reported_high) - _pending_high) <= 1.0)
+        )
         _is_expected_confirmation = (
             _last_cmd_mode is not None
             and _last_cmd_time is not None
             and new_state.state == _last_cmd_mode
             and (dt_util.now() - _last_cmd_time).total_seconds() < 120
+            and _setpoints_match
         )
 
         # Detect manual HVAC override during a door/window pause.

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.4.8"
+  "version": "0.4.9"
 }

--- a/tests/test_automation_celsius.py
+++ b/tests/test_automation_celsius.py
@@ -75,8 +75,9 @@ class TestSetTemperatureCelsius:
 
         asyncio.run(engine._set_temperature(75.2, reason="test"))
 
-        engine.hass.services.async_call.assert_called_once()
-        call_args = engine.hass.services.async_call.call_args
+        # Double-write (Issue #299): pre-write + target-write = 2 calls
+        assert engine.hass.services.async_call.call_count == 2
+        call_args = engine.hass.services.async_call.call_args  # last call = target write
         domain, service, data = call_args[0]
         assert domain == "climate"
         assert service == "set_temperature"
@@ -93,8 +94,9 @@ class TestSetTemperatureCelsius:
 
         asyncio.run(engine._set_temperature(75.0, reason="test"))
 
-        engine.hass.services.async_call.assert_called_once()
-        call_args = engine.hass.services.async_call.call_args
+        # Double-write (Issue #299): pre-write + target-write = 2 calls
+        assert engine.hass.services.async_call.call_count == 2
+        call_args = engine.hass.services.async_call.call_args  # last call = target write
         domain, service, data = call_args[0]
         assert domain == "climate"
         assert service == "set_temperature"
@@ -179,23 +181,31 @@ class TestSetTemperatureDual:
     its internal hold values within 1 second of CA's write.
     """
 
-    def test_dual_includes_hvac_mode_heat_cool(self):
-        """Service data for _set_temperature_dual must include hvac_mode='heat_cool'.
+    def test_dual_includes_hvac_mode_in_pre_write_only(self):
+        """_set_temperature_dual issues two calls when a mode switch is needed (Issue #299).
 
-        Without this key the Ecobee ignores the setpoints and reverts to its
-        own hold within seconds — observed as 74/68 → 77/67 in 1 second.
+        Fix P1 (Issue #299): hvac_mode='heat_cool' is only included in the pre-write when
+        the thermostat is not already in heat_cool mode. The target write omits hvac_mode to
+        prevent the Ecobee from evaluating its comfort program and overwriting CA's setpoints.
+
+        When the thermostat state is unknown/non-heat_cool (as in the test harness):
+        - Call 1 (pre-write): includes hvac_mode='heat_cool' + offset setpoints
+        - Call 2 (target write): NO hvac_mode + exact setpoints
         """
         engine = _make_automation(temp_unit="fahrenheit", comfort_heat=68.0, comfort_cool=74.0)
-
+        # hass.states.get() returns a MagicMock whose .state != "heat_cool" → mode switch needed
         asyncio.run(engine._set_temperature_dual(68.0, 74.0, reason="test"))
 
-        call_args = engine.hass.services.async_call.call_args
-        domain, service, data = call_args[0]
-        assert domain == "climate"
-        assert service == "set_temperature"
-        assert data.get("hvac_mode") == "heat_cool", (
-            "hvac_mode='heat_cool' must be present in set_temperature payload "
-            "so Ecobee processes mode and setpoints atomically"
+        assert engine.hass.services.async_call.call_count == 2
+        pre_write_args = engine.hass.services.async_call.call_args_list[0][0]
+        target_write_args = engine.hass.services.async_call.call_args_list[1][0]
+        # Pre-write must include hvac_mode so the mode switch reaches the Ecobee
+        assert pre_write_args[2].get("hvac_mode") == "heat_cool", (
+            "pre-write must include hvac_mode='heat_cool' to trigger the mode switch"
+        )
+        # Target write must NOT include hvac_mode — omitting it prevents Ecobee comfort-program lookup
+        assert "hvac_mode" not in target_write_args[2], (
+            "target write must omit hvac_mode to prevent Ecobee comfort-program reassertion (Fix P1)"
         )
 
     def test_dual_fahrenheit_passthrough(self):

--- a/tests/test_grace_refresh_and_band_call.py
+++ b/tests/test_grace_refresh_and_band_call.py
@@ -109,6 +109,10 @@ def _minimal_engine() -> AutomationEngine:
             "_thermal_model": {},
             "_hourly_forecast_temps": [],
             "_occupancy_mode": "home",
+            "_write_seq": 0,
+            "_pending_setpoint_low": None,
+            "_pending_setpoint_high": None,
+            "_pending_setpoint_single": None,
         }
     )
     return engine
@@ -202,16 +206,22 @@ class TestGraceExpiryTriggersRefreshCallback:
 
 
 class TestApplyComfortBandSingleServiceCall:
-    """Fix 4 — For a dual-setpoint thermostat in 'cool' mode, _apply_comfort_band
-    must issue exactly ONE climate.set_temperature call, NOT a separate
-    set_hvac_mode call first.
+    """Fix P1/P2 (Issue #299) — For a dual-setpoint thermostat in 'cool' mode,
+    _apply_comfort_band issues two set_temperature calls (pre-write + target write)
+    with NO separate set_hvac_mode call.
 
-    The hvac_mode must appear INSIDE the set_temperature payload so Ecobee
-    receives mode + setpoints atomically.
+    hvac_mode='heat_cool' is embedded in the PRE-WRITE ONLY when a mode switch is needed.
+    The target write intentionally omits hvac_mode to prevent Ecobee comfort-program reassertion.
     """
 
-    def test_single_async_call_for_dual_setpoint_thermostat(self):
-        """Exactly one async_call to climate domain; hvac_mode in the payload."""
+    def test_dual_setpoint_thermostat_issues_two_set_temperature_calls(self):
+        """Double-write: pre-write with mode+offset, then target write without mode (Issue #299).
+
+        When thermostat is in 'cool' mode (needs mode switch):
+        - Call 1 (pre-write): hvac_mode='heat_cool' + widened setpoints (floor-1, ceiling+1)
+        - Call 2 (target write): NO hvac_mode + exact setpoints
+        No separate set_hvac_mode call issued.
+        """
         engine = _minimal_engine()
 
         # Thermostat is currently in 'cool' mode (would previously trigger a mode switch)
@@ -227,23 +237,37 @@ class TestApplyComfortBandSingleServiceCall:
 
         asyncio.run(engine._apply_comfort_band(band, reason="test"))
 
-        # Exactly one service call — no separate set_hvac_mode call
         calls = engine.hass.services.async_call.call_args_list
         climate_calls = [c for c in calls if c.args[0] == "climate"]
-        assert len(climate_calls) == 1, f"Expected 1 climate service call, got {len(climate_calls)}: {climate_calls}"
+        # Two set_temperature calls — no separate set_hvac_mode
+        assert len(climate_calls) == 2, (
+            f"Expected 2 climate service calls (pre-write + target), got {len(climate_calls)}: {climate_calls}"
+        )
+        assert all(c.args[1] == "set_temperature" for c in climate_calls), (
+            "All climate calls must be set_temperature, not set_hvac_mode"
+        )
 
-        # The single call must be set_temperature (not set_hvac_mode)
-        the_call = climate_calls[0]
-        assert the_call.args[1] == "set_temperature", f"Expected set_temperature, got {the_call.args[1]}"
+        pre_write = climate_calls[0].args[2]
+        target_write = climate_calls[1].args[2]
 
-        # hvac_mode must be embedded in the payload
-        payload = the_call.args[2]
-        assert payload.get("hvac_mode") == "heat_cool", f"Expected hvac_mode='heat_cool' in payload, got {payload}"
-        assert "target_temp_low" in payload
-        assert "target_temp_high" in payload
+        # Pre-write must include hvac_mode to trigger mode switch on Ecobee
+        assert pre_write.get("hvac_mode") == "heat_cool", (
+            f"Pre-write must include hvac_mode='heat_cool', got {pre_write}"
+        )
+        # Target write must NOT include hvac_mode to prevent comfort-program reassertion (Fix P1)
+        assert "hvac_mode" not in target_write, (
+            f"Target write must omit hvac_mode to prevent Ecobee comfort-program lookup, got {target_write}"
+        )
+        assert "target_temp_low" in target_write
+        assert "target_temp_high" in target_write
 
-    def test_already_in_heat_cool_mode_still_single_call(self):
-        """Thermostat already in heat_cool: still just one set_temperature call."""
+    def test_already_in_heat_cool_mode_two_calls_no_hvac_mode(self):
+        """Thermostat already in heat_cool: two set_temperature calls, neither includes hvac_mode.
+
+        Double-write (Issue #299) always issues a pre-write + target write to bypass HA
+        deduplication. When the thermostat is already in heat_cool, no mode switch is needed,
+        so neither call includes hvac_mode.
+        """
         engine = _minimal_engine()
 
         state_mock = MagicMock()
@@ -260,5 +284,10 @@ class TestApplyComfortBandSingleServiceCall:
 
         calls = engine.hass.services.async_call.call_args_list
         climate_calls = [c for c in calls if c.args[0] == "climate"]
-        assert len(climate_calls) == 1
-        assert climate_calls[0].args[1] == "set_temperature"
+        assert len(climate_calls) == 2, (
+            f"Expected 2 set_temperature calls (pre-write + target), got {len(climate_calls)}"
+        )
+        assert all(c.args[1] == "set_temperature" for c in climate_calls)
+        # No hvac_mode in either call — thermostat already in the right mode
+        assert "hvac_mode" not in climate_calls[0].args[2]
+        assert "hvac_mode" not in climate_calls[1].args[2]

--- a/tests/test_heat_cool_override.py
+++ b/tests/test_heat_cool_override.py
@@ -130,9 +130,11 @@ def _make_coordinator_stub(
     ae._fan_command_time = None  # no recent fan command by default
     ae._fan_active = False
     ae._natural_vent_active = False
-    # Bug A / C / D — explicit values (not truthy MagicMock defaults)
+    # Bug A / C / D / P3 — explicit values (not truthy MagicMock defaults)
     ae._last_commanded_hvac_mode = last_commanded_hvac_mode
     ae._last_commanded_hvac_time = last_commanded_hvac_time
+    ae._pending_setpoint_low = None  # Fix P3: setpoint confirmation check (Issue #299)
+    ae._pending_setpoint_high = None
     ae.handle_manual_override_during_pause = AsyncMock()
     ae.handle_manual_override = MagicMock()
     ae.handle_fan_manual_override = MagicMock()

--- a/tests/test_nat_vent_restore_dual_setpoint.py
+++ b/tests/test_nat_vent_restore_dual_setpoint.py
@@ -110,6 +110,10 @@ def _minimal_engine(comfort_heat: float = 68.0, comfort_cool: float = 74.0) -> A
             "_thermal_model": {},
             "_hourly_forecast_temps": [],
             "_occupancy_mode": "home",
+            "_write_seq": 0,
+            "_pending_setpoint_low": None,
+            "_pending_setpoint_high": None,
+            "_pending_setpoint_single": None,
         }
     )
     return engine
@@ -175,9 +179,10 @@ class TestNatVentRestoreDualSetpoint:
 
         calls = engine.hass.services.async_call.call_args_list
         climate_calls = [c for c in calls if c.args[0] == "climate" and c.args[1] == "set_temperature"]
-        assert len(climate_calls) == 1, f"Expected 1 set_temperature call, got {len(climate_calls)}"
+        # Double-write (Issue #299): pre-write + target write = 2 calls
+        assert len(climate_calls) == 2, f"Expected 2 set_temperature calls, got {len(climate_calls)}"
 
-        payload = climate_calls[0].args[2]
+        payload = climate_calls[1].args[2]  # target write has the correct setpoints
         # Dual path: must carry both setpoints
         assert "target_temp_high" in payload, f"Expected target_temp_high in payload, got {payload}"
         assert "target_temp_low" in payload, f"Expected target_temp_low in payload, got {payload}"
@@ -215,9 +220,10 @@ class TestNatVentRestoreDualSetpoint:
 
         calls = engine.hass.services.async_call.call_args_list
         climate_calls = [c for c in calls if c.args[0] == "climate" and c.args[1] == "set_temperature"]
-        assert len(climate_calls) == 1, f"Expected 1 set_temperature call, got {len(climate_calls)}"
+        # Double-write (Issue #299): pre-write + target write = 2 calls
+        assert len(climate_calls) == 2, f"Expected 2 set_temperature calls, got {len(climate_calls)}"
 
-        payload = climate_calls[0].args[2]
+        payload = climate_calls[1].args[2]  # target write has the correct setpoint
         # Single path: must carry only temperature
         assert "temperature" in payload, f"Expected 'temperature' in single-setpoint payload, got {payload}"
         assert abs(payload["temperature"] - 72.0) < 0.1, (
@@ -253,9 +259,10 @@ class TestNatVentRestoreDualSetpoint:
 
         calls = engine.hass.services.async_call.call_args_list
         climate_calls = [c for c in calls if c.args[0] == "climate" and c.args[1] == "set_temperature"]
-        assert len(climate_calls) == 1, f"Expected 1 set_temperature call, got {len(climate_calls)}"
+        # Double-write (Issue #299): pre-write + target write = 2 calls
+        assert len(climate_calls) == 2, f"Expected 2 set_temperature calls, got {len(climate_calls)}"
 
-        payload = climate_calls[0].args[2]
+        payload = climate_calls[1].args[2]  # target write has the correct setpoints
         # Dual path: must carry both setpoints
         assert "target_temp_low" in payload, f"Expected target_temp_low in dual payload, got {payload}"
         assert "target_temp_high" in payload, f"Expected target_temp_high in dual payload, got {payload}"

--- a/tests/test_occupancy.py
+++ b/tests/test_occupancy.py
@@ -398,9 +398,10 @@ class TestVacationSetback:
         calls = engine.hass.services.async_call.call_args_list
         # _apply_comfort_band may emit set_hvac_mode + set_temperature; filter to set_temperature.
         temp_calls = [c for c in calls if c[0][0] == "climate" and c[0][1] == "set_temperature"]
-        assert len(temp_calls) == 1
+        # Double-write (Issue #299): pre-write + target write = 2 calls
+        assert len(temp_calls) == 2
 
-        service_data = temp_calls[0][0][2]
+        service_data = temp_calls[1][0][2]  # target write has the correct value
         # Vacation band ceiling = setback_cool + VACATION_SETBACK_EXTRA (no modifier in band).
         expected = 80 + VACATION_SETBACK_EXTRA
         assert service_data["temperature"] == expected
@@ -421,9 +422,10 @@ class TestVacationSetback:
 
         calls = engine.hass.services.async_call.call_args_list
         temp_calls = [c for c in calls if c[0][0] == "climate" and c[0][1] == "set_temperature"]
-        assert len(temp_calls) == 1
+        # Double-write (Issue #299): pre-write + target write = 2 calls
+        assert len(temp_calls) == 2
 
-        service_data = temp_calls[0][0][2]
+        service_data = temp_calls[1][0][2]  # target write has the correct value
         # Vacation band ceiling = setback_cool + VACATION_SETBACK_EXTRA (no modifier in band).
         expected = 80 + VACATION_SETBACK_EXTRA
         assert service_data["temperature"] == expected

--- a/tests/test_occupancy_automation.py
+++ b/tests/test_occupancy_automation.py
@@ -125,8 +125,9 @@ class TestApplyClassificationOccupancy:
         # Away band active='ceiling' → set_temperature(setback_cool=80), not comfort_cool (75).
         calls = engine.hass.services.async_call.call_args_list
         temp_calls = [call for call in calls if call[0][0] == "climate" and call[0][1] == "set_temperature"]
-        assert len(temp_calls) == 1
-        set_temp = temp_calls[0][0][2]["temperature"]
+        # Double-write (Issue #299): pre-write + target write = 2 calls
+        assert len(temp_calls) == 2
+        set_temp = temp_calls[1][0][2]["temperature"]  # target write
         assert set_temp == 80  # setback_cool (away ceiling), not comfort_cool (75)
 
     def test_away_heat_reapplies_heat_setback(self):
@@ -145,8 +146,9 @@ class TestApplyClassificationOccupancy:
 
         calls = engine.hass.services.async_call.call_args_list
         temp_calls = [call for call in calls if call[0][0] == "climate" and call[0][1] == "set_temperature"]
-        assert len(temp_calls) == 1
-        set_temp = temp_calls[0][0][2]["temperature"]
+        # Double-write (Issue #299): pre-write + target write = 2 calls
+        assert len(temp_calls) == 2
+        set_temp = temp_calls[1][0][2]["temperature"]  # target write
         # Away band active='ceiling'; thermostat has cool → set_temperature(setback_cool=80).
         assert set_temp == 80  # setback_cool (away ceiling), not setback_heat (60)
 
@@ -357,8 +359,9 @@ class TestBedtimeOccupancy:
 
         calls = engine.hass.services.async_call.call_args_list
         temp_calls = [call for call in calls if call[0][0] == "climate" and call[0][1] == "set_temperature"]
-        assert len(temp_calls) >= 1
-        set_temp = temp_calls[0][0][2]["temperature"]
+        # Double-write (Issue #299): pre-write + target write = 2 calls
+        assert len(temp_calls) == 2
+        set_temp = temp_calls[1][0][2]["temperature"]  # target write
         assert set_temp == pytest.approx(67.0, abs=0.1)  # sleep band floor = sleep_heat
 
 
@@ -384,8 +387,9 @@ class TestSetTemperatureForModeOccupancy:
 
         calls = engine.hass.services.async_call.call_args_list
         temp_calls = [call for call in calls if call[0][0] == "climate" and call[0][1] == "set_temperature"]
-        assert len(temp_calls) == 1
-        set_temp = temp_calls[0][0][2]["temperature"]
+        # Double-write (Issue #299): pre-write + target write = 2 calls
+        assert len(temp_calls) == 2
+        set_temp = temp_calls[1][0][2]["temperature"]  # target write
         # Away band active='ceiling' on cool-capable thermostat → setback_cool.
         assert set_temp == 80  # setback_cool
 
@@ -405,8 +409,9 @@ class TestSetTemperatureForModeOccupancy:
 
         calls = engine.hass.services.async_call.call_args_list
         temp_calls = [call for call in calls if call[0][0] == "climate" and call[0][1] == "set_temperature"]
-        assert len(temp_calls) == 1
-        set_temp = temp_calls[0][0][2]["temperature"]
+        # Double-write (Issue #299): pre-write + target write = 2 calls
+        assert len(temp_calls) == 2
+        set_temp = temp_calls[1][0][2]["temperature"]  # target write
         # Vacation band active='ceiling' on cool-capable thermostat: setback_cool + VACATION_SETBACK_EXTRA.
         # = 80 + 3 = 83
         assert set_temp == 83
@@ -422,8 +427,9 @@ class TestSetTemperatureForModeOccupancy:
 
         calls = engine.hass.services.async_call.call_args_list
         temp_calls = [call for call in calls if call[0][0] == "climate" and call[0][1] == "set_temperature"]
-        assert len(temp_calls) == 1
-        set_temp = temp_calls[0][0][2]["temperature"]
+        # Double-write (Issue #299): pre-write + target write = 2 calls
+        assert len(temp_calls) == 2
+        set_temp = temp_calls[1][0][2]["temperature"]  # target write
         assert set_temp == 75  # comfort_cool
 
 

--- a/tests/test_override_clears_on_away.py
+++ b/tests/test_override_clears_on_away.py
@@ -127,7 +127,7 @@ class TestAwayTransitionClearsOverride:
             clear_calls.append(reason)
             original_clear(reason=reason)
 
-        async def _spy_set_temperature(temp, reason=""):
+        async def _spy_set_temperature(temp, reason="", mode="cool"):
             # Capture the override state at the moment _set_temperature is called.
             set_temp_states.append(engine._manual_override_active)
 
@@ -152,7 +152,7 @@ class TestAwayTransitionClearsOverride:
             reasons.append(reason)
             original_clear(reason=reason)
 
-        async def _noop_set_temperature(temp, reason=""):
+        async def _noop_set_temperature(temp, reason="", mode="cool"):
             pass
 
         engine.clear_manual_override = _spy_clear
@@ -176,7 +176,7 @@ class TestAwayTransitionClearsOverride:
             clear_called.append(reason)
             original_clear(reason=reason)
 
-        async def _noop_set_temperature(temp, reason=""):
+        async def _noop_set_temperature(temp, reason="", mode="cool"):
             pass
 
         engine.clear_manual_override = _spy_clear
@@ -206,7 +206,7 @@ class TestVacationTransitionClearsOverride:
             clear_calls.append(reason)
             original_clear(reason=reason)
 
-        async def _spy_set_temperature(temp, reason=""):
+        async def _spy_set_temperature(temp, reason="", mode="cool"):
             set_temp_states.append(engine._manual_override_active)
 
         engine.clear_manual_override = _spy_clear
@@ -231,7 +231,7 @@ class TestVacationTransitionClearsOverride:
             clear_called.append(reason)
             original_clear(reason=reason)
 
-        async def _noop_set_temperature(temp, reason=""):
+        async def _noop_set_temperature(temp, reason="", mode="cool"):
             pass
 
         engine.clear_manual_override = _spy_clear

--- a/tests/test_temp_command_guard.py
+++ b/tests/test_temp_command_guard.py
@@ -287,6 +287,8 @@ class TestTempCommandTimeIsSet:
         ae.config = {"temp_unit": "fahrenheit"}
         ae._temp_command_pending = False
         ae._temp_command_time = None
+        ae._write_seq = 0
+        ae._pending_setpoint_single = None
         ae._record_action = MagicMock()
 
         # Bind the real method
@@ -313,6 +315,11 @@ class TestTempCommandTimeIsSet:
         ae.config = {"temp_unit": "fahrenheit"}
         ae._temp_command_pending = False
         ae._temp_command_time = None
+        ae._write_seq = 0
+        ae._pending_setpoint_low = None
+        ae._pending_setpoint_high = None
+        ae._last_commanded_hvac_mode = None
+        ae._last_commanded_hvac_time = None
         ae._record_action = MagicMock()
 
         ae._set_temperature_dual = types.MethodType(AutomationEngine._set_temperature_dual, ae)

--- a/tests/test_thermostat_program.py
+++ b/tests/test_thermostat_program.py
@@ -347,17 +347,21 @@ class TestApplyComfortBandDual:
         assert len(hvac) == 0
 
         temp = _temp_calls(eng)
-        assert len(temp) == 1
-        data = temp[0].args[2]
-        assert data["target_temp_low"] == 60.0  # floor
-        assert data["target_temp_high"] == 74.0  # ceiling
-        # hvac_mode is embedded in the set_temperature payload
-        assert data.get("hvac_mode") == "heat_cool"
+        # Double-write (Issue #299): pre-write + target write = 2 calls
+        assert len(temp) == 2
+        # Pre-write (index 0) includes hvac_mode for the mode switch; target write (index 1) has exact setpoints
+        pre_write = temp[0].args[2]
+        target_write = temp[1].args[2]
+        assert target_write["target_temp_low"] == 60.0  # floor
+        assert target_write["target_temp_high"] == 74.0  # ceiling
+        # hvac_mode is embedded in the pre-write when a mode switch is needed (Fix P1/Issue #299)
+        assert pre_write.get("hvac_mode") == "heat_cool"
+        assert "hvac_mode" not in target_write  # target write omits it
 
     def test_cold_day_band_emits_dual_setpoints(self):
-        """Cold band [floor=70, ceiling=80, active=floor]: single set_temperature call with hvac_mode embedded.
+        """Cold band [floor=70, ceiling=80, active=floor]: two set_temperature calls (pre-write + target).
 
-        Fix 4 (Issue #290): same atomic pattern as warm-day dual; no separate set_hvac_mode call.
+        Fix P1/P2 (Issue #299): double-write for deduplication bypass; hvac_mode in pre-write only.
         """
         eng = _make_apply_engine(hvac_modes=_DUAL_MODES, supported_features=_DUAL_FEATURES, current_mode="off")
         band = ComfortBand(floor=70.0, ceiling=80.0, active="floor", reason="test")
@@ -368,11 +372,14 @@ class TestApplyComfortBandDual:
         assert len(hvac) == 0
 
         temp = _temp_calls(eng)
-        assert len(temp) == 1
-        data = temp[0].args[2]
-        assert data["target_temp_low"] == 70.0
-        assert data["target_temp_high"] == 80.0
-        assert data.get("hvac_mode") == "heat_cool"
+        # Double-write (Issue #299): pre-write + target write = 2 calls
+        assert len(temp) == 2
+        pre_write = temp[0].args[2]
+        target_write = temp[1].args[2]
+        assert target_write["target_temp_low"] == 70.0
+        assert target_write["target_temp_high"] == 80.0
+        assert pre_write.get("hvac_mode") == "heat_cool"
+        assert "hvac_mode" not in target_write
 
     def test_no_mode_change_when_already_in_heat_cool(self):
         """Thermostat already in heat_cool → _set_hvac_mode NOT called (idempotent)."""
@@ -384,7 +391,8 @@ class TestApplyComfortBandDual:
         assert len(hvac) == 0  # already in heat_cool — no redundant mode switch
 
         temp = _temp_calls(eng)
-        assert len(temp) == 1  # but setpoints are still updated
+        # Double-write (Issue #299): pre-write + target write = 2 calls even in steady state
+        assert len(temp) == 2
 
     def test_comfort_band_applied_event_emitted(self):
         """comfort_band_applied event contains floor, ceiling, active, mode, reason."""
@@ -418,10 +426,11 @@ class TestApplyComfortBandCoolOnly:
         assert hvac[0].args[2]["hvac_mode"] == "cool"
 
         temp = _temp_calls(eng)
-        assert len(temp) == 1
-        # Single setpoint call uses "temperature" key, not target_temp_low/high
-        assert temp[0].args[2]["temperature"] == 74.0
-        assert "target_temp_low" not in temp[0].args[2]
+        # Double-write (Issue #299): pre-write + target write = 2 calls
+        assert len(temp) == 2
+        # Single setpoint call uses "temperature" key; target write (index 1) has the correct value
+        assert temp[1].args[2]["temperature"] == 74.0
+        assert "target_temp_low" not in temp[1].args[2]
 
     def test_no_mode_change_when_already_cool(self):
         """Already in cool mode → no set_hvac_mode call; setpoint still updated."""
@@ -433,7 +442,8 @@ class TestApplyComfortBandCoolOnly:
         assert len(hvac) == 0  # already in cool — no redundant mode switch
 
         temp = _temp_calls(eng)
-        assert len(temp) == 1
+        # Double-write (Issue #299): pre-write + target write = 2 calls even in steady state
+        assert len(temp) == 2
 
     def test_floor_band_no_op_cool_only_cannot_heat(self):
         """active=floor on cool-only thermostat → no service calls (can't defend the floor)."""
@@ -460,8 +470,9 @@ class TestApplyComfortBandHeatOnly:
         assert hvac[0].args[2]["hvac_mode"] == "heat"
 
         temp = _temp_calls(eng)
-        assert len(temp) == 1
-        assert temp[0].args[2]["temperature"] == 70.0
+        # Double-write (Issue #299): pre-write + target write = 2 calls
+        assert len(temp) == 2
+        assert temp[1].args[2]["temperature"] == 70.0  # target write
 
     def test_ceiling_band_no_op_heat_only_cannot_cool(self):
         """active=ceiling on heat-only thermostat → no service calls (can't defend the ceiling)."""

--- a/tests/test_warm_day_comfort_gap.py
+++ b/tests/test_warm_day_comfort_gap.py
@@ -151,7 +151,9 @@ class TestWarmDayBandArmingReplacesComfortGap:
         assert len(hvac_calls) == 0
         # hvac_mode="heat_cool" must appear inside the set_temperature payload
         temp_calls = [call for call in calls if call.args[1] == "set_temperature"]
-        assert len(temp_calls) == 1
+        # Double-write (Issue #299): pre-write + target write = 2 calls
+        assert len(temp_calls) == 2
+        # hvac_mode in pre-write (index 0) only when mode switch needed; target write omits it
         assert temp_calls[0].args[2].get("hvac_mode") == "heat_cool"
 
     def test_indoor_below_comfort_sets_dual_setpoints(self):
@@ -166,12 +168,13 @@ class TestWarmDayBandArmingReplacesComfortGap:
 
         calls = engine.hass.services.async_call.call_args_list
         temp_calls = [call for call in calls if call.args[1] == "set_temperature"]
-        assert len(temp_calls) == 1
-        data = temp_calls[0].args[2]
+        # Double-write (Issue #299): pre-write + target write = 2 calls
+        assert len(temp_calls) == 2
+        data = temp_calls[0].args[2]  # pre-write carries hvac_mode + setpoint keys
         # P3: dual setpoints; old assertion was temperature=70.0 (comfort_heat single target)
         assert "target_temp_low" in data
         assert "target_temp_high" in data
-        # Fix 4: hvac_mode embedded in the set_temperature payload
+        # hvac_mode in pre-write only (Fix P1); target write omits it to prevent comfort-program lookup
         assert data.get("hvac_mode") == "heat_cool"
 
     def test_indoor_at_comfort_floor_arms_band_not_off(self):
@@ -185,7 +188,9 @@ class TestWarmDayBandArmingReplacesComfortGap:
         # Fix 4: NO separate set_hvac_mode for dual path
         assert len(hvac_calls) == 0
         temp_calls = [call for call in calls if call.args[1] == "set_temperature"]
-        assert len(temp_calls) == 1
+        # Double-write (Issue #299): pre-write + target write = 2 calls
+        assert len(temp_calls) == 2
+        # hvac_mode in pre-write (index 0) only when mode switch needed; target write omits it
         assert temp_calls[0].args[2].get("hvac_mode") == "heat_cool"
 
     def test_indoor_above_comfort_floor_arms_band_not_off(self):
@@ -199,7 +204,9 @@ class TestWarmDayBandArmingReplacesComfortGap:
         # Fix 4: NO separate set_hvac_mode for dual path
         assert len(hvac_calls) == 0
         temp_calls = [call for call in calls if call.args[1] == "set_temperature"]
-        assert len(temp_calls) == 1
+        # Double-write (Issue #299): pre-write + target write = 2 calls
+        assert len(temp_calls) == 2
+        # hvac_mode in pre-write (index 0) only when mode switch needed; target write omits it
         assert temp_calls[0].args[2].get("hvac_mode") == "heat_cool"
 
     def test_indoor_unavailable_arms_band(self):
@@ -223,7 +230,9 @@ class TestWarmDayBandArmingReplacesComfortGap:
         # Fix 4: NO separate set_hvac_mode for dual path; band arms regardless of indoor temp
         assert len(hvac_calls) == 0
         temp_calls = [call for call in calls if call.args[1] == "set_temperature"]
-        assert len(temp_calls) == 1
+        # Double-write (Issue #299): pre-write + target write = 2 calls
+        assert len(temp_calls) == 2
+        # hvac_mode in pre-write (index 0) only when mode switch needed; target write omits it
         assert temp_calls[0].args[2].get("hvac_mode") == "heat_cool"
 
     def test_no_warm_day_comfort_gap_event(self):
@@ -251,7 +260,9 @@ class TestWarmDayBandArmingReplacesComfortGap:
         # Fix 4: NO separate set_hvac_mode for dual path
         assert len(hvac_calls) == 0
         temp_calls = [call for call in calls if call.args[1] == "set_temperature"]
-        assert len(temp_calls) == 1
+        # Double-write (Issue #299): pre-write + target write = 2 calls
+        assert len(temp_calls) == 2
+        # hvac_mode in pre-write (index 0) only when mode switch needed; target write omits it
         assert temp_calls[0].args[2].get("hvac_mode") == "heat_cool"
 
     def test_no_log_about_deferred_off(self, caplog):

--- a/tests/test_warm_day_setback.py
+++ b/tests/test_warm_day_setback.py
@@ -232,10 +232,12 @@ class TestWarmDayBandArming:
         hvac = _hvac_calls(engine)
         assert len(hvac) == 0
 
-        # hvac_mode="heat_cool" must appear inside the set_temperature payload
+        # Double-write (Issue #299): pre-write + target write = 2 calls
         temp = _temp_calls(engine)
-        assert len(temp) == 1
+        assert len(temp) == 2
+        # hvac_mode in pre-write (index 0) only when mode switch needed
         assert temp[0].args[2].get("hvac_mode") == "heat_cool"
+        assert "hvac_mode" not in temp[1].args[2]  # target write omits it
 
     def test_warm_day_dual_thermostat_sets_dual_setpoints(self):
         """P3: warm day + dual → target_temp_low=comfort_heat, target_temp_high=comfort_cool."""
@@ -246,8 +248,9 @@ class TestWarmDayBandArming:
         asyncio.run(engine.apply_classification(c))
 
         calls = _temp_calls(engine)
-        assert len(calls) == 1
-        data = calls[0].args[2]
+        # Double-write (Issue #299): pre-write + target write = 2 calls
+        assert len(calls) == 2
+        data = calls[1].args[2]  # target write has the correct setpoints
         assert data["target_temp_low"] == 70.0  # comfort_heat — full occupied+awake floor
         assert data["target_temp_high"] == 76.0  # comfort_cool — defended ceiling
 
@@ -261,12 +264,14 @@ class TestWarmDayBandArming:
         assert len(hvac) == 0  # already in heat_cool — no redundant switch
 
         temp = _temp_calls(engine)
-        assert len(temp) == 1  # setpoints are still refreshed
+        # Double-write (Issue #299): pre-write + target write = 2 calls even in steady state
+        assert len(temp) == 2
 
     def test_hot_day_same_band_arming_as_warm(self):
-        """hot day (hvac_mode=cool from classifier) + dual → same single-call atomic shape as warm.
+        """hot day (hvac_mode=cool from classifier) + dual → double-write atomic shape (Issue #299).
 
-        Fix 4 (Issue #290): dual path — no separate set_hvac_mode; hvac_mode="heat_cool" in payload.
+        Fix P1/P2 (Issue #299): dual path — no separate set_hvac_mode; hvac_mode="heat_cool" in
+        pre-write only; target write omits it to prevent Ecobee comfort-program reassertion.
         Old P3 assertion was: 1 set_hvac_mode call to "heat_cool".  Now: 0 set_hvac_mode calls.
         """
         engine = _make_engine(comfort_heat=70.0, current_mode="off")
@@ -278,10 +283,13 @@ class TestWarmDayBandArming:
         assert len(hvac) == 0
 
         temp = _temp_calls(engine)
-        assert len(temp) == 1
-        data = temp[0].args[2]
-        assert "target_temp_low" in data and "target_temp_high" in data
-        assert data.get("hvac_mode") == "heat_cool"
+        # Double-write (Issue #299): pre-write + target write = 2 calls
+        assert len(temp) == 2
+        pre_write = temp[0].args[2]
+        target_write = temp[1].args[2]
+        assert "target_temp_low" in target_write and "target_temp_high" in target_write
+        assert pre_write.get("hvac_mode") == "heat_cool"
+        assert "hvac_mode" not in target_write
 
     def test_comfort_band_applied_event_emitted(self):
         """P3 emits comfort_band_applied instead of warm_day_setback_applied."""
@@ -319,8 +327,9 @@ class TestWarmDayBandArming:
         assert hvac[0].args[2]["hvac_mode"] == "cool"
 
         temp = _temp_calls(engine)
-        assert len(temp) == 1
-        assert temp[0].args[2]["temperature"] == 76.0  # comfort_cool ceiling
+        # Double-write (Issue #299): pre-write + target write = 2 calls
+        assert len(temp) == 2
+        assert temp[1].args[2]["temperature"] == 76.0  # target write — comfort_cool ceiling
 
     def test_no_capable_mode_no_service_calls(self):
         """Entity with no capable modes → silent no-op (band not armed, no false promise)."""
@@ -363,8 +372,9 @@ class TestWarmDayBandArming:
         asyncio.run(engine.apply_classification(c))
 
         temp = _temp_calls(engine)
-        assert len(temp) == 1  # dual setpoints applied regardless of indoor vs comfort_heat
-        data = temp[0].args[2]
+        # Double-write (Issue #299): pre-write + target write = 2 calls
+        assert len(temp) == 2
+        data = temp[1].args[2]  # target write has the exact setpoints
         assert "target_temp_low" in data  # band armed: floor setpoint present
         assert "target_temp_high" in data  # band armed: ceiling setpoint present
 
@@ -383,8 +393,9 @@ class TestWarmDayBandArming:
         asyncio.run(engine.apply_classification(c))
 
         calls = _temp_calls(engine)
-        assert len(calls) == 1
-        data = calls[0].args[2]
+        # Double-write (Issue #299): pre-write + target write = 2 calls
+        assert len(calls) == 2
+        data = calls[1].args[2]  # target write has the correct Celsius values
         # Both low and high must be Celsius values (< 50°F would be wrong)
         assert data["target_temp_low"] < 30.0  # was 60°F → ~15.6°C
         assert data["target_temp_high"] < 30.0  # was 76°F → ~24.4°C


### PR DESCRIPTION
## Summary

- **Root cause confirmed**: `_set_temperature_dual()` always included `hvac_mode="heat_cool"` in every service call. The Ecobee interprets a mode-change request as "apply comfort program" (65/75) rather than "hold these setpoints" (68/74), causing the physical thermostat to silently revert while HA's optimistic state remained stale.
- **HA deduplication bypass**: HA's Ecobee integration drops `set_temperature` calls whose parameters match the entity's current optimistic state. A double-write pattern (offset pre-write → exact target) guarantees the command reaches the physical device.
- **Setpoint confirmation gap**: `_is_expected_confirmation()` in the coordinator accepted any state change within the 120-second window as a CA confirmation, even when the Ecobee reported its own comfort-program setpoints instead of CA's.

## Changes

**`automation.py`**
- `_set_temperature()`: double-write (±1°F offset pre-write to bypass HA dedup, then exact target); new `mode='cool'|'heat'` param controls offset direction so pre-write never triggers unnecessary conditioning
- `_set_temperature_dual()`: same double-write pattern (`low-1`/`high+1` pre-write → exact target); `hvac_mode="heat_cool"` included in pre-write **only** when mode switch is needed, omitted from target write in all cases; `_write_seq` nonce prevents stale validation callbacks
- `_apply_comfort_band()`: passes explicit `mode='cool'`/`mode='heat'` to all `_set_temperature()` callsites
- `_set_temperature_for_mode()`: fallback defaults corrected 68°F→70°F, 76°F→75°F
- `handle_bedtime()`: 30-second cooldown guard prevents startup race with coordinator's first classification cycle

**`coordinator.py`**
- `_async_thermostat_changed()`: `_is_expected_confirmation` now verifies that reported `heat_cool` setpoints are within 1°F of `_pending_setpoint_low`/`_pending_setpoint_high`; mismatch → Ecobee comfort-program reassertion (not a CA confirmation)

**`const.py` / `manifest.json`**: bumped to v0.4.9, added RELEASE_NOTES and KNOWN_FIXES for #299

**Tests**: 11 test files updated to expect 2 service calls per setpoint write; value assertions moved to target write (index 1), `hvac_mode` assertions remain on pre-write (index 0) where applicable

## Test plan

- [x] `pytest tests/` — 2569/2569 passing
- [x] `ruff check` — clean
- [x] `test_version_sync.py` — 2/2 passing
- [x] Opus verification agent reviewed all changes for correctness, security, and logging coverage

Closes #299