### PR TITLE
Fix #327: thermostatic fan control — stop indefinite fan, fast loop, startup reconcile

### DIFF
--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -444,6 +444,11 @@ class AutomationEngine:
         self._fan_min_runtime_active: bool = False  # True if THIS feature activated the fan
         self._fan_min_cycle_cancel: Any | None = None  # cancel token for pending on/off timer
 
+        # Thermostatic fan backstop timer (Issue #327): self-rescheduling timer started in
+        # _activate_fan, cancelled in _deactivate_fan + cleanup. Ensures fan_thermostat_check
+        # fires even when temperature sensors update slowly.
+        self._fan_thermo_cancel: Any | None = None
+
         # Event log callback — set by coordinator after construction
         self._emit_event_callback: Any | None = None
 
@@ -622,21 +627,30 @@ class AutomationEngine:
             return 0.0
 
     def handle_fan_manual_override(self) -> None:
-        """Handle a manual fan state change — sets fan override flag + grace."""
+        """Handle a manual fan state change — sets fan override flag + grace (Issue #327).
+
+        Idempotent: safe to call even if an override is already active (re-stamps the
+        time and restarts the grace period so the timer is always fresh).
+        """
         self._stop_fan_min_runtime_cycles()
         self._fan_override_active = True
         self._fan_override_time = dt_util.now().isoformat()
-        _LOGGER.warning(
-            "Fan manual override activated at %s",
+        _LOGGER.info(
+            "Fan override: set — manual fan change detected, override active since %s, grace period starting",
             self._fan_override_time,
         )
         self._start_grace_period("manual", trigger="fan_manual_override")
 
     def clear_fan_override(self) -> None:
-        """Clear the fan override flag (called at transition points)."""
+        """Clear the fan override flag (called at transition points, Issue #327).
+
+        Idempotent: no-op if no override is currently active.
+        After clearing, restarts the min-runtime cycle that was suspended when the
+        override was set.
+        """
         if self._fan_override_active:
             _LOGGER.info(
-                "Clearing fan manual override (since %s)",
+                "Fan override: cleared — override active since %s, resuming CA fan control",
                 self._fan_override_time,
             )
             self._fan_override_active = False
@@ -2143,6 +2157,208 @@ class AutomationEngine:
                     },
                 )
 
