### PR TITLE
Fix #313: fan command override suppression, post-fan setpoint verify, nat-vent exit fix, v0.4.14

### DIFF
--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -1958,21 +1958,19 @@ class AutomationEngine:
                                     self._start_grace_period("automation", trigger="nat_vent_exit_resume")
                             return
 
-        # NEW (Issue #115): exit if outdoor ≥ indoor — airflow now heating not cooling
+        # NEW (Issue #115): exit if outdoor > indoor — airflow now strictly heating
         indoor = self._get_indoor_temp_f()
-        if self._natural_vent_active and outdoor is not None and indoor is not None and outdoor >= indoor:
+        if self._natural_vent_active and outdoor is not None and indoor is not None and outdoor > indoor:
             self._natural_vent_active = False
             self._paused_by_door = True
             self._nat_vent_outdoor_exit_time = dt_util.now()
             await self._deactivate_fan(
                 reason=(
-                    f"nat vent exit: outdoor {outdoor:.1f}\u00b0F \u2265 indoor {indoor:.1f}\u00b0F"
-                    " \u2014 airflow reversed"
+                    f"nat vent exit: outdoor {outdoor:.1f}\u00b0F > indoor {indoor:.1f}\u00b0F \u2014 airflow reversed"
                 )
             )
             _LOGGER.info(
-                "Natural vent exit: outdoor %.1f\u00b0F \u2265 indoor %.1f\u00b0F"
-                " \u2014 airflow reversed, entering pause",
+                "Natural vent exit: outdoor %.1f\u00b0F > indoor %.1f\u00b0F \u2014 airflow reversed, entering pause",
                 outdoor,
                 indoor,
             )
@@ -2629,6 +2627,47 @@ class AutomationEngine:
             self._fan_active = True
             self._fan_on_since = dt_util.now().isoformat()
             self._record_action("Fan activated", reason)
+
+            # Post-fan setpoint verify: Ecobee may revert to comfort program after a fan command.
+            # Re-assert our setpoint within 30s so the coordinator's _is_recent_temp_command guard
+            # covers any delayed state report.
+            _verify_seq = self._write_seq
+            _expected_temp = self._pending_setpoint_single
+            _expected_mode = self._last_commanded_hvac_mode
+
+            async def _do_verify_after_fan_on() -> None:
+                if self._write_seq != _verify_seq:
+                    return  # newer command issued — skip
+                if _expected_temp is None or _expected_mode is None:
+                    return  # no active setpoint
+                if self._manual_override_active:
+                    return  # genuine confirmed override — don't fight it
+                current_state = self.hass.states.get(self.climate_entity)
+                if current_state is None:
+                    return
+                actual = current_state.attributes.get("temperature")
+                if actual is None:
+                    return
+                try:
+                    if (
+                        abs(float(actual) - _expected_temp) > 0.6
+                    ):  # 0.6°F — same tolerance as _check_single_setpoint_accepted
+                        _LOGGER.info(
+                            "Post-fan setpoint verify: thermostat %.1f°F != expected %.1f°F — re-asserting %s mode",
+                            float(actual),
+                            _expected_temp,
+                            _expected_mode,
+                        )
+                        await self._set_temperature(
+                            _expected_temp, reason="post-fan-verify/repair", mode=_expected_mode
+                        )
+                except (ValueError, TypeError):
+                    pass
+
+            def _verify_setpoint_after_fan_on(_now: Any) -> None:
+                self.hass.async_create_task(_do_verify_after_fan_on())
+
+            async_call_later(self.hass, 30.0, _verify_setpoint_after_fan_on)
         finally:
             self._fan_command_pending = False
 
@@ -2676,6 +2715,47 @@ class AutomationEngine:
             self._fan_active = False
             self._fan_on_since = None
             self._record_action("Fan deactivated", reason)
