### PR TITLE
Fix #365: fan status 'running (manual override)' when WHF physically on under user control

### DIFF
--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,14 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.4.42"
+VERSION = "0.4.43"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.4.43": [
+        "Fix #365: Fan status now correctly shows 'running (manual override)' when the user"
+        " manually turns on a WHF and CA records it as an override (not adopted as nat-vent)."
+        " Previously showed 'off (manual override)' even though the fan was physically running.",
+    ],
     "0.4.42": [
         "Fix #363: WHF fan status sensor now shows 'running (untracked)' when the whole-house fan is"
         " physically on but CA's flags are clear — reads fan_state_entity (Type 2) or fan_entity"
@@ -544,6 +549,25 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    365: {
+        "version_fixed": "0.4.43",
+        "title": "_compute_fan_status() showed 'off (manual override)' when fan physically running under override",
+        "scope_covered": (
+            "coordinator.py _compute_fan_status() override branch: when _fan_override_active=True"
+            " and _fan_active=False, calls _get_fan_physical_state() for FAN_MODE_WHOLE_HOUSE"
+            " and FAN_MODE_BOTH; returns 'running (manual override)' if physically on,"
+            " 'off (manual override)' if physically off. "
+            "tests/test_whf_dual_entity.py: TestComputeFanStatusOverride — 3 new tests. "
+            "docs/08-COMPUTATION-REFERENCE.md §9d updated."
+        ),
+        "scope_not_covered": (
+            "FAN_MODE_HVAC: no physical-state check added (HVAC fan physical state is read"
+            " from thermostat attributes, not a separate entity; existing ground-truth fallback"
+            " at priority 6 covers the untracked case for HVAC fans). "
+            "Command-only mode (fan_state_feedback=False): _get_fan_physical_state() returns"
+            " None; 'off (manual override)' remains the result."
+        ),
+    },
     363: {
         "version_fixed": "0.4.42",
         "title": "WHF _compute_fan_status() ground-truth fallback for fan_state_entity (Type 2)",

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -5418,7 +5418,15 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         if fan_mode == FAN_MODE_DISABLED:
             return "disabled"
         if ae._fan_override_active:
-            return "running (manual override)" if ae._fan_active else "off (manual override)"
+            if ae._fan_active:
+                return "running (manual override)"
+            # _fan_active=False: check physical state to distinguish
+            # "user is running it" from "user turned it on then off"
+            if fan_mode in (FAN_MODE_WHOLE_HOUSE, FAN_MODE_BOTH):
+                physical_on = self._get_fan_physical_state()
+                if physical_on is True:
+                    return "running (manual override)"
+            return "off (manual override)"
         if ae._fan_active:
             return "active"
         # Bug 3 (Issue #321): nat-vent session active but fan is idle between cycles

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.4.42"
+  "version": "0.4.43"
 }

--- a/docs/08-COMPUTATION-REFERENCE.md
+++ b/docs/08-COMPUTATION-REFERENCE.md
@@ -1386,8 +1386,8 @@ The `sensor.climate_advisor_fan_status` entity exposes one of six state strings:
 | `disabled` | Fan control is not configured (`fan_mode = disabled`) |
 | `inactive` | Fan is off; integration is in control |
 | `active` | Fan is on; integration activated it (nat-vent or economizer) |
-| `running (manual override)` | Fan is on; user turned it on manually — `_fan_override_active=True` |
-| `off (manual override)` | Fan is off; manual override still in effect (user turned off before grace expired) |
+| `running (manual override)` | Fan is physically on under manual override. Two sub-cases: (a) `_fan_active=True` (CA-owned flag set) — CA has a record of activating it; (b) `_fan_active=False` but physical state is on — user-owned run, CA recorded the override but did not adopt it as nat-vent. Both sub-cases report the same sensor value. *(Issue #365)* |
+| `off (manual override)` | `_fan_override_active=True` and `_fan_active=False` and physical state is off (or fan_mode is not WHF/BOTH). Override still in effect but the fan has been turned off before grace expired. *(Issue #365)* |
 | `running (untracked)` | Fan is physically running but `_fan_active=False`. Detection path depends on fan mode: **HVAC/Both** — thermostat reports `fan_mode=on` or `hvac_action=fan`; **WHF/Both** — `_get_fan_physical_state()` reads `fan_state_entity` (Type 2) or `fan_entity` (Type 1). Typical after HA restart or user-initiated run from thermostat/wall switch. Returns `"inactive"` instead when `fan_state_feedback=False` (command-only mode, no physical feedback sensor). *(WHF fallback added Issue #363.)* |
 
 The sensor also exposes these attributes:

--- a/tests/test_whf_dual_entity.py
+++ b/tests/test_whf_dual_entity.py
@@ -401,3 +401,114 @@ class TestComputeFanStatusWHF:
 
         result = compute()
         assert result == "inactive"
+
+
+# ---------------------------------------------------------------------------
+# TestComputeFanStatusOverride
+# ---------------------------------------------------------------------------
+
+
+class TestComputeFanStatusOverride:
+    """Tests for _compute_fan_status() override branch fix (Issue #365).
+
+    When _fan_override_active=True and _fan_active=False, the fan may still be
+    physically running (user manually turned it on but CA didn't adopt it as
+    nat-vent). The fix checks physical state to return "running (manual override)"
+    instead of the incorrect "off (manual override)".
+    """
+
+    def _make_override_coord(
+        self,
+        fan_mode: str,
+        fan_active: bool,
+        fan_override_active: bool,
+        physical_on: bool | None,
+        fan_state_entity: str | None = None,
+    ) -> MagicMock:
+        """Build a coord stub wired for _compute_fan_status tests."""
+        config: dict = {
+            CONF_FAN_ENTITY: "switch.whf_command",
+            CONF_FAN_MODE: fan_mode,
+        }
+        if fan_state_entity:
+            config[CONF_FAN_STATE_ENTITY] = fan_state_entity
+
+        coord = _make_coord_stub(config)
+        ae = coord.automation_engine
+        ae.config = {CONF_FAN_MODE: fan_mode}
+        ae._fan_active = fan_active
+        ae._fan_override_active = fan_override_active
+        ae._natural_vent_active = False
+
+        # Stub _get_fan_physical_state to return the desired physical result
+        coord._get_fan_physical_state = MagicMock(return_value=physical_on)
+
+        return coord
+
+    def test_override_active_fan_physically_on_returns_running(self):
+        """_fan_override_active=True, _fan_active=False, physical=on → 'running (manual override)'.
+
+        Scenario: user manually turned on WHF; CA recorded it as a manual override
+        (not adopted as nat-vent). Fan is physically running. Without the fix this
+        returned 'off (manual override)', misleading the occupant.
+        """
+        coord = self._make_override_coord(
+            fan_mode=FAN_MODE_WHOLE_HOUSE,
+            fan_active=False,
+            fan_override_active=True,
+            physical_on=True,
+            fan_state_entity="binary_sensor.whf_running",
+        )
+
+        mod = importlib.import_module("custom_components.climate_advisor.coordinator")
+        method = types.MethodType(mod.ClimateAdvisorCoordinator._compute_fan_status, coord)
+
+        result = method()
+        assert result == "running (manual override)", (
+            f"Expected 'running (manual override)' when fan is physically on under override, got {result!r}"
+        )
+        coord._get_fan_physical_state.assert_called_once()
+
+    def test_override_active_fan_physically_off_returns_off_override(self):
+        """_fan_override_active=True, _fan_active=False, physical=off → 'off (manual override)'.
+
+        Scenario: user turned the WHF on (triggering override), then turned it off
+        before the grace period expired. Override flag is still set, fan is physically off.
+        """
+        coord = self._make_override_coord(
+            fan_mode=FAN_MODE_WHOLE_HOUSE,
+            fan_active=False,
+            fan_override_active=True,
+            physical_on=False,
+            fan_state_entity="binary_sensor.whf_running",
+        )
+
+        mod = importlib.import_module("custom_components.climate_advisor.coordinator")
+        method = types.MethodType(mod.ClimateAdvisorCoordinator._compute_fan_status, coord)
+
+        result = method()
+        assert result == "off (manual override)", (
+            f"Expected 'off (manual override)' when fan is physically off under override, got {result!r}"
+        )
+
+    def test_override_active_fan_active_returns_running_regardless_of_physical(self):
+        """_fan_override_active=True, _fan_active=True → 'running (manual override)'.
+
+        CA owns the fan activation (_fan_active=True); physical state check is
+        not needed and must not be called.
+        """
+        coord = self._make_override_coord(
+            fan_mode=FAN_MODE_WHOLE_HOUSE,
+            fan_active=True,
+            fan_override_active=True,
+            physical_on=None,  # should not be consulted
+        )
+
+        mod = importlib.import_module("custom_components.climate_advisor.coordinator")
+        method = types.MethodType(mod.ClimateAdvisorCoordinator._compute_fan_status, coord)
+
+        result = method()
+        assert result == "running (manual override)", (
+            f"Expected 'running (manual override)' when _fan_active=True under override, got {result!r}"
+        )
+        coord._get_fan_physical_state.assert_not_called()


### PR DESCRIPTION
## Summary

- When user manually turns on a WHF and nat-vent eligibility fails, CA records `_fan_override_active=True` with `_fan_active=False` — previously always returned `"off (manual override)"` even though the fan was running
- In `_compute_fan_status()`, when `_fan_override_active=True` and `_fan_active=False`, now checks `_get_fan_physical_state()` for WHF modes; returns `"running (manual override)"` if physically on, `"off (manual override)"` only if physically off
- `FAN_MODE_HVAC`-only unaffected — no separate fan entity to read

## Test plan

- [ ] `pytest tests/test_whf_dual_entity.py -v` — 12 tests pass (9 existing + 3 new `TestComputeFanStatusOverride`)
- [ ] `pytest tests/test_version_sync.py` — versions match (0.4.43)
- [ ] `pytest -k fan` — 315 tests pass, no regressions