### PR TITLE
Fix #341: nat-vent sleep band thrash + grace started missing context

### DIFF
--- a/custom_components/climate_advisor/ai_skills_activity.py
+++ b/custom_components/climate_advisor/ai_skills_activity.py
@@ -207,6 +207,7 @@ _MANUAL_EVENT_TYPES = frozenset(
         "override_confirmed",
         "override_cleared",
         "override_self_resolved",
+        "fan_manual_override",
     }
 )
 
@@ -461,17 +462,27 @@ def _render_override_self_resolved(p: dict, unit: str) -> tuple[str, str]:
     return "Override self-resolved (transient)", ""
 
 
+_GRACE_TRIGGER_LABELS: dict[str, str] = {
+    "fan_manual_override": "fan override (manual fan change)",
+    "override_confirmed": "HVAC mode override",
+    "dashboard_resume": "user resumed from dashboard",
+    "sensor_closed_resume": "all sensors closed",
+    "nat_vent_exit_resume": "natural ventilation ended",
+}
+
+
 def _render_grace_started(p: dict, unit: str) -> tuple[str, str]:
     trigger = p.get("trigger", "")
     source = p.get("source", "")
     duration = p.get("duration_seconds")
     dur_str = f" ({duration // 60} min)" if isinstance(duration, int) else ""
     label = f"Grace period started{dur_str}"
-    if trigger:
-        label = f"{label} -- trigger: {trigger}"
-    elif source:
+    if source:
         label = f"{label} ({source})"
-    return label, ""
+    # Settings cell: human-readable trigger label for known triggers; empty otherwise.
+    # (The Event cell for this dedup-eligible type always shows _humanize_type → "Grace started".)
+    trigger_label = _GRACE_TRIGGER_LABELS.get(trigger, "")
+    return label, trigger_label
 
 
 def _render_grace_expired(p: dict, unit: str) -> tuple[str, str]:
@@ -517,6 +528,14 @@ def _render_fan_deactivated(p: dict, unit: str) -> tuple[str, str]:
     reason = str(p.get("reason", "")).strip()
     label = f"Fan deactivated -- {reason}" if reason else "Fan deactivated"
     return label, "fan: on->off"
+
+
+def _render_fan_manual_override(p: dict, unit: str) -> tuple[str, str]:
+    fan_before = str(p.get("fan_before", "")).strip()
+    fan_after = str(p.get("fan_after", "")).strip()
+    change = f"{fan_before}->{fan_after}" if fan_before and fan_after else ""
+    settings = f"fan: {change}" if change else ""
+    return "Fan manual override", settings
 
 
 def _render_fan_running_untracked(p: dict, unit: str) -> tuple[str, str]:
@@ -799,6 +818,7 @@ EVENT_RENDERERS: dict[str, Callable[[dict, str], tuple[str, str]]] = {
     "nat_vent_fan_off": _render_nat_vent_fan_off,
     "fan_activated": _render_fan_activated,
     "fan_deactivated": _render_fan_deactivated,
+    "fan_manual_override": _render_fan_manual_override,
     "fan_running_untracked": _render_fan_running_untracked,
     "fan_untracked_cleared": _render_fan_untracked_cleared,
     "nat_vent_outdoor_rise_exit": _render_nat_vent_outdoor_rise_exit,

--- a/custom_components/climate_advisor/ai_skills_investigator.py
+++ b/custom_components/climate_advisor/ai_skills_investigator.py
@@ -224,7 +224,7 @@ _TIMING_MANUAL_EVENT_TYPES: frozenset[str] = frozenset(
         "override_self_resolved",
         "manual_override_cleared",
         "handle_manual_override",
-        "handle_fan_manual_override",
+        "fan_manual_override",
     }
 )
 

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -624,19 +624,34 @@ class AutomationEngine:
         except Exception:
             return 0.0
 
-    def handle_fan_manual_override(self) -> None:
+    def handle_fan_manual_override(self, fan_before: str = "", fan_after: str = "") -> None:
         """Handle a manual fan state change — sets fan override flag + grace (Issue #327).
 
         Idempotent: safe to call even if an override is already active (re-stamps the
         time and restarts the grace period so the timer is always fresh).
+
+        Args:
+            fan_before: Fan state before the manual change (e.g. "on", "auto").
+            fan_after: Fan state after the manual change.
         """
         self._stop_fan_min_runtime_cycles()
         self._fan_override_active = True
         self._fan_override_time = dt_util.now().isoformat()
         _LOGGER.info(
-            "Fan override: set — manual fan change detected, override active since %s, grace period starting",
+            "Fan override: set — manual fan change detected %s->%s, override active since %s, grace period starting",
+            fan_before or "?",
+            fan_after or "?",
             self._fan_override_time,
         )