+
+            # Post-fan setpoint verify: Ecobee may revert to comfort program after a fan command.
+            # Re-assert our setpoint within 30s so the coordinator's _is_recent_temp_command guard
+            # covers any delayed state report.
+            _verify_seq = self._write_seq
+            _expected_temp = self._pending_setpoint_single
+            _expected_mode = self._last_commanded_hvac_mode
+
+            async def _do_verify_after_fan_off() -> None:
+                if self._write_seq != _verify_seq:
+                    return  # newer command issued — skip
+                if _expected_temp is None or _expected_mode is None:
+                    return  # no active setpoint
+                if self._manual_override_active:
+                    return  # genuine confirmed override — don't fight it
+                current_state = self.hass.states.get(self.climate_entity)
+                if current_state is None:
+                    return
+                actual = current_state.attributes.get("temperature")
+                if actual is None:
+                    return
+                try:
+                    if (
+                        abs(float(actual) - _expected_temp) > 0.6
+                    ):  # 0.6°F — same tolerance as _check_single_setpoint_accepted
+                        _LOGGER.info(
+                            "Post-fan setpoint verify: thermostat %.1f°F != expected %.1f°F — re-asserting %s mode",
+                            float(actual),
+                            _expected_temp,
+                            _expected_mode,
+                        )
+                        await self._set_temperature(
+                            _expected_temp, reason="post-fan-verify/repair", mode=_expected_mode
+                        )
+                except (ValueError, TypeError):
+                    pass
+
+            def _verify_setpoint_after_fan_off(_now: Any) -> None:
+                self.hass.async_create_task(_do_verify_after_fan_off())
+
+            async_call_later(self.hass, 30.0, _verify_setpoint_after_fan_off)
         finally:
             self._fan_command_pending = False
 

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,23 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.4.13"
+VERSION = "0.4.14"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.4.14": [
+        "Fix #313: Fan commands no longer trigger false manual-override detection. When Ecobee"
+        " reverts its setpoint after a fan mode change, the coordinator now suppresses the"
+        " setpoint-change override check for 30s after any fan command (matching the existing"
+        " guard on hvac and temp commands).",
+        "Fix #313: After every fan activation or deactivation, CA schedules a 30-second"
+        " verify-and-repair callback. If the thermostat's setpoint has drifted more than 0.6°F"
+        " from what CA commanded, CA re-asserts the correct setpoint — so any delayed Ecobee"
+        " state report arrives within the temp-command recency window and is not misread as an"
+        " override.",
+        "Fix #313: Natural ventilation no longer exits when outdoor and indoor temperatures are"
+        " equal. Equal temps mean neutral airflow (no benefit but no harm); only when outdoor is"
+        " strictly warmer than indoor does nat-vent exit due to airflow reversal.",
+    ],
     "0.4.13": [
         "Fix #185/#310: solar_phase_offset_h now re-fits daily from the chart_log passive-daytime"
         " windows (incremental 2-day lookback). Previously, the one-shot startup backfill flag was"
@@ -1223,6 +1237,42 @@ KNOWN_FIXES: dict[int, dict] = {
             " visible via 'Solar phase fit: 0 windows passed quality filter' in ha_logs",
             "solar_gain abandonment rate — still 99/100 'abandoned' (flat indoor temps); addressed"
             " separately if #185 logging confirms HVAC-on is blocking all passive windows",
+        ],
+    },
+    313: {
+        "version_fixed": "0.4.14",
+        "title": "False override + premature nat-vent exit after fan command (#313)",
+        "scope_covered": [
+            "coordinator.py _async_thermostat_changed(): setpoint-override detection block now"
+            " checks `not self.automation_engine._fan_command_pending` and"
+            " `not self._is_recent_fan_command(threshold_seconds=30.0)` — matches the existing"
+            " pattern in the fan-mode change detection block at line ~2585",
+            "automation.py _activate_fan(): schedules 30s sync callback"
+            " (_verify_setpoint_after_fan_on) via async_call_later; callback re-asserts the"
+            " last commanded setpoint via _set_temperature() if thermostat drifted >0.6°F,"
+            " using _write_seq guard to skip if a newer command was issued",
+            "automation.py _deactivate_fan(): same 30s verify-and-repair callback pattern"
+            " (_verify_setpoint_after_fan_off)",
+            "automation.py nat-vent exit condition: `outdoor >= indoor` changed to"
+            " `outdoor > indoor` — equal temps (neutral airflow) no longer exit nat-vent",
+            "tests/test_temp_command_guard.py: TestFanCommandSetpointGuard — 3 tests for"
+            " pending flag, 30s recency, and expired (60s) genuine override",
+            "tests/test_nat_vent_activation.py: TestNatVentExitEqualTemps — 3 tests"
+            " (equal stays active, above exits, below stays active); TestPostFanVerify — 6"
+            " tests (schedule on activate, schedule on deactivate, repair on drift, skip on"
+            " write_seq advance, skip on manual override, skip within tolerance)",
+        ],
+        "scope_not_covered": [
+            "Ecobee setpoint reversion >60s after the fan command (i.e., after the 30s verify"
+            " fires but before the next classify cycle): the existing 15-min retry (#301) covers"
+            " persistent drift; a second occurrence in the same session will be caught by the"
+            " next classify cycle's setpoint re-assertion",
+            "Pre-fan state validation (check thermostat matches expected setpoint BEFORE fan"
+            " command): not needed for the #313 incident (setpoint was correct before fan-on);"
+            " can be added if pre-drift becomes observed in production",
+            "Tier B integration test for the full cascade (fan command → Ecobee revert →"
+            " verify fires → re-assert): requires the coordinator state-listener layer;"
+            " deferred to Tier B",
         ],
     },
     308: {

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -2553,8 +2553,10 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             and self._today_record
             and not self.automation_engine._temp_command_pending
             and not self.automation_engine._hvac_command_pending
+            and not self.automation_engine._fan_command_pending
             and not self._is_recent_hvac_command(threshold_seconds=30.0)
             and not self._is_recent_temp_command(threshold_seconds=30.0)
+            and not self._is_recent_fan_command(threshold_seconds=30.0)
         ):
             # Mark setpoint detection as fired so Block 3 (fan_mode) is suppressed for this event.
             # A single event that changes both setpoint and fan_mode has one root cause; two

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.4.13"
+  "version": "0.4.14"
 }

