### PR TITLE
Fix #400: nat-vent dashboard target now matches sleep-window cycling target (v0.4.59)

### DIFF
--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,18 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.4.58"
+VERSION = "0.4.59"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.4.59": [
+        "Fix #400: nat-vent dashboard/status showed the daytime comfort-band target (e.g. 71°F)"
+        " even during the overnight sleep window, after Issue #374 already fixed the fan's actual"
+        " cycling target to follow sleep_heat + hysteresis (e.g. 66°F) overnight. The fan was"
+        " behaving correctly, but coordinator.py's get_debug_state() independently recomputed the"
+        " target with a hardcoded daytime-only formula, so the status page never reflected the"
+        " #374 fix. The dashboard now mirrors the same sleep-vs-daytime logic used by the fan"
+        " itself.",
+    ],
     "0.4.58": [
         "Fix #396: The status card could show 'waiting for coalescing' indefinitely after an HA"
         " restart with no clue why. Diagnostics deployed to confirm the cause ruled out the #392"
@@ -665,6 +674,27 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    400: {
+        "version_fixed": "0.4.59",
+        "title": "Nat-vent dashboard target stuck at daytime comfort-band midpoint during sleep window",
+        "scope_covered": (
+            "coordinator.py: get_debug_state() now computes nat_vent_target,"
+            " nat_vent_on_threshold, and nat_vent_off_threshold using the same"
+            " sleep-vs-daytime branch as automation.py::nat_vent_temperature_check() (the"
+            " fix from Issue #374) — during the sleep window (_in_sleep_window() True), the"
+            " target is sleep_heat + hysteresis; otherwise it remains the daytime"
+            " comfort-band midpoint (comfort_heat + comfort_cool) / 2. Previously"
+            " coordinator.py independently recomputed these three fields with a hardcoded"
+            " daytime-only formula, so the dashboard never reflected the #374 fix even"
+            " though the fan's actual cycling behavior was already correct."
+        ),
+        "scope_not_covered": (
+            "The formula is still duplicated between automation.py and coordinator.py"
+            " (not extracted into one shared helper) — a future change to the sleep-window"
+            " target formula in one file could again silently drift from the other. Not"
+            " extracted in this fix to keep the change minimal and reviewable."
+        ),
+    },
     396: {
         "version_fixed": "0.4.58",
         "title": (

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -31,7 +31,7 @@ from homeassistant.helpers.event import (
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
 
-from .automation import AutomationEngine, compute_bedtime_setback
+from .automation import AutomationEngine, _in_sleep_window, compute_bedtime_setback
 from .briefing import generate_briefing
 from .chart_log import ChartStateLog
 from .classifier import DayClassification, ForecastSnapshot, classify_day
@@ -82,8 +82,10 @@ from .const import (
     CONF_HOME_TOGGLE,
     CONF_HOME_TOGGLE_INVERT,
     CONF_MANUAL_GRACE_PERIOD,
+    CONF_NAT_VENT_HYSTERESIS_F,
     CONF_SENSOR_DEBOUNCE,
     CONF_SENSOR_POLARITY_INVERTED,
+    CONF_SLEEP_HEAT,
     CONF_THRESHOLD_COOL,
     CONF_THRESHOLD_HOT,
     CONF_THRESHOLD_MILD,
@@ -115,6 +117,7 @@ from .const import (
     INVESTIGATION_REPORTS_FILE,
     MAX_WEATHER_BIAS_APPLY_F,
     MIN_WEATHER_BIAS_APPLY_F,
+    NAT_VENT_HYSTERESIS_F,
     OBS_TYPE_FAN_ONLY_DECAY,
     OBS_TYPE_HVAC_COOL,
     OBS_TYPE_HVAC_HEAT,
@@ -6074,6 +6077,21 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 "friendly_name": sensor_id.split(".")[-1].replace("_", " ").title(),
             }
 
+        # Issue #400: mirror automation.py's nat_vent_temperature_check() sleep-window branch
+        # so the dashboard target matches the actual cycling target, not always the daytime
+        # comfort-band midpoint.
+        _nat_vent_hysteresis = float(self.config.get(CONF_NAT_VENT_HYSTERESIS_F, NAT_VENT_HYSTERESIS_F))
+        if ae._natural_vent_active:
+            _comfort_heat = float(self.config.get("comfort_heat", 70))
+            _comfort_cool = float(self.config.get("comfort_cool", 75))
+            if _in_sleep_window(dt_util.now(), self.config):
+                _sleep_heat = float(self.config.get(CONF_SLEEP_HEAT, _comfort_heat))
+                _nat_vent_target = _sleep_heat + _nat_vent_hysteresis
+            else:
+                _nat_vent_target = (_comfort_heat + _comfort_cool) / 2.0
+        else:
+            _nat_vent_target = None
+
         return {
             "automation_enabled": self._automation_enabled,
             "occupancy_mode": self._occupancy_mode,
@@ -6178,20 +6196,12 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 and self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED) == FAN_MODE_HVAC
                 and not self.config.get("aggressive_savings", False)
             ),
-            "nat_vent_target": (
-                (float(self.config.get("comfort_heat", 70)) + float(self.config.get("comfort_cool", 75))) / 2.0
-                if ae._natural_vent_active
-                else None
-            ),
+            "nat_vent_target": _nat_vent_target,
             "nat_vent_on_threshold": (
-                (float(self.config.get("comfort_heat", 70)) + float(self.config.get("comfort_cool", 75))) / 2.0 + 1.0
-                if ae._natural_vent_active
-                else None
+                _nat_vent_target + _nat_vent_hysteresis if _nat_vent_target is not None else None
             ),
             "nat_vent_off_threshold": (
-                (float(self.config.get("comfort_heat", 70)) + float(self.config.get("comfort_cool", 75))) / 2.0 - 1.0
-                if ae._natural_vent_active
-                else None
+                _nat_vent_target - _nat_vent_hysteresis if _nat_vent_target is not None else None
             ),
             "nat_vent_cycling_paused": ae._natural_vent_active and not ae._fan_active,
         }

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.4.58"
+  "version": "0.4.59"
 }

--- a/tests/test_nat_vent_dashboard_target.py
+++ b/tests/test_nat_vent_dashboard_target.py
@@ -1,0 +1,135 @@
+"""Tests for nat-vent dashboard target sleep-window alignment (Issue #400).
+
+Issue #374 (v0.4.47) fixed the fan's actual cycling target in
+automation.py::nat_vent_temperature_check() to use sleep_heat + hysteresis during the
+sleep window instead of the daytime comfort-band midpoint. That fix never touched
+coordinator.py::get_debug_state(), which independently (and incorrectly) always
+computed the daytime midpoint for the nat_vent_target/on_threshold/off_threshold
+fields exposed to the dashboard — so during the sleep window the dashboard showed a
+target (e.g. 71°F) that did not match what the fan was actually doing (e.g. 66°F).
+
+Occupant impact: the fan is behaving correctly, but the status page misleads the
+user/developer into thinking nat-vent is still using the daytime target, making it
+impossible to verify the #374 fix from the UI.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+if "homeassistant" not in sys.modules:
+    from conftest import install_ha_stubs
+
+    install_ha_stubs()
+
+_THERMOSTAT_ID = "climate.thermostat"
+_PATCH_DT_NOW = "custom_components.climate_advisor.coordinator.dt_util.now"
+
+
+def _get_coordinator_class():
+    """Return the current ClimateAdvisorCoordinator class — avoids stale __globals__."""
+    mod = importlib.import_module("custom_components.climate_advisor.coordinator")
+    return mod.ClimateAdvisorCoordinator
+
+
+def _make_nat_vent_coord_stub(*, config: dict) -> object:
+    """Build a minimal coordinator stub sufficient to call the real get_debug_state()."""
+    ClimateAdvisorCoordinator = _get_coordinator_class()
+    coord = object.__new__(ClimateAdvisorCoordinator)
+    coord.hass = MagicMock()
+    coord.config = config
+    coord.data = {}
+    coord._resolved_sensors = []
+    coord._door_open_timers = {}
+    coord._current_classification = None
+    coord._automation_enabled = True
+    coord._occupancy_mode = "home"
+    coord._occupancy_away_timer_cancel = None
+    coord._startup_coalesce_active = False
+    coord._startup_coalesce_expiry = None
+    coord._build_thermal_pipeline_summary = MagicMock(return_value={})
+
+    ae = MagicMock()
+    ae._natural_vent_active = True
+    ae._fan_active = True
+    ae._fan_override_active = False
+    ae._manual_override_active = False
+    ae._grace_active = False
+    ae._grace_end_time = None
+    ae.is_paused_by_door = False
+    ae._last_classification_applied = None
+    ae._pre_pause_mode = None
+    ae._last_resume_source = None
+    ae.config = config
+    coord.automation_engine = ae
+
+    return coord
+
+
+class TestNatVentDashboardTargetSleepWindow:
+    """get_debug_state() must match automation.py's sleep-vs-daytime nat-vent target."""
+
+    def test_daytime_target_is_comfort_midpoint(self):
+        """Outside the sleep window, target stays the comfort-band midpoint (regression guard)."""
+        config = {
+            "comfort_heat": 68,
+            "comfort_cool": 74,
+            "sleep_heat": 65,
+            "sleep_time": "22:00",
+            "wake_time": "07:00",
+        }
+        coord = _make_nat_vent_coord_stub(config=config)
+
+        # 14:00 — outside the 22:00-07:00 sleep window
+        with patch(_PATCH_DT_NOW, return_value=datetime(2026, 7, 2, 14, 0, 0)):
+            state = coord.get_debug_state()
+
+        assert state["nat_vent_target"] == 71.0  # (68 + 74) / 2
+        assert state["nat_vent_on_threshold"] == 72.0
+        assert state["nat_vent_off_threshold"] == 70.0
+
+    def test_sleep_window_target_uses_sleep_heat_not_daytime_midpoint(self):
+        """During the sleep window, target must follow sleep_heat + hysteresis (Issue #374 parity).
+
+        Before the fix, this always returned the daytime midpoint (71°F) even overnight,
+        contradicting the fan's actual cycling target from automation.py.
+        """
+        config = {
+            "comfort_heat": 68,
+            "comfort_cool": 74,
+            "sleep_heat": 65,
+            "sleep_time": "22:00",
+            "wake_time": "07:00",
+        }
+        coord = _make_nat_vent_coord_stub(config=config)
+
+        # 02:00 — inside the overnight sleep window
+        with patch(_PATCH_DT_NOW, return_value=datetime(2026, 7, 2, 2, 0, 0)):
+            state = coord.get_debug_state()
+
+        assert state["nat_vent_target"] == 66.0  # sleep_heat(65) + hysteresis(1)
+        assert state["nat_vent_target"] != 71.0
+        assert state["nat_vent_on_threshold"] == 67.0
+        assert state["nat_vent_off_threshold"] == 65.0
+
+    def test_target_is_none_when_nat_vent_inactive(self):
+        """No active nat-vent session → all target/threshold fields are None."""
+        config = {
+            "comfort_heat": 68,
+            "comfort_cool": 74,
+            "sleep_heat": 65,
+            "sleep_time": "22:00",
+            "wake_time": "07:00",
+        }
+        coord = _make_nat_vent_coord_stub(config=config)
+        coord.automation_engine._natural_vent_active = False
+
+        with patch(_PATCH_DT_NOW, return_value=datetime(2026, 7, 2, 2, 0, 0)):
+            state = coord.get_debug_state()
+
+        assert state["nat_vent_target"] is None
+        assert state["nat_vent_on_threshold"] is None
+        assert state["nat_vent_off_threshold"] is None


### PR DESCRIPTION
## Summary
- Issue #374 (v0.4.47) fixed nat-vent's actual fan cycling target in `automation.py::nat_vent_temperature_check()` to use `sleep_heat + hysteresis` during the sleep window instead of the daytime comfort-band midpoint.
- That fix never touched `coordinator.py::get_debug_state()`, which independently computed `nat_vent_target`/`nat_vent_on_threshold`/`nat_vent_off_threshold` with a hardcoded daytime-only formula — so the dashboard kept showing the daytime midpoint (e.g. 71°F) overnight even though the fan was correctly cycling around the sleep-window target (e.g. 66°F).
- `coordinator.py` now computes the same sleep-vs-daytime target as `automation.py` before building the status dict, so the dashboard matches actual fan behavior in both contexts.

Closes #400

## Test plan
- [x] Added `tests/test_nat_vent_dashboard_target.py` — calls the real `get_debug_state()` and covers daytime target, sleep-window target, and inactive-session cases
- [x] `python -m ruff check` / `ruff format` clean
- [x] Full suite: `python -m pytest tests/` — 2961 passed
- [x] `python tools/validate.py` — all checks passed
- [x] Version bump (0.4.58 → 0.4.59) + `RELEASE_NOTES`/`KNOWN_FIXES` entries added