+        if self._emit_event_callback:
+            self._emit_event_callback(
+                "fan_manual_override",
+                {
+                    "fan_before": fan_before,
+                    "fan_after": fan_after,
+                    "override_active_since": self._fan_override_time,
+                },
+            )
         self._start_grace_period("manual", trigger="fan_manual_override")
 
     def clear_fan_override(self) -> None:
@@ -3153,6 +3168,25 @@ class AutomationEngine:
         comfort_cool = float(self.config.get("comfort_cool", 75))
 
         if not aggressive_savings:
+            # Sleep window: skip the full-band setpoint call — apply_classification() will arm
+            # the sleep band immediately after, so a prior full-band write would be overwritten
+            # and would cause redundant thermostat calls all night.  Emit the status event so
+            # the status card and activity report still show nat-vent as active.
+            _in_sleep = _in_sleep_window(dt_util.now(), self.config)
+            if _in_sleep:
+                _LOGGER.info(
+                    "_apply_nat_vent_hvac_state: sleep window in effect — skipping full-band setpoint"
+                    " (deferring to sleep band); nat_vent_ac_assist_armed emitted comfort_heat=%.1f comfort_cool=%.1f",
+                    comfort_heat,
+                    comfort_cool,
+                )
+                if self._emit_event_callback:
+                    self._emit_event_callback(
+                        "nat_vent_ac_assist_armed",
+                        {"comfort_heat": comfort_heat, "comfort_cool": comfort_cool},
+                    )
+                return
+
             # Full comfort band — compressor may assist if breeze cannot hold the ceiling.
             _LOGGER.info(
                 "_apply_nat_vent_hvac_state: AC assist armed — full band comfort_heat=%.1f comfort_cool=%.1f"

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,18 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.4.32"
+VERSION = "0.4.33"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.4.33": [
+        "Fix #341: nat-vent active during sleep window no longer sets two conflicting thermostat "
+        "setpoints every 30 minutes all night — one write per cycle (sleep band) instead of two.",
+        "Fix #341: 'Grace started' activity report entry now shows what triggered it "
+        "(e.g. 'fan override (manual fan change)') in the Settings column instead of a blank.",
+        "Fix #341: fan manual override now emits its own timeline event showing the fan state "
+        "change (e.g. 'fan: on->auto') so the reason for the 90-min grace period is visible "
+        "without reading the Decisions section.",
+    ],
     "0.4.32": [
         "Fix #339: Occupancy→away/vacation no longer arms HVAC setback while windows/doors are open. "
         "HVAC stays off; occupancy mode is recorded for correct setback on resume. "
@@ -480,6 +489,26 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    341: {
+        "version_fixed": "0.4.33",
+        "title": "Dual setpoint thrash + 'Grace started' missing context in activity report",
+        "scope_covered": (
+            "_apply_nat_vent_hvac_state(): sleep window guard skips _apply_comfort_band() call "
+            "when in_sleep_window=True, emits nat_vent_ac_assist_armed event only; "
+            "handle_fan_manual_override(): fan_before/fan_after params added, emits fan_manual_override event; "
+            "coordinator call sites updated to pass fan state; "
+            "_render_grace_started(): trigger codes mapped to human-readable Settings labels; "
+            "_render_fan_manual_override(): dedicated renderer added to EVENT_RENDERERS; "
+            "fan_manual_override added to _MANUAL_EVENT_TYPES and _TIMING_MANUAL_EVENT_TYPES."
+        ),
+        "scope_not_covered": (
+            "activity report timeline Event cell still shows 'Grace started' (humanized type) "
+            "rather than the full rendered label — dedup-eligible events use _humanize_type for "
+            "the Event cell; trigger info now in Settings column as the practical fix. "
+            "Grace started triggered by chat_log or direct API call without fan state available "
+            "will show empty fan state fields."
+        ),
+    },
     339: {
         "version_fixed": "0.4.32",
         "title": "Occupancy→away/vacation bypasses HVAC pause guard while windows open",

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -3014,7 +3014,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 _hvac_cmd_age,
                 _is_expected_confirmation,
             )
-            self.automation_engine.handle_fan_manual_override()
+            self.automation_engine.handle_fan_manual_override(fan_before=str(old_fan_mode), fan_after=str(new_fan_mode))
 
     async def _async_fan_entity_changed(self, event: Event) -> None:
         """Detect manual fan entity state changes (Issue #37)."""
@@ -3048,7 +3048,9 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 old_state.state,
                 new_state.state,
             )