--- a/tests/test_daily_record_accuracy.py
+++ b/tests/test_daily_record_accuracy.py
@@ -184,6 +184,7 @@ def _make_thermostat_coordinator_stub(*, temp_command_pending: bool = False):
     # Helpers used inside _async_thermostat_changed
     coord._is_recent_hvac_command = MagicMock(return_value=False)
     coord._is_recent_temp_command = MagicMock(return_value=False)
+    coord._is_recent_fan_command = MagicMock(return_value=False)
     coord._emit_event = MagicMock()
     coord._hvac_on_since = None
     coord._pending_thermal_event = None

--- a/tests/test_fan_control.py
+++ b/tests/test_fan_control.py
@@ -941,7 +941,7 @@ class TestMinFanRuntime:
             asyncio.run(engine._fan_cycle_on())
         engine.hass.services.async_call.assert_called()
         assert engine._fan_min_runtime_active is True
-        mock_later.assert_called_once()
+        assert mock_later.call_count == 2  # 30s verify + runtime deactivation
         assert engine._fan_min_cycle_cancel is cancel_mock
 
     def test_cycle_on_skips_when_zero(self):
@@ -1011,7 +1011,8 @@ class TestMinFanRuntime:
             asyncio.run(engine._fan_cycle_on())
         engine.hass.services.async_call.assert_called()
         assert engine._fan_min_runtime_active is True
-        mock_later.assert_not_called()
+        assert mock_later.call_count == 1  # only 30s verify; no deactivation for always-on
+        assert mock_later.call_args[0][1] == 30.0
         assert engine._fan_min_cycle_cancel is None
 
     def test_cycle_off_deactivates_fan_and_schedules_next_on(self):
@@ -1031,8 +1032,8 @@ class TestMinFanRuntime:
         assert engine._fan_min_runtime_active is False
         # Deactivation service call was made
         engine.hass.services.async_call.assert_called()
-        # Next "on" is scheduled for (60 - 10) * 60 = 3000 seconds
-        mock_later.assert_called_once()
+        # Next "on" is scheduled for (60 - 10) * 60 = 3000 seconds; also 30s verify
+        assert mock_later.call_count == 2  # 30s verify + next-cycle scheduling
         assert mock_later.call_args[0][1] == (60 - 10) * 60
         assert engine._fan_min_cycle_cancel is cancel_mock
 

--- a/tests/test_nat_vent_activation.py
+++ b/tests/test_nat_vent_activation.py
@@ -298,12 +298,17 @@ class TestNatVentOutdoorRiseExit:
         assert rise_events[0][1]["outdoor"] == 74.5
         assert rise_events[0][1]["indoor"] == 74.0
 