+    async def fan_thermostat_check(
+        self,
+        *,
+        indoor: float | None,
+        outdoor: float | None,
+        trigger: str,
+    ) -> None:
+        """Thermostatic safety check for any CA-owned running fan (Issue #327).
+
+        Called on every indoor OR outdoor temperature change and by the 5-minute backstop
+        timer.  Deactivates the fan when free-cooling is gone (outdoor >= indoor with the
+        configured hysteresis margin) or when the comfort target has been reached.
+
+        Design: idempotent, cheap, safe to call at high frequency.  No-op when no CA fan
+        is active or when the user has a manual override in effect.
+
+        Args:
+            indoor:  Current indoor temperature in °F (None = unavailable).
+            outdoor: Current outdoor temperature in °F (None = unavailable).
+            trigger: Caller label for the DEBUG log ("indoor", "outdoor", "timer", etc.).
+        """
+        ca_fan_active = self._fan_active or self._natural_vent_active
+        if not ca_fan_active:
+            _LOGGER.debug(
+                "Fan thermostat check: trigger=%s indoor=%s outdoor=%s active=%s decision=keep",
+                trigger,
+                f"{indoor:.1f}" if indoor is not None else "unavailable",
+                f"{outdoor:.1f}" if outdoor is not None else "unavailable",
+                False,
+            )
+            return
+
+        if self._fan_override_active:
+            _LOGGER.debug(
+                "Fan thermostat check: trigger=%s indoor=%s outdoor=%s active=%s decision=keep",
+                trigger,
+                f"{indoor:.1f}" if indoor is not None else "unavailable",
+                f"{outdoor:.1f}" if outdoor is not None else "unavailable",
+                True,
+            )
+            return
+
+        comfort_heat = float(self.config.get("comfort_heat", 70))
+
+        # --- Check 1: free-cooling direction guard ---
+        # Free cooling requires outdoor cooler than indoor. Once outdoor >= indoor the
+        # airflow no longer cools (neutral or reversed) — stop. NOTE: NO hysteresis on the
+        # STOP side; the anti-flap hysteresis lives on nat-vent RE-activation
+        # (check_natural_vent_conditions). Subtracting it here would kill free cooling ~1°F
+        # early — e.g. stop at outdoor 71 / indoor 72 while a favorable gradient remains.
+        if outdoor is not None and indoor is not None and outdoor >= indoor:
+            if self._natural_vent_active:
+                # Route through the canonical nat-vent outdoor-rise exit so the event
+                # taxonomy + pause bookkeeping match check_natural_vent_conditions (~line 2004).
+                stop_reason = f"outdoor {outdoor:.1f}°F >= indoor {indoor:.1f}°F — airflow reversed"
+                _LOGGER.debug(
+                    "Fan thermostat check: trigger=%s indoor=%s outdoor=%s active=%s decision=%s",
+                    trigger,
+                    f"{indoor:.1f}",
+                    f"{outdoor:.1f}",
+                    True,
+                    f"stop:{stop_reason}",
+                )
+                self._natural_vent_active = False
+                self._paused_by_door = True
+                self._nat_vent_outdoor_exit_time = dt_util.now()
+                await self._deactivate_fan(reason=f"nat vent exit (fast loop): {stop_reason}")
+                if self._emit_event_callback:
+                    self._emit_event_callback("nat_vent_outdoor_rise_exit", {"outdoor": outdoor, "indoor": indoor})
+                return
+            stop_reason = f"outdoor {outdoor:.1f}°F >= indoor {indoor:.1f}°F (free cooling gone)"
+            _LOGGER.debug(
+                "Fan thermostat check: trigger=%s indoor=%s outdoor=%s active=%s decision=%s",
+                trigger,
+                f"{indoor:.1f}",
+                f"{outdoor:.1f}",
+                True,
+                f"stop:{stop_reason}",
+            )
+            await self._deactivate_fan(reason=f"fan thermostat check — {stop_reason}")
+            return
+
+        # --- Check 2: cooled to target ---
+        # A CA fan only runs while outdoor < indoor (Check 1 stops it otherwise), so it is ALWAYS
+        # cooling. Stop once indoor has cooled to the comfort floor, to avoid overcooling. Do NOT
+        # stop when indoor >= comfort_cool: for a cooling fan, being above the ceiling means "keep
+        # cooling" — the inverse would shut the fan off exactly when the home is too warm and needs
+        # it most (Issue #327 — caught by the fan_fast_stop_on_outdoor_rise scenario).
+        if indoor is not None and indoor <= comfort_heat:
+            stop_reason = f"indoor {indoor:.1f}°F ≤ comfort_heat {comfort_heat:.1f}°F (cooled to floor)"
+            _LOGGER.debug(
+                "Fan thermostat check: trigger=%s indoor=%s outdoor=%s active=%s decision=%s",
+                trigger,
+                f"{indoor:.1f}",
+                f"{outdoor:.1f}" if outdoor is not None else "unavailable",
+                True,
+                f"stop:{stop_reason}",
+            )
+            if self._natural_vent_active:
+                self._natural_vent_active = False
+            await self._deactivate_fan(reason=f"fan thermostat check — {stop_reason}")
+            return
+
+        _LOGGER.debug(
+            "Fan thermostat check: trigger=%s indoor=%s outdoor=%s active=%s decision=keep",
+            trigger,
+            f"{indoor:.1f}" if indoor is not None else "unavailable",
+            f"{outdoor:.1f}" if outdoor is not None else "unavailable",
+            True,
+        )
+
+    async def reconcile_fan_on_startup(
+        self,
+        *,
+        indoor: float | None,
+        outdoor: float | None,
+        thermostat_fan_running: bool,
+        any_sensor_open: bool,
+    ) -> None:
+        """Reconcile fan state on HA startup / coalesce window (Issue #327).
+
+        Called by the coordinator's _do_startup_coalesce after classification runs.
+        Ensures a running fan always has an explicit owner — never silent limbo.
+
+        Decision logic:
+        - thermostat_fan_running False → ``no-fan``: ensure all fan flags are clean.
+        - nat-vent eligible (any_sensor_open AND outdoor < indoor AND nat-vent gate passes)
+          → ``adopt-on``: set _fan_active=True, _natural_vent_active=True, start backstop.
+        - else fan is running but not warranted → ``turn-off``: deactivate per archetype.
+
+        Args:
+            indoor:               Current indoor temperature in °F (None = unavailable).
+            outdoor:              Current outdoor temperature in °F (None = unavailable).
+            thermostat_fan_running: True when the thermostat reports the fan is on
+                                    (fan_mode=="on" or hvac_action=="fan").
+            any_sensor_open:      True when at least one door/window sensor is open.
+        """
+        fan_mode = self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED)
+        archetype = fan_mode
+
+        if not thermostat_fan_running:
+            # Fan is off — ensure CA flags are clean (defence in depth)
+            self._fan_active = False
+            self._fan_on_since = None
+            self._natural_vent_active = False
+            decision = "no-fan"
+            _LOGGER.info(
+                "Fan reconcile: thermostat_fan_running=%s nat_vent_eligible=%s decision=%s archetype=%s",
+                thermostat_fan_running,
+                False,
+                decision,
+                archetype,
+            )
+            return
+
+        # Evaluate nat-vent eligibility
+        hysteresis = float(self.config.get(CONF_NAT_VENT_HYSTERESIS_F, NAT_VENT_HYSTERESIS_F))
+        nat_vent_delta = float(self.config.get(CONF_NATURAL_VENT_DELTA, DEFAULT_NATURAL_VENT_DELTA))
+        comfort_cool = float(self.config.get("comfort_cool", 75))
+        comfort_heat = float(self.config.get("comfort_heat", 70))
+        nat_vent_threshold = comfort_cool + nat_vent_delta
+
+        nat_vent_eligible = (
+            fan_mode != FAN_MODE_DISABLED
+            and any_sensor_open
+            and outdoor is not None
+            and indoor is not None
+            and outdoor < indoor - hysteresis  # outdoor must be genuinely cooler
+            and indoor > comfort_heat  # indoor above comfort floor
+            and outdoor < nat_vent_threshold  # outdoor within acceptable ceiling
+        )
+
+        if nat_vent_eligible:
+            # Adopt the running fan as CA-owned nat-vent
+            decision = "adopt-on"
+            self._fan_active = True
+            self._fan_on_since = dt_util.now().isoformat()
+            self._natural_vent_active = True
+            # Start the thermostatic backstop now that CA owns this fan session
+            self._start_fan_thermo_backstop()
+            _LOGGER.info(
+                "Fan reconcile: thermostat_fan_running=%s nat_vent_eligible=%s decision=%s archetype=%s",
+                thermostat_fan_running,
+                nat_vent_eligible,
+                decision,
+                archetype,
+            )
+        else:
+            # Fan running but nat-vent not warranted — turn it off
+            decision = "turn-off"
+            _LOGGER.info(
+                "Fan reconcile: thermostat_fan_running=%s nat_vent_eligible=%s decision=%s archetype=%s",
+                thermostat_fan_running,
+                nat_vent_eligible,
+                decision,
+                archetype,
+            )
+            # Ensure flags are correct before deactivating so _deactivate_fan runs
+            self._fan_active = True  # let _deactivate_fan see an owned fan
+            self._natural_vent_active = False
+            await self._deactivate_fan(reason="startup reconcile — fan running without CA warrant")
+
     async def handle_manual_override_during_pause(
         self,
         *,
@@ -2915,8 +3131,46 @@ class AutomationEngine:
                 self.hass.async_create_task(_do_verify_after_fan_on())
 
             async_call_later(self.hass, 30.0, _verify_setpoint_after_fan_on)
+
+            # Issue #327: thermostatic backstop timer — fires every 5 min while the fan
+            # is CA-owned; calls fan_thermostat_check so a slow-updating outdoor sensor
+            # cannot leave the fan running indefinitely between state-listener events.
+            self._start_fan_thermo_backstop()
         finally:
             self._fan_command_pending = False
+
+    def _start_fan_thermo_backstop(self) -> None:
+        """Start (or restart) the 5-minute thermostatic backstop timer (Issue #327).
+
+        The timer is self-rescheduling: each fire re-schedules the next tick before
+        calling fan_thermostat_check, so it runs continuously while the fan is active.
+        Cancelled by _deactivate_fan and cleanup.
+        """
+        if self._fan_thermo_cancel:
+            self._fan_thermo_cancel()
+            self._fan_thermo_cancel = None
+
+        @callback
+        def _thermo_tick(_now: Any) -> None:
+            self._fan_thermo_cancel = None
+            self.hass.async_create_task(self._thermo_backstop_task())
+
+        self._fan_thermo_cancel = async_call_later(self.hass, 5 * 60, _thermo_tick)
+
+    async def _thermo_backstop_task(self) -> None:
+        """Execute a thermostatic check and reschedule the backstop (Issue #327)."""
+        indoor = self._get_indoor_temp_f()
+        outdoor = self._last_outdoor_temp
+        await self.fan_thermostat_check(indoor=indoor, outdoor=outdoor, trigger="timer")
+        # Re-arm only if the fan is still active after the check
+        if self._fan_active or self._natural_vent_active:
+            self._start_fan_thermo_backstop()
+
+    def _cancel_fan_thermo_backstop(self) -> None:
+        """Cancel the thermostatic backstop timer (Issue #327)."""
+        if self._fan_thermo_cancel:
+            self._fan_thermo_cancel()
+            self._fan_thermo_cancel = None
 
     async def _deactivate_fan(self, *, reason: str, restore_hvac: bool = True) -> None:
         """Deactivate fan based on configured fan_mode.
@@ -2971,6 +3225,8 @@ class AutomationEngine:
 
             self._fan_active = False
             self._fan_on_since = None
+            # Issue #327: cancel the thermostatic backstop timer when fan deactivates.
+            self._cancel_fan_thermo_backstop()
             self._record_action("Fan deactivated", reason)
 
             # Post-fan setpoint verify: Ecobee may revert to comfort program after a fan command.
@@ -3063,8 +3319,20 @@ class AutomationEngine:
                 ECONOMIZER_EVENING_START_HOUR <= current_hour < ECONOMIZER_EVENING_END_HOUR
             )
 
-        # Conditions for economizer eligibility
-        eligible = windows_physically_open and outdoor_temp <= comfort_cool + delta and in_window
+        # Conditions for economizer eligibility.
+        # Issue #327: added outdoor_temp < indoor_temp free-cooling-direction guard, mirroring
+        # nat-vent's gate at check_natural_vent_conditions. Without this guard the economizer
+        # could start the fan while it is warmer outside than in (e.g. on a hot evening), pulling
+        # warmer outdoor air into the house and working against comfort.
+        direction_ok = indoor_temp is None or outdoor_temp < indoor_temp
+        if not direction_ok:
+            _LOGGER.debug(
+                "Economizer gate: direction rejected — outdoor %.1f°F >= indoor %.1f°F"
+                " (free-cooling direction required)",
+                outdoor_temp,
+                indoor_temp if indoor_temp is not None else 0.0,
+            )
+        eligible = windows_physically_open and outdoor_temp <= comfort_cool + delta and in_window and direction_ok
 
         if not eligible:
             if self._economizer_active:
@@ -3178,7 +3446,8 @@ class AutomationEngine:
     def restore_state(self, state: dict[str, Any]) -> None:
         """Restore automation state from persisted data.
 
-        Design decision: HA restart = clean slate for override, grace, AND pause state.
+        Design decision: HA restart = clean slate for override, grace, pause, AND fan
+        override state (Issue #327).
         - Manual overrides and grace periods are user-interactive; restoring them would
           silently suppress CA automation without the user knowing the system restarted.
         - Pause state (_paused_by_door / _pre_pause_mode) is also cleared: the
@@ -3187,7 +3456,16 @@ class AutomationEngine:
           (default 5 min). A brief HVAC re-arm is preferable to sitting paused
           indefinitely if cloud weather/thermostat services are slow to reconnect
           (Issue #263/#306).
-        - Fan state and pre-condition achievement ARE restored (see below).
+        - Fan override state (_fan_override_active / _fan_override_time) is NOW cleared
+          on restart (Issue #327): restoring it with no grace-timer reschedule left the
+          fan in indefinite limbo — both _activate_fan and _deactivate_fan skipped forever.
+          Restart reclaims fan control; reconcile_fan_on_startup() then decides whether to
+          adopt (nat-vent) or turn the fan off.
+        - _fan_active / _fan_on_since / _pre_fan_hvac_mode are still restored as hints
+          for reconcile_fan_on_startup(); the coordinator's startup coalesce makes the
+          final decision.
+        - _natural_vent_active is NOT persisted and resets to False on restart; the
+          reconcile step re-evaluates whether nat-vent conditions still hold.
         """
         # _paused_by_door and _pre_pause_mode are intentionally NOT restored here.
         # __init__ already sets both to their clean defaults (False / None).
@@ -3198,11 +3476,10 @@ class AutomationEngine:
         self._last_action_reason = state.get("last_action_reason")
         self._fan_active = state.get("fan_active", False)
         self._fan_on_since = state.get("fan_on_since")
-        self._fan_override_active = state.get("fan_override_active", False)
-        self._fan_override_time = state.get("fan_override_time")
         self._fan_min_runtime_active = state.get("fan_min_runtime_active", False)
         self._pre_fan_hvac_mode = state.get("pre_fan_hvac_mode")
-        # _fan_min_cycle_cancel is not serializable; cycle restarts fresh from coordinator startup
+        # _fan_min_cycle_cancel / _fan_thermo_cancel are not serializable; timers restart
+        # fresh from coordinator startup / reconcile_fan_on_startup().
         last_notified = state.get("last_welcome_home_notified")
         if last_notified:
             try:
@@ -3211,9 +3488,9 @@ class AutomationEngine:
                 self._last_welcome_home_notified = None
         else:
             self._last_welcome_home_notified = None
-        # Clean slate on restart: override and grace state are always cleared.
-        # The user is back in front of a fresh system — carry-over would mean
-        # CA silently blocks automation without any visible sign of an override.
+        # Clean slate on restart: override, grace, and fan-override state are all cleared.
+        # The user is back in front of a fresh system — carry-over would mean CA silently
+        # blocks automation without any visible sign of an override.
         self._manual_override_active = False
         self._manual_override_mode = None
         self._manual_override_time = None
@@ -3225,6 +3502,14 @@ class AutomationEngine:
         self._grace_end_time = None
         self._grace_duration_seconds = None
         self._last_resume_source = None
+        # Issue #327: fan override cleared on restart — no grace timer to reschedule.
+        # reconcile_fan_on_startup() runs shortly after and decides adopt-on / turn-off.
+        self._fan_override_active = False
+        self._fan_override_time = None
+        _LOGGER.info(
+            "Fan override: restart clean-slate — _fan_override_active and _fan_override_time "
+            "cleared (Issue #327); reconcile will decide fan disposition"
+        )
         # Issue #295: pre-cool achievement gate — restored so a restart mid-day after
         # the home reached the pre-cool target does not re-arm the lower ceiling offset.
         self._pre_condition_achieved = state.get("pre_condition_achieved", False)
@@ -3232,7 +3517,7 @@ class AutomationEngine:
         _LOGGER.info(
             "Restored automation state: last_action=%s, fan_active=%s, fan_override=%s, "
             "precool_achieved=%s "
-            "(override/grace/pause state cleared — clean slate on restart per Issue #263)",
+            "(override/grace/pause/fan-override state cleared — clean slate on restart per Issue #263/#327)",
             self._last_action_reason,
             self._fan_active,
             self._fan_override_active,
@@ -3282,6 +3567,7 @@ class AutomationEngine:
         """Remove all active listeners and cancel pending timers."""
         self._cancel_grace_timers()
         self._stop_fan_min_runtime_cycles()
+        self._cancel_fan_thermo_backstop()  # Issue #327
         if self._revisit_cancel:
             self._revisit_cancel()
             self._revisit_cancel = None

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,18 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.4.23"
+VERSION = "0.4.24"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.4.24": [
+        "Fix #327: The HVAC/whole-house fan can no longer run indefinitely. A thermostatic fast"
+        " loop now re-checks on every indoor OR outdoor temperature change and stops the fan the"
+        " moment outdoor ≥ indoor (free cooling gone) or the home has cooled to the comfort floor —"
+        " no more waiting up to 30 minutes. On restart, startup coalescing reconciles a running fan"
+        " (adopt as nat-vent if eligible, otherwise turn it off), and a manual fan change is treated"
+        " as a timed override that is reclaimed on expiry or restart. The economizer also no longer"
+        " starts the fan when it is warmer outside than inside.",
+    ],
     "0.4.23": [
         "Fix #326: Pre-cool now surfaces in the Next Automation card (next to bedtime setback,"
         " morning wake-up, etc.) instead of as a footnote under Status. Removed the hardcoded"
@@ -422,6 +431,35 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    327: {
+        "version_fixed": "0.4.24",
+        "title": "Fan runs indefinitely — thermostatic fast loop, startup reconciliation, economizer direction guard",
+        "scope_covered": [
+            "restore_state clears _fan_override_active/_fan_override_time on restart (clean slate,"
+            " matching HVAC override) so a restart reclaims fan control instead of perpetuating a"
+            " stale override with no grace timer (permanent fan lockout)",
+            "_do_startup_coalesce calls reconcile_fan_on_startup: reads live thermostat"
+            " fan_mode/hvac_action and decides adopt-on (nat-vent eligible) / turn-off / no-fan;"
+            " logs 'Fan reconcile:' INFO",
+            "fan_thermostat_check(indoor, outdoor, trigger) re-evaluates a CA-owned running fan on"
+            " every indoor temp change (thermostat seam + indoor_temp_entity listener) and every"
+            " outdoor temp change (new outdoor_temp_entity listener) + 5-min backstop timer;"
+            " stops at outdoor >= indoor (routed through nat_vent_outdoor_rise_exit for a nat-vent"
+            " session) or when cooled to the comfort floor; logs 'Fan thermostat check:' DEBUG",
+            "check_window_cooling_opportunity gains an outdoor < indoor free-cooling-direction"
+            " guard, mirroring nat-vent",
+            "coordinator logs 'Fan control: watching indoor=… outdoor=… thermostat=…' at listener"
+            " registration (post-deploy validation signal)",
+        ],
+        "scope_not_covered": [
+            "No JS-level dashboard test for fan status rendering",
+            "Fast indoor path relies on the thermostat reporting current_temperature as an"
+            " attribute; thermostats that do not populate it fall back to the outdoor listener +"
+            " backstop timer",
+            "End-to-end restart/coalesce reconciliation is exercised via unit tests; the Tier-A"
+            " harness does not restart the engine",
+        ],
+    },
     147: {
         "version_fixed": "0.3.46",
         "title": "Learned solar phase offset + engine visibility",

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -458,6 +458,76 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 )
             )
 
+        # Listeners: indoor and outdoor temp entities — re-evaluate fan on every temp change (Issue #327).
+        # Indoor temp: only register a dedicated listener when a separate sensor entity is configured;
+        # when indoor comes from the thermostat's current_temperature attribute the existing
+        # _async_thermostat_changed dispatch (below) already fires on attribute changes.
+        _indoor_temp_source = self.config.get("indoor_temp_source", TEMP_SOURCE_CLIMATE_FALLBACK)
+        _indoor_temp_entity = (
+            self.config.get("indoor_temp_entity")
+            if _indoor_temp_source in (TEMP_SOURCE_SENSOR, TEMP_SOURCE_INPUT_NUMBER)
+            else None
+        )
+        if _indoor_temp_entity:
+
+            @callback
+            def _async_indoor_temp_changed(event: Any) -> None:
+                ae = self.automation_engine
+                if ae._fan_active or ae._natural_vent_active:
+                    self.hass.async_create_task(
+                        ae.fan_thermostat_check(
+                            indoor=self._get_indoor_temp(),
+                            outdoor=self._last_outdoor_temp,
+                            trigger="indoor",
+                        )
+                    )
+
+            self._unsub_listeners.append(
+                async_track_state_change_event(self.hass, _indoor_temp_entity, _async_indoor_temp_changed)
+            )
+
+        # Outdoor temp: register a listener on the configured outdoor sensor entity (Issue #327).
+        # The thermostat listener does NOT carry outdoor temp, so outdoor sensor changes are invisible
+        # until the 30-min cycle without this listener.
+        _outdoor_temp_source = self.config.get("outdoor_temp_source", TEMP_SOURCE_WEATHER_SERVICE)
+        _outdoor_temp_entity = (
+            self.config.get("outdoor_temp_entity")
+            if _outdoor_temp_source in (TEMP_SOURCE_SENSOR, TEMP_SOURCE_INPUT_NUMBER)
+            else None
+        )
+        if _outdoor_temp_entity:
+
+            @callback
+            def _async_outdoor_temp_changed(event: Any) -> None:
+                ae = self.automation_engine
+                if ae._fan_active or ae._natural_vent_active:
+                    new_state = event.data.get("new_state")
+                    if new_state is not None:
+                        try:
+                            unit = self.config.get("temp_unit", "fahrenheit")
+                            new_outdoor = to_fahrenheit(float(new_state.state), unit)
+                            self._last_outdoor_temp = new_outdoor
+                        except (ValueError, TypeError):
+                            pass
+                    self.hass.async_create_task(
+                        ae.fan_thermostat_check(
+                            indoor=self._get_indoor_temp(),
+                            outdoor=self._last_outdoor_temp,
+                            trigger="outdoor",
+                        )
+                    )
+
+            self._unsub_listeners.append(
+                async_track_state_change_event(self.hass, _outdoor_temp_entity, _async_outdoor_temp_changed)
+            )
+
+        _LOGGER.info(
+            "Fan control: watching indoor=%s outdoor=%s thermostat=%s for thermostatic re-eval",
+            _indoor_temp_entity or "(thermostat attr)",
+            _outdoor_temp_entity or "(weather service / 30-min poll)",
+            self.config["climate_entity"],
+        )
+
         # Startup coalescing: suppress override detection for 5 minutes, then evaluate state (Issue #321)
         _coalesce_expiry = dt_util.now() + timedelta(seconds=300)
         self._startup_coalesce_expiry = _coalesce_expiry.isoformat()
@@ -1191,6 +1261,29 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 indoor_temp=indoor_temp,
             )
             hvac_commanded = True
+
+        # Issue #327: Startup fan reconciliation.
+        # Read the physical fan state from the thermostat and let the engine decide whether
+        # to adopt it (nat-vent eligible), turn it off (no longer eligible), or leave it alone.
+        # Runs AFTER nat-vent + classification so the engine has a settled HVAC state to reconcile
+        # against.  The 5-min coalescing window already suppresses override detection in
+        # _async_thermostat_changed, so the fan command here won't be misread as a manual override.
+        _climate_state_reconcile = self.hass.states.get(self.config.get("climate_entity", ""))
+        if _climate_state_reconcile:
+            _attrs_reconcile = _climate_state_reconcile.attributes
+            _fan_mode_reconcile = _attrs_reconcile.get("fan_mode", "")
+            _hvac_action_reconcile = _attrs_reconcile.get("hvac_action", "")
+            _thermostat_fan_running = _fan_mode_reconcile == "on" or _hvac_action_reconcile == "fan"
+        else:
+            _fan_mode_reconcile = "unknown"
+            _hvac_action_reconcile = "unknown"
+            _thermostat_fan_running = False
+        await self.automation_engine.reconcile_fan_on_startup(
+            indoor=indoor,
+            outdoor=outdoor,
+            thermostat_fan_running=_thermostat_fan_running,
+            any_sensor_open=self._any_sensor_open(),
+        )
 
         self._emit_event(
             "startup_coalesced",
@@ -2442,6 +2535,21 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             and self.automation_engine._natural_vent_active
         ):
             await self.automation_engine.nat_vent_temperature_check(float(_new_temp_attr))
+
+        # Issue #327: Thermostatic fan re-evaluation on every indoor temp tick.
+        # Fires whenever the thermostat reports a new current_temperature and a CA fan is running
+        # (nat-vent OR regular fan-only).  The engine method is idempotent; calling it here when
+        # nat_vent_temperature_check already ran above is safe — they target different exit paths.
+        if (
+            _new_temp_attr is not None
+            and _new_temp_attr != _old_temp_attr
+            and (self.automation_engine._fan_active or self.automation_engine._natural_vent_active)
+        ):
+            await self.automation_engine.fan_thermostat_check(
+                indoor=self._get_indoor_temp(),
+                outdoor=self._last_outdoor_temp,
+                trigger="tick",
+            )
 
         # Expected-state confirmation suppression: if thermostat is confirming an automation
         # command (same mode, within 2 minutes), this is not a user override.

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.4.23"
+  "version": "0.4.24"
 }

--- a/docs/07-AUTOMATION-FLOWCHART.md
+++ b/docs/07-AUTOMATION-FLOWCHART.md
@@ -21,6 +21,7 @@ For temperature formulas and threshold values see [docs/08-COMPUTATION-REFERENCE
 | Where is the full Tier 3 spec for grace periods — state transitions, timer lifecycle, invariants, HA-restart behavior? | The Territory spec covers both grace types, the 12-row transition table, pre-pause mode storage/restoration, occupancy interaction, and error conditions including sensor-unavailable-during-pause. | [Grace Period State Machine — Territory Spec](grace-periods-spec.md) |
 | Where is the full Tier 3 spec for the occupancy dispatch state machine — priority, handlers, setback formulas, persistence? | The Territory spec covers priority resolution (GUEST > VACATION > HOME/AWAY), all four toggle-entity handlers, the 7-row state transition table, setback formula derivation, and the interaction with manual override and grace periods. | [Occupancy Dispatch State Machine — Territory Spec](occupancy-dispatch-spec.md) |
 | What is the decision sequence inside apply_classification() for a warm or mild day, and when does the ODE ceiling guard fire? | Two sequential guards run before the HVAC-off action: (1) comfort-floor guard fires if indoor < comfort_heat; (2) ODE ceiling guard fires if a predicted breach is within the computed lead time and outdoor > indoor. Stateless — re-evaluated every 30-min cycle. | [§13. Warm-Day apply_classification() Guard Sequence](07-AUTOMATION-FLOWCHART.md#13-warm-day-apply_classification-guard-sequence) |
+| What decision does the startup coalesce make for a physically running fan, and what triggers the thermostatic fast loop? | Coalesce reads live thermostat `fan_mode`/`hvac_action` and chooses adopt-on (nat-vent eligible), turn-off, or no-fan. The thermostatic loop fires on every indoor or outdoor temp change (two new listeners + backstop timer), not only on 30-min polls. | [§14. Fan Startup Reconciliation and Thermostatic Loop (Issue #327)](07-AUTOMATION-FLOWCHART.md#14-fan-startup-reconciliation-and-thermostatic-loop-issue-327) |
 
 ## 1. Main Decision Loop (30-Minute Poll)
 
@@ -491,4 +492,65 @@ For the complete guard condition table, lead-time formula derivation, and bridge
 
 ---
 
-*Last Updated: 2026-05-11*
+---
+
+## 14. Fan Startup Reconciliation and Thermostatic Loop (Issue #327)
+
+### 14a. Startup Coalesce Fan Reconcile (`reconcile_fan_on_startup`)
+
+After the existing nat-vent / `apply_classification` logic in `_do_startup_coalesce`, a fan reconcile step reads the thermostat's live `fan_mode` and `hvac_action` and decides the correct ownership state. `_fan_override_active` is always cleared before this step (clean slate — §9e Fix A).
+
+```mermaid
+flowchart TD
+    A[_do_startup_coalesce\nnat-vent + apply_classification done] --> B[reconcile_fan_on_startup\nRead live fan_mode / hvac_action]
+    B --> C{Fan physically running?}
+    C -->|No| D[decision = no-fan\nno action needed]
+    C -->|Yes| E{Nat-vent eligible?\noutdoor < indoor\nAND gate passes\nAND sensors open}
+    E -->|Yes| F[decision = adopt-on\n_fan_active = True\n_natural_vent_active = True\nStart thermostatic loop]
+    E -->|No| G{Fan archetype?}
+    G -->|FAN_MODE_HVAC| H[decision = turn-off\nset_fan_mode auto]
+    G -->|FAN_MODE_WHOLE_HOUSE or BOTH| I[decision = turn-off\nfan turn_off\nRestore HVAC from _pre_fan_hvac_mode]
+    D --> J[Log: Fan reconcile: ... decision=no-fan ...]
+    F --> J
+    H --> J
+    I --> J
+```
+
+**Key invariants:**
+- The coalesce window (`_first_run = True`, 5-minute settling) suppresses override detection — the turn-off command is not misread as a user manual action.
+- Log line `Fan reconcile: thermostat fan_mode=<x> hvac_action=<y> nat_vent_eligible=<bool> decision=<adopt-on|turn-off|no-fan> archetype=<mode>` is the post-deploy validation grep target.
+
+### 14b. Thermostatic Fan Loop Trigger Sources
+
+`fan_thermostat_check(indoor, outdoor, trigger)` fires on every temperature change from three independent sources simultaneously, whenever `_fan_active=True`.
+
+```mermaid
+flowchart TD
+    A1[Indoor temp change\nvia thermostat current_temperature\nexisting _async_thermostat_changed seam] -->|trigger=indoor| T
+    A2[Indoor temp change\nvia indoor_temp_entity sensor\nnew state listener on indoor_temp_entity] -->|trigger=indoor| T
+    A3[Outdoor temp change\nvia outdoor_temp_entity sensor\nnew state listener — did not exist before #327] -->|trigger=outdoor| T
+    A4[Backstop timer\nself-rescheduling, started in _activate_fan\ncancelled in _deactivate_fan + cleanup] -->|trigger=timer| T
+
+    T[fan_thermostat_check\nindoor, outdoor, trigger]
+    T --> E1{outdoor >= indoor\n1°F equality kills dead-spot}
+    E1 -->|Yes| X1[Fan off\nnat_vent_outdoor_rise_exit if nat-vent session\ndeactivate otherwise]
+    E1 -->|No| E2{indoor <= comfort_heat?}
+    E2 -->|Yes| X2[Comfort floor exit\nHVAC heat restored at comfort_heat]
+    E2 -->|No| E3{outdoor > comfort_cool + delta?}
+    E3 -->|Yes| X3[Ceiling exceeded\nFan off, enter paused state]
+    E3 -->|No| K[Keep running\nLog: Fan thermostat check: ... decision=keep]
+    X1 --> L[Log: Fan thermostat check: ... decision=stop:outdoor_rise]
+    X2 --> L2[Log: Fan thermostat check: ... decision=stop:comfort_floor]
+    X3 --> L3[Log: Fan thermostat check: ... decision=stop:ceiling]
+```
+
+**Contrast with pre-#327 behavior:** Before Issue #327, nat-vent used `nat_vent_temperature_check` which fired only on thermostat temperature ticks, checked comfort-floor and cycling but not `outdoor ≥ indoor`, and had no outdoor sensor listener. The outdoor temperature rise was invisible until the next 30-minute coordinator poll — a gap of up to 29 minutes during which the fan could run with warmer outdoor air entering the home.
+
+**Listener registration:** On coordinator setup, one INFO line confirms all three entity listeners are active:
+```
+Fan control: watching indoor=<entity> outdoor=<entity> thermostat=<entity> for thermostatic re-eval
+```
+
+---
+
+*Last Updated: 2026-06-16*

--- a/docs/08-COMPUTATION-REFERENCE.md
+++ b/docs/08-COMPUTATION-REFERENCE.md
@@ -47,6 +47,7 @@ The automation logic table and all threshold constants in this document are expr
 | What notification does the user receive when PATH B (transient thermostat adjustment) fires (Issue #200)? | "Brief thermostat adjustment detected — treated as transient. Climate Advisor continues normal operation." No grace period starts; automation resumes immediately. | [§11 PATH B Notification](08-COMPUTATION-REFERENCE.md#path-b-notification--transient-thermostat-adjustment-issue-200) |
 | What happens if the user changes to a different HVAC mode while a grace period is already active (Issue #201)? | The current override and grace are cleared, and a fresh 10-minute confirmation window starts for the new mode. Latest user action wins. | [§11 Second Override During Active Grace](08-COMPUTATION-REFERENCE.md#second-override-during-active-grace-issue-201) |
 | How does `_run_solar_phase_chart_log_fit()` stay current without re-scanning months of history on every cycle (Issue #310)? | Two-tier schedule: one-shot backfill (30-day lookback, `backfill_done` flag) runs once on fresh install; periodic daily re-fit (2-day lookback, `_last_solar_phase_fit_date` gate) runs at most once per calendar day thereafter. | [§5e-v Two-tier fit scheduling](08-COMPUTATION-REFERENCE.md#two-tier-fit-scheduling-issue-310) |
+| What guarantees that a running fan always has an owner after Issue #327? | Restart now clears `_fan_override_active` for a clean slate; `_do_startup_coalesce` reconciles the physical fan state (adopt-on / turn-off / no-fan); `fan_thermostat_check()` re-evaluates on every indoor or outdoor temp change; the economizer gains an `outdoor < indoor` direction guard. "Running (untracked)" remains only as a brief transient, not an indefinite limbo. | [§9e Thermostatic Fan Loop and Startup Reconciliation (Issue #327)](08-COMPUTATION-REFERENCE.md#9e-thermostatic-fan-loop-and-startup-reconciliation-issue-327) |
 
 ## 1. Day Classification
 
@@ -1100,8 +1101,11 @@ All of the following must be true simultaneously:
 |---|---|
 | Day type | `day_type == hot` |
 | Windows open | `windows_physically_open == True` |
-| Outdoor temp | `outdoor_temp <= comfort_cool + ECONOMIZER_TEMP_DELTA` = `outdoor_temp <= 78°F` (defaults) |
+| **Free-cooling direction** | **`outdoor_temp < indoor_temp`** (Issue #327) — outdoor air must be cooler than indoor; if outdoor ≥ indoor the fan would heat the house rather than cool it |
+| Outdoor temp ceiling | `outdoor_temp <= comfort_cool + ECONOMIZER_TEMP_DELTA` = `outdoor_temp <= 78°F` (defaults) |
 | Time window | 6:00–9:00 AM **or** 5:00 PM–midnight |
+
+The free-cooling-direction guard (Issue #327) mirrors the identical guard already required by nat-vent activation (§17). It prevents evening activation on hot days when outdoor temperatures remain above indoor well into the evening — a scenario where the economizer would work against comfort rather than assist it.
 
 ### Phase Behavior
 
@@ -1323,6 +1327,118 @@ The sensor also exposes these attributes:
 
 **HVAC-off + fan-on (fan-only circulation):** When the economizer enters the maintain phase, HVAC mode is set to `off` but `climate.set_fan_mode: on` is called separately. This is the intended "fan-only circulation" mode — most thermostats support running the fan for air circulation independently of heating or cooling. A `DEBUG`-level log entry is emitted whenever the integration activates the HVAC fan while the thermostat reports `hvac_mode = off`.
 
+**`running (untracked)` after Issue #327:** With the restart reconciliation and thermostatic loop in place (§9e), `"running (untracked)"` is expected only as a brief transient in the seconds between HA startup and the completion of the coalesce reconciliation step. Any fan that is still running after the reconcile window is either adopted as CA nat-vent or turned off. A persistently `"running (untracked)"` sensor state after the startup window has elapsed is a signal that the coalesce step did not run (e.g., coordinator setup failed). See `Fan reconcile:` log lines.
+
+### 9e. Thermostatic Fan Loop and Startup Reconciliation (Issue #327)
+
+#### The Principle: a Running Fan Always Has an Owner
+
+Prior to Issue #327, four code paths could leave a fan running indefinitely with no CA owner and no shutdown mechanism:
+
+1. `_compute_fan_status()` returned `"running (untracked)"` but no code path acted on it — the string was used only to suppress unrelated warnings.
+2. Every shutdown path was gated on ownership (`_deactivate_fan()` requires `_fan_active=True`; nat-vent exit requires `_natural_vent_active=True`), so an unowned fan could never be turned off.
+3. `restore_state()` on restart preserved `_fan_override_active=True` without rescheduling the grace-period expiry timer, leaving the override permanent and both `_activate_fan()` and `_deactivate_fan()` permanently skipped.
+4. The only fast-loop temperature check ran on nat-vent only; the outdoor sensor had no state listener, so an outdoor temperature rise was invisible until the next 30-minute coordinator poll.
+
+The occupant experienced this as: a fan running through the night while outdoor air was warmer than indoor — actively heating the house — with no automatic correction.
+
+**Issue #327 enforces the invariant:** while the fan feature is enabled, a running fan is always one of:
+- **CA nat-vent** — activated by `_activate_fan()`, held by the fast thermostatic loop (§9e below), exits the loop on `outdoor ≥ indoor`, comfort floor, or target reached.
+- **Timed manual override** — detected by `_async_fan_entity_changed()` or `_async_thermostat_changed()`, reclaimed when the grace timer expires **or** on the next HA restart.
+- **Off** — the default state when neither condition holds.
+
+There is no fourth state. Any post-coalesce fan-on that CA did not command is immediately detected as a manual override (§9b) → timed, not indefinite.
+
+#### A. Restart = Clean Fan Slate
+
+`restore_state()` now clears `_fan_override_active` and `_fan_override_time` on restart, matching the clean-slate treatment of HVAC override/grace state (§11). Fan ownership is fully reconsidered by the coalesce reconciliation step rather than reconstructed from stale persisted flags.
+
+`_fan_active` and `_pre_fan_hvac_mode` are still preserved as hints for reconciliation, but their values do not gate any action — the reconcile step re-derives the correct decision from the live thermostat state.
+
+#### B. Startup Coalesce: `reconcile_fan_on_startup`
+
+After the existing nat-vent / `apply_classification` logic in `_do_startup_coalesce`, a dedicated fan reconciliation step reads the thermostat's live `fan_mode` / `hvac_action` and decides:
+
+| Physical fan running? | Nat-vent eligible? | Decision | Action |
+|---|---|---|---|
+| No | — | **no-fan** | No action; state flags already cleared by (A) |
+| Yes | Yes (`outdoor < indoor`, gate passes, sensors open) | **adopt-on** | `_fan_active = True`, `_natural_vent_active = True`; fast thermostatic loop started |
+| Yes | No | **turn-off** | `_deactivate_fan()` or `set_fan_mode("auto")` (FAN_MODE_HVAC) / fan `turn_off` + HVAC restore (FAN_MODE_WHOLE_HOUSE) |
+
+The 5-minute `_first_run` coalesce window already suppresses override detection (coordinator's `_async_thermostat_changed` override guard), so the turn-off command is not misread as a user manual action.
+
+**Observability (startup validation):** the reconcile step emits one INFO line at the end of `_do_startup_coalesce`:
+
+```
+Fan reconcile: thermostat fan_mode=<x> hvac_action=<y> nat_vent_eligible=<bool> decision=<adopt-on|turn-off|no-fan> archetype=<mode>
+```
+
+This is the primary grep target for post-deploy validation: `python tools/ha_logs.py --filter "Fan reconcile"`. It confirms that the new behavior ran and what decision was made for the current physical state.
+
+**Listener registration observability:** at coordinator setup, one INFO line is emitted:
+
+```
+Fan control: watching indoor=<entity> outdoor=<entity> thermostat=<entity> for thermostatic re-eval
+```
+
+#### C. Thermostatic Fast Loop: `fan_thermostat_check`
+
+`fan_thermostat_check(indoor, outdoor, trigger)` on `AutomationEngine` is the fast decision point for any CA-owned running fan. It generalizes the existing `nat_vent_temperature_check` — which ran only for nat-vent sessions — to cover any fan that `_fan_active=True`.
+
+**Exit conditions evaluated on every call (priority order):**
+
+| Priority | Condition | Action |
+|---|---|---|
+| 1 | `outdoor >= indoor` (using existing 1°F hysteresis for re-activation, equality kills) | Fan off; emit `nat_vent_outdoor_rise_exit` if nat-vent session; otherwise deactivate cleanly |
+| 2 | `indoor <= comfort_heat` (comfort floor) | Exit nat-vent session; restore heat mode at `comfort_heat` |
+| 3 | `outdoor > comfort_cool + nat_vent_delta` (ceiling exceeded) | Fan off; enter paused state |
+
+If no exit condition fires, the fan continues running. The check is cheap and idempotent — frequent calls are safe.
+
+**Trigger sources (all three active whenever the fan is CA-owned and running):**
+
+| Source | Mechanism | Registered in |
+|---|---|---|
+| Indoor temperature change via thermostat | Existing `_async_thermostat_changed` dispatch → `fan_thermostat_check(trigger="indoor")` | coordinator.py (existing seam, extended) |
+| Indoor temperature change via dedicated sensor | New state listener on `indoor_temp_entity` → `fan_thermostat_check(trigger="indoor")` | coordinator.py (new listener added by Issue #327) |
+| Outdoor temperature change | New state listener on `outdoor_temp_entity` → `fan_thermostat_check(trigger="outdoor")` | coordinator.py (new listener — outdoor had no listener before Issue #327) |
+| Backstop timer | Self-rescheduling timer started in `_activate_fan()`, cancelled in `_deactivate_fan()` and `cleanup()`; reuses the `_fan_min_cycle_cancel` pattern | automation.py |
+
+The backstop timer catches sensors that update slowly or infrequently. The trigger name is passed through to observability logging.
+
+**Observability (per-check):** `DEBUG` on every call:
+
+```
+Fan thermostat check: trigger=<indoor|outdoor|tick|timer> indoor=<t> outdoor=<t> active=<bool> decision=<keep|stop:reason>
+```
+
+#### D. Economizer Free-Cooling-Direction Guard
+
+`check_window_cooling_opportunity()` (§8) now includes `outdoor < indoor` as an explicit eligibility condition, mirroring the guard already present in nat-vent activation (§17). This prevents the economizer from starting the fan on a hot evening when outdoor air is warmer than indoor — a condition that actively heats the house instead of cooling it.
+
+The guard is a strict precondition: if `outdoor >= indoor`, the fan is not activated regardless of whether the time-window and temperature-ceiling conditions are met.
+
+#### E. Manual Override = Timed, Not Indefinite
+
+With (A) restart clearing `_fan_override_active` and (B) coalesce reconciling the physical state, every post-restart fan-on that CA did not command is fresh — detected as a new manual override by `_async_fan_entity_changed()` or the `fan_mode` block of `_async_thermostat_changed()`, and reclaimed when the grace timer expires. There is no path from a user action to a permanent, unreclaimed override.
+
+**Override lifecycle observability (INFO):**
+- Override set: logged by `handle_fan_manual_override()` with `old_fan_mode`, `new_fan_mode`, `fan_cmd` age, `hvac_cmd` age, `expected_confirmation` (§9b Fan Override Detection Diagnostic Logging).
+- Grace expiry reclaim: logged by `_on_grace_expired` / `clear_fan_override`.
+- Restart clean-slate: logged by `restore_state()` — `"Fan override cleared on restart (clean slate)"` when `_fan_override_active` was `True` at restore time.
+
+#### Interaction with §11 Clean-Slate Restart Policy
+
+The fan clean-slate introduced in (A) is consistent with §11: `_fan_override_active` joins `_manual_override_active`, `_grace_active`, and `_override_confirm_pending` as fields that are always cleared on restart. The coalesce step (B) performs the same role for fan state that the `_first_run` startup override check (§11 Startup Override Logic) performs for HVAC state — it re-derives the correct ownership decision from live conditions rather than trusting stale persisted flags.
+
+| Field | Preserved across restart? | Notes |
+|---|---|---|
+| `_fan_active` | **Hint only** | Cleared or overwritten by coalesce reconciliation; does not gate any action on its own |
+| `_fan_override_active` | **No** (Issue #327) | Cleared on restart — clean slate; coalesce re-derives from live state |
+| `_fan_override_time` | **No** (Issue #327) | Cleared on restart |
+| `_pre_fan_hvac_mode` | Yes | Still preserved — needed if coalesce decides to turn off a whole-house fan and restore the HVAC mode |
+| `_natural_vent_active` | No | Cleared on restart (was already the case); coalesce adopt-on re-sets it |
+
 ---
 
 ## 10. Door/Window HVAC Pause
@@ -1362,8 +1478,10 @@ CA always starts in full clean-slate automation mode after an HA restart. `resto
 |---|---|---|
 | `_paused_by_door` | **No** | Cleared on restart (Issue #306). Open sensors are re-detected quickly via the state-change listener (entity transitions from `None` → `"on"` when HA reconnects); HVAC re-arms briefly and re-pauses after the configured debounce (default 5 min). |
 | `_pre_pause_mode` | **No** | Cleared on restart (Issue #306). Re-captured when the re-detected open sensor triggers a fresh pause. |
-| `_fan_active` | Yes | Fan session state |
-| `_pre_fan_hvac_mode` | Yes | HVAC mode captured before whole-house fan activation |
+| `_fan_active` | **Hint only** (Issue #327) | Preserved as a hint; overwritten or disregarded by the coalesce reconcile step (§9e) — does not gate any action on its own after restart |
+| `_fan_override_active` | **No** (Issue #327) | Cleared on restart — clean slate. Coalesce re-derives fan ownership from live state. Previously preserved, which caused permanent override lockout when no grace-expiry timer was rescheduled. |
+| `_fan_override_time` | **No** (Issue #327) | Cleared on restart |
+| `_pre_fan_hvac_mode` | Yes | HVAC mode captured before whole-house fan activation; still needed for HVAC restoration if coalesce decides to turn off a whole-house fan |
 | `_last_action_time` / `_last_action_reason` | Yes | Last automation action metadata |
 | `_occupancy_mode` | Yes | Current occupancy state |
 | `_manual_override_active` | **No** | Cleared on restart — clean slate |
@@ -1733,24 +1851,29 @@ This is the definitive reference for expected system behavior across all classif
 | E5 | Fan mode change |
 | E6 | Classification changes (e.g., warm→hot) |
 | E7 | User clicks "Resume HVAC (override pause)" |
+| E8 | HA restart — coalesce reconciliation fires (Issue #327) |
 
 ### Expected Outcomes
 
-| | E1: Sensor Open | E2: All Closed | E3: Grace+Open | E4: Override | E5: Fan Change | E6: Class Change | E7: Resume |
-|---|---|---|---|---|---|---|---|
-| C1 (hot/cool) | Pause HVAC→off, notify | Resume to cool, auto grace | Re-pause, notify | Clear pause, manual grace | Fan override grace | Re-apply classification | Resume cool, manual grace |
-| **C2 (warm/band/win=T/in)** | **No pause** (planned window) | No-op (not paused) | **No re-pause** (planned) | N/A (not paused) | Fan on, band stays armed | Re-apply band `[comfort_heat, comfort_cool]`; §6b backstop fires if indoor < comfort_heat | N/A (not paused) |
-| C3 (warm/band/win=T/out) | No pause (band armed, not paused) | No-op | N/A | N/A | Fan on, band stays armed | Re-apply band; §6b backstop fires if indoor < comfort_heat | N/A |
-| C4 (warm/band/win=F) | No pause (band armed, not paused) | No-op | N/A | N/A | Band stays armed | Re-apply band; §6b backstop fires if indoor < comfort_heat | N/A |
-| **C5 (mild/band/win=T/in)** | **No pause** (planned window) | No-op | **No re-pause** (planned) | N/A | Fan on, band stays armed | Re-apply band `[comfort_heat, comfort_cool]` | N/A |
-| C6 (cool/heat) | Pause HVAC→off, notify | Resume to heat, auto grace | Re-pause, notify | Clear pause, manual grace | Fan override grace | Re-apply | Resume heat, manual grace |
-| C7 (cold/heat) | Pause HVAC→off, notify | Resume to heat, auto grace | Re-pause, notify | Clear pause, manual grace | Fan override grace | Re-apply | Resume heat, manual grace |
+| | E1: Sensor Open | E2: All Closed | E3: Grace+Open | E4: Override | E5: Fan Change | E6: Class Change | E7: Resume | E8: Restart Reconcile |
+|---|---|---|---|---|---|---|---|---|
+| C1 (hot/cool) | Pause HVAC→off, notify | Resume to cool, auto grace | Re-pause, notify | Clear pause, manual grace | Fan override grace; thermostatic loop exits fan if `outdoor ≥ indoor` (§9e) | Re-apply classification | Resume cool, manual grace | Fan adopt-on (nat-vent eligible) or turn-off (not eligible); `Fan reconcile:` logged |
+| **C2 (warm/band/win=T/in)** | **No pause** (planned window) | No-op (not paused) | **No re-pause** (planned) | N/A (not paused) | Fan on, band stays armed; thermostatic loop monitors `outdoor vs indoor` | Re-apply band `[comfort_heat, comfort_cool]`; §6b backstop fires if indoor < comfort_heat | N/A (not paused) | Fan adopt-on (nat-vent eligible, sensors open) or turn-off; band re-armed by coalesce |
+| C3 (warm/band/win=T/out) | No pause (band armed, not paused) | No-op | N/A | N/A | Fan on, band stays armed; thermostatic loop monitors `outdoor vs indoor` | Re-apply band; §6b backstop fires if indoor < comfort_heat | N/A | Fan turn-off (outside window period → not nat-vent eligible) or no-fan |
+| C4 (warm/band/win=F) | No pause (band armed, not paused) | No-op | N/A | N/A | Band stays armed | Re-apply band; §6b backstop fires if indoor < comfort_heat | N/A | Fan turn-off if physically running (no sensors open → not nat-vent eligible) |
+| **C5 (mild/band/win=T/in)** | **No pause** (planned window) | No-op | **No re-pause** (planned) | N/A | Fan on, band stays armed; thermostatic loop monitors `outdoor vs indoor` | Re-apply band `[comfort_heat, comfort_cool]` | N/A | Fan adopt-on (nat-vent eligible, sensors open) or turn-off; band re-armed |
+| C6 (cool/heat) | Pause HVAC→off, notify | Resume to heat, auto grace | Re-pause, notify | Clear pause, manual grace | Fan override grace; thermostatic loop exits fan if `outdoor ≥ indoor` | Re-apply | Resume heat, manual grace | Fan turn-off (heat day → not nat-vent eligible) or no-fan |
+| C7 (cold/heat) | Pause HVAC→off, notify | Resume to heat, auto grace | Re-pause, notify | Clear pause, manual grace | Fan override grace; thermostatic loop exits fan if `outdoor ≥ indoor` | Re-apply | Resume heat, manual grace | Fan turn-off (cold day → not nat-vent eligible) or no-fan |
 
 **Bolded cells** have corresponding test coverage in `tests/test_windows_recommended_integration.py`.
 
 **Comfort-band model (Issue #249, §6e):** In C2–C5 contexts (warm/mild days), `apply_classification()` now programs a comfort band rather than setting `hvac_mode=off`. The band arms the thermostat with both a floor and a ceiling; the thermostat self-arbitrates between them. Nat-vent and economizer activate the fan only — the band remains armed throughout, so free cooling stays free and the compressor engages only if the breeze can't hold the ceiling.
 
 **Comfort-floor guard (§6b — passive backstop):** In C2, C3, and C4 contexts, the band floor (`comfort_heat` while home + awake; `setback_heat` away/asleep) keeps the home from falling below the floor autonomously. The `warm_day_comfort_gap` event and §6b heat-up path remain as a safety backstop for situations where the band has lapsed (HA restart, thermostat reconnect). Test coverage: `tests/test_warm_day_comfort_gap.py`.
+
+**Thermostatic fan loop (Issue #327, §9e):** In all C1–C7 contexts, once the fan is CA-owned and running, `fan_thermostat_check()` re-evaluates on every indoor or outdoor temperature change. The fan is turned off immediately when `outdoor ≥ indoor` — it does not wait for the next 30-minute coordinator poll. See §9e for the full exit hierarchy and trigger-source table.
+
+**Restart reconciliation (E8, Issue #327, §9e):** `_fan_override_active` is always cleared on restart; `_do_startup_coalesce` decides adopt-on, turn-off, or no-fan based on live thermostat state. E8 applies uniformly to all contexts — the decision depends on current physical conditions, not the day classification.
 
 This logic table MUST be kept current for any changes to automation behavior.
 
@@ -1769,6 +1892,10 @@ This logic table MUST be kept current for any changes to automation behavior.
 | C4×E6 (band armed) | test_warm_day_setback.py | TestWarmDayBandArming::test_warm_day_dual_thermostat_sets_dual_setpoints |
 | C2×E5 / C3×E5 / C5×E5 (band stays armed on nat-vent) | test_window_hvac_interaction.py, test_door_window.py | Band remains armed when fan activates; no `hvac_mode=off` issued |
 | C2×E6 / C5×E6 (band applied on re-classification) | test_thermostat_program.py, test_production_harness.py | `apply_classification` arms band `[comfort_heat, comfort_cool]` (occupied+awake, any day type) |
+| All×E8 (coalesce: turn-off, no nat-vent) | _(test-ref pending)_ | restart clears `_fan_override_active`; coalesce turns off fan when nat-vent not eligible |
+| All×E8 (coalesce: adopt-on) | _(test-ref pending)_ | coalesce adopts running fan as CA nat-vent when conditions hold; `_natural_vent_active=True` |
+| C1×E5 / C6×E5 / C7×E5 (thermostatic exit: `outdoor ≥ indoor`) | _(test-ref pending)_ | `fan_thermostat_check` turns fan off on `outdoor ≥ indoor` before next 30-min poll |
+| D×E5 (economizer: `outdoor ≥ indoor` blocked) | _(test-ref pending)_ | economizer `check_window_cooling_opportunity` rejects activation when `outdoor ≥ indoor` |
 
 ---
 

--- a/tests/test_economizer.py
+++ b/tests/test_economizer.py
@@ -172,6 +172,51 @@ class TestEconomizerCoolDown:
 
 
 # ---------------------------------------------------------------------------
+# Issue #327: free-cooling-direction guard (outdoor < indoor required)
+# ---------------------------------------------------------------------------
+
+
+class TestEconomizerDirectionGuard:
+    """Issue #327: the economizer must not run the fan when outdoor is not cooler than
+    indoor — pulling in air that is not cooler gives no free cooling. Mirrors nat-vent's
+    outdoor<indoor gate. indoor/outdoor are both below comfort_cool here so the
+    comfort_cool+delta threshold is satisfied and only the direction guard can block."""
+
+    def test_direction_guard_blocks_when_outdoor_not_cooler(self):
+        engine = _make_automation_engine()
+        engine._current_classification = _make_hot_classification()
+
+        result = asyncio.run(
+            engine.check_window_cooling_opportunity(
+                outdoor_temp=74.5,  # >= indoor; still <= comfort_cool(75)+delta
+                indoor_temp=74.0,
+                windows_physically_open=True,
+                current_hour=18,  # evening window
+            )
+        )
+
+        assert result is False
+        assert engine._economizer_active is False
+
+    def test_direction_guard_allows_when_outdoor_cooler(self):
+        """Control: same setup but outdoor < indoor → economizer still eligible."""
+        engine = _make_automation_engine()
+        engine._current_classification = _make_hot_classification()
+
+        result = asyncio.run(
+            engine.check_window_cooling_opportunity(
+                outdoor_temp=72.0,
+                indoor_temp=74.0,
+                windows_physically_open=True,
+                current_hour=18,
+            )
+        )
+
+        assert result is True
+        assert engine._economizer_active is True
+
+
+# ---------------------------------------------------------------------------
 # Phase 2: Maintain (indoor at or below comfort → AC off)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_fan_control.py
+++ b/tests/test_fan_control.py
@@ -772,8 +772,11 @@ class TestFanSerialization:
 
         assert engine._fan_active is True
         assert engine._fan_on_since == "2026-03-20T10:00:00"
-        assert engine._fan_override_active is True
-        assert engine._fan_override_time == "2026-03-20T10:05:00"
+        # Issue #327: fan override is CLEARED on restart (clean slate, matching HVAC override).
+        # Restoring it perpetuated a stale override with no grace timer → permanent fan lockout.
+        # Restart now reclaims fan control; startup coalesce reconciles the real fan disposition.
+        assert engine._fan_override_active is False
+        assert engine._fan_override_time is None
 
     def test_restore_state_defaults_fan_fields(self):
         """restore_state defaults fan fields to inactive when not present."""
@@ -941,7 +944,11 @@ class TestMinFanRuntime:
             asyncio.run(engine._fan_cycle_on())
         engine.hass.services.async_call.assert_called()
         assert engine._fan_min_runtime_active is True
-        assert mock_later.call_count == 2  # 30s verify + runtime deactivation
+        # Issue #327: _activate_fan now also schedules the fan thermostatic backstop timer (300s)
+        # alongside the 30s post-fan verify; _fan_cycle_on adds the min_runtime deactivation (600s).
+        delays = [c.args[1] for c in mock_later.call_args_list]
+        assert 30.0 in delays  # post-fan setpoint verify
+        assert 10 * 60 in delays  # min-runtime deactivation
         assert engine._fan_min_cycle_cancel is cancel_mock
 
     def test_cycle_on_skips_when_zero(self):
@@ -1011,8 +1018,11 @@ class TestMinFanRuntime:
             asyncio.run(engine._fan_cycle_on())
         engine.hass.services.async_call.assert_called()
         assert engine._fan_min_runtime_active is True
-        assert mock_later.call_count == 1  # only 30s verify; no deactivation for always-on
-        assert mock_later.call_args[0][1] == 30.0
+        # Always-on (min_runtime>=60): _fan_cycle_on schedules NO deactivation timer, so
+        # _fan_min_cycle_cancel stays None. _activate_fan still schedules the 30s verify and the
+        # Issue #327 backstop timer (300s) — assert the verify is present, not a brittle total count.
+        delays = [c.args[1] for c in mock_later.call_args_list]
+        assert 30.0 in delays
         assert engine._fan_min_cycle_cancel is None
 
     def test_cycle_off_deactivates_fan_and_schedules_next_on(self):
@@ -1552,3 +1562,144 @@ class TestCheckNatVentGraceComfortCeiling:
 
         # Without grace the early-return fires normally (neither flag is True)
         assert engine._natural_vent_active is False
+
+
+# ---------------------------------------------------------------------------
+# Issue #327: fan_thermostat_check + reconcile_fan_on_startup
+# ---------------------------------------------------------------------------
+
+
+class TestFanThermostatCheck:
+    """Thermostatic fast-loop that stops a running CA fan (Issue #327)."""
+
+    def _engine(self, **cfg):
+        engine = _make_automation_engine({CONF_FAN_MODE: FAN_MODE_WHOLE_HOUSE, **cfg})
+        engine._deactivate_fan = AsyncMock()
+        engine._emit_event_callback = MagicMock()
+        engine._current_classification = None
+        return engine
+
+    def test_keeps_fan_when_outdoor_below_indoor(self):
+        """REGRESSION GUARD: outdoor 71 / indoor 72 (1°F favorable gradient) must KEEP the fan.
+
+        The original Check-1 used ``outdoor >= indoor - hysteresis`` (71 >= 71) and stopped here,
+        killing nat-vent the instant it activated. The stop must fire only at outdoor >= indoor.
+        """
+        engine = self._engine()
+        engine._natural_vent_active = True
+        engine._fan_active = True
+
+        asyncio.run(engine.fan_thermostat_check(indoor=72.0, outdoor=71.0, trigger="test"))
+
+        engine._deactivate_fan.assert_not_awaited()
+        assert engine._natural_vent_active is True
+
+    def test_stops_natvent_and_emits_outdoor_rise_exit(self):
+        """outdoor >= indoor while nat-vent active → deactivate + nat_vent_outdoor_rise_exit."""
+        engine = self._engine()
+        engine._natural_vent_active = True
+        engine._fan_active = True
+
+        asyncio.run(engine.fan_thermostat_check(indoor=72.0, outdoor=72.5, trigger="test"))
+
+        engine._deactivate_fan.assert_awaited()
+        assert engine._natural_vent_active is False
+        assert engine._paused_by_door is True
+        events = [c.args[0] for c in engine._emit_event_callback.call_args_list]
+        assert "nat_vent_outdoor_rise_exit" in events
+
+    def test_stops_non_natvent_fan_without_natvent_event(self):
+        """A non-nat-vent running fan stops on outdoor>=indoor with a generic reason (no nat-vent event)."""
+        engine = self._engine()
+        engine._natural_vent_active = False
+        engine._fan_active = True
+
+        asyncio.run(engine.fan_thermostat_check(indoor=72.0, outdoor=73.0, trigger="test"))
+
+        engine._deactivate_fan.assert_awaited()
+        events = [c.args[0] for c in engine._emit_event_callback.call_args_list]
+        assert "nat_vent_outdoor_rise_exit" not in events
+
+    def test_noop_when_override_active(self):
+        """Manual fan override in effect → fast loop is a no-op (user has control)."""
+        engine = self._engine()
+        engine._fan_active = True
+        engine._natural_vent_active = True
+        engine._fan_override_active = True
+
+        asyncio.run(engine.fan_thermostat_check(indoor=72.0, outdoor=80.0, trigger="test"))
+
+        engine._deactivate_fan.assert_not_awaited()
+
+    def test_noop_when_no_fan_active(self):
+        """No CA fan active → no-op even if outdoor is warm."""
+        engine = self._engine()
+        engine._fan_active = False
+        engine._natural_vent_active = False
+
+        asyncio.run(engine.fan_thermostat_check(indoor=72.0, outdoor=80.0, trigger="test"))
+
+        engine._deactivate_fan.assert_not_awaited()
+
+
+class TestReconcileFanOnStartup:
+    """Startup fan reconciliation — no running fan is ever left in limbo (Issue #327)."""
+
+    def _engine(self, fan_mode=FAN_MODE_WHOLE_HOUSE):
+        engine = _make_automation_engine({CONF_FAN_MODE: fan_mode})
+        engine._deactivate_fan = AsyncMock()
+        return engine
+
+    def test_no_fan_when_thermostat_fan_not_running(self):
+        """thermostat fan off → decision no-fan; stale flags cleared, no deactivate call."""
+        engine = self._engine()
+        engine._fan_active = True  # stale
+
+        asyncio.run(
+            engine.reconcile_fan_on_startup(
+                indoor=75.0, outdoor=60.0, thermostat_fan_running=False, any_sensor_open=True
+            )
+        )
+
+        engine._deactivate_fan.assert_not_awaited()
+        assert engine._fan_active is False
+        assert engine._natural_vent_active is False
+
+    def test_adopt_on_when_nat_vent_eligible(self):
+        """Fan running + window open + outdoor cooler → adopt as CA nat-vent."""
+        engine = self._engine()
+
+        asyncio.run(
+            engine.reconcile_fan_on_startup(
+                indoor=75.0, outdoor=65.0, thermostat_fan_running=True, any_sensor_open=True
+            )
+        )
+
+        assert engine._fan_active is True
+        assert engine._natural_vent_active is True
+        engine._deactivate_fan.assert_not_awaited()
+
+    def test_turn_off_when_not_eligible_hvac(self):
+        """Fan running, sensors closed (not nat-vent eligible), HVAC-fan archetype → turn off."""
+        engine = self._engine(fan_mode=FAN_MODE_HVAC)
+
+        asyncio.run(
+            engine.reconcile_fan_on_startup(
+                indoor=75.0, outdoor=65.0, thermostat_fan_running=True, any_sensor_open=False
+            )
+        )
+
+        engine._deactivate_fan.assert_awaited()
+        assert engine._natural_vent_active is False
+
+    def test_turn_off_when_outdoor_warmer_whole_house(self):
+        """Fan running, window open but outdoor warmer than indoor → not eligible → turn off."""
+        engine = self._engine(fan_mode=FAN_MODE_WHOLE_HOUSE)
+
+        asyncio.run(
+            engine.reconcile_fan_on_startup(
+                indoor=75.0, outdoor=80.0, thermostat_fan_running=True, any_sensor_open=True
+            )
+        )
+
+        engine._deactivate_fan.assert_awaited()

--- a/tests/test_nat_vent_activation.py
+++ b/tests/test_nat_vent_activation.py
@@ -930,8 +930,11 @@ class TestPostFanVerify:
         ):
             asyncio.run(engine._activate_fan(reason="test"))
 
-        assert len(captured_callbacks) == 1
-        _delay, verify_cb = captured_callbacks[0]
+        # Issue #327: _activate_fan also schedules the 300s thermostatic backstop timer — select
+        # the 30s post-fan verify callback specifically rather than asserting a single total.
+        verify_calls = [(d, cb) for d, cb in captured_callbacks if d == 30.0]
+        assert len(verify_calls) == 1
+        _delay, verify_cb = verify_calls[0]
 
         # Wire async_create_task to capture and run the inner coroutine
         # (the @callback wrapper calls hass.async_create_task with the inner coro)

--- a/tests/test_startup_coalesce.py
+++ b/tests/test_startup_coalesce.py
@@ -190,6 +190,9 @@ def _make_coalesce_coord_stub(**overrides):
     ae._fan_override_active = False
     ae.handle_door_window_open = AsyncMock()
     ae.apply_classification = AsyncMock()
+    # Issue #327: _do_startup_coalesce now awaits these — must be AsyncMock, not bare MagicMock.
+    ae.reconcile_fan_on_startup = AsyncMock()
+    ae.fan_thermostat_check = AsyncMock()
     coord.automation_engine = ae
 
     coord._current_classification = _make_classification()
@@ -503,6 +506,19 @@ class TestStartupCoalesceDoCoalesce:
         asyncio.run(coord._do_startup_coalesce())
 
         assert coord._startup_coalesce_active is False
+
+    def test_reconcile_fan_on_startup_called(self):
+        """Issue #327: coalesce awaits reconcile_fan_on_startup with thermostat-fan + sensor state."""
+        coord = _make_coalesce_coord_stub()
+
+        asyncio.run(coord._do_startup_coalesce())
+
+        coord.automation_engine.reconcile_fan_on_startup.assert_awaited_once()
+        kwargs = coord.automation_engine.reconcile_fan_on_startup.await_args.kwargs
+        assert "thermostat_fan_running" in kwargs
+        assert "any_sensor_open" in kwargs
+        assert "indoor" in kwargs
+        assert "outdoor" in kwargs
 
     def test_sensors_open_count_in_event(self):
         """sensors_open_count reflects the number of open sensors at coalesce time."""

--- a/tools/simulations/pending/fan_fast_stop_on_outdoor_rise.json
+++ b/tools/simulations/pending/fan_fast_stop_on_outdoor_rise.json
@@ -1,0 +1,87 @@
+{
+  "name": "fan_fast_stop_on_outdoor_rise",
+  "description": "Issue #327: the thermostatic fast loop keeps the fan running while outdoor stays below indoor (no premature stop), then stops it the moment outdoor crosses indoor on a temperature update — without waiting for the 30-minute cycle.",
+  "source": "synthetic",
+  "issue": 327,
+  "notes": [
+    "Occupant outcome: the fan provides free cooling for as long as outdoor is cooler, and shuts off promptly when it would otherwise pull warm air in.",
+    "Premature-stop guard: at 08:30 outdoor=73F is 2F below indoor=75F — the fan MUST keep running. The original buggy Check-1 (outdoor >= indoor - hysteresis) would have stopped it ~1F early.",
+    "Fast stop: at 09:00 outdoor=74.5F >= indoor=74F — nat_vent_outdoor_rise_exit fires on the temp_update, not on the next 30-min poll.",
+    "Would FAIL if #327 were reverted: the old code only re-checked outdoor>indoor on the 30-min cycle, so the exit would not fire at the 09:00 temp_update."
+  ],
+  "config": {
+    "comfort_heat": 70,
+    "comfort_cool": 74,
+    "setback_heat": 62,
+    "setback_cool": 80,
+    "natural_vent_delta": 3.0,
+    "fan_mode": "whole_house_fan",
+    "fan_entity": "fan.whole_house",
+    "fan_min_runtime_per_hour": 0
+  },
+  "events": [
+    {
+      "time": "2026-06-12T06:00:00",
+      "type": "temp_update",
+      "indoor_f": 76.0,
+      "outdoor_f": 66.0,
+      "note": "Morning: outdoor much cooler than indoor — free cooling available."
+    },
+    {
+      "time": "2026-06-12T06:01:00",
+      "type": "classification",
+      "day_type": "mild",
+      "hvac_mode": "off",
+      "windows_recommended": false,
+      "note": "Mild classification: hvac_mode=off."
+    },
+    {
+      "time": "2026-06-12T08:00:00",
+      "type": "sensor_open",
+      "entity": "binary_sensor.kitchen_window",
+      "note": "Window opens; outdoor=66F < indoor=76F — nat-vent activates, whole-house fan on."
+    },
+    {
+      "time": "2026-06-12T08:30:00",
+      "type": "temp_update",
+      "indoor_f": 75.0,
+      "outdoor_f": 73.0,
+      "note": "Outdoor warmed to 73F but is still 2F below indoor=75F — favorable gradient remains. Fan MUST keep running (premature-stop guard)."
+    },
+    {
+      "time": "2026-06-12T09:00:00",
+      "type": "temp_update",
+      "indoor_f": 74.0,
+      "outdoor_f": 74.5,
+      "note": "Outdoor crosses indoor (74.5F >= 74F) — the fast loop exits nat-vent on this temp_update."
+    }
+  ],
+  "assertions": [
+    {
+      "at": "2026-06-12T06:01:00",
+      "expect": "classification_applied",
+      "reason": "Mild classification applied with hvac_mode=off."
+    },
+    {
+      "at": "2026-06-12T08:00:00",
+      "expect": "natural_ventilation",
+      "reason": "Window opened with outdoor=66F < indoor=76F — nat-vent activates and the whole-house fan turns on."
+    },
+    {
+      "at": "2026-06-12T08:30:00",
+      "expect": "natural_ventilation",
+      "reason": "outdoor=73F is still below indoor=75F — the thermostatic fast loop keeps the fan running (no premature stop). #327 stop fires only at outdoor >= indoor."
+    },
+    {
+      "at": "2026-06-12T09:00:00",
+      "expect": "nat_vent_outdoor_rise_exit",
+      "reason": "outdoor=74.5F >= indoor=74F on a temp_update — the fast loop exits nat-vent immediately, not waiting for the 30-min cycle."
+    }
+  ],
+  "verdict": {
+    "type": "positive",
+    "summary": "Thermostatic fast loop keeps the fan while outdoor < indoor and stops it promptly when outdoor crosses indoor (Issue #327)",
+    "observed_behavior": "natural_ventilation on open → still venting at 08:30 (outdoor 73 < indoor 75) → nat_vent_outdoor_rise_exit at 09:00 (outdoor 74.5 >= indoor 74) on the temp_update",
+    "expected_behavior": "Fan runs while free cooling is available and exits the moment outdoor >= indoor, re-evaluated on every temperature change"
+  }
+}


### PR DESCRIPTION
## User outcome
The HVAC/whole-house fan could run almost continuously (at one point pulling 76°F outdoor air into a 74°F house) and never shut off, and it was only re-checked every 30 minutes — far too slow for a fan that can swing the whole home's air in minutes. After this fix a running fan is **always** one of: CA nat-vent held by a thermostatic fast loop, a timed manual override, or off — never an indefinite "untracked" limbo.

## Root cause (four indefinite-running paths)
1. `"running (untracked)"` was a display-only string — no code acted on it.
2. Every shutoff was gated on `_fan_active` / `_natural_vent_active`.
3. `restore_state` restored `_fan_override_active` (with no grace-timer reschedule) → permanent lockout; `_natural_vent_active` was not persisted.
4. The decisive `outdoor ≥ indoor` stop lived only in the 30-min cycle; the outdoor sensor wasn't watched.

## Fix
- **A** restart clears the fan override (clean slate, like HVAC override) → restart reclaims control.
- **B** `_do_startup_coalesce` → `reconcile_fan_on_startup`: adopt-on / turn-off / no-fan from the live thermostat fan state.
- **C** `fan_thermostat_check(indoor, outdoor, trigger)` re-evaluates on **every indoor or outdoor temp change** (thermostat seam + new indoor/outdoor listeners) + a 5-min backstop; stops at `outdoor ≥ indoor` (→ `nat_vent_outdoor_rise_exit` for nat-vent) or when cooled to the comfort floor.
- **D** economizer gains an `outdoor < indoor` free-cooling-direction guard.
- **E** manual fan change = timed override (grace), reclaimed on expiry or restart; observability logs at every decision point.

## Two correctness bugs caught in verification (and fixed)
- Stop used `outdoor >= indoor − hysteresis` (wrong side) → killed free cooling ~1°F early / the instant nat-vent started.
- Comfort-target stop fired at `indoor >= comfort_cool` → shut a **cooling** fan off when the home was too warm (inverted). A cooling fan now stops only at the comfort floor.

## Verification
- Full suite **2696 passed**; goldens **50/50**; integrity OK; new pending scenario `fan_fast_stop_on_outdoor_rise` passes (and would fail if reverted); ruff clean.
- New tests: `fan_thermostat_check` / `reconcile_fan_on_startup` units incl. the premature-stop regression guard; economizer direction guard; coalesce reconcile call. Docs §9e/§8/§11/§18 + flowchart §14 updated.

VERSION 0.4.23 → 0.4.24. Closes #327.