-            self.automation_engine.handle_fan_manual_override()
+            self.automation_engine.handle_fan_manual_override(
+                fan_before=str(old_state.state), fan_after=str(new_state.state)
+            )
         elif not is_on and self.automation_engine._fan_active:
             # Fan turned off externally — manual override
             _LOGGER.info(
@@ -3056,7 +3058,9 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 old_state.state,
                 new_state.state,
             )
-            self.automation_engine.handle_fan_manual_override()
+            self.automation_engine.handle_fan_manual_override(
+                fan_before=str(old_state.state), fan_after=str(new_state.state)
+            )
 
     async def _initialize_hvac_session_from_current_state(self, climate_state: Any) -> None:
         """Late-start HVAC session when HA restarted mid-session (Issue #96).

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.4.32"
+  "version": "0.4.33"
 }

--- a/docs/08-COMPUTATION-REFERENCE.md
+++ b/docs/08-COMPUTATION-REFERENCE.md
@@ -1045,11 +1045,14 @@ Natural ventilation and the economizer **no longer set `hvac_mode=off`** when th
 
 `_apply_nat_vent_hvac_state()` is called at every nat-vent activation site — initial activation, re-activation from paused state, and on every 30-minute `apply_classification()` cycle while nat-vent is active — to ensure the correct band is armed alongside the running fan.
 
-| Fan archetype | `aggressive_savings` | Band armed | Rationale |
-|---|---|---|---|
-| `FAN_MODE_WHOLE_HOUSE` or `DISABLED` | any | No-op | HVAC already suppressed by fan activation path; no band to arm |
-| `FAN_MODE_HVAC` only | `False` | Cool setpoint at `comfort_cool` ceiling (`cool` mode, single-setpoint) | AC assists if the breeze cannot hold the ceiling; floor is re-armed on the next 30-min `apply_classification()` cycle |
-| `FAN_MODE_HVAC` only | `True` | Floor-only: `heat` mode @ `comfort_heat`; ceiling disarmed | Running the compressor through open windows defeats the savings the user configured; occupant accepts ceiling drift if breeze fails |
+| Fan archetype | `aggressive_savings` | Sleep window? | Band armed | Rationale |
+|---|---|---|---|---|
+| `FAN_MODE_WHOLE_HOUSE` or `DISABLED` | any | any | No-op | HVAC already suppressed by fan activation path; no band to arm |
+| `FAN_MODE_HVAC` only | `False` | **Yes** | No setpoint call — emits `nat_vent_ac_assist_armed` only | Sleep band applied by the subsequent `select_comfort_band(in_sleep_window=True)` call in `apply_classification()`; avoids redundant thermostat write at daytime comfort ceiling immediately overwritten by sleep ceiling (Issue #341) |
+| `FAN_MODE_HVAC` only | `False` | No | Full comfort band at `[comfort_heat, comfort_cool]` ceiling | AC assists if the breeze cannot hold the ceiling; floor is re-armed on the next 30-min `apply_classification()` cycle |
+| `FAN_MODE_HVAC` only | `True` | any | Floor-only: `heat` mode @ `comfort_heat`; ceiling disarmed | Running the compressor through open windows defeats the savings the user configured; occupant accepts ceiling drift if breeze fails |
+
+**Sleep window deference (Issue #341):** When nat-vent is active during the sleep window and `aggressive_savings=False`, `_apply_nat_vent_hvac_state()` emits `nat_vent_ac_assist_armed` (so the status card and activity report show nat-vent active) but skips `_apply_comfort_band()`. The `select_comfort_band(in_sleep_window=True)` call immediately following in `apply_classification()` programs the thermostat with the sleep band (`sleep_heat`/`sleep_cool`). Without this guard, two conflicting setpoints were written every 30-min cycle all night: the daytime comfort ceiling first, then the sleep ceiling immediately after. The sleep ceiling won (applied last), but the thermostat received redundant writes and the activity report showed confusing dual entries.
 
 **Path B fix (re-activation from paused state):** Before Fix #338, when nat-vent re-activated from a paused state (all conditions met again after the 300 s lockout), `_apply_nat_vent_hvac_state()` was not called on that path. The band was not re-armed until the next 30-minute `apply_classification()` cycle — a window of up to 30 minutes during which the thermostat ran with no CA-programmed ceiling. Fix #338 calls `_apply_nat_vent_hvac_state()` in `check_natural_vent_conditions()` at the re-activate node (§12b in the flowchart).
 

--- a/tests/test_activity_renderers.py
+++ b/tests/test_activity_renderers.py
@@ -271,31 +271,30 @@ class TestBuildEventTimelineTable:
 
         assert "Sensor opened" in table
 
-    def test_grace_started_settings_blank(self):
-        """grace_started → Event cell shows humanized type, Settings cell is empty.
+    def test_grace_started_settings_blank_for_unknown_trigger(self):
+        """grace_started with unknown trigger → Event cell 'Grace started', Settings empty.
 
         grace_started is not in _NO_DEDUP, so the dedup flush path uses
         _humanize_type('grace_started') → 'Grace started' for the Event cell
         (the renderer ev_text is discarded for dedup-eligible types).
-        The renderer returns Settings='', confirmed here.
+        For triggers not in _GRACE_TRIGGER_LABELS the renderer returns Settings=''
+        so the Settings cell stays blank.
         """
         event = _make_event(
             "grace_started",
-            trigger="door_opened",
+            trigger="door_opened",  # not a known trigger — Settings stays blank
             duration_seconds=5400,
         )
         table = _build_table([event])
 