-    def test_outdoor_equal_indoor_fires_exit(self):
-        """outdoor 74.0F == indoor 74.0F (boundary) → directional exit fires."""
+    def test_outdoor_equal_indoor_does_not_exit(self):
+        """outdoor 74.0F == indoor 74.0F (boundary) → directional exit does NOT fire (Bug #313 fix).
+
+        Equal temps mean neutral airflow — not reversed — so nat vent should stay active.
+        The exit condition is strict: outdoor > indoor (not >=).
+        """
         engine = _make_engine(indoor_f=74.0)
         engine._natural_vent_active = True
         engine._paused_by_door = False
         engine._last_outdoor_temp = 74.0
+        engine._deactivate_fan = AsyncMock()
 
         events: list[tuple] = []
         engine._emit_event_callback = lambda name, payload: events.append((name, payload))
@@ -311,9 +316,9 @@ class TestNatVentOutdoorRiseExit:
         with patch(_DT_NOW_PATH, return_value=datetime(2026, 4, 20, 20, 0, 0)):
             asyncio.run(engine.check_natural_vent_conditions())
 
-        assert engine._natural_vent_active is False
+        assert engine._natural_vent_active is True, "nat vent must stay active when outdoor == indoor"
         rise_events = [e for e in events if e[0] == "nat_vent_outdoor_rise_exit"]
-        assert len(rise_events) == 1
+        assert len(rise_events) == 0, "nat_vent_outdoor_rise_exit must not fire on equal temps"
 
     def test_outdoor_rise_exit_fires_before_threshold_exit(self):
         """outdoor 74.5F >= indoor 74.0F but still below threshold 75F — directional exit fires first."""
@@ -743,3 +748,280 @@ class TestProactiveFloorExit:
         assert len(floor_events) == 1
         assert "time_to_floor_hr" in floor_events[0][1]
         assert floor_events[0][1]["time_to_floor_hr"] < MIN_VIABLE_NAT_VENT_HOURS
