### PR TITLE
Fix #318: Remove incorrect sleep setpoint ordering constraints from config flow (v0.4.15)

### DIFF
--- a/custom_components/climate_advisor/config_flow.py
+++ b/custom_components/climate_advisor/config_flow.py
@@ -612,15 +612,6 @@ class ClimateAdvisorOptionsFlow(config_entries.OptionsFlow):
                 errors["setback_heat"] = "setback_must_be_lower"
             if user_input.get("setback_cool", 999) <= user_input.get("comfort_cool", 0):
                 errors["setback_cool"] = "setback_must_be_higher"
-            # Cross-field: sleep temps must be between setback and comfort
-            if user_input.get("sleep_heat", 999) >= user_input.get("comfort_heat", 0):
-                errors["sleep_heat"] = "sleep_must_be_below_comfort"
-            if user_input.get("sleep_heat", 0) <= user_input.get("setback_heat", 999):
-                errors["sleep_heat"] = "sleep_must_be_above_setback"
-            if user_input.get("sleep_cool", 0) <= user_input.get("comfort_cool", 999):
-                errors["sleep_cool"] = "sleep_must_be_above_comfort"
-            if user_input.get("sleep_cool", 999) >= user_input.get("setback_cool", 0):
-                errors["sleep_cool"] = "sleep_must_be_below_setback"
             if not errors:
                 # Convert display values → stored °F
                 for key in ("comfort_heat", "comfort_cool", "setback_heat", "setback_cool", "sleep_heat", "sleep_cool"):

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,13 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.4.14"
+VERSION = "0.4.15"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.4.15": [
+        "Fix #318: Sleep setpoint config no longer blocks users from setting sleep"
+        " temperatures cooler or warmer than daytime comfort bounds",
+    ],
     "0.4.14": [
         "Fix #313: Fan commands no longer trigger false manual-override detection. When Ecobee"
         " reverts its setpoint after a fan mode change, the coordinator now suppresses the"
@@ -1300,6 +1304,17 @@ KNOWN_FIXES: dict[int, dict] = {
             " with frequent away/vacation setpoint changes learn the secondary EWMA slowly",
             "k_solar staleness gate — not yet implemented; tracked as future investigation"
             " in #314 (closed as working-as-designed for k_passive; only k_solar is at risk)",
+        ],
+    },
+    318: {
+        "title": "Sleep setpoint ordering constraint regression",
+        "version_fixed": "0.4.15",
+        "scope_covered": [
+            "config_flow.py async_step_setpoints — removed 4 incorrect cross-field constraints"
+            " on sleep_cool/sleep_heat vs comfort/setback bounds",
+        ],
+        "scope_not_covered": [
+            "No runtime impact — automation.py uses sleep setpoints as-is; this fix is config flow validation only",
         ],
     },
     313: {

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.4.14"
+  "version": "0.4.15"
 }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -16,6 +16,7 @@ Covers:
 from __future__ import annotations
 
 import asyncio
+import os
 from unittest.mock import MagicMock
 
 import pytest
@@ -1874,3 +1875,59 @@ class TestOptionsFlowMultiStep:
         assert defaults["notify_service"] == "notify.notify"
         assert defaults["wake_time"] == "06:30:00"
         assert defaults["learning_enabled"] is True
+
+
+# ---------------------------------------------------------------------------
+# Sleep setpoint ordering regression guard (Issue #318)
+# ---------------------------------------------------------------------------
+
+
+class TestSleepSetpointValidation:
+    """Regression guard: async_step_setpoints must NOT enforce any ordering
+    relationship between sleep setpoints and daytime comfort setpoints.
+
+    Fix #108 removed these constraints; Fix #112 re-introduced them (regression).
+    Fix #318 removes them again.
+
+    Implementation note: ClimateAdvisorOptionsFlow inherits from a MagicMock stub
+    (config_entries.OptionsFlow) in this test environment, making it impossible to
+    call the real method via types.MethodType or direct instantiation (the class
+    itself becomes a MagicMock with no real attributes). Instead we use a static
+    source-text guard: if the error-key strings are absent from config_flow.py, the
+    constraints cannot be active regardless of how the flow is wired internally.
+    This catches re-introduction even if the error key is spelled the same way.
+    """
+
+    _CONFIG_FLOW_PATH = os.path.normpath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "custom_components",
+            "climate_advisor",
+            "config_flow.py",
+        )
+    )
+
+    @pytest.mark.parametrize(
+        "error_key",
+        [
+            pytest.param("sleep_must_be_above_comfort", id="sleep_cool_above_comfort"),
+            pytest.param("sleep_must_be_below_comfort", id="sleep_heat_below_comfort"),
+            pytest.param("sleep_must_be_above_setback", id="sleep_heat_above_setback"),
+            pytest.param("sleep_must_be_below_setback", id="sleep_cool_below_setback"),
+        ],
+    )
+    def test_sleep_ordering_error_keys_absent_from_source(self, error_key):
+        """The four sleep ordering error keys must not appear anywhere in config_flow.py.
+
+        Regression: Fix #112 re-introduced these keys after Fix #108 removed them.
+        If any of them reappears in the source, this test fails immediately, before
+        any config-flow test exercises the step.
+        """
+        with open(self._CONFIG_FLOW_PATH) as fh:
+            source = fh.read()
+        assert error_key not in source, (
+            f"Regression detected: '{error_key}' found in config_flow.py. "
+            "Sleep setpoint ordering constraints were removed in Fix #318 and must "
+            "not be re-introduced. See Issue #318 for history."
+        )


### PR DESCRIPTION
## Summary

- Removes 4 incorrect cross-field validation constraints from `config_flow.py async_step_setpoints` that blocked users from configuring sleep temperatures cooler (or warmer) than their daytime comfort bounds
- Adds `TestSleepSetpointValidation` (4 parametrized static-source tests) to prevent silent re-introduction
- Bumps version to v0.4.15

## Regression history

Fix #108 (v0.3.22) correctly removed these constraints. Commit `abaf0e1` ("Fix #112: Move temperature setpoints to dedicated section in settings", 2026-04-18) re-introduced them verbatim when refactoring the config flow into a dedicated temperature-setpoints step.

## What was wrong

Lines 615–623 enforced:
- `sleep_heat < comfort_heat` (sleep heating must be below daytime comfort floor)
- `sleep_heat > setback_heat` (sleep heating must be above away setback)
- `sleep_cool > comfort_cool` (sleep cooling must be above daytime comfort ceiling — backwards)
- `sleep_cool < setback_cool` (sleep cooling must be below away setback)

The `sleep_cool > comfort_cool` constraint is the primary user-visible bug: it prevents setting a sleep temperature cooler than the daytime AC ceiling, which is the canonical use case (e.g., sleep at 72F when daytime comfort is 75F).

## What remains (correct constraints)

The setback-vs-comfort ordering constraints are preserved:
- `setback_heat < comfort_heat` — away setback must be cooler than comfort floor
- `setback_cool > comfort_cool` — away setback must be warmer than comfort ceiling

## Regression guard

`TestSleepSetpointValidation::test_sleep_ordering_error_keys_absent_from_source` asserts all four error-key strings are absent from `config_flow.py` source text. Had this test existed before Fix #112 landed, CI would have caught the regression immediately.

## Test results

2628 tests passed (0 failures).