### PR TITLE
Fix #262: decode simulate.py UTF-8 stdout in test subprocess (Windows cp1252 noise)

### DIFF
--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,7 +4,7 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.4.10"
+VERSION = "0.4.11"
 
 RELEASE_NOTES: dict[str, list[str]] = {
     "0.4.10": [

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.4.10"
+  "version": "0.4.11"
 }

--- a/tests/test_pending_scenarios.py
+++ b/tests/test_pending_scenarios.py
@@ -23,6 +23,27 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parent.parent
 PENDING_DIR = REPO_ROOT / "tools" / "simulations" / "pending"
 
+# tools/simulate.py reconfigures its stdout to UTF-8 (simulate.py:35-36), so the child
+# always emits UTF-8. The parent must decode with UTF-8 too -- not the OS locale codec
+# (cp1252 on Windows), which kills the subprocess reader thread on any byte undefined in
+# that codec and silently empties stdout. This single dict is the one home for that
+# contract; both the scenario runner and the regression test use it (#262).
+_SUBPROCESS_TEXT_KWARGS: dict = {
+    "capture_output": True,
+    "text": True,
+    "encoding": "utf-8",  # decode to match simulate.py's UTF-8 stdout, not the OS locale codec
+    "errors": "replace",  # belt-and-suspenders: never let a stray byte crash the reader thread
+}
+
+
+def _run_simulate(scenario_stem: str) -> subprocess.CompletedProcess:
+    """Run a scenario through simulate.py, decoding its UTF-8 stdout correctly."""
+    return subprocess.run(
+        [sys.executable, str(REPO_ROOT / "tools" / "simulate.py"), "-s", scenario_stem],
+        cwd=str(REPO_ROOT),
+        **_SUBPROCESS_TEXT_KWARGS,
+    )
+
 
 def _collect_pending_scenarios() -> list[Path]:
     if not PENDING_DIR.exists():
@@ -58,13 +79,34 @@ def test_pending_scenario(scenario_path: Path) -> None:
     if pending_issue:
         pytest.xfail(f"Pending fix for issue #{pending_issue} -- scenario passes when bug is resolved")
 
-    result = subprocess.run(
-        [sys.executable, str(REPO_ROOT / "tools" / "simulate.py"), "-s", scenario_path.stem],
-        capture_output=True,
-        text=True,
-        cwd=str(REPO_ROOT),
-    )
+    result = _run_simulate(scenario_path.stem)
 
     assert result.returncode == 0, (
         f"Scenario '{scenario_path.stem}' FAILED.\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
+def test_simulate_subprocess_decodes_utf8_stdout(recwarn) -> None:
+    """The subprocess text kwargs must decode UTF-8 child stdout, not the OS locale (#262).
+
+    Windows-only bug: simulate.py emits UTF-8; under the locale codec (cp1252) the parent
+    reader thread dies on any byte undefined in cp1252 (e.g. 0x9d) and silently empties
+    stdout while returncode stays 0 -- so a returncode-only assertion never catches it.
+    This drives a controlled child that prints U+045D (UTF-8 ``d1 9d``) through the SAME
+    ``_SUBPROCESS_TEXT_KWARGS`` the scenario runner uses, so removing ``encoding="utf-8"``
+    re-breaks this test. On Linux the locale is already UTF-8, so this passes there
+    regardless -- the bug, and thus the guard, are Windows-specific.
+    """
+    child = "import sys; sys.stdout.reconfigure(encoding='utf-8'); print('verdict ѝ ok')"
+    result = subprocess.run(
+        [sys.executable, "-c", child],
+        cwd=str(REPO_ROOT),
+        **_SUBPROCESS_TEXT_KWARGS,
+    )
+    assert result.stdout and result.stdout.strip(), (
+        "stdout empty/None -- reader thread died decoding UTF-8 as the OS locale codec"
+    )
+    assert "ѝ" in result.stdout, "non-ASCII char lost -- stream not decoded as UTF-8"
+    assert not any(issubclass(w.category, pytest.PytestUnhandledThreadExceptionWarning) for w in recwarn.list), (
+        "reader-thread UnicodeDecodeError surfaced as a PytestUnhandledThreadExceptionWarning"
     )


### PR DESCRIPTION
## Summary

`tests/test_pending_scenarios.py` ran `simulate.py` via `subprocess.run(..., text=True)` with **no `encoding=`**. On Windows the parent reader thread decoded the child's UTF-8 stdout with the locale codec (cp1252); any byte undefined in cp1252 (e.g. `0x9d`) killed the reader thread with `UnicodeDecodeError`, surfaced by pytest as `PytestUnhandledThreadExceptionWarning` — one per pending scenario. The test still **passed** because it only asserted `returncode` (unaffected by the parent decode) while `stdout` was silently emptied.

## Root cause (hypothesis confirmed via scientific method)

- `tools/simulate.py:35-36` actively reconfigures stdout to UTF-8 → child genuinely emits UTF-8, so it's a **parent-side decode** failure (not a child encode failure).
- Reproduced in isolation: `_readerthread` → `cp1252.decode` → `UnicodeDecodeError: byte 0x9d`.
- Discriminator is **stdout content, not returncode**: buggy → `stdout` empty/`None`, `rc=0`; fixed → full stream.
- Only fires on the 5 bytes undefined in cp1252 — em-dash/arrow/degree merely mojibake, so it's scenario-dependent (a "first golden" target would be flaky).
- **Regression origin:** original design gap since file creation in #220/#223 — Windows-latent; Linux CI never saw it (locale already UTF-8).

## Fix

- Factor the subprocess text kwargs into `_SUBPROCESS_TEXT_KWARGS` with `encoding="utf-8", errors="replace"` (one home for the decode contract) and route the runner through `_run_simulate()`.
- Add behavioral regression test `test_simulate_subprocess_decodes_utf8_stdout` driving a controlled child that emits `U+045D` (UTF-8 `d1 9d`) through the **same** kwargs — removing the encoding re-empties stdout on Windows. TDD red→green verified.

## Scope

Test-infra only — **no production behavior change**, no golden change, no deploy, no `KNOWN_FIXES`. Bump `VERSION` 0.4.10 → 0.4.11.

## Verification

- `pytest tests/test_pending_scenarios.py` → 2 passed, **zero warnings** (previously 1/scenario).
- Full suite: **2563 passed, zero warnings** repo-wide.
- ruff check + format clean; `test_version_sync` green.

Closes #262.