+
+
+# ---------------------------------------------------------------------------
+# Bug #313 Fix — equal outdoor==indoor should NOT exit nat vent
+# ---------------------------------------------------------------------------
+
+
+class TestNatVentExitEqualTemps:
+    """Bug #313: outdoor >= indoor exit condition must be strict (>), not >=.
+
+    Equal temps mean neutral airflow — not reversed.  Exiting nat vent when
+    outdoor == indoor causes the occupant to lose free cooling unnecessarily
+    every time a sensor read happens to land on exactly the same value as indoor.
+
+    These three tests document the correct post-fix semantics:
+      1. Equal temps → nat vent STAYS active  (was wrong: exited)
+      2. outdoor > indoor → nat vent exits     (regression guard, unchanged)
+      3. outdoor < indoor → nat vent stays     (regression guard, unchanged)
+    """
+
+    def test_equal_temps_does_not_exit_nat_vent(self):
+        """outdoor == indoor (72.0 == 72.0) → nat vent stays active after fix.
+
+        Before the fix (outdoor >= indoor) this test FAILS because the engine
+        exits nat vent on equal temps.  After the fix (outdoor > indoor) it passes.
+        """
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=72.0, nat_vent_delta=3.0, indoor_f=72.0)
+        engine._natural_vent_active = True
+        engine._paused_by_door = False
+        engine._fan_override_active = False
+        engine._last_outdoor_temp = 72.0  # equal to indoor
+        engine._deactivate_fan = AsyncMock()
+
+        events: list[tuple] = []
+        engine._emit_event_callback = lambda name, payload: events.append((name, payload))
+
+        with patch(_DT_NOW_PATH, return_value=datetime(2026, 4, 20, 20, 0, 0)):
+            asyncio.run(engine.check_natural_vent_conditions())
+
+        # Equal temps → airflow is neutral, not reversed → do NOT exit
+        assert engine._natural_vent_active is True, (
+            "nat vent should stay active when outdoor == indoor (neutral airflow)"
+        )
+        rise_events = [e for e in events if e[0] == "nat_vent_outdoor_rise_exit"]
+        assert len(rise_events) == 0, "nat_vent_outdoor_rise_exit must NOT fire on equal temps"
+
+    def test_outdoor_above_indoor_exits_nat_vent(self):
+        """outdoor > indoor (73.0 > 72.0) → nat vent exits (regression guard).
+
+        This must still exit after the fix — strictly greater means reversed airflow.
+        """
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=72.0, nat_vent_delta=3.0, indoor_f=72.0)
+        engine._natural_vent_active = True
+        engine._paused_by_door = False
+        engine._fan_override_active = False
+        engine._last_outdoor_temp = 73.0  # strictly above indoor
+        engine._deactivate_fan = AsyncMock()
+
+        events: list[tuple] = []
+        engine._emit_event_callback = lambda name, payload: events.append((name, payload))
+
+        with patch(_DT_NOW_PATH, return_value=datetime(2026, 4, 20, 20, 0, 0)):
+            asyncio.run(engine.check_natural_vent_conditions())
+
+        assert engine._natural_vent_active is False, (
+            "nat vent must exit when outdoor strictly > indoor (reversed airflow)"
+        )
+        rise_events = [e for e in events if e[0] == "nat_vent_outdoor_rise_exit"]
+        assert len(rise_events) == 1
+
+    def test_outdoor_below_indoor_stays_active(self):
+        """outdoor < indoor (71.0 < 72.0) → nat vent stays active (regression guard).
+
+        Outdoor cooler than indoor — airflow is beneficial.  Must not exit.
+        """
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=72.0, nat_vent_delta=3.0, indoor_f=72.0)
+        engine._natural_vent_active = True
+        engine._paused_by_door = False
+        engine._fan_override_active = False
+        engine._last_outdoor_temp = 71.0  # strictly below indoor
+        engine._deactivate_fan = AsyncMock()
+
+        events: list[tuple] = []
+        engine._emit_event_callback = lambda name, payload: events.append((name, payload))
+
+        with patch(_DT_NOW_PATH, return_value=datetime(2026, 4, 20, 20, 0, 0)):
+            asyncio.run(engine.check_natural_vent_conditions())
+
+        assert engine._natural_vent_active is True, (
+            "nat vent must stay active when outdoor < indoor (beneficial airflow)"
+        )
+        rise_events = [e for e in events if e[0] == "nat_vent_outdoor_rise_exit"]
+        assert len(rise_events) == 0
+
+
+# ---------------------------------------------------------------------------
+# Bug #313 1B — post-fan verify-and-repair callback
+# ---------------------------------------------------------------------------
+
+_ACL_PATH = "custom_components.climate_advisor.automation.async_call_later"
+
+
+def _make_fan_engine(indoor_f: float = 72.0) -> AutomationEngine:
+    """Engine with FAN_MODE_HVAC so _activate_fan/_deactivate_fan reach the callback."""
+    from custom_components.climate_advisor.const import FAN_MODE_HVAC
+
+    engine = _make_engine(indoor_f=indoor_f)
+    engine.config["fan_mode"] = FAN_MODE_HVAC
+    return engine
+
+
+class TestPostFanVerify:
+    """Bug #313-1B: post-fan 30s setpoint verify-and-repair callback.
+
+    After every fan activation or deactivation the engine schedules a 30s callback
+    that re-asserts the last commanded setpoint if the thermostat has drifted.
+    This guards against Ecobee comfort-program reversions after fan commands.
+    """
+
+    def test_activate_fan_schedules_verify_callback(self):
+        """_activate_fan() schedules exactly one async_call_later(30s) callback."""
+        engine = _make_fan_engine()
+        engine._pending_setpoint_single = 72.0
+        engine._last_commanded_hvac_mode = "cool"
+
+        captured_callbacks: list = []
+
+        def _fake_acl(hass, delay, callback):
+            captured_callbacks.append((delay, callback))
+
+        with patch(_ACL_PATH, side_effect=_fake_acl):
+            asyncio.run(engine._activate_fan(reason="test"))
+
+        # Should have scheduled exactly one verify callback
+        verify_calls = [(d, cb) for d, cb in captured_callbacks if d == 30.0]
+        assert len(verify_calls) == 1, "Expected exactly one 30s verify callback from _activate_fan"
+
+    def test_deactivate_fan_schedules_verify_callback(self):
+        """_deactivate_fan() schedules exactly one async_call_later(30s) callback."""
+        engine = _make_fan_engine()
+        engine._fan_active = True
+        engine._pending_setpoint_single = 72.0
+        engine._last_commanded_hvac_mode = "cool"
+
+        captured_callbacks: list = []
+
+        def _fake_acl(hass, delay, callback):
+            captured_callbacks.append((delay, callback))
+
+        with patch(_ACL_PATH, side_effect=_fake_acl):
+            asyncio.run(engine._deactivate_fan(reason="test"))
+
+        verify_calls = [(d, cb) for d, cb in captured_callbacks if d == 30.0]
+        assert len(verify_calls) == 1, "Expected exactly one 30s verify callback from _deactivate_fan"
+
+    def test_verify_callback_repairs_drifted_setpoint(self):
+        """Callback fires and re-asserts setpoint when thermostat drifted > 0.6°F."""
+        engine = _make_fan_engine(indoor_f=72.0)
+        engine._pending_setpoint_single = 70.0
+        engine._last_commanded_hvac_mode = "cool"
+        engine._manual_override_active = False
+
+        # Thermostat reports 71.9°F — drifted 1.9°F away from commanded 70.0°F
+        climate_state = MagicMock()
+        climate_state.state = "cool"
+        climate_state.attributes = {"current_temperature": 72.0, "temperature": 71.9}
+        engine.hass.states.get = MagicMock(return_value=climate_state)
+
+        # Capture _set_temperature calls
+        engine._set_temperature = AsyncMock()
+
+        captured_callbacks: list = []
+
+        def _fake_acl(hass, delay, callback):
+            captured_callbacks.append((delay, callback))
+
+        with patch(_ACL_PATH, side_effect=_fake_acl):
+            asyncio.run(engine._activate_fan(reason="test"))
+
+        assert len(captured_callbacks) == 1
+        _delay, verify_cb = captured_callbacks[0]
+
+        # Wire async_create_task to capture and run the inner coroutine
+        # (the sync wrapper calls hass.async_create_task with the inner coro)
+        captured_coros: list = []
+        engine.hass.async_create_task = MagicMock(side_effect=lambda c: captured_coros.append(c))
+
+        verify_cb(None)
+        assert len(captured_coros) == 1
+        asyncio.run(captured_coros[0])
+
+        engine._set_temperature.assert_called_once()
+        call_kwargs = engine._set_temperature.call_args
+        assert call_kwargs[1]["reason"] == "post-fan-verify/repair"
+        assert call_kwargs[1]["mode"] == "cool"
+
+    def test_verify_callback_skips_when_write_seq_advanced(self):
+        """Callback is a no-op when a newer write command superseded it (_write_seq changed)."""
+        engine = _make_fan_engine()
+        engine._pending_setpoint_single = 70.0
+        engine._last_commanded_hvac_mode = "cool"
+        engine._manual_override_active = False
+
+        climate_state = MagicMock()
+        climate_state.state = "cool"
+        climate_state.attributes = {"temperature": 71.9}
+        engine.hass.states.get = MagicMock(return_value=climate_state)
+
+        engine._set_temperature = AsyncMock()
+
+        captured_callbacks: list = []
+
+        def _fake_acl(hass, delay, callback):
+            captured_callbacks.append((delay, callback))
+
+        with patch(_ACL_PATH, side_effect=_fake_acl):
+            asyncio.run(engine._activate_fan(reason="test"))
+
+        # Advance write_seq before callback fires (simulates a newer command)
+        engine._write_seq += 1
+
+        captured_callbacks[0][1](None)  # sync wrapper; inner coro closed by _consume_coroutine
+
+        engine._set_temperature.assert_not_called()
+
+    def test_verify_callback_skips_when_manual_override_active(self):
+        """Callback is a no-op when a genuine manual override is active."""
+        engine = _make_fan_engine()
+        engine._pending_setpoint_single = 70.0
+        engine._last_commanded_hvac_mode = "cool"
+        engine._manual_override_active = True  # user took control
+
+        climate_state = MagicMock()
+        climate_state.state = "cool"
+        climate_state.attributes = {"temperature": 71.9}
+        engine.hass.states.get = MagicMock(return_value=climate_state)
+
+        engine._set_temperature = AsyncMock()
+
+        captured_callbacks: list = []
+
+        def _fake_acl(hass, delay, callback):
+            captured_callbacks.append((delay, callback))
+
+        with patch(_ACL_PATH, side_effect=_fake_acl):
+            asyncio.run(engine._activate_fan(reason="test"))
+
+        captured_callbacks[0][1](None)  # sync wrapper; inner coro closed by _consume_coroutine
+
+        engine._set_temperature.assert_not_called()
+
+    def test_verify_callback_skips_when_setpoint_within_tolerance(self):
+        """Callback is a no-op when thermostat is within 0.6°F of commanded setpoint."""
+        engine = _make_fan_engine()
+        engine._pending_setpoint_single = 70.0
+        engine._last_commanded_hvac_mode = "cool"
+        engine._manual_override_active = False
+
+        # Thermostat reports 70.4°F — within 0.6°F tolerance
+        climate_state = MagicMock()
+        climate_state.state = "cool"
+        climate_state.attributes = {"temperature": 70.4}
+        engine.hass.states.get = MagicMock(return_value=climate_state)
+
+        engine._set_temperature = AsyncMock()
+
+        captured_callbacks: list = []
+
+        def _fake_acl(hass, delay, callback):
+            captured_callbacks.append((delay, callback))
+
+        with patch(_ACL_PATH, side_effect=_fake_acl):
+            asyncio.run(engine._activate_fan(reason="test"))
+
+        captured_callbacks[0][1](None)  # sync wrapper; inner coro closed by _consume_coroutine
+
+        engine._set_temperature.assert_not_called()

