### PR TITLE
Feat #370: nat-vent bedtime continuation — fan runs to sleep target, stops at sleep_cool (v0.4.46)

### DIFF
--- a/custom_components/climate_advisor/ai_skills_activity.py
+++ b/custom_components/climate_advisor/ai_skills_activity.py
@@ -655,6 +655,32 @@ def _render_nat_vent_ac_assist_armed(p: dict, unit: str) -> tuple[str, str]:
     return "Nat-vent + AC assist armed (full band)", ""
 
 
+def _render_nat_vent_sleep_ceiling_reached(p: dict, unit: str) -> tuple[str, str]:
+    indoor = p.get("indoor_temp")
+    cool = p.get("sleep_cool")
+    label = "Nat-vent exit -- sleep ceiling reached"
+    if indoor is not None and cool is not None:
+        with contextlib.suppress(TypeError, ValueError):
+            label = (
+                f"Nat-vent exit (sleep) -- indoor {format_temp(float(indoor), unit)}"
+                f" <= sleep ceiling {format_temp(float(cool), unit)}"
+            )
+    return label, ""
+
+
+def _render_nat_vent_bedtime_continue(p: dict, unit: str) -> tuple[str, str]:
+    outdoor = p.get("outdoor_temp")
+    cool = p.get("sleep_cool")
+    label = "Nat-vent continues through bedtime"
+    if outdoor is not None and cool is not None:
+        with contextlib.suppress(TypeError, ValueError):
+            label = (
+                f"Nat-vent continues at bedtime -- outdoor {format_temp(float(outdoor), unit)}"
+                f" < sleep ceiling {format_temp(float(cool), unit)}"
+            )
+    return label, ""
+
+
 def _render_sensor_opened(p: dict, unit: str) -> tuple[str, str]:
     entity = p.get("entity", "")
     result = p.get("result", "")
@@ -855,6 +881,8 @@ EVENT_RENDERERS: dict[str, Callable[[dict, str], tuple[str, str]]] = {
     "nat_vent_predicted_floor_exit": _render_nat_vent_predicted_floor_exit,
     "nat_vent_ceiling_escalation": _render_nat_vent_ceiling_escalation,
     "nat_vent_ac_assist_armed": _render_nat_vent_ac_assist_armed,
+    "nat_vent_sleep_ceiling_reached": _render_nat_vent_sleep_ceiling_reached,
+    "nat_vent_bedtime_continue": _render_nat_vent_bedtime_continue,
     "sensor_opened": _render_sensor_opened,
     "sensor_all_closed": _render_sensor_all_closed,
     "nat_vent_forecast_skip": _render_nat_vent_forecast_skip,

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -2015,6 +2015,46 @@ class AutomationEngine:
                     )
             return
 
+        # Issue #370: Priority 0 — Sleep-ceiling exit. If nat-vent was allowed to continue
+        # past bedtime (via the continuation gate in handle_bedtime), stop the fan when
+        # indoor reaches the sleep target. Use restore_hvac=False — the sleep band is
+        # already programmed by handle_bedtime() and must not be overwritten.
+        if self._natural_vent_active and _in_sleep_window(dt_util.now(), self.config):
+            _c_sleep = self._current_classification
+            if _c_sleep is not None:
+                _sleep_band_exit = select_comfort_band(
+                    _c_sleep,
+                    self.config,
+                    occupancy_mode=self._occupancy_mode,
+                    in_sleep_window=True,
+                    aggressive_savings=bool(self.config.get("aggressive_savings", False)),
+                )
+                _indoor_sleep = self._get_indoor_temp_f()
+                if _indoor_sleep is not None and _indoor_sleep <= _sleep_band_exit.ceiling:
+                    self._natural_vent_active = False
+                    await self._deactivate_fan(
+                        reason=(
+                            f"nat-vent sleep ceiling reached: indoor {_indoor_sleep:.1f}°F"
+                            f" ≤ sleep_cool {_sleep_band_exit.ceiling:.1f}°F"
+                        ),
+                        restore_hvac=False,
+                    )
+                    _LOGGER.info(
+                        "Nat-vent sleep ceiling reached: indoor=%.1f°F ≤ sleep_cool=%.1f°F"
+                        " — fan deactivated, sleep band retained",
+                        _indoor_sleep,
+                        _sleep_band_exit.ceiling,
+                    )
+                    if self._emit_event_callback:
+                        self._emit_event_callback(
+                            "nat_vent_sleep_ceiling_reached",
+                            {
+                                "indoor_temp": _indoor_sleep,
+                                "sleep_cool": _sleep_band_exit.ceiling,
+                            },
+                        )
+                    return
+
         # Issue #99: Comfort-floor exit — check BEFORE outdoor warmth to avoid conflicting
         # transitions. If indoor drops to comfort_heat, stop fan and restore heat.
         # Do NOT enter pause — the house needs to warm up, not wait for nat vent re-evaluation.
@@ -3002,21 +3042,19 @@ class AutomationEngine:
         _LOGGER.warning("Bedtime setback: clearing any pending override state before applying sleep setback")
         self.clear_manual_override(reason="bedtime")
 
-        # Deactivate fan at bedtime (fan running overnight is noisy/wasteful)
-        if self._fan_active and not self._fan_override_active:
-            await self._deactivate_fan(reason="bedtime — fan off for night")
-        if self._economizer_active:
-            await self._deactivate_economizer(outdoor_temp=0)
-
         c = self._current_classification
         if not c:
             if self._today_record is not None:
                 self._today_record.setback_skipped_reason = "no_classification"
+            # No sleep target available — deactivate fan unconditionally
+            if self._fan_active and not self._fan_override_active:
+                await self._deactivate_fan(reason="bedtime — no classification")
+                self._natural_vent_active = False
+            if self._economizer_active:
+                await self._deactivate_economizer(outdoor_temp=0)
             return
 
-        # Arm the sleep band — the thermostat holds both edges through the night.
-        # Note: adaptive compute_bedtime_setback depth is a follow-up (P3 follow-up documented);
-        # for now the band uses configured sleep_heat/sleep_cool which are the standard sleep setpoints.
+        # Compute sleep band first — needed for the nat-vent continuation gate below.
         _sleep_band = select_comfort_band(
             c,
             self.config,
@@ -3024,6 +3062,31 @@ class AutomationEngine:
             in_sleep_window=True,
             aggressive_savings=bool(self.config.get("aggressive_savings", False)),
         )
