### PR TITLE
Feat #312: AC duty solar phase estimator + 90-day staleness gate

### DIFF
--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -2063,6 +2063,23 @@ THERMAL_SOLAR_PHASE_MIN_ENTRIES = 3  # Min chart_log entries in window
 THERMAL_SOLAR_PHASE_MIN_WINDOW_H = 4  # Min window span (hours)
 THERMAL_SOLAR_PHASE_MIN_DT_F = 1.5  # Min indoor ΔT for visible peak
 THERMAL_SOLAR_PHASE_ALPHA = 0.10  # EWMA alpha (slow — stable building physics)
+THERMAL_PARAM_STALE_DAYS = 90  # days — parameter older than this treated as None at resolver
+
+# AC duty-cycle secondary solar phase estimator (Issue #312)
+THERMAL_SOLAR_PHASE_AC_ALPHA = 0.07  # EWMA alpha (slower — less reliable signal)
+THERMAL_SOLAR_PHASE_AC_MIN_OBS = 3  # Min observations before secondary is trusted
+THERMAL_SOLAR_PHASE_AC_SETPOINT_MIN_F = 68.0  # Setpoint range lower bound
+THERMAL_SOLAR_PHASE_AC_SETPOINT_MAX_F = 80.0  # Setpoint range upper bound
+THERMAL_SOLAR_PHASE_AC_SETPOINT_STABILITY_F = 1.5  # Max allowed setpoint spread (°F)
+THERMAL_SOLAR_PHASE_AC_MIN_COOL_ENTRIES = 4  # Min cool entries in 11:00-16:00 window
+THERMAL_SOLAR_PHASE_AC_PEAK_WINDOW_START_H = 11  # Peak window start (inclusive)
+THERMAL_SOLAR_PHASE_AC_PEAK_WINDOW_END_H = 16  # Peak window end (exclusive)
+THERMAL_SOLAR_PHASE_AC_STABILITY_WINDOW_END_H = 18  # Setpoint stability check end (exclusive)
+REJECT_AC_NO_COOL_SETPOINTS = "ac_no_cool_setpoints"
+REJECT_AC_SETPOINT_UNSTABLE = "ac_setpoint_unstable"
+REJECT_AC_SETPOINT_OUT_OF_RANGE = "ac_setpoint_out_of_range"
+REJECT_AC_INSUFFICIENT_MIDDAY_ACTIVITY = "ac_insufficient_midday_activity"
+REJECT_AC_NO_SETPOINT_BREACH = "ac_no_setpoint_breach"
 
 # Shared cap across all observation types
 THERMAL_MAX_OBS_SAMPLES = 200

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -112,6 +112,11 @@ from .const import (
     OCCUPANCY_VACATION,
     PRED_ARCHIVE_HORIZON_HOURS,
     REJECT_ABANDONED,
+    REJECT_AC_INSUFFICIENT_MIDDAY_ACTIVITY,
+    REJECT_AC_NO_COOL_SETPOINTS,
+    REJECT_AC_NO_SETPOINT_BREACH,
+    REJECT_AC_SETPOINT_OUT_OF_RANGE,
+    REJECT_AC_SETPOINT_UNSTABLE,
     REJECT_NO_INTERIOR_PEAK,
     REJECT_OLS_BAD_FIT,
     REJECT_OLS_BOUNDS,
@@ -157,6 +162,13 @@ from .const import (
     THERMAL_SOLAR_FACTOR_MIN_RANGE,
     THERMAL_SOLAR_MIN_RATE_F_PER_HR,
     THERMAL_SOLAR_MIN_SAMPLES,
+    THERMAL_SOLAR_PHASE_AC_MIN_COOL_ENTRIES,
+    THERMAL_SOLAR_PHASE_AC_PEAK_WINDOW_END_H,
+    THERMAL_SOLAR_PHASE_AC_PEAK_WINDOW_START_H,
+    THERMAL_SOLAR_PHASE_AC_SETPOINT_MAX_F,
+    THERMAL_SOLAR_PHASE_AC_SETPOINT_MIN_F,
+    THERMAL_SOLAR_PHASE_AC_SETPOINT_STABILITY_F,
+    THERMAL_SOLAR_PHASE_AC_STABILITY_WINDOW_END_H,
     THERMAL_SOLAR_PHASE_ALPHA,
     THERMAL_SOLAR_PHASE_MIN_DT_F,
     THERMAL_SOLAR_PHASE_MIN_ENTRIES,
@@ -316,6 +328,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         # Solar phase offset (Issue #147)
         self._solar_phase_offset: float = THERMAL_SOLAR_PHASE_OFFSET_H_DEFAULT
         self._solar_phase_backfill: bool = False
+        self._solar_phase_ac_backfill: bool = False  # Issue #312: AC duty cycle estimator
 
         # Occupancy state machine
         self._occupancy_mode: str = OCCUPANCY_HOME
@@ -576,6 +589,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         self._vent_k_backfill_v2 = bool(state.get("vent_k_backfill_v2", False))
         # Solar phase offset backfill flag (Issue #147)
         self._solar_phase_backfill = bool(state.get("solar_phase_backfill", False))
+        self._solar_phase_ac_backfill = bool(state.get("solar_phase_ac_backfill", False))  # Issue #312
 
         # Prediction archive — restore only on same-day restores (already gated above)
         raw_archive = state.get("pred_archive")
@@ -669,6 +683,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             "passive_k_backfill_v2": self._passive_k_backfill_v2,
             "vent_k_backfill_v2": self._vent_k_backfill_v2,
             "solar_phase_backfill": self._solar_phase_backfill,
+            "solar_phase_ac_backfill": self._solar_phase_ac_backfill,  # Issue #312
             "event_log": list(self._event_log),
         }
 
@@ -1244,6 +1259,9 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                         self._run_solar_phase_chart_log_fit(backfill=True)
                         self._solar_phase_backfill = True
                         _LOGGER.info("chart_log solar_phase: phase offset backfill complete")
+                    if not self._solar_phase_ac_backfill:
+                        self._run_ac_duty_solar_phase_fit()
+                        # Flag is set inside the method after completion
 
             # Refresh the thermal model on every 30-min cycle, not just at the daily
             # briefing. get_thermal_model() is a pure computation (no I/O), so calling it
@@ -1925,6 +1943,10 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         self._current_classification = classification
         self._last_outdoor_temp = forecast.current_outdoor_temp
         self._apply_outdoor_windows_gate()
+
+        # Daily incremental solar phase re-fit (Issue #310/#312)
+        if self.config.get("learning_enabled", True):
+            self._maybe_run_periodic_solar_phase_fit()
 
         # Inject thermal model into automation engine for adaptive scheduling
         if self.config.get("learning_enabled", True):
@@ -3782,6 +3804,86 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             rejected,
         )
 