-        # Row present (humanized type name from the dedup flush path)
         assert "Grace started" in table, f"grace_started row must appear. Table:\n{table}"
-        # Settings column is blank for grace_started (renderer returns Settings='')
         rows = [line for line in table.splitlines() if "Grace started" in line]
         assert rows, "No grace_started row found"
-        # The row format is: | Time | Event | Settings | Source |
-        # cells[0]='' cells[1]=time cells[2]=event cells[3]=settings cells[4]=source
         cells = rows[0].split("|")
         if len(cells) >= 4:
-            assert cells[3].strip() == "", f"grace_started Settings cell should be empty. Got: {cells[3]!r}"
+            assert cells[3].strip() == "", (
+                f"grace_started Settings cell should be empty for unknown trigger. Got: {cells[3]!r}"
+            )
 
     def test_empty_event_log_returns_header_and_sentinel(self):
         """Empty event log → table has header + '(no events in window)' sentinel row."""
@@ -522,3 +521,97 @@ class TestFanEventRenderers:
         ev, st = _act_mod.EVENT_RENDERERS["fan_untracked_cleared"]({}, "fahrenheit")
         assert "untracked" in ev.lower()
         assert st == "fan: off"
+
+
+class TestGraceStartedRendering:
+    """Issue #341: grace_started trigger field renders as human-readable Settings cell."""
+
+    def test_fan_manual_override_trigger_shows_in_settings(self):
+        """grace_started with trigger=fan_manual_override → Settings shows readable label.
+
+        The occupant sees 'Grace started | fan override (manual fan change)' rather than
+        the raw internal code 'fan_manual_override' — making the reason for the pause clear.
+        """
+        ev, st = _act_mod.EVENT_RENDERERS["grace_started"](
+            {"source": "manual", "duration_seconds": 5400, "trigger": "fan_manual_override"},
+            "fahrenheit",
+        )
+        assert "fan override" in st, f"Settings must show readable trigger label. Got: {st!r}"
+        assert "manual fan change" in st
+
+    def test_hvac_override_trigger(self):
+        ev, st = _act_mod.EVENT_RENDERERS["grace_started"](
+            {"source": "manual", "duration_seconds": 5400, "trigger": "override_confirmed"},
+            "fahrenheit",
+        )
+        assert "HVAC mode override" in st
+
+    def test_sensor_closed_resume_trigger(self):
+        ev, st = _act_mod.EVENT_RENDERERS["grace_started"](
+            {"source": "automation", "duration_seconds": 300, "trigger": "sensor_closed_resume"},
+            "fahrenheit",
+        )
+        assert "all sensors closed" in st
+
+    def test_unknown_trigger_settings_blank(self):
+        """Unknown trigger codes do not appear in Settings (no junk internal codes shown)."""
+        ev, st = _act_mod.EVENT_RENDERERS["grace_started"](
+            {"source": "manual", "duration_seconds": 5400, "trigger": "some_future_trigger"},
+            "fahrenheit",
+        )
+        assert st == "", f"Unknown trigger must leave Settings empty. Got: {st!r}"
+
+    def test_no_trigger_field_settings_blank(self):
+        """Legacy events without a trigger key render without error; Settings stays empty."""
+        ev, st = _act_mod.EVENT_RENDERERS["grace_started"](
+            {"source": "manual", "duration_seconds": 5400},
+            "fahrenheit",
+        )
+        assert st == ""
+
+    def test_fan_manual_override_trigger_in_table(self):
+        """End-to-end: fan_manual_override trigger appears in Settings column of timeline table."""
+        event = _make_event(
+            "grace_started",
+            trigger="fan_manual_override",
+            duration_seconds=5400,
+            source="manual",
+        )
+        table = _build_table([event])
+        assert "Grace started" in table
+        rows = [line for line in table.splitlines() if "Grace started" in line]
+        assert rows, "No grace_started row found"
+        cells = rows[0].split("|")
+        if len(cells) >= 4:
+            assert "fan override" in cells[3], f"Settings cell must contain 'fan override'. Got: {cells[3]!r}"
+
+
+class TestFanManualOverrideRenderer:
+    """Issue #341: fan_manual_override event renders fan state change in Settings."""
+
+    def test_fan_state_change_shows_in_settings(self):
+        """fan_manual_override with fan_before/fan_after → Settings shows 'fan: on->auto'."""
+        ev, st = _act_mod.EVENT_RENDERERS["fan_manual_override"](
+            {"fan_before": "on", "fan_after": "auto", "override_active_since": "2026-06-20T06:48:00"},
+            "fahrenheit",
+        )
+        assert ev == "Fan manual override"
+        assert st == "fan: on->auto"
+
+    def test_fan_state_change_off_to_on(self):
+        ev, st = _act_mod.EVENT_RENDERERS["fan_manual_override"](
+            {"fan_before": "off", "fan_after": "on"},
+            "fahrenheit",
+        )
+        assert st == "fan: off->on"
+
+    def test_missing_fan_states_settings_blank(self):
+        """No fan_before/fan_after → Settings stays blank (graceful fallback)."""
+        ev, st = _act_mod.EVENT_RENDERERS["fan_manual_override"]({}, "fahrenheit")
+        assert ev == "Fan manual override"
+        assert st == ""
+
+    def test_fan_manual_override_source_is_manual(self):
+        """fan_manual_override source resolves to 'manual' for timeline Source column."""
+        source = _act_mod._event_source_label("fan_manual_override", {"source": ""})
+        assert source == "manual"

