### PR TITLE
Fix #263: clear pause state on restart — clean-slate recovery via state listener (#306)

### DIFF
--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -2840,14 +2840,20 @@ class AutomationEngine:
     def restore_state(self, state: dict[str, Any]) -> None:
         """Restore automation state from persisted data.
 
-        Design decision: HA restart = clean slate for override and grace state.
-        Manual overrides and grace periods are user-interactive; carrying them
-        across a restart would silently suppress CA automation without the user
-        knowing the system restarted.  Only pause state and fan state are
-        restored so HVAC resumes correctly from its last known mode.
+        Design decision: HA restart = clean slate for override, grace, AND pause state.
+        - Manual overrides and grace periods are user-interactive; restoring them would
+          silently suppress CA automation without the user knowing the system restarted.
+        - Pause state (_paused_by_door / _pre_pause_mode) is also cleared: the
+          door/window state-change listener re-detects any open sensors quickly after
+          startup (None → "on" transition), re-pausing after the configured debounce
+          (default 5 min). A brief HVAC re-arm is preferable to sitting paused
+          indefinitely if cloud weather/thermostat services are slow to reconnect
+          (Issue #263/#306).
+        - Fan state and pre-condition achievement ARE restored (see below).
         """
-        self._paused_by_door = state.get("paused_by_door", False)
-        self._pre_pause_mode = state.get("pre_pause_mode")
+        # _paused_by_door and _pre_pause_mode are intentionally NOT restored here.
+        # __init__ already sets both to their clean defaults (False / None).
+        # The door/window listener re-detects open sensors on startup.
         self._economizer_active = state.get("economizer_active", False)
         self._economizer_phase = state.get("economizer_phase", "inactive")
         self._last_action_time = state.get("last_action_time")