+
+        # Issue #370: Nat-vent continuation gate — if nat-vent is actively running and
+        # outdoor air is below the sleep ceiling, allow free cooling to continue to the
+        # sleep target instead of deactivating the fan and handing off to the compressor.
+        # Applies to all fan archetypes (WHF, HVAC fan, BOTH).
+        _outdoor_370 = self._last_outdoor_temp
+        _nat_vent_can_reach = (
+            self._natural_vent_active
+            and self._fan_active
+            and not self._fan_override_active
+            and _outdoor_370 is not None
+            and _outdoor_370 < _sleep_band.ceiling
+        )
+        if _nat_vent_can_reach:
+            _LOGGER.info(
+                "Nat-vent continues at bedtime: outdoor=%.1f°F below sleep_cool=%.1f°F — fan runs to sleep target",
+                _outdoor_370,
+                _sleep_band.ceiling,
+            )
+        else:
+            if self._fan_active and not self._fan_override_active:
+                await self._deactivate_fan(reason="bedtime — nat-vent not favorable for continuation")
+                self._natural_vent_active = False
+        if self._economizer_active:
+            await self._deactivate_economizer(outdoor_temp=0)
         if self._emit_event_callback:
             self._emit_event_callback(
                 "bedtime_setback",
@@ -3033,6 +3096,14 @@ class AutomationEngine:
                     "ceiling": _sleep_band.ceiling,
                     "active": _sleep_band.active,
                     "modifier": c.setback_modifier,
+                },
+            )
+        if _nat_vent_can_reach and self._emit_event_callback:
+            self._emit_event_callback(
+                "nat_vent_bedtime_continue",
+                {
+                    "outdoor_temp": _outdoor_370,
+                    "sleep_cool": _sleep_band.ceiling,
                 },
             )
         if self._today_record is not None:

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,15 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.4.45"
+VERSION = "0.4.46"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.4.46": [
+        "Feat #370: Nat-vent (WHF/HVAC fan) now continues past bedtime when outdoor air"
+        " is below the sleep target — free cooling closes the gap before handing off to"
+        " the compressor. Fan stops automatically when indoor reaches sleep_cool."
+        " Fixes stale _natural_vent_active flag after bedtime fan deactivation.",
+    ],
     "0.4.45": [
         "Fix #369: add diagnostic logging to nat-vent paused-by-door reactivation gate.",
     ],
@@ -557,6 +563,27 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    370: {
+        "version_fixed": "0.4.46",
+        "title": "Bedtime setback + WHF/nat-vent: fan blindly deactivated even when outdoor below sleep target",
+        "scope_covered": (
+            "automation.py handle_bedtime(): compute sleep band before fan block; gate preserves"
+            " nat-vent (all archetypes) when _natural_vent_active AND outdoor < sleep_cool."
+            " automation.py check_natural_vent_conditions(): Priority 0 sleep-ceiling exit fires"
+            " when in_sleep_window AND indoor <= sleep_cool; calls _deactivate_fan(restore_hvac=False)"
+            " and clears _natural_vent_active. State inconsistency fix: _natural_vent_active cleared"
+            " on bedtime fan deactivation (was left True when _deactivate_fan ran)."
+            " New activity-log events: nat_vent_bedtime_continue, nat_vent_sleep_ceiling_reached."
+        ),
+        "scope_not_covered": (
+            "Nat-vent activation at bedtime when not already active (separate activation question)."
+            " outdoor == sleep_cool exactly: gate uses strict <, fan deactivates (conservative)."
+            " Priority 0 sleep-ceiling exit requires sleep_time/wake_time to be configured —"
+            " _in_sleep_window() returns False without them; fan runs to comfort_heat instead of"
+            " sleep_cool for users with sleep_cool set but no sleep schedule."
+            " Multi-zone scope not covered."
+        ),
+    },
     369: {
         "version_fixed": "0.4.45",
         "title": "Nat-vent paused-by-door reactivation — diagnostic logging",

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.4.45"
+  "version": "0.4.46"
 }

