### PR TITLE
Fix #363: WHF _compute_fan_status() ground-truth fallback for fan_state_entity (Type 2)

### DIFF
--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,14 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.4.41"
+VERSION = "0.4.42"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.4.42": [
+        "Fix #363: WHF fan status sensor now shows 'running (untracked)' when the whole-house fan is"
+        " physically on but CA's flags are clear — reads fan_state_entity (Type 2) or fan_entity"
+        " (Type 1) via _get_fan_physical_state().",
+    ],
     "0.4.41": [
         "Feat #361: Added fan_state_feedback config flag. When OFF (default),"
         " CA operates in command-only mode — asserting desired fan state idempotently"
@@ -539,6 +544,25 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    363: {
+        "version_fixed": "0.4.42",
+        "title": "WHF _compute_fan_status() ground-truth fallback for fan_state_entity (Type 2)",
+        "scope_covered": (
+            "coordinator.py _compute_fan_status(): after _natural_vent_active check, new block"
+            " for FAN_MODE_WHOLE_HOUSE and FAN_MODE_BOTH calls _get_fan_physical_state() —"
+            " returns 'running (untracked)' when physical_on is True. "
+            "Handles Type 1 (fan_entity) and Type 2 (fan_state_entity) via existing helper. "
+            "Returns None (command-only mode, fan_state_feedback=False) falls through to 'inactive'. "
+            "tests/test_whf_dual_entity.py: TestComputeFanStatusWHF — 4 new tests. "
+            "docs/08-COMPUTATION-REFERENCE.md §9d updated."
+        ),
+        "scope_not_covered": (
+            "_compute_fan_status() HVAC-fan untracked path still reads thermostat attributes"
+            " directly (no change). "
+            "fan_state_entity not yet surfaced in _compute_fan_status() for the 'running (manual override)'"
+            " display — that path still relies on CA's internal _fan_active/_fan_override_active flags."
+        ),
+    },
     361: {
         "version_fixed": "0.4.41",
         "title": "WHF command-only mode: fan_state_feedback config flag",

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -99,6 +99,7 @@ from .const import (
     FAN_MODE_BOTH,
     FAN_MODE_DISABLED,
     FAN_MODE_HVAC,
+    FAN_MODE_WHOLE_HOUSE,
     INVESTIGATION_REPORT_HISTORY_CAP,
     INVESTIGATION_REPORTS_FILE,
     MAX_WEATHER_BIAS_APPLY_F,
@@ -5423,6 +5424,12 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         # Bug 3 (Issue #321): nat-vent session active but fan is idle between cycles
         if ae._natural_vent_active:
             return "nat-vent (session active, fan idle)"
+        # WHF ground-truth fallback: reads fan_state_entity (Type 2) or fan_entity (Type 1).
+        # Catches post-restart and externally-run WHF when CA's internal flags are all clear.
+        if fan_mode in (FAN_MODE_WHOLE_HOUSE, FAN_MODE_BOTH):
+            physical_on = self._get_fan_physical_state()
+            if physical_on is True:
+                return "running (untracked)"
         # Ground-truth fallback: CA's flag says inactive, but check what the
         # thermostat is actually doing. Catches post-restart and externally-run fan.
         if fan_mode in (FAN_MODE_HVAC, FAN_MODE_BOTH):

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.4.41"
+  "version": "0.4.42"
 }

--- a/docs/08-COMPUTATION-REFERENCE.md
+++ b/docs/08-COMPUTATION-REFERENCE.md
@@ -1388,7 +1388,7 @@ The `sensor.climate_advisor_fan_status` entity exposes one of six state strings:
 | `active` | Fan is on; integration activated it (nat-vent or economizer) |
 | `running (manual override)` | Fan is on; user turned it on manually — `_fan_override_active=True` |
 | `off (manual override)` | Fan is off; manual override still in effect (user turned off before grace expired) |
-| `running (untracked)` | Thermostat reports fan running (`fan_mode=on` or `hvac_action=fan`) but `_fan_active=False` — typical after HA restart or user-initiated fan run from thermostat app |
+| `running (untracked)` | Fan is physically running but `_fan_active=False`. Detection path depends on fan mode: **HVAC/Both** — thermostat reports `fan_mode=on` or `hvac_action=fan`; **WHF/Both** — `_get_fan_physical_state()` reads `fan_state_entity` (Type 2) or `fan_entity` (Type 1). Typical after HA restart or user-initiated run from thermostat/wall switch. Returns `"inactive"` instead when `fan_state_feedback=False` (command-only mode, no physical feedback sensor). *(WHF fallback added Issue #363.)* |
 
 The sensor also exposes these attributes:
 - `fan_runtime_minutes` — minutes since the integration last activated the fan (0.0 when inactive or in override)

--- a/tests/test_whf_dual_entity.py
+++ b/tests/test_whf_dual_entity.py
@@ -30,7 +30,13 @@ if "homeassistant" not in sys.modules:
 
 sys.modules["homeassistant.util.dt"].now = lambda: datetime(2026, 6, 28, 8, 0, 0)
 
-from custom_components.climate_advisor.const import CONF_FAN_ENTITY, CONF_FAN_STATE_ENTITY  # noqa: E402
+from custom_components.climate_advisor.const import (  # noqa: E402
+    CONF_FAN_ENTITY,
+    CONF_FAN_MODE,
+    CONF_FAN_STATE_ENTITY,
+    CONF_FAN_STATE_FEEDBACK,
+    FAN_MODE_WHOLE_HOUSE,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -273,3 +279,125 @@ class TestWHFDualEntity:
 
         ae.on_fan_turned_off.assert_called_once()
         ae.handle_fan_manual_override.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TestComputeFanStatusWHF
+# ---------------------------------------------------------------------------
+
+
+class TestComputeFanStatusWHF:
+    """Tests for WHF ground-truth fallback in _compute_fan_status() (Issue #363)."""
+
+    def _make_whf_coord(self, config: dict) -> MagicMock:
+        """Build a coord stub for _compute_fan_status tests with CA flags all clear."""
+        coord = _make_coord_stub(config)
+        ae = coord.automation_engine
+        ae._fan_active = False
+        ae._fan_override_active = False
+        ae._natural_vent_active = False
+        ae.config = config
+        return coord
+
+    def test_type2_status_running_untracked_when_state_entity_on(self):
+        """Type 2: binary_sensor on + CA flags clear → 'running (untracked)'."""
+        config = {
+            CONF_FAN_ENTITY: "switch.whf_command",
+            CONF_FAN_STATE_ENTITY: "binary_sensor.whf_running",
+            CONF_FAN_MODE: FAN_MODE_WHOLE_HOUSE,
+            CONF_FAN_STATE_FEEDBACK: True,
+        }
+        coord = self._make_whf_coord(config)
+
+        def _states_get(entity_id):
+            if entity_id == "binary_sensor.whf_running":
+                return _make_fake_state("on")
+            if entity_id == "switch.whf_command":
+                return _make_fake_state("off")
+            return None
+
+        coord.hass.states.get = MagicMock(side_effect=_states_get)
+
+        mod = importlib.import_module("custom_components.climate_advisor.coordinator")
+        compute = types.MethodType(mod.ClimateAdvisorCoordinator._compute_fan_status, coord)
+        get_physical = types.MethodType(mod.ClimateAdvisorCoordinator._get_fan_physical_state, coord)
+        feedback_enabled = types.MethodType(mod.ClimateAdvisorCoordinator._fan_state_feedback_enabled, coord)
+        coord._compute_fan_status = compute
+        coord._get_fan_physical_state = get_physical
+        coord._fan_state_feedback_enabled = feedback_enabled
+
+        result = compute()
+        assert result == "running (untracked)"
+
+    def test_type2_status_inactive_when_state_entity_off(self):
+        """Type 2: binary_sensor off + CA flags clear → 'inactive'."""
+        config = {
+            CONF_FAN_ENTITY: "switch.whf_command",
+            CONF_FAN_STATE_ENTITY: "binary_sensor.whf_running",
+            CONF_FAN_MODE: FAN_MODE_WHOLE_HOUSE,
+            CONF_FAN_STATE_FEEDBACK: True,
+        }
+        coord = self._make_whf_coord(config)
+
+        def _states_get(entity_id):
+            if entity_id == "binary_sensor.whf_running":
+                return _make_fake_state("off")
+            return _make_fake_state("off")
+
+        coord.hass.states.get = MagicMock(side_effect=_states_get)
+
+        mod = importlib.import_module("custom_components.climate_advisor.coordinator")
+        compute = types.MethodType(mod.ClimateAdvisorCoordinator._compute_fan_status, coord)
+        get_physical = types.MethodType(mod.ClimateAdvisorCoordinator._get_fan_physical_state, coord)
+        feedback_enabled = types.MethodType(mod.ClimateAdvisorCoordinator._fan_state_feedback_enabled, coord)
+        coord._compute_fan_status = compute
+        coord._get_fan_physical_state = get_physical
+        coord._fan_state_feedback_enabled = feedback_enabled
+
+        result = compute()
+        assert result == "inactive"
+
+    def test_type1_status_running_untracked_when_fan_entity_on(self):
+        """Type 1 (no fan_state_entity): fan_entity on + CA flags clear → 'running (untracked)'."""
+        config = {
+            CONF_FAN_ENTITY: "switch.whf_command",
+            CONF_FAN_MODE: FAN_MODE_WHOLE_HOUSE,
+            CONF_FAN_STATE_FEEDBACK: True,
+        }
+        coord = self._make_whf_coord(config)
+
+        coord.hass.states.get = MagicMock(return_value=_make_fake_state("on"))
+
+        mod = importlib.import_module("custom_components.climate_advisor.coordinator")
+        compute = types.MethodType(mod.ClimateAdvisorCoordinator._compute_fan_status, coord)
+        get_physical = types.MethodType(mod.ClimateAdvisorCoordinator._get_fan_physical_state, coord)
+        feedback_enabled = types.MethodType(mod.ClimateAdvisorCoordinator._fan_state_feedback_enabled, coord)
+        coord._compute_fan_status = compute
+        coord._get_fan_physical_state = get_physical
+        coord._fan_state_feedback_enabled = feedback_enabled
+
+        result = compute()
+        assert result == "running (untracked)"
+
+    def test_command_only_mode_returns_inactive(self):
+        """command-only mode (fan_state_feedback=False): _get_fan_physical_state returns None → 'inactive'."""
+        config = {
+            CONF_FAN_ENTITY: "switch.whf_command",
+            CONF_FAN_MODE: FAN_MODE_WHOLE_HOUSE,
+            CONF_FAN_STATE_FEEDBACK: False,
+        }
+        coord = self._make_whf_coord(config)
+
+        # fan_entity appears on, but feedback is disabled — should not count as running
+        coord.hass.states.get = MagicMock(return_value=_make_fake_state("on"))
+
+        mod = importlib.import_module("custom_components.climate_advisor.coordinator")
+        compute = types.MethodType(mod.ClimateAdvisorCoordinator._compute_fan_status, coord)
+        get_physical = types.MethodType(mod.ClimateAdvisorCoordinator._get_fan_physical_state, coord)
+        feedback_enabled = types.MethodType(mod.ClimateAdvisorCoordinator._fan_state_feedback_enabled, coord)
+        coord._compute_fan_status = compute
+        coord._get_fan_physical_state = get_physical
+        coord._fan_state_feedback_enabled = feedback_enabled
+
+        result = compute()
+        assert result == "inactive"


### PR DESCRIPTION
## Summary

- Adds a WHF physical-state fallback to `_compute_fan_status()` so when CA's flags are clear but the fan is physically running, the fan status sensor shows `"running (untracked)"` instead of `"inactive"`
- Calls the existing `_get_fan_physical_state()` helper which already handles Type 1 (`fan_entity`) and Type 2 (`fan_state_entity`) correctly
- Command-only mode (`fan_state_feedback=False`) returns `None` from the helper; `physical_on is True` guard ensures this falls through to `"inactive"` correctly
- Closes the scope gap noted in `KNOWN_FIXES[359]`

## Test plan

- [ ] `pytest tests/test_whf_dual_entity.py -v` — 13 tests pass (9 existing + 4 new `TestComputeFanStatusWHF`)
- [ ] `pytest tests/test_version_sync.py` — versions match (0.4.42)
- [ ] Full fan suite (`pytest -k fan`) — 316 tests pass, no regressions