### PR TITLE
Fix #405: release stranded WHF HVAC suppression at startup reconcile

### DIFF
--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -2745,7 +2745,13 @@ class AutomationEngine:
         archetype = fan_mode
 
         if not thermostat_fan_running:
-            # Fan is off — ensure CA flags are clean (defence in depth)
+            # Fan is off — ensure CA flags are clean (defence in depth), and release any
+            # stranded WHF HVAC suppression left over from a session that ended without
+            # a matching _deactivate_fan() call (Issue #405). Without this, a nat-vent
+            # cycling-off (restore_hvac=False, by design) followed by a coalesce boundary
+            # that observes the fan already off would clear _natural_vent_active here but
+            # leave _pre_fan_hvac_mode stranded non-None forever, permanently blocking
+            # every future HVAC write via _whf_owns_hvac() with no recovery path.
             self._fan_active = False
             self._fan_on_since = None
             self._natural_vent_active = False
@@ -2756,6 +2762,10 @@ class AutomationEngine:
                 False,
                 decision,
                 archetype,
+            )
+            await self._deactivate_fan(
+                reason="startup reconcile — fan confirmed off, releasing any stranded HVAC suppression",
+                restore_hvac=True,
             )
             return
 

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,17 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.4.60"
+VERSION = "0.4.61"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.4.61": [
+        "Fix #405: HVAC writes no longer stay permanently blocked after a whole-house-fan"
+        " nat-vent session ends with the fan already off at a restart/coalesce boundary."
+        " reconcile_fan_on_startup()'s 'no-fan' decision now releases any stranded HVAC"
+        " suppression flag (_pre_fan_hvac_mode) the same way a normal fan deactivation"
+        " does, instead of only clearing the fan-tracking flags — previously the home"
+        " could be left with no automated cooling response for the rest of the day.",
+    ],
     "0.4.60": [
         "Fix #402: whole-house-fan nat-vent could silently stop controlling the home for hours"
         " overnight. Two causes: (1) fan_thermostat_check() — the tick-level safety check that"
@@ -701,6 +709,36 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    405: {
+        "version_fixed": "0.4.61",
+        "title": "HVAC writes permanently blocked by stale WHF suppression flag after nat-vent fan goes idle",
+        "scope_covered": (
+            "automation.py: reconcile_fan_on_startup()'s 'no-fan' branch (fires when a"
+            " coalesce/restart boundary observes the thermostat fan confirmed off) now calls"
+            " _deactivate_fan(restore_hvac=True) after clearing the fan-tracking flags, instead"
+            " of only clearing _fan_active/_fan_on_since/_natural_vent_active. Previously, a WHF"
+            " nat-vent session that ended via cycling-off (nat_vent_temperature_check() calling"
+            " _deactivate_fan(restore_hvac=False) by design, so the session can resume) and then"
+            " never reactivated left _pre_fan_hvac_mode stranded non-None forever once a later"
+            " coalesce boundary cleared _natural_vent_active — _whf_owns_hvac() then permanently"
+            " blocked every subsequent HVAC write with no recovery path short of a config change"
+            " or manual fan cycling. The fix reuses the existing 'already inactive but restore"
+            " pending' branch inside _deactivate_fan() (built for the #402 follow-up) — no new"
+            " restore-write logic was added, only a new caller of the existing correct path."
+        ),
+        "scope_not_covered": (
+            "If _fan_override_active is True at the moment a no-fan reconcile fires (user"
+            " manually turned the fan off while a WHF suppression session was active),"
+            " _deactivate_fan()'s override guard returns before reaching the restore logic —"
+            " the stranded flag is not released until the override clears and a later reconcile"
+            " runs. This mirrors existing, intentional behavior everywhere else _deactivate_fan()"
+            " is called (CA never fights a manual override) and is not new to this fix. Also:"
+            " this fix does not address the repeated HA-restart-boundary churn itself observed"
+            " in the issue #405 activity log (4 restarts within about an hour) — that instability"
+            " is tracked separately (see #403's restart-cause classification work, added the"
+            " same morning) and was not investigated as part of this fix."
+        ),
+    },
     402: {
         "version_fixed": "0.4.60",
         "title": (

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.4.60"
+  "version": "0.4.61"
 }

--- a/docs/08-COMPUTATION-REFERENCE.md
+++ b/docs/08-COMPUTATION-REFERENCE.md
@@ -1259,7 +1259,7 @@ The coordinator maintains six internal fields to manage fan state across activat
 | `_fan_override_time` | `datetime \| None` | Timestamp of when the fan override was detected |
 | `_fan_command_pending` | `bool` | Set to `True` immediately before the integration issues a fan command; cleared immediately after |
 | `_fan_command_time` | `datetime \| None` | Timestamp recorded at the start of every `_activate_fan()` and `_deactivate_fan()` call; used by `_is_recent_fan_command()` as a timestamp-based secondary guard |
-| `_pre_fan_hvac_mode` | `str \| None` | **`FAN_MODE_WHOLE_HOUSE` only.** Captures the thermostat's HVAC mode immediately before fan activation (e.g., `"heat_cool"`, `"cool"`). Restored to the thermostat on deactivation, then cleared to `None`. `None` when no whole-house fan session is active or when using `FAN_MODE_HVAC`. Persisted in state across HA restarts so HVAC restoration survives a restart during a fan session. |
+| `_pre_fan_hvac_mode` | `str \| None` | **`FAN_MODE_WHOLE_HOUSE` only.** Captures the thermostat's HVAC mode immediately before fan activation (e.g., `"heat_cool"`, `"cool"`). Restored to the thermostat on deactivation, then cleared to `None`. `None` when no whole-house fan session is active or when using `FAN_MODE_HVAC`. Persisted in state across HA restarts so HVAC restoration survives a restart during a fan session. Released by two call sites: `_deactivate_fan(restore_hvac=True)` (the normal end-of-session path) and `reconcile_fan_on_startup()`'s `no-fan` branch (§9e-B, Issue #405 — catches a session that ended via cycling-off and never reactivated). |
 
 **`_activate_fan()`** sets `_fan_command_time = dt_util.now()` and `_fan_command_pending = True`, issues the fan-on service call, then sets `_fan_active = True` and records `_fan_on_since`. If `_fan_override_active` is `True` at activation time, the call is skipped so the integration does not fight the user's manual setting. For `FAN_MODE_WHOLE_HOUSE` (or `both`), the current thermostat HVAC mode is captured in `_pre_fan_hvac_mode` and HVAC is set to `off` before the fan is turned on.
 
@@ -1498,9 +1498,11 @@ After the existing nat-vent / `apply_classification` logic in `_do_startup_coale
 
 | Physical fan running? | Nat-vent eligible? | Decision | Action |
 |---|---|---|---|
-| No | — | **no-fan** | No action; state flags already cleared by (A) |
+| No | — | **no-fan** | `_fan_active`/`_fan_on_since`/`_natural_vent_active` cleared, then `_deactivate_fan(restore_hvac=True)` is called to release any stranded WHF HVAC suppression (Issue #405) |
 | Yes | Yes (`outdoor < indoor`, gate passes, sensors open) | **adopt-on** | `_fan_active = True`, `_natural_vent_active = True`; fast thermostatic loop started |
 | Yes | No | **turn-off** | `_deactivate_fan()` or `set_fan_mode("auto")` (FAN_MODE_HVAC) / fan `turn_off` + HVAC restore (FAN_MODE_WHOLE_HOUSE) |
+
+**Issue #405 — the `no-fan` path is a second `_pre_fan_hvac_mode` release point, not just a flag-clear.** A WHF nat-vent session can end via cycling-off (`nat_vent_temperature_check()` calling `_deactivate_fan(restore_hvac=False)` by design — see the `_pre_fan_hvac_mode` row above), which intentionally leaves `_pre_fan_hvac_mode` set so the session can resume. If the fan never reactivates and a later coalesce boundary observes it confirmed off, the `no-fan` branch must still release that suppression — otherwise `_pre_fan_hvac_mode` stays stranded non-`None` forever and `_whf_owns_hvac()` permanently blocks every future HVAC write with no recovery path. Calling `_deactivate_fan(restore_hvac=True)` here is a safe no-op when nothing is stranded (`_fan_active` is already `False`, so it takes the "already inactive" early-return path added for the #402 follow-up) and correctly restores HVAC when it is stranded.
 
 The 5-minute `_first_run` coalesce window already suppresses override detection (coordinator's `_async_thermostat_changed` override guard), so the turn-off command is not misread as a user manual action.
 

--- a/tests/test_fan_control.py
+++ b/tests/test_fan_control.py
@@ -1915,7 +1915,8 @@ class TestReconcileFanOnStartup:
         return engine
 
     def test_no_fan_when_thermostat_fan_not_running(self):
-        """thermostat fan off → decision no-fan; stale flags cleared, no deactivate call."""
+        """thermostat fan off → decision no-fan; stale flags cleared, deactivate called to
+        release any stranded HVAC suppression (Issue #405)."""
         engine = self._engine()
         engine._fan_active = True  # stale
 
@@ -1925,9 +1926,77 @@ class TestReconcileFanOnStartup:
             )
         )
 
-        engine._deactivate_fan.assert_not_awaited()
+        engine._deactivate_fan.assert_awaited_once()
+        assert engine._deactivate_fan.call_args.kwargs.get("restore_hvac") is True
         assert engine._fan_active is False
         assert engine._natural_vent_active is False
+
+    def test_stranded_hvac_suppression_released_when_fan_confirmed_off(self):
+        """Issue #405: a WHF suppression session that ends via nat-vent cycling-off
+        (restore_hvac=False, by design) followed by a coalesce boundary that confirms
+        the fan is off must not leave _pre_fan_hvac_mode stranded forever — it must be
+        restored via the real _deactivate_fan() restore path, not just flag-cleared."""
+        engine = self._engine()
+        engine._deactivate_fan = AutomationEngine._deactivate_fan.__get__(engine)  # use the real method
+        engine._set_hvac_mode = AsyncMock()
+        engine._fan_active = False
+        engine._natural_vent_active = False
+        engine._pre_fan_hvac_mode = "cool"  # stranded from a prior _activate_fan() session
+
+        asyncio.run(
+            engine.reconcile_fan_on_startup(
+                indoor=69.0, outdoor=70.0, thermostat_fan_running=False, any_sensor_open=True
+            )
+        )
+
+        engine._set_hvac_mode.assert_awaited_once()
+        assert engine._set_hvac_mode.call_args.args[0] == "cool"
+        assert engine._pre_fan_hvac_mode is None
+
+    def test_no_fan_and_nothing_stranded_is_a_true_noop(self):
+        """Companion to the #405 regression test: when nothing is stranded, releasing
+        the (nonexistent) suppression must not issue a spurious HVAC write or Activity
+        Log event on every ordinary restart — the common case."""
+        engine = self._engine()
+        engine._deactivate_fan = AutomationEngine._deactivate_fan.__get__(engine)  # real method
+        engine._set_hvac_mode = AsyncMock()
+        engine._emit_event_callback = MagicMock()
+        engine._fan_active = False
+        engine._natural_vent_active = False
+        engine._pre_fan_hvac_mode = None
+
+        asyncio.run(
+            engine.reconcile_fan_on_startup(
+                indoor=75.0, outdoor=60.0, thermostat_fan_running=False, any_sensor_open=True
+            )
+        )
+
+        engine._set_hvac_mode.assert_not_awaited()
+        engine._emit_event_callback.assert_not_called()
+        assert engine._pre_fan_hvac_mode is None
+
+    def test_no_fan_stranded_suppression_stays_inert_during_manual_override(self):
+        """Known scope boundary: if a manual fan override is active when a no-fan
+        reconcile fires, _deactivate_fan()'s override guard returns before ever
+        reaching the restore logic — the stranded flag is left untouched until the
+        override clears and a later reconcile runs. This is existing, intentional
+        behavior (CA never fights a manual override), not a gap introduced here."""
+        engine = self._engine()
+        engine._deactivate_fan = AutomationEngine._deactivate_fan.__get__(engine)  # real method
+        engine._set_hvac_mode = AsyncMock()
+        engine._fan_active = False
+        engine._natural_vent_active = False
+        engine._pre_fan_hvac_mode = "cool"
+        engine._fan_override_active = True
+
+        asyncio.run(
+            engine.reconcile_fan_on_startup(
+                indoor=69.0, outdoor=70.0, thermostat_fan_running=False, any_sensor_open=True
+            )
+        )
+
+        engine._set_hvac_mode.assert_not_awaited()
+        assert engine._pre_fan_hvac_mode == "cool"
 
     def test_adopt_on_when_nat_vent_eligible(self):
         """Fan running + window open + outdoor cooler → adopt as CA nat-vent."""


### PR DESCRIPTION
## Summary

- `reconcile_fan_on_startup()`'s `no-fan` branch (fires at every HA/coordinator coalesce-restart boundary when the thermostat fan is confirmed off) cleared `_fan_active`/`_fan_on_since`/`_natural_vent_active` but never touched `_pre_fan_hvac_mode` and never called `_deactivate_fan()`. A WHF nat-vent session that ends via cycling-off (`nat_vent_temperature_check()` calling `_deactivate_fan(restore_hvac=False)` by design, leaving `_pre_fan_hvac_mode` set so the session can resume) followed by a coalesce boundary where the fan never reactivates left `_pre_fan_hvac_mode` stranded non-`None` forever — `_whf_owns_hvac()` then permanently blocked every subsequent HVAC write with no recovery path short of a config change or manual fan cycling.
- **Occupant impact:** the home is left with no automated cooling response (no fan, no AC) potentially for the rest of the day, with the system's own logs showing it repeatedly trying and failing to arm cooling.
- **Confirmed live** against the production HA instance via SSH — deployed code was already current `main`/v0.4.60 (not stale), and the stranded flag (`pre_fan_hvac_mode: "off"`) was directly observed in `climate_advisor_state.json` at time of investigation.

## Fix

`reconcile_fan_on_startup()`'s `no-fan` branch now calls `_deactivate_fan(restore_hvac=True)` after clearing the tracking flags, reusing the "already inactive but restore pending" branch inside `_deactivate_fan()` (built for the #402 follow-up). Safe no-op when nothing is stranded (the common case); correctly restores HVAC when it is.

## Regression analysis

Checked against every recent `automation.py` fix touching fan/HVAC suppression:
- **#327** — origin of `reconcile_fan_on_startup()`; this fix completes its `no-fan` branch, doesn't alter `adopt-on`/`turn-off`.
- **#392** — added the choke-point guard and the clear-before-restore-write ordering; this fix inherits both automatically since it calls the existing correct path, no new restore-write code.
- **#396/#398** — confirmed `reconcile_fan_on_startup()` runs outside `_decision_lock`, same as today; no new lock-ordering risk.
- **#400/#401** — dashboard-only, no interaction.
- **#402** (merged same morning) — built the exact "fan already off, restore pending" branch this fix now calls into. Confirmed via `git show` that #402 touched `reconcile_fan_on_startup()`'s `adopt-on` branch only (added event logging) — came right up to the edge of this bug without closing it.

**Known scope boundary (not new, not a regression):** if `_fan_override_active=True` when a `no-fan` reconcile fires, `_deactivate_fan()`'s override guard returns before the restore logic — matches existing behavior everywhere else `_deactivate_fan()` is called. Documented in `KNOWN_FIXES[405]` and covered by a dedicated test.

## Test plan

- [x] Updated `test_no_fan_when_thermostat_fan_not_running` (previously asserted `_deactivate_fan.assert_not_awaited()`, which encoded the bug)
- [x] Added `test_stranded_hvac_suppression_released_when_fan_confirmed_off` — direct #405 regression test using the real `_deactivate_fan()`
- [x] Added `test_no_fan_and_nothing_stranded_is_a_true_noop` — guards against spurious writes on ordinary restarts
- [x] Added `test_no_fan_stranded_suppression_stays_inert_during_manual_override` — documents the scope boundary
- [x] Revert-test proof: reverted the fix, confirmed 2 new tests fail; restored, confirmed all pass
- [x] Full suite: 3015 passed
- [x] `python tools/simulate.py`: 51/51 golden scenarios pass
- [x] `ruff check` / `ruff format` clean
- [x] `docs/08-COMPUTATION-REFERENCE.md` §9a and §9e-B updated
- [x] Version bumped 0.4.60 → 0.4.61, `RELEASE_NOTES`/`KNOWN_FIXES[405]` added, `test_version_sync.py` passing