--- a/tests/test_temp_command_guard.py
+++ b/tests/test_temp_command_guard.py
@@ -96,6 +96,7 @@ def _make_coord(*, temp_command_time: datetime | None = None):
     ae._temp_command_pending = False  # cleared (as in production post-finally)
     ae._temp_command_time = temp_command_time
     ae._hvac_command_time = None
+    ae._fan_command_time = None
     ae._manual_override_active = False
     ae._override_confirm_pending = False
     # Must be explicitly None (not truthy MagicMock) so Bug C/D _ca_active_mode
@@ -301,3 +302,135 @@ class TestTempCommandTimeIsSet:
             asyncio.run(ae._set_temperature(72.0, reason="away setback"))
 
         assert ae._temp_command_time == cmd_now
+
+
+# ---------------------------------------------------------------------------
+# Tests: fan command pending / recent fan command suppresses setpoint override
+# (Bug 1A — Issue #313)
+# ---------------------------------------------------------------------------
+
+
+def _make_state_cool(temp: float) -> MagicMock:
+    """Like _make_state() but hvac_mode='cool' for setpoint override detection."""
+    s = MagicMock()
+    s.state = "cool"
+    s.attributes = {
+        "hvac_action": "cooling",
+        "temperature": temp,
+        "fan_mode": "auto",
+    }
+    return s
+
+
+class TestFanCommandSetpointGuard:
+    """Fan command guards must suppress setpoint override detection.
+
+    Before Bug 1A fix: _fan_command_pending and _is_recent_fan_command were
+    NOT checked in the setpoint-override block, so a CA-issued fan command
+    could race with the thermostat event and be recorded as a manual override.
+    """
+
+    def _make_coord_fan(
+        self,
+        *,
+        fan_command_pending: bool,
+        fan_command_time,
+    ):
+        """Coordinator stub configured for fan-guard setpoint tests."""
+        ClimateAdvisorCoordinator = _get_coordinator_class()
+        coord = _make_coord(temp_command_time=None)
+
+        ae = coord.automation_engine
+        ae._fan_command_pending = fan_command_pending
+        ae._fan_command_time = fan_command_time
+        # Ensure HVAC command guards are inactive so only fan guards matter
+        ae._hvac_command_pending = False
+        ae._hvac_command_time = None
+        ae._temp_command_pending = False
+        ae._temp_command_time = None
+        # Set last commanded hvac to cool >2 min ago so _is_expected_confirmation
+        # does not suppress the override path
+        ae._last_commanded_hvac_mode = "cool"
+        ae._last_commanded_hvac_time = datetime(2026, 6, 7, 11, 55, 0)
+
+        # Bind real _is_recent_fan_command so it reads ae._fan_command_time
+        coord._is_recent_fan_command = types.MethodType(ClimateAdvisorCoordinator._is_recent_fan_command, coord)
+        # _is_recent_hvac_command is already mocked to return False in _make_coord()
+
+        # Update classification to hvac_mode='cool' so mode-match logic fires
+        coord._current_classification.hvac_mode = "cool"
+
+        return coord
+
+    def test_fan_command_pending_suppresses_override(self):
+        """_fan_command_pending=True must suppress setpoint override detection.
+
+        FAILS before Bug 1A fix: the pending flag is not checked, so the
+        override is recorded even while the fan command is still in flight.
+        """
+        now = datetime(2026, 6, 7, 12, 0, 0)
+        coord = self._make_coord_fan(
+            fan_command_pending=True,
+            fan_command_time=now,
+        )
+
+        old = _make_state_cool(74.0)
+        new = _make_state_cool(77.0)
+
+        with patch("custom_components.climate_advisor.coordinator.dt_util") as mock_dt:
+            mock_dt.now.return_value = now
+            asyncio.run(coord._async_thermostat_changed(_make_thermostat_event(old, new)))
+
+        coord.automation_engine.handle_manual_override.assert_not_called()
+        assert coord._today_record.manual_overrides == 0, (
+            "_fan_command_pending should suppress setpoint override but manual_overrides > 0"
+        )
+
+    def test_recent_fan_command_suppresses_override(self):
+        """_is_recent_fan_command(30s) must suppress setpoint override detection.
+
+        FAILS before Bug 1A fix: the recency check is not in the setpoint block,
+        so a setpoint change arriving 15 s after a CA fan command is wrongly
+        recorded as a user manual override.
+        """
+        now = datetime(2026, 6, 7, 12, 0, 0)
+        fan_cmd_time = now - timedelta(seconds=15)  # 15 s ago — within 30 s window
+        coord = self._make_coord_fan(
+            fan_command_pending=False,
+            fan_command_time=fan_cmd_time,
+        )
+
+        old = _make_state_cool(74.0)
+        new = _make_state_cool(77.0)
+
+        with patch("custom_components.climate_advisor.coordinator.dt_util") as mock_dt:
+            mock_dt.now.return_value = now
+            asyncio.run(coord._async_thermostat_changed(_make_thermostat_event(old, new)))
+
+        coord.automation_engine.handle_manual_override.assert_not_called()
+        assert coord._today_record.manual_overrides == 0, (
+            "_is_recent_fan_command(30s) should suppress override but manual_overrides > 0"
+        )
+
+    def test_expired_fan_command_allows_genuine_override(self):
+        """Fan command older than 30 s must NOT suppress a genuine user override.
+
+        This is a regression guard: after the race window closes, real user
+        setpoint changes must still be detected.  Must PASS before AND after fix.
+        """
+        now = datetime(2026, 6, 7, 12, 0, 0)
+        fan_cmd_time = now - timedelta(seconds=60)  # 60 s ago — window expired
+        coord = self._make_coord_fan(
+            fan_command_pending=False,
+            fan_command_time=fan_cmd_time,
+        )
+
+        old = _make_state_cool(74.0)
+        new = _make_state_cool(77.0)
+
+        with patch("custom_components.climate_advisor.coordinator.dt_util") as mock_dt:
+            mock_dt.now.return_value = now
+            asyncio.run(coord._async_thermostat_changed(_make_thermostat_event(old, new)))
+
+        coord.automation_engine.handle_manual_override.assert_called_once()
+        assert coord._today_record.manual_overrides == 1, "Expired fan command should NOT suppress a genuine override"