@@ -2886,11 +2892,9 @@ class AutomationEngine:
         self._pre_condition_achieved = state.get("pre_condition_achieved", False)
         self._pre_condition_achieved_date = state.get("pre_condition_achieved_date")
         _LOGGER.info(
-            "Restored automation state: paused=%s, pre_pause_mode=%s, "
-            "last_action=%s, fan_active=%s, fan_override=%s, precool_achieved=%s "
-            "(override/grace state cleared — clean slate on restart)",
-            self._paused_by_door,
-            self._pre_pause_mode,
+            "Restored automation state: last_action=%s, fan_active=%s, fan_override=%s, "
+            "precool_achieved=%s "
+            "(override/grace/pause state cleared — clean slate on restart per Issue #263)",
             self._last_action_reason,
             self._fan_active,
             self._fan_override_active,

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,7 +4,7 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.4.10"
+VERSION = "0.4.11"
 
 RELEASE_NOTES: dict[str, list[str]] = {
     "0.4.10": [

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.4.10"
+  "version": "0.4.11"
 }

--- a/docs/08-COMPUTATION-REFERENCE.md
+++ b/docs/08-COMPUTATION-REFERENCE.md
@@ -40,7 +40,7 @@ The automation logic table and all threshold constants in this document are expr
 | What are the two fan archetypes and how does each affect HVAC mode and fan-stops-on-close behavior? | `FAN_MODE_HVAC` (HVAC blower): band stays armed, HVAC unchanged when fan activates, fan does NOT stop when windows close unless `_natural_vent_active=True`. `FAN_MODE_WHOLE_HOUSE` (exhaust fan): HVAC set to off on activation (mode captured in `_pre_fan_hvac_mode`), restored on deactivation, fan stops when ALL sensors close even if `_natural_vent_active=False`. | [§9 Fan Archetype Behavioral Contract](08-COMPUTATION-REFERENCE.md#fan-archetype-behavioral-contract-issue-277) |
 | Why does `_set_hvac_mode("off")` also set `_fan_command_time` (Issue #277 Bug A1)? | The `set_fan_mode(auto)` assertion inside `_set_hvac_mode("off")` sets `_fan_command_time = dt_util.now()` before the service call, so cloud thermostat echoes of the fan_mode attribute change are suppressed within the `_is_recent_fan_command` window instead of triggering a false manual override. | [§9b Race Guard — `_set_hvac_mode("off")` fan_command_time](08-COMPUTATION-REFERENCE.md#_set_hvac_mode-off-fan_command_time-guard-issue-277-bug-a1) |
 | How does `_async_thermostat_changed()` prevent a single event from triggering both a setpoint and a fan override (Issue #277 Bug B)? | A local `_setpoint_override_detected` flag is initialized to `False` before Block 2 (setpoint detection) and Block 3 (fan_mode detection). If Block 2 fires and sets it `True`, Block 3 is suppressed via `and not _setpoint_override_detected`. One event → at most one override type. | [§9b Setpoint/Fan Mutual Exclusion](08-COMPUTATION-REFERENCE.md#setpointfan-override-mutual-exclusion-issue-277-bug-b) |
-| What override and grace state is preserved vs discarded on HA restart (Issue #282)? | Pause state (`_paused_by_door`, `_pre_pause_mode`) is preserved. Override state (`_manual_override_active`, `_grace_active`, `_override_confirm_pending`) is discarded — CA always starts in clean automation mode. A 5-minute `_first_run` settling window replaces persisted override as the startup debounce. | [§11 Clean-Slate Override State on HA Restart](08-COMPUTATION-REFERENCE.md#clean-slate-override-state-on-ha-restart-issue-282) |
+| What override and grace state is preserved vs discarded on HA restart (Issue #282/#306)? | Both pause state (`_paused_by_door`, `_pre_pause_mode`) and override state (`_manual_override_active`, `_grace_active`, `_override_confirm_pending`) are discarded — CA always starts in full clean-slate automation mode. Open sensors are re-detected within 30–90 s via the state-change listener (None → "on" transition). A 5-minute `_first_run` settling window provides startup debounce. | [§11 Clean-Slate Override State on HA Restart](08-COMPUTATION-REFERENCE.md#clean-slate-override-state-on-ha-restart-issue-282) |
 | What notification does the user receive when PATH B (transient thermostat adjustment) fires (Issue #200)? | "Brief thermostat adjustment detected — treated as transient. Climate Advisor continues normal operation." No grace period starts; automation resumes immediately. | [§11 PATH B Notification](08-COMPUTATION-REFERENCE.md#path-b-notification--transient-thermostat-adjustment-issue-200) |
 | What happens if the user changes to a different HVAC mode while a grace period is already active (Issue #201)? | The current override and grace are cleared, and a fresh 10-minute confirmation window starts for the new mode. Latest user action wins. | [§11 Second Override During Active Grace](08-COMPUTATION-REFERENCE.md#second-override-during-active-grace-issue-201) |
 
@@ -1189,16 +1189,16 @@ Only one grace timer of each type is active at a time; starting a new one cancel
 
 **Grace expiry sensor re-check:** When either grace period expires, the system re-checks whether any monitored contact sensor is currently open. If one or more sensors are still open, HVAC is re-paused immediately (`_paused_by_door = True`, HVAC set to `off`) rather than restoring normal automation. This prevents the safety issue of running HVAC with a door or window open after the grace window closes.
 
-### Clean-Slate Override State on HA Restart (Issue #282)
+### Clean-Slate Override State on HA Restart (Issue #282 / #306)
 
-CA always starts in clean automation mode after an HA restart. `restore_state()` does **not** restore override or grace state — those fields are intentionally omitted from `get_serializable_state()`.
+CA always starts in full clean-slate automation mode after an HA restart. `restore_state()` does **not** restore override, grace, or pause state. All three categories are intentionally kept out of `get_serializable_state()` (override/grace since Issue #282; pause state since Issue #306).
 
 **What is preserved across restarts:**
 
 | Field | Preserved? | Notes |
 |---|---|---|
-| `_paused_by_door` | Yes | Sensor-driven pause state survives restart |
-| `_pre_pause_mode` | Yes | HVAC mode to restore when sensors close |
+| `_paused_by_door` | **No** | Cleared on restart (Issue #306). Open sensors are re-detected quickly via the state-change listener (entity transitions from `None` → `"on"` when HA reconnects); HVAC re-arms briefly and re-pauses after the configured debounce (default 5 min). |
+| `_pre_pause_mode` | **No** | Cleared on restart (Issue #306). Re-captured when the re-detected open sensor triggers a fresh pause. |
 | `_fan_active` | Yes | Fan session state |
 | `_pre_fan_hvac_mode` | Yes | HVAC mode captured before whole-house fan activation |
 | `_last_action_time` / `_last_action_reason` | Yes | Last automation action metadata |
@@ -1207,6 +1207,8 @@ CA always starts in clean automation mode after an HA restart. `restore_state()`
 | `_grace_active` / `_grace_end_time` | **No** | Cleared on restart — clean slate |
 | `_override_confirm_pending` | **No** | Cleared on restart — clean slate |
 | `_manual_override_mode` / `_manual_override_time` | **No** | Cleared on restart |
+
+**Why pause state is not restored (Issue #306):** Persisting `_paused_by_door` risks leaving CA paused indefinitely if cloud services (weather, thermostat) reconnect slowly — the sensor may not fire a state-change callback unless it transitions away from `None`. Re-detecting via the normal `None → "on"` listener path is more reliable than trusting stale persisted state. The sensor entity registers quickly after HA startup, but the re-pause takes the configured debounce (default 5 min) before `handle_door_window_open()` fires. During that window HVAC briefly re-arms — a small trade-off that is strictly better than sitting paused indefinitely on a hot day. This matches the existing clean-slate policy for manual overrides and grace periods.
 
 **Settling window:** `restore_state()` sets `_first_run = True`. The coordinator's `_async_update_data()` delays the first full automation evaluation by 5 minutes (`_first_run` guard) to let the thermostat and HA state settle before CA takes any HVAC action. This replaces the role previously played by persisted override state in preventing false automations after restart.
 

--- a/tests/test_paused_restart_recovery.py
+++ b/tests/test_paused_restart_recovery.py
@@ -1,0 +1,237 @@
+"""Tests for Issue #263/#306: restore_state() must NOT restore _paused_by_door / _pre_pause_mode.
+
+Clean-slate rule: HA restart clears override, grace, AND door/window pause state.
+The door/window state-change listener re-detects open sensors within 30–90 s of startup
+(None → "on" entity transition), so carry-over would only cause indefinite pause if
+cloud weather or thermostat services are slow to reconnect.
+
+Pattern: AutomationEngine direct with mocked HA dependencies, mirroring
+tests/test_nat_vent_activation.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Patch dt_util.now so isoformat() calls inside the engine always work.
+sys.modules["homeassistant.util.dt"].now = lambda: datetime(2026, 6, 13, 10, 0, 0)
+
+import custom_components.climate_advisor.automation as _automation_mod  # noqa: E402
+
+
+def _real_parse_datetime(dt_str: str):
+    try:
+        return datetime.fromisoformat(dt_str)
+    except Exception:
+        return None
+
+
+_automation_mod.dt_util.parse_datetime = _real_parse_datetime
+
+from custom_components.climate_advisor.automation import AutomationEngine  # noqa: E402
+from custom_components.climate_advisor.classifier import DayClassification  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_DT_NOW_PATH = "custom_components.climate_advisor.automation.dt_util.now"
+
+
+def _make_engine(
+    comfort_heat: float = 68.0,
+    comfort_cool: float = 76.0,
+) -> AutomationEngine:
+    """Create an AutomationEngine with mocked HA dependencies."""
+    hass = MagicMock()
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+
+    def _consume_coroutine(coro):
+        coro.close()
+
+    hass.async_create_task = MagicMock(side_effect=_consume_coroutine)
+
+    # Climate entity reports "cool" mode so apply_classification can arm a band.
+    climate_state = MagicMock()
+    climate_state.state = "cool"
+    climate_state.attributes = {
+        "current_temperature": 74.0,
+        "hvac_modes": ["off", "cool", "heat", "heat_cool"],
+        "supported_features": 0,
+    }
+
+    hass.states = MagicMock()
+    hass.states.get = MagicMock(return_value=climate_state)
+
+    config = {
+        "comfort_heat": comfort_heat,
+        "comfort_cool": comfort_cool,
+        "setback_heat": 60,
+        "setback_cool": 82,
+        "notify_service": "notify.notify",
+    }
+
+    engine = AutomationEngine(
+        hass=hass,
+        climate_entity="climate.thermostat",
+        weather_entity="weather.forecast_home",
+        door_window_sensors=["binary_sensor.front_door"],
+        notify_service="notify.notify",
+        config=config,
+    )
+    return engine
+
+
+def _make_cool_classification() -> DayClassification:
+    """Minimal warm-day classification that causes apply_classification to arm a cool band."""
+    obj = object.__new__(DayClassification)
+    obj.day_type = "warm"
+    obj.trend_direction = "stable"
+    obj.trend_magnitude = 2.0
+    obj.today_high = 88.0
+    obj.today_low = 65.0
+    obj.tomorrow_high = 88.0
+    obj.tomorrow_low = 65.0
+    obj.hvac_mode = "cool"
+    obj.pre_condition = False
+    obj.pre_condition_target = None
+    obj.windows_recommended = False
+    obj.window_open_time = None
+    obj.window_close_time = None
+    obj.setback_modifier = 0.0
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# Test 1: _paused_by_door not restored
+# ---------------------------------------------------------------------------
+
+
+class TestPausedByDoorNotRestoredOnRestart:
+    """restore_state() with paused_by_door=True must leave _paused_by_door False."""
+
+    def test_paused_by_door_not_restored_on_restart(self):
+        """Core assertion: persisted paused_by_door=True is discarded on restore."""
+        engine = _make_engine()
+
+        # Confirm default is already False
+        assert engine._paused_by_door is False
+
+        engine.restore_state({"paused_by_door": True, "pre_pause_mode": "cool"})
+
+        # Clean-slate: pause must NOT be carried across restart
+        assert engine._paused_by_door is False, (
+            "restore_state() must not restore _paused_by_door — clean-slate rule (Issue #263/#306)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: _pre_pause_mode not restored
+# ---------------------------------------------------------------------------
+
+
+class TestPrePauseModeNotRestoredOnRestart:
+    """restore_state() must leave _pre_pause_mode as None regardless of persisted value."""
+
+    def test_pre_pause_mode_not_restored_on_restart(self):
+        """Persisted pre_pause_mode is discarded — no stale mode to resume from."""
+        engine = _make_engine()
+
+        assert engine._pre_pause_mode is None
+
+        engine.restore_state({"paused_by_door": True, "pre_pause_mode": "cool"})
+
+        assert engine._pre_pause_mode is None, (
+            "restore_state() must not restore _pre_pause_mode — clean-slate rule (Issue #263/#306)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: other state fields ARE still restored
+# ---------------------------------------------------------------------------
+
+
+class TestOtherStateFieldsStillRestored:
+    """Pause fields are cleared but other engine state must still be restored normally."""
+
+    def test_fan_active_restored(self):
+        """_fan_active is a legitimate carry-across field and must be restored."""
+        engine = _make_engine()
+        engine.restore_state({"fan_active": True})
+        assert engine._fan_active is True
+
+    def test_pre_condition_achieved_restored(self):
+        """_pre_condition_achieved is persisted so a restart mid-day does not re-arm the ceiling offset."""
+        engine = _make_engine()
+        engine.restore_state({"pre_condition_achieved": True, "pre_condition_achieved_date": "2026-06-13"})
+        assert engine._pre_condition_achieved is True
+
+    def test_economizer_active_restored(self):
+        """_economizer_active is a carry-across field and must be restored."""
+        engine = _make_engine()
+        engine.restore_state({"economizer_active": True})
+        assert engine._economizer_active is True
+
+    def test_last_action_reason_restored(self):
+        """_last_action_reason is restored so briefing shows the last known action."""
+        engine = _make_engine()
+        engine.restore_state({"last_action_reason": "daily classification"})
+        assert engine._last_action_reason == "daily classification"
+
+    def test_pause_cleared_while_fan_restored_simultaneously(self):
+        """Both rules apply together: pause cleared, fan_active restored."""
+        engine = _make_engine()
+        engine.restore_state(
+            {
+                "paused_by_door": True,
+                "pre_pause_mode": "heat",
+                "fan_active": True,
+                "last_action_reason": "test",
+            }
+        )
+        assert engine._paused_by_door is False
+        assert engine._pre_pause_mode is None
+        assert engine._fan_active is True
+        assert engine._last_action_reason == "test"
+
+
+# ---------------------------------------------------------------------------
+# Test 4: apply_classification reaches _apply_comfort_band after clean-slate restart
+# ---------------------------------------------------------------------------
+
+
+class TestApplyClassificationAfterCleanSlateRestart:
+    """After restore_state (which clears pause), apply_classification must arm the thermostat."""
+
+    def test_apply_classification_reaches_comfort_band_after_restart(self):
+        """With _paused_by_door=False (clean-slate), apply_classification must call set_temperature.
+
+        Confirms that the clean-slate restore does not leave the engine in a state that
+        blocks automation. The occupant's thermostat must be set after an HA restart,
+        not left indefinitely paused.
+        """
+        engine = _make_engine()
+
+        # Simulate what the coordinator does on startup: restore state from persisted JSON.
+        # The persisted state had pause active, but restore_state must clear it.
+        engine.restore_state({"paused_by_door": True, "pre_pause_mode": "cool"})
+
+        assert engine._paused_by_door is False  # clean slate confirmed
+
+        classification = _make_cool_classification()
+
+        with patch(_DT_NOW_PATH, return_value=datetime(2026, 6, 13, 10, 0, 0)):
+            asyncio.run(engine.apply_classification(classification))
+
+        # _apply_comfort_band must have called set_temperature → hass.services.async_call
+        assert engine.hass.services.async_call.called, (
+            "apply_classification must arm the thermostat after a clean-slate restart "
+            "(no indefinite pause — Issue #263/#306)"
+        )
+        call_args = engine.hass.services.async_call.call_args_list
+        climate_calls = [c for c in call_args if c[0][0] == "climate"]
+        assert len(climate_calls) >= 1, "Expected at least one 'climate' service call from apply_classification"

--- a/tests/test_pending_scenarios.py
+++ b/tests/test_pending_scenarios.py
@@ -23,6 +23,27 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parent.parent
 PENDING_DIR = REPO_ROOT / "tools" / "simulations" / "pending"
 
+# tools/simulate.py reconfigures its stdout to UTF-8 (simulate.py:35-36), so the child
+# always emits UTF-8. The parent must decode with UTF-8 too -- not the OS locale codec
+# (cp1252 on Windows), which kills the subprocess reader thread on any byte undefined in
+# that codec and silently empties stdout. This single dict is the one home for that
+# contract; both the scenario runner and the regression test use it (#262).
+_SUBPROCESS_TEXT_KWARGS: dict = {
+    "capture_output": True,
+    "text": True,
+    "encoding": "utf-8",  # decode to match simulate.py's UTF-8 stdout, not the OS locale codec
+    "errors": "replace",  # belt-and-suspenders: never let a stray byte crash the reader thread
+}
+
+
+def _run_simulate(scenario_stem: str) -> subprocess.CompletedProcess:
+    """Run a scenario through simulate.py, decoding its UTF-8 stdout correctly."""
+    return subprocess.run(
+        [sys.executable, str(REPO_ROOT / "tools" / "simulate.py"), "-s", scenario_stem],
+        cwd=str(REPO_ROOT),
+        **_SUBPROCESS_TEXT_KWARGS,
+    )
+
 
 def _collect_pending_scenarios() -> list[Path]:
     if not PENDING_DIR.exists():
@@ -58,13 +79,34 @@ def test_pending_scenario(scenario_path: Path) -> None:
     if pending_issue:
         pytest.xfail(f"Pending fix for issue #{pending_issue} -- scenario passes when bug is resolved")
 
-    result = subprocess.run(
-        [sys.executable, str(REPO_ROOT / "tools" / "simulate.py"), "-s", scenario_path.stem],
-        capture_output=True,
-        text=True,
-        cwd=str(REPO_ROOT),
-    )
+    result = _run_simulate(scenario_path.stem)
 
     assert result.returncode == 0, (
         f"Scenario '{scenario_path.stem}' FAILED.\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
+def test_simulate_subprocess_decodes_utf8_stdout(recwarn) -> None:
+    """The subprocess text kwargs must decode UTF-8 child stdout, not the OS locale (#262).
+
+    Windows-only bug: simulate.py emits UTF-8; under the locale codec (cp1252) the parent
+    reader thread dies on any byte undefined in cp1252 (e.g. 0x9d) and silently empties
+    stdout while returncode stays 0 -- so a returncode-only assertion never catches it.
+    This drives a controlled child that prints U+045D (UTF-8 ``d1 9d``) through the SAME
+    ``_SUBPROCESS_TEXT_KWARGS`` the scenario runner uses, so removing ``encoding="utf-8"``
+    re-breaks this test. On Linux the locale is already UTF-8, so this passes there
+    regardless -- the bug, and thus the guard, are Windows-specific.
+    """
+    child = "import sys; sys.stdout.reconfigure(encoding='utf-8'); print('verdict ѝ ok')"
+    result = subprocess.run(
+        [sys.executable, "-c", child],
+        cwd=str(REPO_ROOT),
+        **_SUBPROCESS_TEXT_KWARGS,
+    )
+    assert result.stdout and result.stdout.strip(), (
+        "stdout empty/None -- reader thread died decoding UTF-8 as the OS locale codec"
+    )
+    assert "ѝ" in result.stdout, "non-ASCII char lost -- stream not decoded as UTF-8"
+    assert not any(issubclass(w.category, pytest.PytestUnhandledThreadExceptionWarning) for w in recwarn.list), (
+        "reader-thread UnicodeDecodeError surfaced as a PytestUnhandledThreadExceptionWarning"
     )

--- a/tests/test_state_persistence.py
+++ b/tests/test_state_persistence.py
@@ -440,7 +440,7 @@ class TestAutomationRestoreState:
     """Test the AutomationEngine.restore_state method."""
 
     def test_restore_paused_state(self):
-        """Pause state (paused_by_door, pre_pause_mode) IS restored; grace/override are clean-slated."""
+        """Pause state is NOT restored on restart (clean slate per Issue #306); grace/override are also clean-slated."""
         from custom_components.climate_advisor.automation import AutomationEngine
 
         engine = AutomationEngine(
@@ -463,8 +463,8 @@ class TestAutomationRestoreState:
             }
         )
 
-        assert engine._paused_by_door is True
-        assert engine._pre_pause_mode == "heat"
+        assert engine._paused_by_door is False
+        assert engine._pre_pause_mode is None  # Issue #306: pause state NOT restored on restart
         # Clean-slate on restart: grace and override state always reset
         assert engine._grace_active is False
         assert engine._last_resume_source is None
@@ -490,6 +490,11 @@ class TestAutomationRestoreState:
         assert engine._grace_active is False
 
     def test_restore_missing_keys_uses_defaults(self):
+        """restore_state with a persisted paused_by_door=True must leave pause cleared.
+
+        Clean-slate rule (Issue #263/#306): pause state is NOT restored across restarts.
+        The door/window listener re-detects open sensors within 30–90 s of startup.
+        """
         from custom_components.climate_advisor.automation import AutomationEngine
 
         engine = AutomationEngine(
@@ -503,7 +508,8 @@ class TestAutomationRestoreState:
 
         engine.restore_state({"paused_by_door": True})
 
-        assert engine._paused_by_door is True
+        # Pause state is NOT restored — clean slate on restart.
+        assert engine._paused_by_door is False
         assert engine._pre_pause_mode is None
 
     def test_restore_clean_slates_override_state(self):


### PR DESCRIPTION
## Summary

- **Occupant experience fixed**: After an HA restart with a window or door open, the home previously sat with HVAC off and fan off — "paused — door/window open" — for up to 30 minutes (observed: 7 min on 2026-06-10 due to cloud weather + Ecobee both slow to reconnect). Natural ventilation was available but never activated. Occupant had to manually unpause.
- **Root cause**: `restore_state()` was persisting `_paused_by_door=True` across restarts. The nat-vent re-evaluation path at `check_natural_vent_conditions()` depends on the weather entity being available — a timing race that can fail for the full startup retry window (~7.5 min).
- **Fix**: Stop restoring `_paused_by_door` and `_pre_pause_mode` on restart (clean-slate, matching the existing policy for overrides and grace periods). The door/window state-change listener already re-detects open sensors via the `None → "on"` entity transition after restart; HVAC briefly re-arms (~5 min debounce window), then re-pauses automatically.

## Changes

- **`automation.py`**: Remove two lines from `restore_state()` that were loading `_paused_by_door` and `_pre_pause_mode` from persisted state. Update docstring to document the clean-slate design for pause state (Issue #263/#306).
- **`tests/test_paused_restart_recovery.py`** (new): 7 TDD tests covering the clean-slate behavior — pause fields not restored, other fields still restored, `apply_classification()` reaches comfort band after clean-slate restart.
- **`tests/test_state_persistence.py`**: Update 2 stale assertions that previously expected `_paused_by_door=True` and `_pre_pause_mode="heat"` after `restore_state()`.
- **`docs/08-COMPUTATION-REFERENCE.md`**: Document the design decision in §11, noting the 5-minute debounce timing and the re-detection mechanism.

## Test plan

- [x] `pytest tests/test_paused_restart_recovery.py -v` — all 7 new tests pass
- [x] `pytest tests/ -x -q -W error::pytest.PytestUnraisableExceptionWarning -W error::RuntimeWarning` — all 2,571 tests pass
- [ ] Post-deploy: after next HA restart with open sensor, `python tools/ha_logs.py --lines 200` should show classification applied (HVAC re-armed), then ~5 min later door-open event + re-pause — no 7-minute silence

Closes #306, resolves #263.