--- a/tests/test_nat_vent_activation.py
+++ b/tests/test_nat_vent_activation.py
@@ -1272,3 +1272,111 @@ class TestNatVentAcAssist:
         ]
         cool_calls = [c for c in hvac_calls if c[0][2].get("hvac_mode") == "cool"]
         assert len(cool_calls) >= 1, "hot-day close must restore 'cool' HVAC mode"
+
+
+# ---------------------------------------------------------------------------
+# Issue #341 — nat-vent active during sleep window: single setpoint per cycle
+# ---------------------------------------------------------------------------
+
+
+class TestNatVentSleepWindowBand:
+    """Issue #341: during sleep window, _apply_nat_vent_hvac_state() skips setpoint call.
+
+    Before the fix: apply_classification() called _apply_nat_vent_hvac_state() (which wrote
+    comfort_cool=75°F to the thermostat) and then immediately called select_comfort_band()
+    (which wrote sleep_cool=78°F), generating two conflicting thermostat writes every 30 minutes
+    all night.
+
+    After the fix: _apply_nat_vent_hvac_state() emits nat_vent_ac_assist_armed but skips
+    the _apply_comfort_band() call during the sleep window. Only one setpoint write occurs per
+    cycle — the sleep band from select_comfort_band().
+    """
+
+    # dt_util.now() inside automation.py is a child MagicMock; patch it so _in_sleep_window
+    # gets a real datetime and .time() comparisons work.
+    _NOW = datetime(2026, 4, 20, 22, 30, 0)  # 22:30 — within a 22:00–07:00 sleep window
+
+    def _make_sleep_engine(self) -> AutomationEngine:
+        """Engine with sleep window covering the patched 'now' (22:30)."""
+        engine = _make_hvac_engine(
+            fan_mode="hvac_fan",
+            aggressive_savings=False,
+            comfort_heat=70.0,
+            comfort_cool=75.0,
+            indoor_f=74.0,
+        )
+        # 22:00–07:00 window includes _NOW (22:30)
+        engine.config["sleep_time"] = "22:00"
+        engine.config["wake_time"] = "07:00"
+        return engine
+
+    def test_sleep_window_single_comfort_band_call(self):
+        """Nat-vent active + sleep window → _apply_comfort_band called once (sleep band only).
+
+        Occupant experience: after the fix, the thermostat receives one setpoint write per
+        30-minute cycle overnight — the sleep ceiling (78°F by default) — not two competing
+        writes at 75°F and 78°F that make the thermostat history look like the integration
+        is malfunctioning.
+        """
+        engine = self._make_sleep_engine()
+        engine._natural_vent_active = True
+
+        engine._apply_comfort_band = AsyncMock()
+        classification = _make_classification(day_type="warm", hvac_mode="off")
+        with patch(_DT_NOW_PATH, return_value=self._NOW):
+            asyncio.run(engine.apply_classification(classification))
+
+        assert engine._apply_comfort_band.call_count == 1, (
+            f"Expected 1 _apply_comfort_band call during sleep window; got {engine._apply_comfort_band.call_count}"
+        )
+        band = engine._apply_comfort_band.call_args[0][0]
+        # Sleep band uses DEFAULT_SLEEP_HEAT=66 / DEFAULT_SLEEP_COOL=78, not comfort band 70/75
+        assert band.floor == 66.0, f"Sleep band floor must be sleep_heat=66. Got: {band.floor}"
+        assert band.ceiling == 78.0, f"Sleep band ceiling must be sleep_cool=78. Got: {band.ceiling}"
+
+    def test_sleep_window_nat_vent_ac_assist_event_still_emitted(self):
+        """nat_vent_ac_assist_armed event fires during sleep window despite skipped setpoint.
+
+        The activity report and status card must still show nat-vent as active while the
+        fan is running overnight. Without the event, the occupant sees the fan on but the
+        report shows no nat-vent activity — a confusing gap.
+        """
+        engine = self._make_sleep_engine()
+        engine._natural_vent_active = True
+
+        emitted: list[tuple[str, dict]] = []
+        engine._emit_event_callback = lambda et, pl: emitted.append((et, pl))
+        engine._apply_comfort_band = AsyncMock()
+
+        classification = _make_classification(day_type="warm", hvac_mode="off")
+        with patch(_DT_NOW_PATH, return_value=self._NOW):
+            asyncio.run(engine.apply_classification(classification))
+
+        event_types = [e[0] for e in emitted]
+        assert "nat_vent_ac_assist_armed" in event_types, (
+            f"nat_vent_ac_assist_armed must still fire during sleep window. Got events: {event_types}"
+        )
+
+    def test_awake_window_two_comfort_band_calls(self):
+        """Nat-vent active + awake hours → two _apply_comfort_band calls (regression guard).
+
+        During awake hours, _apply_nat_vent_hvac_state() still writes the full comfort band
+        so the thermostat's own deadband can let the compressor assist if the breeze alone
+        cannot hold the comfort ceiling.
+        """
+        engine = _make_hvac_engine(fan_mode="hvac_fan", aggressive_savings=False, indoor_f=74.0)
+        # No sleep_time/wake_time in config → _in_sleep_window() returns False
+        engine._natural_vent_active = True
+
+        engine._apply_comfort_band = AsyncMock()
+        classification = _make_classification(day_type="warm", hvac_mode="off")
+        asyncio.run(engine.apply_classification(classification))
+
+        # Two calls: (1) nat-vent full comfort band, (2) apply_classification() comfort band
+        assert engine._apply_comfort_band.call_count == 2, (
+            f"Expected 2 _apply_comfort_band calls during awake hours; got {engine._apply_comfort_band.call_count}"
+        )
+        for call in engine._apply_comfort_band.call_args_list:
+            band = call[0][0]
+            assert band.floor == 70.0, f"Awake band floor must be comfort_heat=70. Got: {band.floor}"
+            assert band.ceiling == 75.0, f"Awake band ceiling must be comfort_cool=75. Got: {band.ceiling}"