+    def _run_ac_duty_solar_phase_fit(self) -> None:
+        """Estimate solar phase offset from AC duty cycle pattern (Issue #312).
+
+        Secondary estimator — only used when the primary (passive window) method has
+        never produced an observation. Reads the chart_log, groups entries by local
+        calendar date, applies quality filter, estimates peak-load hour, and updates
+        the EWMA via learning.update_ac_duty_solar_phase_offset().
+
+        Sets self._solar_phase_ac_backfill = True on completion.
+        """
+        chart_log = getattr(self, "_chart_log", None)
+        if chart_log is None:
+            _LOGGER.debug("AC duty solar phase fit: chart_log not initialized — skipping")
+            return
+        entries = list(getattr(chart_log, "_entries", []))
+        if not entries:
+            _LOGGER.debug("AC duty solar phase fit: chart_log empty — skipping")
+            return
+
+        # Group entries by local calendar date
+        from collections import defaultdict
+
+        days: dict[str, list[dict]] = defaultdict(list)
+        for entry in entries:
+            h = _entry_hour(entry)
+            if h is None:
+                continue
+            try:
+                day_str = datetime.fromisoformat(entry["ts"]).strftime("%Y-%m-%d")
+            except (KeyError, ValueError):
+                continue
+            days[day_str].append(entry)
+
+        committed = 0
+        rejected = 0
+        for day_str, day_entries in sorted(days.items()):
+            ok, reason = _is_ac_duty_solar_day(day_entries)
+            if not ok:
+                rejected += 1
+                _LOGGER.debug("AC duty solar phase: skip day=%s reason=%s", day_str, reason)
+                continue
+            offset = _estimate_ac_duty_solar_phase(day_entries)
+            if offset is None:
+                rejected += 1
+                continue
+            self.learning.update_ac_duty_solar_phase_offset(offset, day_str)
+            committed += 1
+
+        current: float | None = None
+        if hasattr(self, "learning") and hasattr(self.learning, "_state"):
+            current = (self.learning._state.thermal_model_cache or {}).get("solar_phase_offset_ac_h")
+        _LOGGER.info(
+            "AC duty solar phase fit: committed=%d rejected=%d current_offset=%s",
+            committed,
+            rejected,
+            f"{current:.2f}h" if current is not None else "none",
+        )
+        self._solar_phase_ac_backfill = True
+
+    def _maybe_run_periodic_solar_phase_fit(self) -> None:
+        """Run the incremental daily solar phase re-fit if due (Issue #310/#312).
+
+        Called once per day from _async_send_briefing after the primary backfill has
+        completed. Runs both the primary passive-window estimator (backfill=False) and
+        the secondary AC duty cycle estimator to pick up any new observations since the
+        last backfill.
+
+        No-ops until the initial backfill has been run at least once
+        (_solar_phase_backfill must be True).
+        """
+        if not self._solar_phase_backfill:
+            return
+        _today = dt_util.now().date()
+        if getattr(self, "_last_solar_phase_fit_date", None) == _today:
+            return
+        self._run_solar_phase_chart_log_fit(backfill=False)
+        self._run_ac_duty_solar_phase_fit()
+        self._last_solar_phase_fit_date = _today
+        _LOGGER.info("chart_log solar_phase: daily incremental re-fit complete (date=%s)", _today)
+
     def _start_decay_observation(self, obs_type: str) -> None:
         """Create a new monitoring observation for a passive/fan/vent/solar type."""
         import uuid as _uuid_mod
@@ -5292,6 +5394,110 @@ def _estimate_solar_phase_offset(
     )
 
     return phase_obs_clamped, None
