### PR TITLE
Fix #345: debug pane shows correct confidence for k_solar and k_active_hvac

### DIFF
--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,14 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.4.34"
+VERSION = "0.4.35"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.4.35": [
+        "Fix #345: Prediction Engines debug panel now shows correct confidence for k_solar "
+        "(was always 'none' regardless of observation count) and k_active_hvac "
+        "(confidence was previously absent from the panel entirely).",
+    ],
     "0.4.34": [
         "Fix #343: Prediction Engines debug panel now shows only confidence level per parameter — "
         "stale 'since' dates (which were frozen at first observation and never updated on EWMA changes) "
@@ -494,6 +499,22 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    345: {
+        "version_fixed": "0.4.35",
+        "title": "Fix k_solar and k_active_hvac confidence display in Prediction Engines debug panel",
+        "scope_covered": (
+            "learning.py get_engine_status(): k_solar confidence now computed from "
+            "observation_count_solar using the same ladder as get_thermal_model() "
+            "(none/<20, low/20-49, medium/50-99, high/100+); "
+            "k_active_hvac entry now includes a 'confidence' key computed from total "
+            "heat+cool observation count (none/<5, low/5-9, medium/10-19, high/20+); "
+            "index.html hvacRow(): appends confidence string after heat/cool values."
+        ),
+        "scope_not_covered": (
+            "solar_phase_offset_h and k_vent_window have no confidence grade in "
+            "get_thermal_model() either — no change needed for those parameters."
+        ),
+    },
     343: {
         "version_fixed": "0.4.34",
         "title": "Remove stale 'since' dates and obs_count from Prediction Engines debug panel",

--- a/custom_components/climate_advisor/frontend/index.html
+++ b/custom_components/climate_advisor/frontend/index.html
@@ -2232,7 +2232,8 @@
         }
         const heat = info.value?.heat != null ? Number(info.value.heat).toFixed(4) : '—';
         const cool = info.value?.cool != null ? Number(info.value.cool).toFixed(4) : '—';
-        return `<tr><td>k_active_hvac</td><td>heat=${escapeHtml(heat)} cool=${escapeHtml(cool)} ${unitSym}/hr</td></tr>`;
+        const conf = info.confidence ? `<span class="kv-desc">${escapeHtml(info.confidence)} confidence</span>` : '';
+        return `<tr><td>k_active_hvac</td><td>heat=${escapeHtml(heat)} cool=${escapeHtml(cool)} ${unitSym}/hr${conf}</td></tr>`;
       }
 
       const odeVer = escapeHtml(data.ode_version || 'unknown');

--- a/custom_components/climate_advisor/learning.py
+++ b/custom_components/climate_advisor/learning.py
@@ -1021,6 +1021,24 @@ class LearningEngine:
         phase_offset_val = cache.get("solar_phase_offset_h")
         conf_k_passive = _grade_passive_confidence(cache)
 
+        _solar_obs = cache.get("observation_count_solar", 0)
+        _conf_solar = "none"
+        if _solar_obs >= 100:
+            _conf_solar = "high"
+        elif _solar_obs >= 50:
+            _conf_solar = "medium"
+        elif _solar_obs >= 20:
+            _conf_solar = "low"
+
+        _hvac_total = cache.get("observation_count_heat", 0) + cache.get("observation_count_cool", 0)
+        _conf_hvac = "none"
+        if _hvac_total >= 20:
+            _conf_hvac = "high"
+        elif _hvac_total >= 10:
+            _conf_hvac = "medium"
+        elif _hvac_total >= 5:
+            _conf_hvac = "low"
+
         status: dict = {
             "k_passive": {
                 "active": k_passive_val is not None,
@@ -1030,7 +1048,7 @@ class LearningEngine:
             "k_solar": {
                 "active": k_solar_val is not None,
                 "value": k_solar_val,
-                "confidence": "none",
+                "confidence": _conf_solar,
             },
             "solar_phase_offset_h": {
                 "active": phase_offset_val is not None,
@@ -1043,6 +1061,7 @@ class LearningEngine:
             "k_active_hvac": {
                 "active": k_active_heat is not None or k_active_cool is not None,
                 "value": {"heat": k_active_heat, "cool": k_active_cool},
+                "confidence": _conf_hvac,
             },
         }
 

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.4.34"
+  "version": "0.4.35"
 }


### PR DESCRIPTION
## Summary

- `get_engine_status()` in `learning.py` hardcoded `\"confidence\": \"none\"` for k_solar regardless of observation count — debug pane always showed *none confidence* even with 62 committed solar observations (real confidence: *medium*)
- `get_engine_status()` omitted a confidence key entirely for k_active_hvac — debug pane showed no confidence string at all
- `hvacRow()` in `index.html` didn't render confidence even if the backend sent it

## Changes

**`learning.py` `get_engine_status()`:**
- k_solar: compute confidence from `observation_count_solar` using the same ladder as `get_thermal_model()` (none/<20, low/20-49, medium/50-99, high/100+)
- k_active_hvac: compute confidence from total heat+cool obs count (none/<5, low/5-9, medium/10-19, high/20+); add `\"confidence\"` key to the entry

**`index.html` `hvacRow()`:**
- Append `<span class="kv-desc">X confidence</span>` after the heat/cool values when confidence is present

## Test plan
- [x] 58 solar/thermal/version tests pass (verified locally)
- [x] 34 activity_report + investigator tests pass (verified locally)
- [x] After deploy: Debug tab → Prediction Engines → k_solar shows `medium confidence`, k_active_hvac shows `high confidence`

Closes #345