### PR DESCRIPTION
## Summary

- **Bug A — Dual setpoint thrash during sleep window**: `_apply_nat_vent_hvac_state()` applied the full daytime comfort band (74°F cool) on every 30-min cycle, immediately overwritten by `apply_classification()`'s sleep band (72°F). ~60 redundant thermostat service calls per night.
- **Bug B — Grace started with no context**: `grace_started` event captured `trigger: "fan_manual_override"` but the activity report never rendered it; no dedicated `fan_manual_override` event existed in the timeline.

## Changes

| File | Change |
|---|---|
| `automation.py` | `_apply_nat_vent_hvac_state()`: guard setpoint call with sleep window check; emit `nat_vent_ac_assist_armed` only during sleep window. `handle_fan_manual_override()`: emit `fan_manual_override` event with `fan_before`/`fan_after` before starting grace. |
| `coordinator.py` | Pass `fan_before`/`fan_after` to `handle_fan_manual_override()` at all three call sites. |
| `ai_skills_activity.py` | Add `_GRACE_TRIGGER_LABELS` dict; update `_render_grace_started()` to put trigger label in Settings column; add `_render_fan_manual_override()` renderer; register both. Add `fan_manual_override` to `_MANUAL_EVENT_TYPES`. |
| `ai_skills_investigator.py` | Fix stale `"handle_fan_manual_override"` (function name) in `_TIMING_MANUAL_EVENT_TYPES` → correct event type `"fan_manual_override"`. |
| `docs/08-COMPUTATION-REFERENCE.md` | Add sleep window column to nat-vent routing table; document Issue #341 fix. |
| `tests/test_nat_vent_activation.py` | `TestNatVentSleepWindowBand`: 3 tests covering sleep guard + event emission + regression. |
| `tests/test_activity_renderers.py` | `TestGraceStartedRendering` (6 tests) + `TestFanManualOverrideRenderer` (4 tests). |
| `const.py` | Version 0.4.32 → 0.4.33; `RELEASE_NOTES["0.4.33"]`; `KNOWN_FIXES[341]`. |
| `manifest.json` | Version 0.4.32 → 0.4.33. |