+
+
+def _entry_hour(entry: dict) -> int | None:
+    """Parse local hour from a chart_log entry ts field. Returns None on failure."""
+    try:
+        return datetime.fromisoformat(entry["ts"]).hour
+    except (KeyError, ValueError, TypeError):
+        return None
+
+
+def _is_ac_duty_solar_day(day_entries: list[dict]) -> tuple[bool, str]:
+    """Quality filter for AC duty cycle solar phase estimation.
+
+    Returns (True, "") if the day qualifies, or (False, reject_reason) otherwise.
+    Pure function — no instance state.
+
+    Quality gates (in order):
+      1. At least one entry in 11:00-18:00 has setpoint_cool field.
+      1b. Setpoint must be in [SETPOINT_MIN_F, SETPOINT_MAX_F].
+      2. Setpoint spread across 11:00-18:00 < SETPOINT_STABILITY_F.
+      3. >= AC_MIN_COOL_ENTRIES cool entries in 11:00-16:00.
+      4. At least one 11:00-16:00 entry has indoor > median setpoint.
+    """
+    # Collect entries in the stability window (11:00-18:00)
+    stability_entries = [
+        e
+        for e in day_entries
+        if _entry_hour(e) is not None
+        and THERMAL_SOLAR_PHASE_AC_PEAK_WINDOW_START_H <= _entry_hour(e) < THERMAL_SOLAR_PHASE_AC_STABILITY_WINDOW_END_H
+    ]
+
+    # Gate 1: must have setpoint_cool field in at least one stability-window entry
+    setpoints = [e["setpoint_cool"] for e in stability_entries if e.get("setpoint_cool") is not None]
+    if not setpoints:
+        return False, REJECT_AC_NO_COOL_SETPOINTS
+
+    # Gate 1b: setpoint must be in a reasonable range
+    if min(setpoints) < THERMAL_SOLAR_PHASE_AC_SETPOINT_MIN_F or max(setpoints) > THERMAL_SOLAR_PHASE_AC_SETPOINT_MAX_F:
+        return False, REJECT_AC_SETPOINT_OUT_OF_RANGE
+
+    # Gate 2: setpoint must be stable across the stability window
+    if max(setpoints) - min(setpoints) > THERMAL_SOLAR_PHASE_AC_SETPOINT_STABILITY_F:
+        return False, REJECT_AC_SETPOINT_UNSTABLE
+
+    # Gate 3: >= AC_MIN_COOL_ENTRIES cool entries in peak window (11:00-16:00)
+    peak_cool_count = sum(
+        1
+        for e in day_entries
+        if e.get("hvac") == "cool"
+        and _entry_hour(e) is not None
+        and THERMAL_SOLAR_PHASE_AC_PEAK_WINDOW_START_H <= _entry_hour(e) < THERMAL_SOLAR_PHASE_AC_PEAK_WINDOW_END_H
+    )
+    if peak_cool_count < THERMAL_SOLAR_PHASE_AC_MIN_COOL_ENTRIES:
+        return False, REJECT_AC_INSUFFICIENT_MIDDAY_ACTIVITY
+
+    # Gate 4: at least one peak-window entry has indoor > median setpoint
+    median_setpoint = sorted(setpoints)[len(setpoints) // 2]
+    breach = any(
+        e.get("indoor", 0) > median_setpoint
+        for e in day_entries
+        if _entry_hour(e) is not None
+        and THERMAL_SOLAR_PHASE_AC_PEAK_WINDOW_START_H <= _entry_hour(e) < THERMAL_SOLAR_PHASE_AC_PEAK_WINDOW_END_H
+    )
+    if not breach:
+        return False, REJECT_AC_NO_SETPOINT_BREACH
+
+    return True, ""
+
+
+def _estimate_ac_duty_solar_phase(day_entries: list[dict]) -> float | None:
+    """Estimate solar phase offset from AC duty cycle peak hour.
+
+    Counts cool entries per hour in the 11:00-16:00 window, computes duty fraction,
+    finds the peak-duty hour, and returns (peak_hour - 13) clamped to
+    [THERMAL_SOLAR_PHASE_OFFSET_MIN, THERMAL_SOLAR_PHASE_OFFSET_MAX].
+
+    Returns None if no cool entries exist in the window.
+    Pure function — no instance state.
+    """
+    # Count cool and total entries per hour in 11:00-16:00 window
+    cool_counts: dict[int, int] = {}
+    total_counts: dict[int, int] = {}
+    for e in day_entries:
+        h = _entry_hour(e)
+        _start = THERMAL_SOLAR_PHASE_AC_PEAK_WINDOW_START_H
+        _end = THERMAL_SOLAR_PHASE_AC_PEAK_WINDOW_END_H
+        in_peak = h is not None and _start <= h < _end
+        if not in_peak:
+            continue
+        total_counts[h] = total_counts.get(h, 0) + 1
+        if e.get("hvac") == "cool":
+            cool_counts[h] = cool_counts.get(h, 0) + 1
+
+    if not cool_counts:
+        return None
+
+    # Duty fraction per hour
+    duty = {h: cool_counts[h] / total_counts[h] for h in cool_counts if total_counts.get(h, 0) > 0}
+    if not duty:
+        return None
+
+    peak_hour = max(duty, key=lambda h: duty[h])
+    offset = float(peak_hour - 13)
+    return max(float(THERMAL_SOLAR_PHASE_OFFSET_MIN), min(float(THERMAL_SOLAR_PHASE_OFFSET_MAX), offset))
 
 
 def _simulate_indoor_physics_v3(

--- a/custom_components/climate_advisor/learning.py
+++ b/custom_components/climate_advisor/learning.py
@@ -170,6 +170,53 @@ def _grade_swing_confidence(count: int) -> str:
     return "high"
 
 
+def _resolve_solar_phase_offset(cache: dict) -> float:
+    """Return the best current solar phase offset.
+
+    A parameter is stale if its last_obs_date is absent or older than THERMAL_PARAM_STALE_DAYS.
+    Stale home-specific measurements are always preferred over a generic default prior —
+    the default is only returned when nothing has ever been observed.
+
+    Priority:
+      1. Fresh primary (passive-decay fit, within THERMAL_PARAM_STALE_DAYS)
+      2. Fresh secondary (AC duty cycle, within THERMAL_PARAM_STALE_DAYS, obs >= min)
+      3. Stale primary (EWMA value preserved in cache — better than a generic prior)
+      4. Stale secondary (obs >= min — better than a generic prior)
+      5. Default prior (THERMAL_SOLAR_PHASE_OFFSET_H_DEFAULT) — only when nothing learned
+    """
+    from datetime import date as _date
+
+    from .const import THERMAL_PARAM_STALE_DAYS, THERMAL_SOLAR_PHASE_AC_MIN_OBS, THERMAL_SOLAR_PHASE_OFFSET_H_DEFAULT
+
+    def _is_stale(last_obs_date_str: str | None) -> bool:
+        if last_obs_date_str is None:
+            return True
+        try:
+            return (_date.today() - _date.fromisoformat(last_obs_date_str)).days > THERMAL_PARAM_STALE_DAYS
+        except (ValueError, TypeError):
+            return True
+
+    primary = cache.get("solar_phase_offset_h")
+    secondary = cache.get("solar_phase_offset_ac_h")
+    ac_obs = cache.get("solar_phase_offset_ac_obs_count", 0)
+    secondary_qualified = secondary is not None and ac_obs >= THERMAL_SOLAR_PHASE_AC_MIN_OBS
+
+    # Fresh data first
+    if primary is not None and not _is_stale(cache.get("solar_phase_offset_last_obs_date")):
+        return float(primary)
+    if secondary_qualified and not _is_stale(cache.get("solar_phase_offset_ac_last_obs_date")):
+        return float(secondary)
+
+    # Stale home-specific data beats a generic prior
+    if primary is not None:
+        return float(primary)
+    if secondary_qualified:
+        return float(secondary)
+
+    # Nothing has ever been learned — use configured default
+    return float(THERMAL_SOLAR_PHASE_OFFSET_H_DEFAULT)
+
+
 def _smooth_temps(temps: list[float]) -> list[float]:
     """Apply 3-sample centered moving average to smooth 1-degF integer staircase noise.
 
@@ -774,6 +821,10 @@ class LearningEngine:
                 "k_vent_window": None,
                 "k_solar": None,
                 "solar_phase_offset_h": None,
+                "solar_phase_offset_last_obs_date": None,
+                "solar_phase_offset_ac_h": None,
+                "solar_phase_offset_ac_obs_count": 0,
+                "solar_phase_offset_ac_last_obs_date": None,
                 "observation_count_heat": 0,
                 "observation_count_cool": 0,
                 "observation_count_passive": 0,
@@ -932,6 +983,10 @@ class LearningEngine:
                 "k_vent_window": None,
                 "k_solar": None,
                 "solar_phase_offset_h": None,
+                "solar_phase_offset_last_obs_date": None,
+                "solar_phase_offset_ac_h": None,
+                "solar_phase_offset_ac_obs_count": 0,
+                "solar_phase_offset_ac_last_obs_date": None,
                 "observation_count_heat": 0,
                 "observation_count_cool": 0,
                 "observation_count_passive": 0,
@@ -957,10 +1012,35 @@ class LearningEngine:
         new_val = obs_clamped if current is None else (1.0 - alpha) * float(current) + alpha * obs_clamped
 
         cache["solar_phase_offset_h"] = new_val
+        cache["solar_phase_offset_last_obs_date"] = _date.today().isoformat()
 
         if cache.get("first_active_date_phase_offset") is None:
             cache["first_active_date_phase_offset"] = _date.today().isoformat()
 
+        self._state.thermal_model_cache = cache
+
+    def update_ac_duty_solar_phase_offset(self, observed_offset_h: float, today_str: str) -> None:
+        """Update the secondary (AC duty cycle) solar phase EWMA.
+
+        Never called by the primary passive-decay path. Called by the coordinator's
+        AC duty cycle estimator (_run_ac_duty_solar_phase_fit) after Phase 2.
+
+        Args:
+            observed_offset_h: Estimated offset from AC duty peak (peak_hour - 13).
+            today_str: ISO date string (YYYY-MM-DD) for the observation date.
+        """
+        from .const import THERMAL_SOLAR_PHASE_AC_ALPHA
+
+        cache = self._state.thermal_model_cache or {}
+        current = cache.get("solar_phase_offset_ac_h")
+        if current is None:
+            cache["solar_phase_offset_ac_h"] = observed_offset_h
+        else:
+            cache["solar_phase_offset_ac_h"] = (
+                THERMAL_SOLAR_PHASE_AC_ALPHA * observed_offset_h + (1.0 - THERMAL_SOLAR_PHASE_AC_ALPHA) * current
+            )
+        cache["solar_phase_offset_ac_obs_count"] = cache.get("solar_phase_offset_ac_obs_count", 0) + 1
+        cache["solar_phase_offset_ac_last_obs_date"] = today_str
         self._state.thermal_model_cache = cache
 
     def get_engine_status(self) -> dict:
@@ -1117,7 +1197,9 @@ class LearningEngine:
             "k_vent": cache.get("k_vent"),
             "k_vent_window": cache.get("k_vent_window"),
             "k_solar": k_solar,
-            "solar_phase_offset_h": cache.get("solar_phase_offset_h"),
+            "solar_phase_offset_h": _resolve_solar_phase_offset(cache),
+            "solar_phase_offset_ac_h": cache.get("solar_phase_offset_ac_h"),
+            "solar_phase_offset_ac_obs_count": cache.get("solar_phase_offset_ac_obs_count", 0),
             "thermal_equilibrium_f": thermal_equilibrium_f,
             # Legacy compat
             "heating_rate_f_per_hour": round(k_active_heat, 2) if k_active_heat is not None else None,

--- a/docs/08-COMPUTATION-REFERENCE.md
+++ b/docs/08-COMPUTATION-REFERENCE.md
@@ -37,6 +37,8 @@ The automation logic table and all threshold constants in this document are expr
 | What is the comfort-band programming model introduced in Issue #249? | CA programs a floor+ceiling band every 30 min via one `select_comfort_band` decision and one `_apply_comfort_band` actuation; the thermostat's own deadband holds the house inside the band continuously — no more off+supervisor pattern. | [§6e Comfort-Band Programming](08-COMPUTATION-REFERENCE.md#6e-comfort-band-programming-issue-249) |
 | What command shape does `_apply_comfort_band` emit per thermostat capability? | Dual-capable: `heat_cool` mode + `set_temperature(target_temp_low=floor, target_temp_high=ceiling)`. Cool-only (active=ceiling): `cool` + `set_temperature(ceiling)`. Heat-only (active=floor): `heat` + `set_temperature(floor)`. | [§6e — `_apply_comfort_band` command shapes](08-COMPUTATION-REFERENCE.md#_apply_comfort_band-command-shapes) |
 | Why does nat-vent no longer set HVAC off when windows open (Issue #249)? | The band stays armed when nat-vent activates; the thermostat self-arbitrates — free cooling is free, AC kicks in only if the breeze can't hold the ceiling. Turning HVAC off also disarmed the floor, making cold-snap escalation impossible. | [§6e — Nat-vent and economizer with the band armed](08-COMPUTATION-REFERENCE.md#nat-vent-and-economizer-with-the-band-armed) |
+| How does the solar phase offset resolver decide which EWMA to use, and what is the fallback? | Fresh primary wins; fresh secondary (≥ 3 obs) next; then stale primary; stale secondary; generic default only when nothing has ever been learned. Staleness = last_obs_date absent or > 90 days old (`THERMAL_PARAM_STALE_DAYS`). | [§5e-viii Two-EWMA Solar Phase Architecture](08-COMPUTATION-REFERENCE.md#5e-viii-solar-phase-offset--two-ewma-architecture-issue-312) |
+| What quality gates must a chart_log day pass before the AC duty cycle solar phase method estimates an offset? | Five gates: setpoint_cool field present; setpoint in [68, 80]°F; spread < 1.5°F over 11:00–18:00; ≥ 4 cool entries in 11:00–16:00; at least one 11:00–16:00 entry has indoor > median setpoint. | [§5e-viii AC duty cycle quality filter](08-COMPUTATION-REFERENCE.md#5e-viii-solar-phase-offset--two-ewma-architecture-issue-312) |
 | What are the two fan archetypes and how does each affect HVAC mode and fan-stops-on-close behavior? | `FAN_MODE_HVAC` (HVAC blower): band stays armed, HVAC unchanged when fan activates, fan does NOT stop when windows close unless `_natural_vent_active=True`. `FAN_MODE_WHOLE_HOUSE` (exhaust fan): HVAC set to off on activation (mode captured in `_pre_fan_hvac_mode`), restored on deactivation, fan stops when ALL sensors close even if `_natural_vent_active=False`. | [§9 Fan Archetype Behavioral Contract](08-COMPUTATION-REFERENCE.md#fan-archetype-behavioral-contract-issue-277) |
 | Why does `_set_hvac_mode("off")` also set `_fan_command_time` (Issue #277 Bug A1)? | The `set_fan_mode(auto)` assertion inside `_set_hvac_mode("off")` sets `_fan_command_time = dt_util.now()` before the service call, so cloud thermostat echoes of the fan_mode attribute change are suppressed within the `_is_recent_fan_command` window instead of triggering a false manual override. | [§9b Race Guard — `_set_hvac_mode("off")` fan_command_time](08-COMPUTATION-REFERENCE.md#_set_hvac_mode-off-fan_command_time-guard-issue-277-bug-a1) |
 | How does `_async_thermostat_changed()` prevent a single event from triggering both a setpoint and a fan override (Issue #277 Bug B)? | A local `_setpoint_override_detected` flag is initialized to `False` before Block 2 (setpoint detection) and Block 3 (fan_mode detection). If Block 2 fires and sets it `True`, Block 3 is suppressed via `and not _setpoint_override_detected`. One event → at most one override type. | [§9b Setpoint/Fan Mutual Exclusion](08-COMPUTATION-REFERENCE.md#setpointfan-override-mutual-exclusion-issue-277-bug-b) |
@@ -518,6 +520,86 @@ by 5/9 for Celsius), never `from_fahrenheit()`. The +32 offset does not apply.
 | `THERMAL_SWING_CONF_LOW` | 1 | none → low threshold |
 | `THERMAL_SWING_CONF_MEDIUM` | 3 | low → medium threshold |
 | `THERMAL_SWING_CONF_HIGH` | 10 | medium → high threshold |
+
+#### 5e-viii. Solar Phase Offset — Two-EWMA Architecture (Issue #312)
+
+The solar phase offset (`solar_phase_offset_h`) corrects the `solar_factor` sinusoid so it peaks at the hour where heat actually reaches the interior rather than at a fixed 1 pm clock-noon. Two independent EWMAs learn this offset from different signal sources; a resolver selects the best available value at call time.
+
+**Two-EWMA architecture:**
+
+| EWMA | Cache key | Alpha | Source | Trust |
+|---|---|---|---|---|
+| Primary | `solar_phase_offset_h` | 0.10 (`THERMAL_SOLAR_PHASE_ALPHA`) | Passive-decay chart_log windows (`_run_solar_phase_chart_log_fit()`) | Higher — measures thermal response directly, no confound |
+| Secondary | `solar_phase_offset_ac_h` | 0.07 (`THERMAL_SOLAR_PHASE_AC_ALPHA`) | AC duty cycle peak hour (`_run_ac_duty_solar_phase_fit()`) | Lower — AC cycling is an indirect proxy; alpha is slower to reflect this |
+
+The two EWMAs never cross-update: `update_solar_phase_offset()` in `learning.py` writes only `solar_phase_offset_h`; `update_ac_duty_solar_phase_offset()` writes only `solar_phase_offset_ac_h`.
+
+**Resolver — `_resolve_solar_phase_offset(cache)` (`learning.py`):**
+
+Each EWMA stores a `last_obs_date` field (`solar_phase_offset_last_obs_date`, `solar_phase_offset_ac_last_obs_date`). A parameter is **stale** if its date is absent or older than `THERMAL_PARAM_STALE_DAYS` (90 days). Stale home-specific data is still preferred over a generic default — the default is only used when nothing has ever been learned.
+
+```
+1. primary = cache["solar_phase_offset_h"]
+   if primary is not None AND fresh (within 90 days) → return primary   ← preferred
+
+2. secondary = cache["solar_phase_offset_ac_h"]
+   ac_obs = cache["solar_phase_offset_ac_obs_count"]
+   if secondary is not None AND ac_obs >= 3 AND fresh → return secondary
+
+3. if primary is not None (stale) → return primary                       ← best stale data
+
+4. if secondary is not None AND ac_obs >= 3 (stale) → return secondary  ← next best stale
+
+5. return THERMAL_SOLAR_PHASE_OFFSET_H_DEFAULT (2)                       ← nothing ever learned
+```
+
+The secondary requires at least 3 accepted observations (`THERMAL_SOLAR_PHASE_AC_MIN_OBS`) before it is trusted in either the fresh or stale tier. The default prior (`THERMAL_SOLAR_PHASE_OFFSET_H_DEFAULT = 2`, peak at 3 pm local) is only returned when both EWMAs have never received an accepted observation.
+
+**Staleness principle (applies to all computed thermal parameters — see Issue #314):** A learned value is only "current" if it was recently observed. An EWMA frozen by seasonal inactivity is stale, but it still encodes home-specific geometry and is a better estimate than a generic prior. The resolver prefers fresh > stale > default, with primary (passive method) winning within each tier.
+
+`get_thermal_model()` returns `solar_phase_offset_h` as the **resolved** value — call sites (ODE, chart) receive the best available estimate without needing to know which source was used. The raw secondary EWMA is also exposed as `solar_phase_offset_ac_h` for diagnostic inspection.
+
+**AC duty cycle quality filter — `_is_ac_duty_solar_day(day_entries)` (`coordinator.py`):**
+
+The AC duty method is only meaningful on days where the thermostat was cooling steadily in the midday window. Days that don't meet the quality criteria are rejected before estimation.
+
+| Gate | Criterion | Constant | Reject code |
+|---|---|---|---|
+| 1 | At least one 11:00–18:00 chart_log entry has a `setpoint_cool` field | — | `ac_no_cool_setpoints` |
+| 1b | All setpoints in [68, 80]°F | `THERMAL_SOLAR_PHASE_AC_SETPOINT_MIN/MAX_F` | `ac_setpoint_out_of_range` |
+| 2 | Setpoint spread across 11:00–18:00 < 1.5°F | `THERMAL_SOLAR_PHASE_AC_SETPOINT_STABILITY_F` | `ac_setpoint_unstable` |
+| 3 | ≥ 4 cool entries in 11:00–16:00 | `THERMAL_SOLAR_PHASE_AC_MIN_COOL_ENTRIES` | `ac_insufficient_midday_activity` |
+| 4 | At least one 11:00–16:00 entry has indoor > median setpoint | — | `ac_no_setpoint_breach` |
+
+Gates are evaluated in order; the first failure returns `(False, reject_code)`. A day passing all gates returns `(True, "")`. The function is a pure module-level helper — no coordinator state.
+
+**Estimation — `_estimate_ac_duty_solar_phase(day_entries)` (`coordinator.py`):**
+
+1. For each hour in 11:00–16:00, compute `duty_fraction = cool_entries / total_entries`.
+2. Identify `peak_hour = argmax(duty_fraction)`.
+3. `offset = peak_hour − 13`, clamped to `[THERMAL_SOLAR_PHASE_OFFSET_MIN (0), THERMAL_SOLAR_PHASE_OFFSET_MAX (4)]`.
+
+A `peak_hour` of 14 (2 pm) yields `offset = 1`; a peak at 16 (4 pm) yields `offset = 3`. Returns `None` if no cool entries exist in the window (should not occur after gate 3, but guards the return).
+
+**Integration — `_run_ac_duty_solar_phase_fit()` (`coordinator.py`):**
+
+Called once per coordinator update cycle (inside the `_run_solar_phase_chart_log_fit()` block). Iterates chart_log entries grouped by date. For each date, calls `_is_ac_duty_solar_day()` then `_estimate_ac_duty_solar_phase()`; on success calls `learning.update_ac_duty_solar_phase_offset(offset, date_str)`. Rejection reasons are logged at DEBUG level; accepted estimates at INFO.
+
+**Constants summary:**
+
+| Constant | Value | Purpose |
+|---|---|---|
+| `THERMAL_SOLAR_PHASE_AC_ALPHA` | 0.07 | Secondary EWMA smoothing factor |
+| `THERMAL_SOLAR_PHASE_AC_MIN_OBS` | 3 | Minimum observations before secondary is trusted by resolver |
+| `THERMAL_SOLAR_PHASE_AC_SETPOINT_MIN_F` | 68.0 | Setpoint range lower bound |
+| `THERMAL_SOLAR_PHASE_AC_SETPOINT_MAX_F` | 80.0 | Setpoint range upper bound |
+| `THERMAL_SOLAR_PHASE_AC_SETPOINT_STABILITY_F` | 1.5 | Max allowed setpoint spread across 11:00–18:00 |
+| `THERMAL_SOLAR_PHASE_AC_MIN_COOL_ENTRIES` | 4 | Min cool entries in 11:00–16:00 to qualify |
+| `THERMAL_SOLAR_PHASE_OFFSET_H_DEFAULT` | 2 | Default prior (resolves to 3 pm peak) |
+| `THERMAL_SOLAR_PHASE_OFFSET_MIN` | 0 | Offset clamp lower bound |
+| `THERMAL_SOLAR_PHASE_OFFSET_MAX` | 4 | Offset clamp upper bound (5 pm peak) |
+
+**Test coverage:** `tests/test_solar_phase.py` — `TestAcDutySolarPhase` (quality filter reject paths, estimation, EWMA update, resolver priority).
 
 ---
 

--- a/tests/test_event_log_persistence.py
+++ b/tests/test_event_log_persistence.py
@@ -92,6 +92,7 @@ def _make_minimal_coordinator(*, initial_event_log: list | None = None):
     coord._passive_k_backfill_v2 = False
     coord._vent_k_backfill_v2 = False
     coord._solar_phase_backfill = False
+    coord._solar_phase_ac_backfill = False  # Issue #312
 
     # automation_engine — MagicMock (NOT AsyncMock) per project convention
     ae = MagicMock()
@@ -145,6 +146,7 @@ def _make_restore_coordinator():
     coord._passive_k_backfill_v2 = False
     coord._vent_k_backfill_v2 = False
     coord._solar_phase_backfill = False
+    coord._solar_phase_ac_backfill = False  # Issue #312
 
     ae = MagicMock()
     ae.restore_state = MagicMock()

--- a/tests/test_solar_ac_phase.py
+++ b/tests/test_solar_ac_phase.py
@@ -1,0 +1,348 @@
+"""Tests for AC duty-cycle secondary solar phase estimator (Issue #312).
+
+Covers:
+  - _is_ac_duty_solar_day(): quality filter (5 reject paths + 1 pass)
+  - _estimate_ac_duty_solar_phase(): peak-hour duty-fraction estimator
+  - _resolve_solar_phase_offset(): resolver in learning.py
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_entries(
+    hours_hvac: dict,
+    setpoint: float = 74.0,
+    indoor_base: float = 74.0,
+    outdoor: float = 85.0,
+) -> list[dict]:
+    """Build synthetic chart_log entries for a single day.
+
+    hours_hvac maps hour (int) -> 'cool' | 'off'.
+    Covers 08:30-21:30 (one entry per hour) to give a realistic daily spread.
+    """
+    entries = []
+    for h in range(8, 22):
+        hvac = hours_hvac.get(h, "off")
+        indoor = indoor_base + (0.5 if hvac == "cool" else 0.0)
+        entry = {
+            "ts": f"2026-06-13T{h:02d}:30:00-07:00",
+            "hvac": hvac,
+            "indoor": indoor,
+            "outdoor": outdoor,
+            "fan": "off",
+            "windows_open": False,
+            "setpoint_cool": setpoint,
+        }
+        entries.append(entry)
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# Import production functions (will fail until Phase 1 implementation)
+# ---------------------------------------------------------------------------
+
+from custom_components.climate_advisor.const import (  # noqa: E402
+    REJECT_AC_INSUFFICIENT_MIDDAY_ACTIVITY,
+    REJECT_AC_NO_COOL_SETPOINTS,
+    REJECT_AC_NO_SETPOINT_BREACH,
+    REJECT_AC_SETPOINT_OUT_OF_RANGE,
+    REJECT_AC_SETPOINT_UNSTABLE,
+    THERMAL_SOLAR_PHASE_OFFSET_MIN,
+)
+from custom_components.climate_advisor.coordinator import (  # noqa: E402
+    _estimate_ac_duty_solar_phase,
+    _is_ac_duty_solar_day,
+)
+
+# ---------------------------------------------------------------------------
+# Tests: _is_ac_duty_solar_day
+# ---------------------------------------------------------------------------
+
+
+class TestIsAcDutySolarDay:
+    def test_reject_no_cool_setpoints(self):
+        """REJECT when no entry has a setpoint_cool field."""
+        entries = _make_entries({11: "cool", 12: "cool", 13: "cool", 14: "cool"})
+        for e in entries:
+            e.pop("setpoint_cool", None)
+        ok, reason = _is_ac_duty_solar_day(entries)
+        assert not ok
+        assert reason == REJECT_AC_NO_COOL_SETPOINTS
+
+    def test_reject_setpoint_out_of_range(self):
+        """REJECT when setpoint is outside [68, 80]F."""
+        entries = _make_entries(
+            {11: "cool", 12: "cool", 13: "cool", 14: "cool"},
+            setpoint=85.0,
+        )
+        ok, reason = _is_ac_duty_solar_day(entries)
+        assert not ok
+        assert reason == REJECT_AC_SETPOINT_OUT_OF_RANGE
+
+    def test_reject_setpoint_unstable(self):
+        """REJECT when setpoint varies > 1.5F during 11:00-18:00 window."""
+        entries = _make_entries(
+            {11: "cool", 12: "cool", 13: "cool", 14: "cool"},
+            setpoint=74.0,
+        )
+        # Introduce a 4F spread within the stability window
+        for e in entries:
+            if e["ts"].startswith("2026-06-13T15"):
+                e["setpoint_cool"] = 78.0
+        ok, reason = _is_ac_duty_solar_day(entries)
+        assert not ok
+        assert reason == REJECT_AC_SETPOINT_UNSTABLE
+
+    def test_reject_insufficient_midday_activity(self):
+        """REJECT when fewer than 4 cool entries in 11:00-16:00."""
+        # Only 3 cool entries in 11-16 window
+        entries = _make_entries(
+            {11: "cool", 12: "cool", 13: "cool"},
+            setpoint=74.0,
+            indoor_base=75.5,
+        )
+        ok, reason = _is_ac_duty_solar_day(entries)
+        assert not ok
+        assert reason == REJECT_AC_INSUFFICIENT_MIDDAY_ACTIVITY
+
+    def test_reject_no_setpoint_breach(self):
+        """REJECT when no 11-16 entry has indoor > setpoint."""
+        # indoor_base=74.0 < setpoint=78.0 — no breach possible
+        entries = _make_entries(
+            {11: "cool", 12: "cool", 13: "cool", 14: "cool"},
+            setpoint=78.0,
+            indoor_base=74.0,
+        )
+        ok, reason = _is_ac_duty_solar_day(entries)
+        assert not ok
+        assert reason == REJECT_AC_NO_SETPOINT_BREACH
+
+    def test_pass_valid_ac_duty_day(self):
+        """PASS when all quality criteria are met."""
+        entries = _make_entries(
+            {11: "cool", 12: "cool", 13: "cool", 14: "cool"},
+            setpoint=74.0,
+            indoor_base=75.5,  # 1.5F above setpoint -> breach confirmed
+        )
+        ok, reason = _is_ac_duty_solar_day(entries)
+        assert ok, f"Expected pass, got reject: {reason}"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _estimate_ac_duty_solar_phase
+# ---------------------------------------------------------------------------
+
+
+class TestEstimateAcDutySolarPhase:
+    def _build_entries(self, cool_hours: list[int], all_hours: list[int]) -> list[dict]:
+        """Build entries with cool at cool_hours and 'off' elsewhere, all within all_hours."""
+        entries = []
+        for h in all_hours:
+            for m in [0, 30]:
+                hvac = "cool" if h in cool_hours else "off"
+                entries.append(
+                    {
+                        "ts": f"2026-06-13T{h:02d}:{m:02d}:00-07:00",
+                        "hvac": hvac,
+                    }
+                )
+        return entries
+
+    def test_estimate_peak_at_14(self):
+        """Peak duty at hour 14 -> offset = 14 - 13 = 1.0."""
+        # Only 14 is "cool"; 11, 12, 13, 15 are "off" — duty fraction highest at 14
+        entries = self._build_entries(cool_hours=[14], all_hours=[11, 12, 13, 14, 15])
+        result = _estimate_ac_duty_solar_phase(entries)
+        assert result == pytest.approx(1.0)
+
+    def test_estimate_peak_at_13(self):
+        """Peak duty at hour 13 -> offset clamped to THERMAL_SOLAR_PHASE_OFFSET_MIN."""
+        entries = self._build_entries(cool_hours=[13], all_hours=[11, 12, 13, 14, 15])
+        result = _estimate_ac_duty_solar_phase(entries)
+        assert result is not None
+        # offset = 13 - 13 = 0, clamped to MIN
+        assert result >= THERMAL_SOLAR_PHASE_OFFSET_MIN
+
+    def test_estimate_no_cool_entries(self):
+        """Returns None when no cool entries exist in the peak window."""
+        entries = [{"ts": "2026-06-13T12:00:00-07:00", "hvac": "off"}]
+        result = _estimate_ac_duty_solar_phase(entries)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: _resolve_solar_phase_offset (in learning.py)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSolarPhaseOffset:
+    def setup_method(self):
+        import datetime
+
+        from custom_components.climate_advisor.const import THERMAL_SOLAR_PHASE_OFFSET_H_DEFAULT
+        from custom_components.climate_advisor.learning import _resolve_solar_phase_offset
+
+        self._resolve = _resolve_solar_phase_offset
+        self._default = THERMAL_SOLAR_PHASE_OFFSET_H_DEFAULT
+        self._today = datetime.date.today().isoformat()
+
+    def test_primary_wins(self):
+        """Primary solar_phase_offset_h (fresh) is used when not None, even if secondary present."""
+        cache = {
+            "solar_phase_offset_h": 3.0,
+            "solar_phase_offset_last_obs_date": self._today,
+            "solar_phase_offset_ac_h": 1.0,
+            "solar_phase_offset_ac_last_obs_date": self._today,
+            "solar_phase_offset_ac_obs_count": 5,
+        }
+        assert self._resolve(cache) == pytest.approx(3.0)
+
+    def test_secondary_fallback_when_enough_obs(self):
+        """Secondary (AC, fresh) is used when primary is None and obs_count >= 3."""
+        cache = {
+            "solar_phase_offset_h": None,
+            "solar_phase_offset_last_obs_date": None,
+            "solar_phase_offset_ac_h": 1.5,
+            "solar_phase_offset_ac_last_obs_date": self._today,
+            "solar_phase_offset_ac_obs_count": 3,
+        }
+        assert self._resolve(cache) == pytest.approx(1.5)
+
+    def test_default_when_both_absent(self):
+        """Default returned when both primary and secondary are None."""
+        cache = {
+            "solar_phase_offset_h": None,
+            "solar_phase_offset_last_obs_date": None,
+            "solar_phase_offset_ac_h": None,
+            "solar_phase_offset_ac_last_obs_date": None,
+            "solar_phase_offset_ac_obs_count": 0,
+        }
+        assert self._resolve(cache) == pytest.approx(self._default)
+
+    def test_default_when_secondary_insufficient_obs(self):
+        """Default returned when secondary has value but obs_count < 3."""
+        cache = {
+            "solar_phase_offset_h": None,
+            "solar_phase_offset_last_obs_date": None,
+            "solar_phase_offset_ac_h": 1.0,
+            "solar_phase_offset_ac_last_obs_date": self._today,
+            "solar_phase_offset_ac_obs_count": 2,
+        }
+        assert self._resolve(cache) == pytest.approx(self._default)
+
+
+# ---------------------------------------------------------------------------
+# Tests: staleness gate in _resolve_solar_phase_offset (Issue #312 Phase 2)
+# ---------------------------------------------------------------------------
+
+
+class TestSolarPhaseOffsetStaleness:
+    """_resolve_solar_phase_offset must treat parameters older than THERMAL_PARAM_STALE_DAYS as None."""
+
+    def _cache(self, primary=None, primary_date=None, secondary=None, secondary_date=None, ac_obs=0):
+        return {
+            "solar_phase_offset_h": primary,
+            "solar_phase_offset_last_obs_date": primary_date,
+            "solar_phase_offset_ac_h": secondary,
+            "solar_phase_offset_ac_last_obs_date": secondary_date,
+            "solar_phase_offset_ac_obs_count": ac_obs,
+        }
+
+    def _today(self):
+        from datetime import date
+
+        return date.today().isoformat()
+
+    def _days_ago(self, n):
+        from datetime import date, timedelta
+
+        return (date.today() - timedelta(days=n)).isoformat()
+
+    def test_fresh_primary_is_used(self):
+        """Primary with recent last_obs_date (within 90 days) must be returned."""
+        from custom_components.climate_advisor.learning import _resolve_solar_phase_offset
+
+        cache = self._cache(primary=3.0, primary_date=self._days_ago(1))
+        assert _resolve_solar_phase_offset(cache) == pytest.approx(3.0)
+
+    def test_stale_primary_falls_to_secondary(self):
+        """Primary older than 90 days must be masked; fresh secondary with obs>=3 used instead."""
+        from custom_components.climate_advisor.learning import _resolve_solar_phase_offset
+
+        cache = self._cache(
+            primary=3.0,
+            primary_date=self._days_ago(91),
+            secondary=1.5,
+            secondary_date=self._days_ago(1),
+            ac_obs=3,
+        )
+        assert _resolve_solar_phase_offset(cache) == pytest.approx(1.5)
+
+    def test_primary_with_no_date_falls_to_stale_value(self):
+        """Primary with last_obs_date=None (pre-312 migration) is stale but still used — better than default."""
+        from custom_components.climate_advisor.learning import _resolve_solar_phase_offset
+
+        cache = self._cache(primary=3.0, primary_date=None)  # no date = stale, but value exists
+        # Stale home-specific data beats generic default
+        assert _resolve_solar_phase_offset(cache) == pytest.approx(3.0)
+
+    def test_stale_primary_used_over_stale_secondary(self):
+        """Both primary and secondary stale → stale primary returned (better than generic default)."""
+        from custom_components.climate_advisor.learning import _resolve_solar_phase_offset
+
+        cache = self._cache(
+            primary=3.0,
+            primary_date=self._days_ago(91),
+            secondary=1.5,
+            secondary_date=self._days_ago(91),
+            ac_obs=5,
+        )
+        assert _resolve_solar_phase_offset(cache) == pytest.approx(3.0)
+
+    def test_stale_primary_secondary_insufficient_obs(self):
+        """Stale primary + secondary with ac_obs < 3 → stale primary used (obs gate still applies to secondary)."""
+        from custom_components.climate_advisor.learning import _resolve_solar_phase_offset
+
+        cache = self._cache(
+            primary=3.0,
+            primary_date=self._days_ago(91),
+            secondary=1.5,
+            secondary_date=self._days_ago(1),
+            ac_obs=2,
+        )
+        # Secondary disqualified by obs count; stale primary is the best available data
+        assert _resolve_solar_phase_offset(cache) == pytest.approx(3.0)
+
+    def test_primary_exactly_at_threshold_is_fresh(self):
+        """Primary at exactly 90 days (not 91) must still be returned (inclusive threshold)."""
+        from custom_components.climate_advisor.learning import _resolve_solar_phase_offset
+
+        cache = self._cache(primary=3.0, primary_date=self._days_ago(90))
+        assert _resolve_solar_phase_offset(cache) == pytest.approx(3.0)
+
+    def test_stale_secondary_used_when_no_primary(self):
+        """Stale secondary with obs>=3 and no primary → stale secondary used (better than default)."""
+        from custom_components.climate_advisor.learning import _resolve_solar_phase_offset
+
+        cache = self._cache(
+            primary=None,
+            primary_date=None,
+            secondary=1.5,
+            secondary_date=self._days_ago(91),
+            ac_obs=5,
+        )
+        assert _resolve_solar_phase_offset(cache) == pytest.approx(1.5)
+
+    def test_nothing_learned_returns_default(self):
+        """When both primary and secondary are None (never observed), return the generic default."""
+        from custom_components.climate_advisor.const import THERMAL_SOLAR_PHASE_OFFSET_H_DEFAULT
+        from custom_components.climate_advisor.learning import _resolve_solar_phase_offset
+
+        cache = self._cache(primary=None, primary_date=None, secondary=None, secondary_date=None, ac_obs=0)
+        assert _resolve_solar_phase_offset(cache) == pytest.approx(THERMAL_SOLAR_PHASE_OFFSET_H_DEFAULT)

--- a/tests/test_solar_phase_periodic.py
+++ b/tests/test_solar_phase_periodic.py
@@ -155,6 +155,7 @@ def _make_build_state_stub(mod, fit_date):
     """Minimal stub sufficient for _build_state_dict to run."""
     coord = MagicMock(spec=mod.ClimateAdvisorCoordinator)
     coord._solar_phase_backfill = True
+    coord._solar_phase_ac_backfill = False  # Issue #312
     coord._last_solar_phase_fit_date = fit_date
     coord._current_classification = None
     coord._today_record = None


### PR DESCRIPTION
## Summary

- **AC duty cycle secondary estimator**: when the primary passive-window method is blocked by summer AC (HVAC-on prevents HVAC-off observations), a secondary method estimates solar phase from the peak AC duty-cycle hour in the 11:00–16:00 window. Five quality gates filter out setpoint-unstable and evening-only AC days.
- **Two-EWMA architecture**: primary (`solar_phase_offset_h`, α=0.10) and secondary (`solar_phase_offset_ac_h`, α=0.07) never cross-update. A resolver in `get_thermal_model()` selects the best available value transparently — all consumers (ODE, chart, briefing) receive the resolved offset without knowing the source.
- **90-day staleness gate**: `solar_phase_offset_last_obs_date` is stored per primary update. Parameters older than `THERMAL_PARAM_STALE_DAYS=90` are treated as stale but still returned if no fresher data exists — stale home-specific data always beats a generic default prior. Resolver precedence: fresh primary → fresh secondary → stale primary → stale secondary → default.
- **Daily re-fit wiring**: `_run_ac_duty_solar_phase_fit()` is called alongside the existing primary fit in `_maybe_run_periodic_solar_phase_fit()` and the startup backfill block. `_solar_phase_ac_backfill` state is persisted/restored so backfill runs once per install.

## Files changed

| File | Change |
|---|---|
| `coordinator.py` | `_entry_hour()`, `_is_ac_duty_solar_day()`, `_estimate_ac_duty_solar_phase()` (pure module-level); `_run_ac_duty_solar_phase_fit()` instance method; backfill + periodic wiring; `_solar_phase_ac_backfill` state |
| `learning.py` | `update_ac_duty_solar_phase_offset()`, `_resolve_solar_phase_offset()` (5-tier), `solar_phase_offset_last_obs_date` cache field, 3 new AC cache fields, `get_thermal_model()` uses resolver |
| `const.py` | 9 `THERMAL_SOLAR_PHASE_AC_*` constants, 5 `REJECT_AC_*` strings, `THERMAL_PARAM_STALE_DAYS=90` |
| `tests/test_solar_ac_phase.py` | 21 new TDD tests: all 5 reject paths, estimator peak-hour, 5-tier resolver, staleness edge cases |
| `docs/08-COMPUTATION-REFERENCE.md` | §5e-viii: two-EWMA architecture, resolver precedence, quality filter table, staleness principle |

## Test plan

- [x] 21 new tests in `test_solar_ac_phase.py` — all reject paths, estimator, resolver, staleness
- [x] `test_event_log_persistence.py` updated for new state field
- [x] Full suite: 2603 tests pass with `-W error::pytest.PytestUnraisableExceptionWarning -W error::RuntimeWarning`
- [x] Ruff clean
- [x] Opus verification agent: all 10 correctness concerns passed (resolver precedence, alpha values, filter thresholds, log coverage, no call-site regressions)

Closes #312