### PR DESCRIPTION
## Summary

- **False override on fan command**: Ecobee reverts its setpoint after receiving a fan mode change (HA quirk). The coordinator's setpoint-change override detector was firing on this revert, incorrectly suppressing automation for 90 minutes. Fixed by guarding the detection block with `_fan_command_pending` and `_is_recent_fan_command(30s)`, matching the existing pattern used for hvac/temp commands.
- **Post-fan setpoint verify**: After every fan activation or deactivation, a 30-second callback re-asserts the commanded setpoint if the thermostat's reported value drifted >0.6°F. This ensures any delayed Ecobee state report arrives within the temp-command recency window and is not misread as an override. Protected by `_write_seq` so newer commands cancel the repair.
- **Nat-vent exit boundary fix**: Exit condition changed from `outdoor >= indoor` to `outdoor > indoor`. When outdoor equals indoor there is no net airflow — no reason to exit nat-vent. Only strictly warmer outdoor air reverses the cooling benefit.

## Test plan

- [ ] `tests/test_nat_vent_activation.py` — new tests for `>` vs `>=` boundary and post-fan verify callback
- [ ] `tests/test_temp_command_guard.py` — new tests for fan-command suppression in override detection
- [ ] `tests/test_fan_control.py` — updated for post-fan verify async_call_later scheduling
- [ ] Full suite passes (`pytest tests/ -q`)
- [ ] Validate in production: fan command → wait 30s → confirm setpoint not treated as override