## User Outcome Cards

### Bug A — Dual Setpoint Thrash (Sleep Window)

**Before:** Every 30 minutes from 20:50–06:10 the thermostat was written twice: 74°F (nat-vent AC assist), then immediately 72°F (sleep band). ~60 redundant service calls per night. Occupants checking Ecobee/Nest history saw chaotic back-and-forth setpoints suggesting the integration was malfunctioning.

**After:** One setpoint call per 30-min cycle during the sleep window — the correct sleep band. `nat_vent_ac_assist_armed` event still fires so the status card shows nat-vent is active. Thermostat history is clean.

### Bug B — Grace Started with No Context

**Before:** `| 06:48 | Grace started | | manual |` — no explanation of what triggered the grace period. Occupant reading the report couldn't tell if it was a fan change, thermostat mode change, or a door sensor.

**After:** Two rows at 06:48:
- `| 06:48 | Fan manual override | fan: on->auto | manual |`
- `| 06:48 | Grace started | fan override (manual fan change) | manual |`

The occupant can see exactly what they did and why automation paused.

## Test plan

- [x] `TestNatVentSleepWindowBand` — sleep guard fires, single `_apply_comfort_band` call, `nat_vent_ac_assist_armed` still emitted, awake-window regression passes
- [x] `TestGraceStartedRendering` — all trigger labels render correctly in Settings column, unknown triggers fall back gracefully
- [x] `TestFanManualOverrideRenderer` — fan state change `on->auto` renders in Settings; empty fan states handled gracefully
- [x] All 213 existing tests pass (`pytest tests/ -W error::pytest.PytestUnraisableExceptionWarning -W error::RuntimeWarning`)
- [x] `test_version_sync.py` passes (const.py / manifest.json versions match)
- [x] Pre-commit hooks pass (ruff, validate.py, check-yaml, check-json)

Fixes #341