### PR TITLE
Fix #390: WHF status refresh on override-active state confirmation (v0.4.55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.4.55] — 2026-07-02
+
+- Fix #390: Whole-house fan status could show "off (manual override)" for up to 30 minutes after the fan was actually confirmed running — the coordinator listener that detects the fan_state_entity confirming physical on/off silently dropped the event once a manual override was already active, so the displayed status only caught up at the next scheduled poll. Now a coordinator refresh is requested immediately so the status reflects reality within one cycle.
+
 ## [0.4.54] — 2026-07-02
 
 - Fix #388: Climate Advisor was missing from the Integrations page in Settings → Devices & Services — v0.4.53 set manifest.json integration_type to 'helper', which Home Assistant's frontend excludes from the Integrations dashboard and routes to the Helpers tab instead. Corrected to 'service', the accurate HA taxonomy value for a full custom integration.

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,17 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.4.54"
+VERSION = "0.4.55"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.4.55": [
+        "Fix #390: Whole-house fan status could show 'off (manual override)' for up to 30 minutes"
+        " after the fan was actually confirmed running — the coordinator listener that detects the"
+        " fan_state_entity confirming physical on/off silently dropped the event once a manual"
+        " override was already active, so the displayed status only caught up at the next scheduled"
+        " poll. Now a coordinator refresh is requested immediately so the status reflects reality"
+        " within one cycle.",
+    ],
     "0.4.54": [
         "Fix #388: Climate Advisor was missing from the Integrations page in Settings → Devices &"
         " Services — v0.4.53 set manifest.json integration_type to 'helper', which Home Assistant's"
@@ -626,6 +634,26 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    390: {
+        "version_fixed": "0.4.55",
+        "title": "WHF status showed 'off (manual override)' for up to 30 min while fan was physically running",
+        "scope_covered": (
+            "coordinator.py _async_fan_entity_changed(): when a state change arrives on"
+            " fan_entity or fan_state_entity while _fan_override_active is already True, the"
+            " listener now calls await self.async_request_refresh() before returning, instead of"
+            " silently dropping the event. This lets a physical-state confirmation (e.g. the"
+            " fan_state_entity flipping on a few seconds after fan_entity did) correct the"
+            " displayed fan_status/whf_status within one refresh cycle rather than waiting for the"
+            " next scheduled 30-minute poll. handle_fan_manual_override()/on_fan_turned_off() are"
+            " still correctly skipped on this path — only the display-refresh trigger was added."
+        ),
+        "scope_not_covered": (
+            "Does not change the coordinator's update_interval (still 30 minutes); only removes"
+            " the silent-drop that made this specific confirmation event invisible between polls."
+            " Command-only mode (fan_state_feedback=False) is unaffected — that path already"
+            " returns before reaching this branch."
+        ),
+    },
     388: {
         "version_fixed": "0.4.54",
         "title": "Integration missing from Settings → Devices & Services → Integrations page",

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -3292,8 +3292,18 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         if self.automation_engine._fan_command_pending:
             return
 
-        # Skip if fan override is already active
+        # Skip if fan override is already active — but a physical-state confirmation
+        # event (e.g. the fan_state_entity flipping on right after fan_entity did) still
+        # needs to reach the displayed status promptly, otherwise it stays stale until
+        # the next scheduled coordinator poll (up to update_interval, currently 30 min).
         if self.automation_engine._fan_override_active:
+            _LOGGER.info(
+                "Fan/state entity changed while override already active (%s -> %s) — "
+                "requesting refresh so displayed status reflects confirmed physical state",
+                old_state.state,
+                new_state.state,
+            )
+            await self.async_request_refresh()
             return
 
         # Skip if a fan command was issued recently (cloud thermostat echo guard)

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.4.54"
+  "version": "0.4.55"
 }

--- a/tests/test_whf_dual_entity.py
+++ b/tests/test_whf_dual_entity.py
@@ -21,7 +21,7 @@ import importlib
 import sys
 import types
 from datetime import datetime
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 if "homeassistant" not in sys.modules:
     from tools.sim_harness.ha_stubs import install_ha_stubs
@@ -73,6 +73,7 @@ def _make_coord_stub(config: dict) -> MagicMock:
     coord.automation_engine = ae
 
     coord._is_recent_fan_command = MagicMock(return_value=False)
+    coord.async_request_refresh = AsyncMock()
 
     return coord
 
@@ -512,3 +513,68 @@ class TestComputeFanStatusOverride:
             f"Expected 'running (manual override)' when _fan_active=True under override, got {result!r}"
         )
         coord._get_fan_physical_state.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TestOverrideActiveRequestsRefresh (Issue #390)
+# ---------------------------------------------------------------------------
+
+
+class TestOverrideActiveRequestsRefresh:
+    """Tests for Issue #390: a physical-state confirmation event arriving after
+    _fan_override_active is already True must request a coordinator refresh so the
+    displayed status catches up immediately, instead of staying stale until the next
+    scheduled poll (up to update_interval, currently 30 minutes).
+    """
+
+    def test_state_entity_confirms_on_while_override_active_requests_refresh(self):
+        """fan_state_entity flips on shortly after override started → refresh requested.
+
+        Scenario: fan_entity turns on, override is set. Seconds later fan_state_entity
+        (the real physical-state confirmation sensor) flips on too. Before the fix this
+        event was silently dropped; the status stayed at 'off (manual override)' until
+        the next scheduled poll.
+        """
+        config = {
+            CONF_FAN_ENTITY: "switch.whf_command",
+            CONF_FAN_STATE_ENTITY: "binary_sensor.whf_running",
+        }
+        coord = _make_coord_stub(config)
+        ae = coord.automation_engine
+        ae._fan_active = False
+        ae._fan_override_active = True  # override already active
+
+        mod = importlib.import_module("custom_components.climate_advisor.coordinator")
+        method = types.MethodType(mod.ClimateAdvisorCoordinator._async_fan_entity_changed, coord)
+
+        old_state = _make_fake_state("off")
+        new_state = _make_fake_state("on")
+        event = MagicMock()
+        event.data = {"old_state": old_state, "new_state": new_state}
+
+        asyncio.run(method(event))
+
+        coord.async_request_refresh.assert_called_once()
+        ae.handle_fan_manual_override.assert_not_called()
+        ae.on_fan_turned_off.assert_not_called()
+
+    def test_no_state_change_does_not_request_refresh(self):
+        """No-op state change (old == new) must not request a refresh."""
+        config = {
+            CONF_FAN_ENTITY: "switch.whf_command",
+            CONF_FAN_STATE_ENTITY: "binary_sensor.whf_running",
+        }
+        coord = _make_coord_stub(config)
+        ae = coord.automation_engine
+        ae._fan_override_active = True
+
+        mod = importlib.import_module("custom_components.climate_advisor.coordinator")
+        method = types.MethodType(mod.ClimateAdvisorCoordinator._async_fan_entity_changed, coord)
+
+        same_state = _make_fake_state("on")
+        event = MagicMock()
+        event.data = {"old_state": same_state, "new_state": same_state}
+
+        asyncio.run(method(event))
+
+        coord.async_request_refresh.assert_not_called()


### PR DESCRIPTION
## Summary
- Fixes #390: `whf_status`/`sensor.climate_advisor_fan_status` could show `"off (manual override)"` for up to 30 minutes even though the whole-house fan was physically confirmed running.
- Root cause: `_async_fan_entity_changed()` in `coordinator.py` silently dropped state-change events on the early-return guard `if self.automation_engine._fan_override_active: return` — so when `fan_state_entity` (the real physical-state confirmation sensor) flipped on a few seconds after `fan_entity` did, the event was ignored and no coordinator refresh was requested. The display only self-corrected at the next scheduled 30-minute poll.
- Fix: that branch now calls `await self.async_request_refresh()` before returning, so the displayed status catches up within one refresh cycle. `handle_fan_manual_override()`/`on_fan_turned_off()` are still correctly skipped on this path — only the refresh trigger was added.
- Diagnosed and confirmed live against the running production instance (`.deploy.env` REST API): observed the exact override-start → state-entity-confirm timeline, and confirmed `whf_status` flipped from `"off (manual override)"` to `"running (manual override)"` only once the scheduled poll ran, matching the code-level root cause.
- Version bumped 0.4.54 → 0.4.55; `RELEASE_NOTES`, `KNOWN_FIXES`, and `CHANGELOG.md` updated.

## Test plan
- [x] `python -m ruff check` / `ruff format` clean on modified files
- [x] `tests/test_whf_dual_entity.py` — 18/18 passing, including 2 new regression tests (`TestOverrideActiveRequestsRefresh`) asserting `async_request_refresh()` is called when a state-entity confirmation arrives after override is already active, and that `handle_fan_manual_override`/`on_fan_turned_off` are not re-invoked
- [x] Full fan test suite (`test_fan_control.py`, `test_fan_cancel.py`, `test_fan_command_guard.py`, `test_whf_command_only.py`, `test_whf_dual_entity.py`) — 187/187 passing
- [x] Full test suite — 2911/2911 passing
- [x] `python tools/simulate.py` — 50/50 golden scenarios passing (no automation-decision regressions; this change only affects when a refresh is requested)
- [x] `tests/test_version_sync.py` passing (const.py/manifest.json version match)
- [x] Live confirmation: `whf_status` on the production instance now reads `"running (manual override)"` correctly