--- a/docs/07-AUTOMATION-FLOWCHART.md
+++ b/docs/07-AUTOMATION-FLOWCHART.md
@@ -16,7 +16,7 @@ For temperature formulas and threshold values see [docs/08-COMPUTATION-REFERENCE
 | How does the door/window pause flow work from sensor open to HVAC off? | Sensor open → debounce timer (default 5 min) → verify still open → check grace, planned window period → **check nat-vent first** (if outdoor cooler than indoor, fan on, band stays armed, no shutoff) → if nat-vent gates fail: set `_hvac_command_pending` → HVAC off + notification. | [§4. Door/Window Pause Flow](07-AUTOMATION-FLOWCHART.md#4-doorwindow-pause-flow) |
 | When a grace period expires, what prevents it from blindly restoring HVAC? | `_grace_expired()` calls `_re_pause_for_open_sensor()`, which checks `_is_within_planned_window_period()` before re-pausing — sensors open in a recommended window period are not re-paused. | [§4b. Grace Expiry with Planned Window Period Check](07-AUTOMATION-FLOWCHART.md#4b-grace-expiry-with-planned-window-period-check) |
 | How does manual override protection work — what sets it and what clears it? | `_async_thermostat_changed()` detects mode changes not preceded by `_hvac_command_pending`; starts a **10-min confirmation window** (`_override_confirm_pending = True`). If thermostat is still divergent after the window (PATH A), sets `_manual_override_active = True` and starts grace. If it self-reverted (PATH B), no grace. Cleared at wakeup or bedtime schedule boundary. | [§5. Manual Override Protection](07-AUTOMATION-FLOWCHART.md#5-manual-override-protection) |
-| What are the natural ventilation exit conditions and in what order are they checked? | Priority order: all sensors closed → comfort floor exit (indoor ≤ comfort_heat) → outdoor-rise exit (outdoor ≥ indoor) → ceiling threshold exit (outdoor > comfort_cool + delta). First match wins. | [§12b. Continuous Monitoring](07-AUTOMATION-FLOWCHART.md#12b-continuous-monitoring-check_natural_vent_conditions) |
+| What are the natural ventilation exit conditions and in what order are they checked? | Priority order: **0** sleep-ceiling reached (sleep window + indoor ≤ sleep_cool) → **1** all sensors closed → **2** comfort floor exit (indoor ≤ comfort_heat) → **3** outdoor-rise exit (outdoor ≥ indoor) → **4** ceiling threshold exit (outdoor > comfort_cool + delta). First match wins. | [§12b. Continuous Monitoring](07-AUTOMATION-FLOWCHART.md#12b-continuous-monitoring-check_natural_vent_conditions) |
 | What HVAC state does `_apply_nat_vent_hvac_state()` arm when nat-vent activates, and how does `aggressive_savings` change it? | `FAN_MODE_HVAC` + `aggressive_savings=False` → full comfort band `[comfort_heat, comfort_cool]` (compressor can assist if breeze can't hold ceiling). `FAN_MODE_HVAC` + `aggressive_savings=True` → heat-only at `comfort_heat` (floor protected, ceiling disarmed — no compressor through open windows). `WHOLE_HOUSE` or `DISABLED` → no-op. | [§12c. Nat-Vent HVAC State](07-AUTOMATION-FLOWCHART.md#12c-nat-vent-hvac-state--_apply_nat_vent_hvac_state) |
 | How does occupancy priority resolve when multiple toggles are active? | Guest > Vacation > Home/Away > default (home). `_compute_occupancy_mode()` in the coordinator reads all three toggle states and dispatches to the matching handler. | [§9. Occupancy State Machine](07-AUTOMATION-FLOWCHART.md#9-occupancy-state-machine) |
 | Where is the full Tier 3 spec for grace periods — state transitions, timer lifecycle, invariants, HA-restart behavior? | The Territory spec covers both grace types, the 12-row transition table, pre-pause mode storage/restoration, occupancy interaction, and error conditions including sensor-unavailable-during-pause. | [Grace Period State Machine — Territory Spec](grace-periods-spec.md) |
@@ -301,18 +301,23 @@ graph TD
 
 Fan and economizer state are explicitly managed at the two main daily schedule boundaries: bedtime and morning wakeup. `clear_manual_override()` calls `clear_fan_override()` internally, so both override flags are cleared together at each boundary.
 
+**Nat-vent continuation gate (Issue #370):** At bedtime, if nat-vent is active and outdoor air is still cooler than the sleep target, the fan is allowed to continue past bedtime rather than being stopped unconditionally. The fan stops when `check_natural_vent_conditions()` detects the sleep ceiling has been reached (Priority 0 exit — see §12b).
+
 ```mermaid
 graph TD
     A[10:30 PM - Bedtime fires] --> B[clear_manual_override]
     B --> C[clear_fan_override\n_fan_override_active = False]
     C --> D{Economizer currently active?}
     D -->|Yes| E[_deactivate_economizer\nRestore normal AC mode]
-    D -->|No| F{Fan currently running\nvia automation?}
+    D -->|No| F{Fan currently running\nvia automation?\n_natural_vent_active AND _fan_active\nAND NOT _fan_override_active}
     E --> F
-    F -->|Yes| G[Deactivate fan\nSet fan to auto/off]
     F -->|No| H[No fan action needed]
-    G --> I[Apply bedtime setback temp]
+    F -->|Yes| NV{Nat-vent continuation gate:\noutdoor < sleep_band.ceiling?}
+    NV -->|Yes| NVC[Emit nat_vent_bedtime_continue\nFan stays running\nno _deactivate_fan call\n_natural_vent_active stays True]
+    NV -->|No| G[_deactivate_fan\n_natural_vent_active = False]
+    G --> I[Apply bedtime setback\nsleep band programmed]
     H --> I
+    NVC --> I
 
     J[6:30 AM - Wakeup fires] --> K[clear_manual_override]
     K --> L[clear_fan_override\n_fan_override_active = False]
@@ -483,7 +488,9 @@ This check runs on every coordinator update while nat vent is active or paused. 
 ```mermaid
 flowchart TD
     A{State?} -->|Neither active nor paused| Z[Return — no action]
-    A -->|Natural vent active| B{All sensors closed?}
+    A -->|Natural vent active| P0{Priority 0: sleep window\nAND indoor ≤ sleep_cool?}
+    P0 -->|Yes| P0A[nat_vent_sleep_ceiling_reached\n_deactivate_fan restore_hvac=False\n_natural_vent_active = False\nSleep band retained]
+    P0 -->|No| B{All sensors closed?}
     B -->|Yes| C[Exit nat vent\nResume HVAC from classification]
     B -->|No| D{indoor ≤ comfort_heat?}
     D -->|Yes| E[nat_vent_comfort_floor_exit\nRestore heat at comfort_heat]
@@ -499,6 +506,8 @@ flowchart TD
     N --> N2[_apply_nat_vent_hvac_state\nSee §12c]
     M -->|Any no| O[Stay paused\nRe-check next coordinator update]
 ```
+
+**Priority 0 note (Issue #370):** The sleep-ceiling exit fires only when nat-vent continued past bedtime via the `nat_vent_bedtime_continue` gate (§7). `_deactivate_fan(restore_hvac=False)` is used — the sleep band bedtime already programmed must not be overwritten by an HVAC restore.
 
 **Hysteresis note:** The 1°F gap in the re-activation check (`outdoor < indoor - 1°F`) and the 300-second lockout timer together prevent rapid oscillation when outdoor and indoor temperatures are near equilibrium. Without both guards, a small thermal fluctuation could toggle nat vent on and off multiple times within a single hour.
 

--- a/docs/08-COMPUTATION-REFERENCE.md
+++ b/docs/08-COMPUTATION-REFERENCE.md
@@ -24,6 +24,7 @@ The automation logic table and all threshold constants in this document are expr
 | What temperature thresholds map to each day type? | HOT ≥ 85°F, WARM ≥ 75°F, MILD ≥ 60°F, COOL ≥ 45°F, COLD < 45°F; all thresholds are °F constants in `const.py`. | [§1. Day Classification](08-COMPUTATION-REFERENCE.md#1-day-classification) |
 | How is the setback modifier computed and what values can it take? | `avg_delta = ((tomorrow_high − today_high) + (tomorrow_low − today_low)) / 2`; modifier ranges from −3.0 (strong warming) to +3.0 (significant cold front); stable trend → 0. | [§3. Setback Modifier](08-COMPUTATION-REFERENCE.md#3-setback-modifier) |
 | What is the bedtime setpoint formula and when does the thermal model change it? | Default: `comfort_heat − 4°F` (heat) / `comfort_cool + 3°F` (cool). When thermal model confidence ≥ "low", `compute_bedtime_setback()` scales depth from `heating_rate_f_per_hour × recovery_window_hours`, clamped to `[MIN_SETBACK_DEPTH, MAX_SETBACK_DEPTH]`. | [§5a. Adaptive Bedtime Setback](08-COMPUTATION-REFERENCE.md#5a-adaptive-bedtime-setback-compute_bedtime_setback) |
+| When does nat-vent continue past bedtime instead of stopping, and what stops it afterward? | When nat-vent is active, the fan is CA-owned, and `outdoor < sleep_cool`, bedtime emits `nat_vent_bedtime_continue` and keeps the fan running. The fan stops when `check_natural_vent_conditions()` detects `indoor ≤ sleep_cool` in the sleep window (Priority 0 exit, event `nat_vent_sleep_ceiling_reached`). | [§5a nat-vent continuation gate](08-COMPUTATION-REFERENCE.md#5a-adaptive-bedtime-setback-compute_bedtime_setback) · [Exit Hierarchy Priority 0](08-COMPUTATION-REFERENCE.md#exit-hierarchy) |
 | When and how does CA pre-cool the home on warming-trend nights? | Mid-night trigger (nat-vent close + 30 min, or wake − 4 h fallback); target = `sleep_cool + setback_modifier` floored at `comfort_heat + 2°F`. AC suppressed if nat-vent already reached target. Morning guard emits `pre_cool_overshoot` if indoor < `comfort_heat` at wake-up. | [§5a-i. Overnight Pre-Cool Phase](08-COMPUTATION-REFERENCE.md#5a-i-overnight-pre-cool-phase-issue-258) |
 | How does the physics ODE predict future indoor temperature? | `T(t+dt) = T_outdoor + (T − T_outdoor) × exp(k_p × dt) + (Q/k_p) × (exp(k_p × dt) − 1)`, where Q switches between k_active_heat, k_active_cool, and 0 per schedule period. | [§5c. Predicted Temperature Graph — Physics Path](08-COMPUTATION-REFERENCE.md#5c-predicted-temperature-graph--physics-path) |
 | What is the dynamic target band and how does occupancy mode change it? | `_compute_target_band_schedule()` returns `[{ts, lower, upper}]` per forecast hour; away = setback today only, vacation = deep setback all days, home/guest = comfort with sleep/wake ramps. | [§5d. Dynamic Target Band](08-COMPUTATION-REFERENCE.md#5d-dynamic-target-band--_compute_target_band_schedule) |
@@ -162,6 +163,8 @@ Bedtime setback depth is computed from the thermal model HVAC rates and the over
 `setback_modifier` is always added to the heat setback result regardless of whether the model or the fallback was used.
 
 **Cool-mode sign convention (Issue #258):** For cool-mode nights, `setback_modifier < 0` means a warming trend — the next day will be hotter. The modifier is applied as `sleep_cool + setback_modifier`, which _lowers_ the cool ceiling (more aggressive cooling, thermal mass banking). A _positive_ modifier (cooling trend) _raises_ the ceiling (relaxed setback, AC cycles less). No sign flip is applied in cool mode.
+
+**Nat-vent continuation gate at bedtime (Issue #370):** `handle_bedtime()` evaluates the sleep band before deciding whether to deactivate the fan. When nat-vent is active (`_natural_vent_active=True`), the fan is running under CA control (`_fan_active=True`), no manual override is in effect, and `outdoor_temp < sleep_band.ceiling` (outdoor air is still cooler than the sleep target), bedtime skips fan deactivation and emits `nat_vent_bedtime_continue`. The fan continues until `check_natural_vent_conditions()` detects the sleep ceiling has been reached (see Priority 0 exit in §check_natural_vent_conditions below). If any gate fails, `_deactivate_fan()` is called and `_natural_vent_active` is cleared to `False`. This applies to all fan archetypes (WHF, HVAC fan, BOTH).
 
 ### 5a-i. Overnight Pre-Cool Phase (Issue #258)
 
@@ -1803,14 +1806,17 @@ When all conditions are met: the comfort band **stays armed** (HVAC is **not** s
 
 Exit conditions are evaluated in priority order on every continuous-monitoring check (`check_natural_vent_conditions()`). The highest-priority matching condition wins.
 
-| Priority | Trigger | Action | Event emitted |
-|---|---|---|---|
-| 1 | All monitored sensors close | Exit nat vent; resume HVAC from current classification | — |
-| 2 | `indoor_temp ≤ comfort_heat` | Exit; restore heat mode at `comfort_heat` (Issue #99 comfort floor exit) | `nat_vent_comfort_floor_exit` |
-| 3 | `outdoor_temp ≥ indoor_temp` | Exit to paused state; fan off; start hysteresis lockout timer | `nat_vent_outdoor_rise_exit` |
-| 4 | `outdoor_temp > comfort_cool + nat_vent_delta` | Exit to paused state; fan off | — |
+| Priority | Trigger | Condition | Action | Event emitted | Notes |
+|---|---|---|---|---|---|
+| 0 | Sleep ceiling reached (sleep window only) | `_in_sleep_window AND indoor_temp ≤ sleep_cool` | `_deactivate_fan(restore_hvac=False)`; `_natural_vent_active = False` | `nat_vent_sleep_ceiling_reached` | No HVAC restore — sleep band already programmed; nat-vent ran through bedtime and has reached its sleep target (Issue #370) |
+| 1 | All monitored sensors close | — | Exit nat vent; resume HVAC from current classification | — | — |
+| 2 | `indoor_temp ≤ comfort_heat` | — | Exit; restore heat mode at `comfort_heat` (Issue #99 comfort floor exit) | `nat_vent_comfort_floor_exit` | — |
+| 3 | `outdoor_temp ≥ indoor_temp` | — | Exit to paused state; fan off; start hysteresis lockout timer | `nat_vent_outdoor_rise_exit` | — |
+| 4 | `outdoor_temp > comfort_cool + nat_vent_delta` | — | Exit to paused state; fan off | — | — |
 
-**Priority 1 (sensor closes)** always wins. When the physical path for airflow is closed, nat vent ends immediately regardless of outdoor temperature comparisons.
+**Priority 0 (sleep ceiling reached)** fires only during the sleep window and only when nat-vent continued past bedtime via the `nat_vent_bedtime_continue` gate (§5a). `_deactivate_fan(restore_hvac=False)` is used so the sleep band that bedtime already programmed is preserved — a full HVAC restore would overwrite the sleep setpoints with the classification's daytime band.
+
+**Priority 1 (sensor closes)** always wins outside the sleep-ceiling context. When the physical path for airflow is closed, nat vent ends immediately regardless of outdoor temperature comparisons.
 
 **Priority 2 (comfort floor)** restores heat rather than simply pausing. Once indoor temperature has dropped to `comfort_heat`, the right action is to heat the space back up, not to wait for outdoor conditions to change.
 

--- a/docs/activity-report-table.md
+++ b/docs/activity-report-table.md
@@ -11,7 +11,7 @@ _Introduced: Issue #330 (deterministic table) · Chart Vent bar: Issue #331_
 | How is the per-event table built — LLM or Python? | Deterministically in Python by `build_event_timeline_table()` in `ai_skills_activity.py`. Not LLM-generated. The AI still writes the summary, decisions, and anomalies sections. | [Overview](#overview) |
 | What do the Event, Settings, Indoor, and Outdoor columns mean? | Event = what happened. Settings = the concrete HVAC action (setpoint, mode, fan state). Indoor/Outdoor = ambient temperatures at event emit time, sourced from coordinator.data; `—` for events recorded before Issue #352. | [Overview](#overview) |
 | How does `_format_band_setpoint` render a setpoint? | Active edge first (the live thermostat setpoint), other edge in parens as the monitored bound: `setpoint: 72°F Cool (64°F Heat)`. | [Setpoint Convention](#setpoint-convention) |
-| What is the full set of event types the table must handle? | 38 registered types across 6 groups: band/setpoint-program, setpoint/mode delta, override lifecycle, nat-vent/fan, skip/advisory, system/diagnostic. | [Event Catalog](#event-catalog) |
+| What is the full set of event types the table must handle? | 40 registered types across 6 groups: band/setpoint-program, setpoint/mode delta, override lifecycle, nat-vent/fan, skip/advisory, system/diagnostic. | [Event Catalog](#event-catalog) |
 | What happens when an unrecognised event type appears? | `_default_renderer` fires: humanized type name + `reason` field as Event; generic field extraction as Settings. Never blank, never crashes. | [Default Renderer](#default-renderer) |
 | How does the table handle many consecutive band rows of the same type? | Consecutive same-type rows collapse to `{name} ×N ({start}–{end})` while preserving the shared Settings cell. | [Dedup Contract](#dedup-contract) |
 | How do I add or change an event renderer? | Four steps: emit with structured fields, add/update `EVENT_RENDERERS` entry, add catalog row here, add unit test. | [Runbook: Adding or Changing a Renderer](#runbook-adding-or-changing-a-renderer) |
@@ -85,7 +85,7 @@ the user's configured unit (°F or °C).
 One row per emitted event type. Emitters are `automation.py` (via
 `_emit_event_callback`) and `coordinator.py` (via `_emit_event`).
 
-Grouped by functional area. 34 registered types total.
+Grouped by functional area. 36 registered types total.
 
 ### Band / Setpoint-Program
 
@@ -136,6 +136,8 @@ These events signal a mode or setpoint change triggered by automation logic.
 | `nat_vent_comfort_floor_exit` | `automation.py` `_check_nat_vent_conditions` / `_check_nat_vent_cycling` | `indoor_temp`, `comfort_heat` | "Nat-vent exit — comfort floor reached" | `indoor: {indoor_temp}°F ≤ floor: {comfort_heat}°F; fan: off, heat restored` |
 | `nat_vent_away_ceiling_exit` | `automation.py` `_check_nat_vent_conditions` | `indoor`, `comfort_cool` | "Nat-vent exit — away ceiling" | `indoor: {indoor}°F ≥ ceiling: {comfort_cool}°F` |
 | `nat_vent_predicted_floor_exit` | `automation.py` `_check_nat_vent_conditions` | `time_to_floor_hr`, `fan_mode_change`, `hvac_mode_restored` | "Nat-vent proactive exit — floor predicted" | `floor in {time_to_floor_hr:.1f} hr; fan: {fan_mode_change}` |
+| `nat_vent_bedtime_continue` | `automation.py` `handle_bedtime` | `outdoor_temp`, `sleep_cool` | "Nat-vent continues at bedtime" | `outdoor: {outdoor_temp}°F < sleep target: {sleep_cool}°F; fan continues to sleep ceiling` |
+| `nat_vent_sleep_ceiling_reached` | `automation.py` `check_natural_vent_conditions` | `indoor_temp`, `sleep_cool` | "Nat-vent sleep ceiling reached" | `indoor: {indoor_temp}°F ≤ sleep target: {sleep_cool}°F; fan deactivated, sleep band retained` |
 | `nat_vent_ceiling_escalation` | `automation.py` `apply_classification` | `indoor`, `outdoor`, `comfort_cool` | "Nat-vent escalated to AC — ceiling breached" | `indoor: {indoor}°F > ceiling: {comfort_cool}°F; nat-vent ended, AC armed` |
 | `sensor_opened` | `automation.py` `handle_door_window_opened` | `entity`, `result` (natural_ventilation / paused), `hvac_mode_change`, optionally `fan_mode_change` | "Sensor opened — {entity}" with result label | `result: {result}; mode: {hvac_mode_change}` (+ `fan: {fan_mode_change}` if present) |
 | `sensor_all_closed` | `automation.py` `handle_all_doors_windows_closed` | `was_paused`, `was_nat_vent` | "All sensors closed" | `was paused: {was_paused}, was nat-vent: {was_nat_vent}` |

--- a/tests/test_bedtime_setback.py
+++ b/tests/test_bedtime_setback.py
@@ -18,6 +18,8 @@ from unittest.mock import AsyncMock, MagicMock
 from custom_components.climate_advisor.automation import AutomationEngine
 from custom_components.climate_advisor.classifier import DayClassification
 from custom_components.climate_advisor.const import (
+    FAN_MODE_HVAC,
+    FAN_MODE_WHOLE_HOUSE,
     OCCUPANCY_AWAY,
     OCCUPANCY_HOME,
     OCCUPANCY_VACATION,
@@ -488,3 +490,202 @@ class TestHandleBedtimeEventCallbackGuard:
         engine.set_occupancy_mode(OCCUPANCY_AWAY)
 
         asyncio.run(engine.handle_bedtime())
+
+
+# ── Issue #370: Nat-vent bedtime continuation gate ────────────────────────────
+
+
+def _make_nat_vent_engine(config_overrides: dict | None = None) -> AutomationEngine:
+    """Engine pre-wired for nat-vent bedtime continuation tests.
+
+    Sets up a warm-day classification (hvac_mode='off') so that
+    select_comfort_band() returns the sleep band with sleep_cool as ceiling.
+    """
+    hass = MagicMock()
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+    hass.async_create_task = MagicMock(side_effect=lambda coro: coro.close())
+    hass.states = MagicMock()
+
+    # Climate entity reports 73°F indoors by default
+    climate_state = MagicMock()
+    climate_state.state = "off"
+    climate_state.attributes = {"current_temperature": 73.0}
+    hass.states.get = MagicMock(return_value=climate_state)
+
+    config = {
+        "comfort_heat": 68.0,
+        "comfort_cool": 74.0,
+        "sleep_heat": 66.0,
+        "sleep_cool": 72.0,
+        "setback_heat": 60,
+        "setback_cool": 80,
+        "notify_service": "notify.notify",
+        "temp_unit": "fahrenheit",
+        "fan_mode": FAN_MODE_WHOLE_HOUSE,
+    }
+    if config_overrides:
+        config.update(config_overrides)
+
+    engine = AutomationEngine(
+        hass=hass,
+        climate_entity="climate.thermostat",
+        weather_entity="weather.forecast_home",
+        door_window_sensors=["binary_sensor.front_door"],
+        notify_service=config["notify_service"],
+        config=config,
+    )
+
+    # Attach a warm-day classification so sleep band resolves sleep_cool as ceiling
+    classification = _make_classification(hvac_mode="off", day_type="warm")
+    engine._current_classification = classification
+
+    return engine
+
+
+class TestNatVentBedtimeContinuation:
+    """Issue #370: nat-vent continuation gate in handle_bedtime().
+
+    When nat-vent is actively running and outdoor air is below the sleep ceiling,
+    handle_bedtime() must NOT deactivate the fan — free cooling should run until
+    indoor reaches the sleep target. The check_natural_vent_conditions() sleep-ceiling
+    exit (Priority 0) then handles the fan deactivation.
+
+    Occupant experience: on a mild evening, the fan keeps running quietly to cool the
+    house to the sleep temperature instead of shutting off and handing off to the
+    compressor — saving energy and reducing HVAC cycling noise.
+    """
+
+    def test_nat_vent_continues_when_outdoor_below_sleep_cool(self):
+        """Gate passes: outdoor 69°F < sleep_cool 72°F → fan preserved, event emitted.
+
+        Occupant experience: the whole-house fan stays on at bedtime because outdoor
+        air is cool enough to reach the sleep target — no compressor needed.
+        """
+        engine = _make_nat_vent_engine()
+        engine._natural_vent_active = True
+        engine._fan_active = True
+        engine._fan_override_active = False
+        engine._last_outdoor_temp = 69.0
+        engine._last_indoor_temp = 73.0
+
+        engine._deactivate_fan = AsyncMock()
+        engine._async_save_state = AsyncMock()
+
+        emitted: list[tuple] = []
+        engine._emit_event_callback = lambda name, payload: emitted.append((name, payload))
+        engine.set_occupancy_mode(OCCUPANCY_HOME)
+
+        asyncio.run(engine.handle_bedtime())
+
+        # Fan must NOT have been deactivated
+        engine._deactivate_fan.assert_not_called()
+
+        # nat_vent_bedtime_continue event must be present
+        event_names = [e[0] for e in emitted]
+        assert "nat_vent_bedtime_continue" in event_names, (
+            f"Expected 'nat_vent_bedtime_continue' event; got: {event_names}"
+        )
+
+        # Fan state preserved
+        assert engine._fan_active is True
+
+    def test_fan_deactivated_when_outdoor_above_sleep_cool(self):
+        """Gate fails: outdoor 74°F >= sleep_cool 72°F → fan deactivated.
+
+        Occupant experience: at bedtime, outdoor air is too warm to cool the house
+        further — the fan shuts off and the thermostat takes over with the sleep band.
+        """
+        engine = _make_nat_vent_engine()
+        engine._natural_vent_active = True
+        engine._fan_active = True
+        engine._fan_override_active = False
+        engine._last_outdoor_temp = 74.0  # >= sleep_cool=72
+        engine._last_indoor_temp = 73.0
+
+        engine._deactivate_fan = AsyncMock()
+        engine._async_save_state = AsyncMock()
+        engine.set_occupancy_mode(OCCUPANCY_HOME)
+
+        asyncio.run(engine.handle_bedtime())
+
+        # Fan MUST have been deactivated
+        engine._deactivate_fan.assert_called_once()
+
+        # _natural_vent_active must be cleared (state consistency fix)
+        assert engine._natural_vent_active is False
+
+    def test_fan_deactivated_when_nat_vent_not_active(self):
+        """Gate fails: nat-vent flag False → fan deactivated at bedtime as before.
+
+        Occupant experience: fan was running for some other reason (e.g., manual
+        override already ended), so bedtime correctly deactivates it.
+        """
+        engine = _make_nat_vent_engine()
+        engine._natural_vent_active = False
+        engine._fan_active = True
+        engine._fan_override_active = False
+        engine._last_outdoor_temp = 65.0  # outdoor is cool, but nat-vent not active
+
+        engine._deactivate_fan = AsyncMock()
+        engine._async_save_state = AsyncMock()
+        engine.set_occupancy_mode(OCCUPANCY_HOME)
+
+        asyncio.run(engine.handle_bedtime())
+
+        # Without nat-vent active, the gate cannot pass — fan is deactivated
+        engine._deactivate_fan.assert_called_once()
+
+    def test_nat_vent_active_flag_cleared_on_bedtime_deactivation(self):
+        """State consistency: _natural_vent_active=False after gate-fails deactivation.
+
+        Before Issue #370, the fan was deactivated but _natural_vent_active was left
+        True — causing the engine to believe nat-vent was still running after bedtime.
+
+        Occupant experience: without this fix, the next classification cycle would
+        incorrectly suppress HVAC as if nat-vent was providing free cooling.
+        """
+        engine = _make_nat_vent_engine()
+        engine._natural_vent_active = True
+        engine._fan_active = True
+        engine._fan_override_active = False
+        engine._last_outdoor_temp = 74.0  # gate fails: outdoor >= sleep_cool=72
+        engine._last_indoor_temp = 73.0
+
+        engine._deactivate_fan = AsyncMock()
+        engine._async_save_state = AsyncMock()
+        engine.set_occupancy_mode(OCCUPANCY_HOME)
+
+        asyncio.run(engine.handle_bedtime())
+
+        # State must be cleared — not left True after fan deactivation
+        assert engine._natural_vent_active is False
+
+    def test_hvac_fan_archetype_also_continues(self):
+        """Gate works for FAN_MODE_HVAC too — all archetypes are eligible.
+
+        Occupant experience: whether the fan is a whole-house fan or the HVAC
+        blower, bedtime continuation applies equally when outdoor is cool enough.
+        """
+        engine = _make_nat_vent_engine(config_overrides={"fan_mode": FAN_MODE_HVAC})
+        engine._natural_vent_active = True
+        engine._fan_active = True
+        engine._fan_override_active = False
+        engine._last_outdoor_temp = 69.0  # < sleep_cool=72 → gate passes
+        engine._last_indoor_temp = 73.0
+
+        engine._deactivate_fan = AsyncMock()
+        engine._async_save_state = AsyncMock()
+
+        emitted: list[tuple] = []
+        engine._emit_event_callback = lambda name, payload: emitted.append((name, payload))
+        engine.set_occupancy_mode(OCCUPANCY_HOME)
+
+        asyncio.run(engine.handle_bedtime())
+
+        # HVAC fan archetype: gate still passes, fan preserved
+        engine._deactivate_fan.assert_not_called()
+        event_names = [e[0] for e in emitted]
+        assert "nat_vent_bedtime_continue" in event_names, (
+            f"FAN_MODE_HVAC: expected 'nat_vent_bedtime_continue'; got: {event_names}"
+        )

--- a/tests/test_nat_vent_activation.py
+++ b/tests/test_nat_vent_activation.py
@@ -1450,3 +1450,128 @@ class TestNatVentSleepWindowBand:
             band = call[0][0]
             assert band.floor == 70.0, f"Awake band floor must be comfort_heat=70. Got: {band.floor}"
             assert band.ceiling == 75.0, f"Awake band ceiling must be comfort_cool=75. Got: {band.ceiling}"
+
+
+# ---------------------------------------------------------------------------
+# Issue #370 — Priority 0 sleep-ceiling exit in check_natural_vent_conditions
+# ---------------------------------------------------------------------------
+
+# Patched 'now' values for sleep-window tests
+_SLEEP_NOW = datetime(2026, 4, 20, 23, 15, 0)  # 23:15 — inside 22:00–07:00 window
+_AWAKE_NOW = datetime(2026, 4, 20, 14, 0, 0)  # 14:00 — outside sleep window
+
+
+def _make_sleep_ceiling_engine(
+    indoor_f: float = 71.0,
+    comfort_heat: float = 68.0,
+    comfort_cool: float = 76.0,
+    sleep_cool: float = 72.0,
+    sleep_heat: float = 66.0,
+    in_sleep_window: bool = True,
+) -> AutomationEngine:
+    """Engine pre-wired for Issue #370 sleep-ceiling exit tests.
+
+    Sets nat-vent active and positions indoor below sleep_cool so Priority 0
+    fires on the first check_natural_vent_conditions() call (when in sleep window).
+    """
+    engine = _make_engine(
+        comfort_heat=comfort_heat,
+        comfort_cool=comfort_cool,
+        indoor_f=indoor_f,
+    )
+    engine.config["sleep_cool"] = sleep_cool
+    engine.config["sleep_heat"] = sleep_heat
+
+    if in_sleep_window:
+        # 22:00–07:00 window encloses _SLEEP_NOW (23:15)
+        engine.config["sleep_time"] = "22:00"
+        engine.config["wake_time"] = "07:00"
+    # else: no sleep_time/wake_time → _in_sleep_window() returns False
+
+    # Nat-vent is active and running at entry
+    engine._natural_vent_active = True
+    engine._fan_active = True
+    engine._fan_override_active = False
+
+    # Attach a warm-day classification so select_comfort_band resolves the sleep band
+    engine._current_classification = _make_classification(day_type="warm", hvac_mode="off")
+
+    return engine
+
+
+class TestNatVentSleepCeilingExit:
+    """Issue #370: Priority 0 sleep-ceiling exit in check_natural_vent_conditions().
+
+    After handle_bedtime() allows nat-vent to continue past bedtime, the fan should
+    stop once indoor reaches (or is already at) the sleep ceiling. This is a NEW exit
+    path that fires BEFORE the existing comfort-floor exit (Priority 1).
+
+    Occupant experience: the fan runs quietly overnight until the room cools to the
+    sleep temperature, then stops on its own — no compressor needed, minimal noise.
+    """
+
+    def test_sleep_ceiling_exit_stops_fan_in_sleep_window(self):
+        """Priority 0 fires: indoor 71°F ≤ sleep_cool 72°F, in sleep window → fan off.
+
+        Occupant experience: the room has reached the sleep target — the fan stops
+        so the occupant sleeps without fan noise, and the thermostat sleep band
+        (already programmed by bedtime) guards against further cooling.
+        """
+        engine = _make_sleep_ceiling_engine(indoor_f=71.0, sleep_cool=72.0, in_sleep_window=True)
+        engine._deactivate_fan = AsyncMock()
+        engine._async_save_state = AsyncMock()
+
+        emitted: list[tuple] = []
+        engine._emit_event_callback = lambda name, payload: emitted.append((name, payload))
+
+        with patch(_DT_NOW_PATH, return_value=_SLEEP_NOW):
+            asyncio.run(engine.check_natural_vent_conditions())
+
+        # _deactivate_fan must be called with restore_hvac=False
+        engine._deactivate_fan.assert_called_once()
+        call_kwargs = engine._deactivate_fan.call_args[1]
+        assert call_kwargs.get("restore_hvac") is False, (
+            f"sleep-ceiling exit must pass restore_hvac=False; got: {call_kwargs}"
+        )
+
+        # _natural_vent_active must be cleared
+        assert engine._natural_vent_active is False, "_natural_vent_active must be False after sleep-ceiling exit"
+
+        # nat_vent_sleep_ceiling_reached event must be emitted
+        event_names = [e[0] for e in emitted]
+        assert "nat_vent_sleep_ceiling_reached" in event_names, (
+            f"Expected 'nat_vent_sleep_ceiling_reached'; got: {event_names}"
+        )
+
+    def test_sleep_ceiling_exit_not_fire_outside_sleep_window(self):
+        """Priority 0 skipped: same temps but outside sleep window → fan NOT deactivated.
+
+        Occupant experience: during daytime, nat-vent uses the normal comfort-floor
+        exit — if indoor is between comfort_heat and comfort_cool the fan stays on.
+        """
+        # indoor=71 > comfort_heat=68 and 71 < comfort_cool=76 → comfort-floor exit won't fire
+        # sleep-ceiling exit also won't fire (not in sleep window)
+        engine = _make_sleep_ceiling_engine(
+            indoor_f=71.0,
+            comfort_heat=68.0,
+            comfort_cool=76.0,
+            sleep_cool=72.0,
+            in_sleep_window=False,  # no sleep_time/wake_time → not in sleep window
+        )
+        engine._deactivate_fan = AsyncMock()
+        engine._async_save_state = AsyncMock()
+        # outdoor must satisfy the outdoor-rise guard too; set it well below indoor
+        engine._last_outdoor_temp = 62.0
+        engine._nat_vent_outdoor_exit_time = None
+
+        with patch(_DT_NOW_PATH, return_value=_AWAKE_NOW):
+            asyncio.run(engine.check_natural_vent_conditions())
+
+        # Sleep-ceiling exit is NOT applicable outside sleep window
+        # Comfort-floor exit also does not fire (indoor=71 > comfort_heat=68)
+        engine._deactivate_fan.assert_not_called()
+
+        # _natural_vent_active must remain True (fan still running)
+        assert engine._natural_vent_active is True, (
+            "_natural_vent_active must remain True outside sleep window when comfort is maintained"
+        )

--- a/tools/sim_harness/outcomes.py
+++ b/tools/sim_harness/outcomes.py
@@ -37,8 +37,10 @@ Mapped (production → legacy):
   sensor_all_closed  neither flag            → resumed
     (production always calls resumed; if nothing was happening this is still
      a resumed decision — mirrors simulate.py _handle_all_closed)
-  nat_vent_comfort_floor_exit   → nat_vent_comfort_floor_exit
-  nat_vent_outdoor_rise_exit    → nat_vent_outdoor_rise_exit
+  nat_vent_comfort_floor_exit      → nat_vent_comfort_floor_exit
+  nat_vent_outdoor_rise_exit       → nat_vent_outdoor_rise_exit
+  nat_vent_bedtime_continue        → nat_vent_bedtime_continue        (Issue #370 — gate passed, fan continues)
+  nat_vent_sleep_ceiling_reached   → nat_vent_sleep_ceiling_reached   (Issue #370 — indoor ≤ sleep_cool in window)
   bedtime_setback               → setback_applied
     (P3 payload changed: was {target_f}; now {mode, floor, ceiling, active,
      modifier}.  target_temp = floor when active="floor"; ceiling when
@@ -312,6 +314,13 @@ def _map_event_to_outcome(
 
     if event_type == "nat_vent_outdoor_rise_exit":
         return ProductionDecision(ts_str, event_type, "nat_vent_outdoor_rise_exit")
+
+    # Issue #370: bedtime continuation and sleep-ceiling exit events
+    if event_type == "nat_vent_bedtime_continue":
+        return ProductionDecision(ts_str, event_type, "nat_vent_bedtime_continue")
+
+    if event_type == "nat_vent_sleep_ceiling_reached":
+        return ProductionDecision(ts_str, event_type, "nat_vent_sleep_ceiling_reached")
 
     # --- Nat-vent thermostat cycling events (Issue #321 Bug 3) ---
     if event_type == "nat_vent_fan_off":

--- a/tools/simulations/pending/bedtime_natvent_continuation.json
+++ b/tools/simulations/pending/bedtime_natvent_continuation.json
@@ -1,0 +1,85 @@
+{
+  "name": "bedtime_natvent_continuation",
+  "description": "Nat-vent active at bedtime with outdoor below sleep target — fan continues past bedtime, stops when indoor reaches sleep ceiling",
+  "source": "synthetic",
+  "issue": 370,
+  "simulator_support": true,
+  "track": "unit",
+  "notes": [
+    "Occupant outcome: On a warm evening the occupant opens windows; outdoor air (69°F) is cooler than indoors (73°F) and below the sleep target (72°F). At bedtime CA normally deactivates the fan — but with nat-vent continuation (Issue #370), the fan keeps running through the night. The occupant's home cools naturally to 72°F while they sleep, without the AC ever turning on.",
+    "Scenario effectiveness: If the nat-vent continuation gate is deleted from handle_bedtime(), bedtime unconditionally calls _deactivate_fan() and nat_vent_bedtime_continue is never emitted — the assertion at 22:30 fails. If the Priority 0 sleep-ceiling exit is deleted from check_natural_vent_conditions(), nat_vent_sleep_ceiling_reached is never emitted and the assertion at 01:00 fails.",
+    "Two-way alignment: handle_bedtime() evaluates sleep band before fan deactivation; gate condition is _natural_vent_active AND _fan_active AND NOT _fan_override_active AND outdoor < sleep_band.ceiling. check_natural_vent_conditions() Priority 0 fires when _in_sleep_window AND indoor <= sleep_cool, calls _deactivate_fan(restore_hvac=False), sets _natural_vent_active=False, emits nat_vent_sleep_ceiling_reached.",
+    "User outcome if test fails: Occupant loses free cooling past bedtime — CA shuts the fan off exactly at 22:30, running the AC unnecessarily to bring indoor to sleep temp instead of letting natural ventilation do the work for free.",
+    "Config note: sleep_cool=72 is explicitly set below. sleep_heat=64 provides the floor. comfort_cool=74 gives headroom so the outdoor temp (69°F) is below both comfort_cool and sleep_cool, satisfying the nat-vent continuation gate. sleep_time and wake_time are required — _in_sleep_window() returns False without them, so the Priority 0 sleep-ceiling exit would never fire. fan_mode=hvac is required — _activate_fan() returns early when fan_mode==disabled and never sets _fan_active=True, so the bedtime gate (which requires _fan_active) would always fail. The HVAC fan archetype uses set_fan_mode on the climate entity, which the headless harness supports without a separate fan_entity."
+  ],
+  "config": {
+    "comfort_heat": 68,
+    "comfort_cool": 74,
+    "sleep_heat": 64,
+    "sleep_cool": 72,
+    "sleep_time": "22:30",
+    "wake_time": "07:00",
+    "setback_heat": 60,
+    "setback_cool": 79,
+    "natural_vent_delta": 3.0,
+    "fan_mode": "hvac",
+    "initial_thermostat_mode": "cool"
+  },
+  "events": [
+    {
+      "time": "2026-07-20T20:00:00",
+      "type": "classification",
+      "day_type": "warm",
+      "hvac_mode": "cool",
+      "note": "Evening classification — warm day, comfort band armed at [68/74]."
+    },
+    {
+      "time": "2026-07-20T20:30:00",
+      "type": "temp_update",
+      "indoor_f": 73.0,
+      "outdoor_f": 69.0,
+      "note": "Evening: indoor 73°F above comfort_cool 74°F? No — 73 < 74, just below ceiling. Outdoor 69°F is 4°F cooler than indoor, well below sleep target 72°F. Nat-vent conditions met."
+    },
+    {
+      "time": "2026-07-20T20:30:00",
+      "type": "sensor_open",
+      "entity": "binary_sensor.living_room_window",
+      "note": "Window opens. Nat-vent activates: outdoor 69°F < indoor 73°F, indoor 73°F > comfort_heat 68°F, outdoor 69°F < comfort_cool+delta 77°F."
+    },
+    {
+      "time": "2026-07-20T22:30:00",
+      "type": "bedtime",
+      "note": "Bedtime fires. sleep band = [64/72]. Nat-vent continuation gate: _natural_vent_active=True, _fan_active=True, NOT _fan_override_active, outdoor 69°F < sleep_cool 72°F → gate passes. Fan stays running; emit nat_vent_bedtime_continue instead of deactivating. Sleep band still programmed."
+    },
+    {
+      "time": "2026-07-21T01:00:00",
+      "type": "temp_update",
+      "indoor_f": 72.0,
+      "outdoor_f": 67.0,
+      "note": "Indoor has cooled to 72°F — exactly at sleep_cool. Priority 0 exit fires: _in_sleep_window AND indoor(72) <= sleep_cool(72). _deactivate_fan(restore_hvac=False) called. nat_vent_sleep_ceiling_reached emitted. Sleep band retained."
+    }
+  ],
+  "assertions": [
+    {
+      "at": "2026-07-20T20:30:00",
+      "expect": "natural_ventilation",
+      "reason": "Window opens with outdoor 69°F < indoor 73°F and outdoor below threshold 77°F — nat-vent activates, fan on, _natural_vent_active=True."
+    },
+    {
+      "at": "2026-07-20T22:30:00",
+      "expect": "nat_vent_bedtime_continue",
+      "reason": "Bedtime fires with outdoor 69°F < sleep_cool 72°F — continuation gate passes, nat_vent_bedtime_continue event emitted, fan preserved. If gate is deleted, bedtime calls _deactivate_fan() instead and this event is never emitted."
+    },
+    {
+      "at": "2026-07-21T01:00:00",
+      "expect": "nat_vent_sleep_ceiling_reached",
+      "reason": "Indoor reaches sleep_cool 72°F in the sleep window — Priority 0 exit fires, _deactivate_fan(restore_hvac=False) called. If Priority 0 exit is deleted, this event is never emitted."
+    }
+  ],
+  "verdict": {
+    "type": "positive",
+    "summary": "Nat-vent continues past bedtime (Issue #370) when outdoor is below sleep target; stops automatically when indoor reaches sleep ceiling",
+    "observed_behavior": "sensor_open → natural_ventilation (20:30) → bedtime fires → nat_vent_bedtime_continue (22:30, fan stays running) → indoor reaches 72°F → nat_vent_sleep_ceiling_reached (01:00, fan off, sleep band retained)",
+    "expected_behavior": "Occupant opens windows at 20:30; CA activates nat-vent. At 22:30 bedtime, CA checks outdoor (69°F) vs sleep target (72°F) — outdoor is cooler, so fan keeps running. At 01:00 the home has cooled to the sleep target naturally; CA stops the fan without touching the sleep band. AC never ran overnight — maximum free cooling, minimum energy use."
+  }
+}


### PR DESCRIPTION
## Summary

- **handle_bedtime()**: Added nat-vent continuation gate — if `_natural_vent_active AND _fan_active AND outdoor < sleep_cool`, the fan is preserved past bedtime. Sleep band still applied unconditionally. Applies to all fan archetypes (WHF, HVAC fan, BOTH).
- **check_natural_vent_conditions()**: Added Priority 0 sleep-ceiling exit — when in the sleep window and `indoor <= sleep_cool`, deactivates the fan with `restore_hvac=False` (preserves the already-programmed sleep band) and emits `nat_vent_sleep_ceiling_reached`.
- **State fix**: `_natural_vent_active` is now cleared on both bedtime paths. Previously left stale (True) after bedtime deactivated the fan.

**Occupant impact (before):** Bedtime fires with the house at 73F, outdoor at 69F, sleep target 72F. CA shuts the fan off and the AC runs 20-30 min to close the last 1F — wasted electricity when free cooling was available.

**Occupant impact (after):** CA keeps the fan running. The house cools naturally to 72F overnight. When indoor reaches sleep_cool, the fan stops quietly with the sleep band already in place. AC never triggers for that segment.

## New events
- `nat_vent_bedtime_continue` — gate passed, fan preserved at bedtime
- `nat_vent_sleep_ceiling_reached` — fan stopped when indoor <= sleep_cool in sleep window

## Test plan
- [x] `tests/test_bedtime_setback.py::TestNatVentBedtimeContinuation` — 5 new tests
- [x] `tests/test_nat_vent_activation.py::TestNatVentSleepCeilingExit` — 2 new tests
- [x] `tools/simulations/pending/bedtime_natvent_continuation.json` — pending scenario (all 3 assertions pass)
- [x] Full suite: 2878 tests pass