### PR TITLE
Fix #407: Status card shows accurate nat-vent info (target + merged card, v0.4.63)

### DIFF
--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,14 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.4.61"
+VERSION = "0.4.62"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.4.62": [
+        "Fix #407: the dashboard Status card no longer shows a stale daytime nat-vent target"
+        " (e.g. 71°F) overnight during the sleep window — it now matches the Natural Vent"
+        " card's correct sleep-window target (e.g. 65°F).",
+    ],
     "0.4.61": [
         "Fix #405: HVAC writes no longer stay permanently blocked after a whole-house-fan"
         " nat-vent session ends with the fan already off at a restart/coalesce boundary."
@@ -709,6 +714,29 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    407: {
+        "version_fixed": "0.4.62",
+        "title": "Dashboard Status card showed stale daytime nat-vent target overnight during the sleep window",
+        "scope_covered": (
+            "coordinator.py: _compute_automation_status()'s nat-vent branch now calls the"
+            " existing compute_nat_vent_cycling_band() helper (the Issue #402 follow-up single"
+            " source of truth for this value) instead of independently recomputing the flat"
+            " daytime comfort-band midpoint ((comfort_heat + comfort_cool) / 2). Previously the"
+            " main Status card always showed the daytime midpoint (e.g. 71°F) even overnight"
+            " during the sleep window, contradicting the already-correct Natural Vent card,"
+            " which fed off compute_nat_vent_cycling_band() and correctly showed the"
+            " sleep_heat + hysteresis target (e.g. 65-66°F). This repeats the exact"
+            " fix-one-duplicate-implementation-miss-the-sibling pattern documented on that"
+            " helper's docstring from #374, #400, and #402."
+        ),
+        "scope_not_covered": (
+            "Does not touch automation.py's nat_vent_temperature_check() (the fan's actual"
+            " cycling logic, already correct since #374) or api.py's status endpoint (already"
+            " correct since #402's extraction of compute_nat_vent_cycling_band()). Does not"
+            " touch the unrelated, pre-existing stale test replica of _compute_automation_status()"
+            " in tests/test_status_sensors.py — that is a separate, already-known issue."
+        ),
+    },
     405: {
         "version_fixed": "0.4.61",
         "title": "HVAC writes permanently blocked by stale WHF suppression flag after nat-vent fan goes idle",

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,15 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.4.62"
+VERSION = "0.4.63"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.4.63": [
+        "Fix #407 follow-up: removed the standalone 'Natural Vent' dashboard card — its"
+        " cycling-band and AC-assist info is now shown as a supplemental line on the main"
+        " Status card instead of a separate card, per the project's 'no new cards, extend"
+        " existing ones' dashboard convention.",
+    ],
     "0.4.62": [
         "Fix #407: the dashboard Status card no longer shows a stale daytime nat-vent target"
         " (e.g. 71°F) overnight during the sleep window — it now matches the Natural Vent"
@@ -715,8 +721,8 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
     407: {
-        "version_fixed": "0.4.62",
-        "title": "Dashboard Status card showed stale daytime nat-vent target overnight during the sleep window",
+        "version_fixed": "0.4.63",
+        "title": "Dashboard Status card showed stale nat-vent target + redundant Natural Vent card",
         "scope_covered": (
             "coordinator.py: _compute_automation_status()'s nat-vent branch now calls the"
             " existing compute_nat_vent_cycling_band() helper (the Issue #402 follow-up single"
@@ -727,7 +733,12 @@ KNOWN_FIXES: dict[int, dict] = {
             " which fed off compute_nat_vent_cycling_band() and correctly showed the"
             " sleep_heat + hysteresis target (e.g. 65-66°F). This repeats the exact"
             " fix-one-duplicate-implementation-miss-the-sibling pattern documented on that"
-            " helper's docstring from #374, #400, and #402."
+            " helper's docstring from #374, #400, and #402. Follow-up (0.4.63): the separate"
+            " standalone 'Natural Vent' status-item card in frontend/index.html (added by the"
+            " #402 follow-up) duplicated this info and was never requested — its AC-assist"
+            " label and cycling-band line are now rendered as a supplemental line inside the"
+            " Status card instead, and the standalone card was removed, per the project's"
+            " existing 'no new cards, extend existing ones' dashboard convention."
         ),
         "scope_not_covered": (
             "Does not touch automation.py's nat_vent_temperature_check() (the fan's actual"

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -5463,10 +5463,12 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         if self.automation_engine._is_within_planned_window_period() and self._any_sensor_open():
             return "windows open (as planned)"
         if self.automation_engine.natural_vent_active:
-            # Bug 3 (Issue #321): surface midpoint target in status for at-a-glance visibility
-            _nh = float(self.config.get("comfort_heat", 70))
-            _nc = float(self.config.get("comfort_cool", 75))
-            _nt = (_nh + _nc) / 2.0
+            # Bug 3 (Issue #321): surface cycling target in status for at-a-glance visibility.
+            # Issue #407: was hardcoded to the flat daytime comfort-band midpoint, ignoring the
+            # sleep window, and never migrated to compute_nat_vent_cycling_band() (the Issue #402
+            # follow-up single source of truth for this exact value) — see that method's docstring
+            # for the fix-one-duplicate-miss-the-sibling history this repeats (#374, #400, #402).
+            _nt = self.compute_nat_vent_cycling_band()["nat_vent_target"]
             return f"windows open · nat-vent (target {_nt:.0f}°F)"
         if self.automation_engine.is_paused_by_door:
             if self._occupancy_mode == OCCUPANCY_AWAY:

--- a/custom_components/climate_advisor/frontend/index.html
+++ b/custom_components/climate_advisor/frontend/index.html
@@ -951,6 +951,15 @@
           <div class="label">Status</div>
           <div class="value">${data.automation_status || 'unknown'}</div>
           ${data.pause_suppressed_classification ? `<div class="value">Classification suppressed — HVAC held off until windows close</div>` : ''}
+          ${data.nat_vent_active ? `
+          <div class="value" style="font-size:0.8rem;opacity:0.85">
+            ${escapeHtml(data.nat_vent_ac_assist ? 'Natural ventilation + AC assist' : 'Natural ventilation (savings mode — fan only)')}${
+              data.nat_vent_off_threshold != null && data.nat_vent_on_threshold != null
+                ? `<br>cycling ${Math.round(data.nat_vent_off_threshold)}${unitSym}–${Math.round(data.nat_vent_on_threshold)}${unitSym}${data.nat_vent_target != null ? ` (target ${Math.round(data.nat_vent_target)}${unitSym})` : ''}`
+                : ''
+            }
+          </div>
+          ` : ''}
         </div>
         <div class="status-item">
           <div class="label">Occupancy</div>
@@ -988,18 +997,6 @@
         <div class="status-item">
           <div class="label">Fan</div>
           <div class="value">${escapeHtml(data.fan_status || 'disabled')}</div>
-        </div>
-        ` : ''}
-        ${data.nat_vent_active ? `
-        <div class="status-item">
-          <div class="label">Natural Vent</div>
-          <div class="value">${escapeHtml(data.nat_vent_ac_assist
-            ? 'Natural ventilation + AC assist'
-            : 'Natural ventilation (savings mode — fan only)')}${
-            data.nat_vent_off_threshold != null && data.nat_vent_on_threshold != null
-              ? `<br><span style="font-size:0.8rem;opacity:0.85">cycling ${Math.round(data.nat_vent_off_threshold)}${unitSym}–${Math.round(data.nat_vent_on_threshold)}${unitSym}${data.nat_vent_target != null ? ` (target ${Math.round(data.nat_vent_target)}${unitSym})` : ''}</span>`
-              : ''
-          }</div>
         </div>
         ` : ''}
         ${data.contact_sensors && data.contact_sensors.length > 0 ? `

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.4.62"
+  "version": "0.4.63"
 }

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.4.61"
+  "version": "0.4.62"
 }

--- a/tests/test_nat_vent_dashboard_target.py
+++ b/tests/test_nat_vent_dashboard_target.py
@@ -185,3 +185,66 @@ class TestComputeNatVentCyclingBand:
         assert state["nat_vent_target"] == band["nat_vent_target"]
         assert state["nat_vent_on_threshold"] == band["nat_vent_on_threshold"]
         assert state["nat_vent_off_threshold"] == band["nat_vent_off_threshold"]
+
+
+class TestComputeAutomationStatusNatVentTarget:
+    """Issue #407: _compute_automation_status()'s nat-vent branch must call
+
+    compute_nat_vent_cycling_band() — the same single source of truth used by the
+    "Natural Vent" status card — instead of independently recomputing the flat
+    daytime comfort-band midpoint. Before this fix, the main Status card always
+    showed the daytime midpoint (e.g. 71°F) even overnight during the sleep window,
+    contradicting the already-correct Natural Vent card (e.g. 65-66°F), repeating the
+    exact "fix one duplicate implementation, miss the sibling" pattern documented on
+    compute_nat_vent_cycling_band() from #374/#400/#402.
+    """
+
+    def _config(self):
+        return {
+            "comfort_heat": 68,
+            "comfort_cool": 74,
+            "sleep_heat": 65,
+            "sleep_time": "22:00",
+            "wake_time": "07:00",
+        }
+
+    def test_daytime_status_uses_comfort_midpoint(self):
+        """Outside the sleep window, the status string shows the daytime midpoint target."""
+        coord = _make_nat_vent_coord_stub(config=self._config())
+
+        # 14:00 — outside the 22:00-07:00 sleep window
+        with patch(_PATCH_DT_NOW, return_value=datetime(2026, 7, 2, 14, 0, 0)):
+            status = coord._compute_automation_status()
+
+        assert status == "windows open · nat-vent (target 71°F)"
+
+    def test_sleep_window_status_uses_sleep_heat_not_daytime_midpoint(self):
+        """During the sleep window, the status string must show the sleep-window target
+        (sleep_heat + hysteresis), NOT the daytime comfort-band midpoint.
+
+        This is the exact regression this bug produced: the Status card previously showed
+        71°F (the daytime midpoint) overnight instead of 66°F (sleep_heat(65) + hysteresis(1)).
+        """
+        coord = _make_nat_vent_coord_stub(config=self._config())
+
+        # 02:00 — inside the overnight sleep window
+        with patch(_PATCH_DT_NOW, return_value=datetime(2026, 7, 2, 2, 0, 0)):
+            status = coord._compute_automation_status()
+
+        assert status == "windows open · nat-vent (target 66°F)"
+        assert "71" not in status
+
+    def test_status_and_cycling_band_agree(self):
+        """The target embedded in the status string must equal
+
+        compute_nat_vent_cycling_band()["nat_vent_target"], formatted the same way — a
+        guard against the two ever drifting apart again.
+        """
+        coord = _make_nat_vent_coord_stub(config=self._config())
+
+        with patch(_PATCH_DT_NOW, return_value=datetime(2026, 7, 2, 2, 0, 0)):
+            status = coord._compute_automation_status()
+            band = coord.compute_nat_vent_cycling_band()
+
+        expected = f"windows open · nat-vent (target {band['nat_vent_target']:.0f}°F)"
+        assert status == expected

--- a/tests/ui/status-divergence.spec.js
+++ b/tests/ui/status-divergence.spec.js
@@ -71,15 +71,17 @@ test.describe('Status card CA-target divergence indicator (Issue #402)', () => {
 
 });
 
-// Issue #402 follow-up: nat_vent_active/nat_vent_ac_assist were never included in the
-// status endpoint at all, so the "Natural Vent" status card was unreachable dead code —
-// it could never render regardless of whether nat-vent was actually active. Also adds the
-// cycling band (off/on threshold + target) to the card, addressing "target 71°F but indoor
-// is 69°F, why is the fan still on" — showing the band makes clear 69°F is within the
-// fan's normal cycling range, not a contradiction.
-test.describe('Natural Vent status card (Issue #402 follow-up)', () => {
+// Issue #407: the "Natural Vent" info previously rendered as its own separate
+// status-item card, duplicating (and drifting from) the main Status card's own
+// nat-vent target text — a UI the user never asked for (a byproduct of the #402
+// follow-up fix). Merged the cycling band (off/on threshold + target) and
+// AC-assist/savings-mode label back into the Status card as a supplemental line,
+// and removed the standalone card. This still guards against "target 71°F but
+// indoor is 69°F, why is the fan still on" by showing the band makes clear 69°F
+// is within the fan's normal cycling range, not a contradiction.
+test.describe('Natural Vent info merged into Status card (Issue #407)', () => {
 
-  test('renders and shows the cycling band when nat-vent is active', async ({ page }) => {
+  test('Status card shows the cycling band when nat-vent is active', async ({ page }) => {
     await page.route('**/api/climate_advisor/status', (route) => {
       route.fulfill({
         status: 200,
@@ -105,15 +107,19 @@ test.describe('Natural Vent status card (Issue #402 follow-up)', () => {
     await page.goto('/');
     await page.waitForSelector('#status-grid', { state: 'visible' });
 
-    const natVentItem = page.locator('.status-item', { hasText: 'Natural Vent' });
-    await expect(natVentItem).toBeVisible();
-    const html = await natVentItem.innerHTML();
+    // No separate "Natural Vent" card should exist anymore.
+    await expect(page.locator('.status-item .label', { hasText: 'Natural Vent' })).toHaveCount(0);
+
+    const statusItem = page.locator('.status-item', { hasText: 'Status' }).first();
+    await expect(statusItem).toBeVisible();
+    const html = await statusItem.innerHTML();
     expect(html).toContain('70');
     expect(html).toContain('72');
     expect(html).toContain('71');
+    expect(html).toContain('savings mode');
   });
 
-  test('does not render when nat-vent is not active', async ({ page }) => {
+  test('Status card shows no nat-vent line when nat-vent is not active', async ({ page }) => {
     await page.route('**/api/climate_advisor/status', (route) => {
       route.fulfill({
         status: 200,
@@ -135,8 +141,9 @@ test.describe('Natural Vent status card (Issue #402 follow-up)', () => {
     await page.goto('/');
     await page.waitForSelector('#status-grid', { state: 'visible' });
 
-    const natVentItem = page.locator('.status-item', { hasText: 'Natural Vent' });
-    await expect(natVentItem).toHaveCount(0);
+    const statusItem = page.locator('.status-item', { hasText: 'Status' }).first();
+    const html = await statusItem.innerHTML();
+    expect(html).not.toContain('Natural ventilation');
   });
 
 });


### PR DESCRIPTION
## Summary
- `_compute_automation_status()` (the dashboard's main **Status** card text) independently recomputed the flat daytime comfort-band midpoint for its nat-vent branch, instead of calling `compute_nat_vent_cycling_band()` — the single source of truth extracted by the #402 follow-up specifically to prevent this class of bug. This is the third occurrence of the fix-one-duplicate-miss-the-sibling pattern from #374/#400/#402.
- **Follow-up**: the standalone "Natural Vent" status-item card (a byproduct of the #402 follow-up, never requested) duplicated this info in a separate card. Its cycling-band and AC-assist text now render as a supplemental line inside the Status card, and the standalone card is removed — per the project's "no new cards, extend existing ones" dashboard convention.
- Fixes #407.

## Root cause
`coordinator.py::_compute_automation_status()` always showed `(comfort_heat + comfort_cool) / 2.0` (e.g. 71°F), even overnight during the sleep window, while `compute_nat_vent_cycling_band()` (already used by the Natural Vent card and `api.py`) correctly returns the sleep-window target (e.g. 65°F). Additionally, that correct info was living in its own separate dashboard card instead of the existing Status card.

## Fix
- Replace the duplicate 4-line calculation with `self.compute_nat_vent_cycling_band()["nat_vent_target"]`.
- Move the Natural Vent card's cycling-band/AC-assist markup into the Status card's `.status-item` block in `frontend/index.html`; delete the standalone card.

## Test plan
- [x] Added 3 regression tests to `tests/test_nat_vent_dashboard_target.py`: daytime target, sleep-window target, and status/cycling-band agreement
- [x] Verified via an actual revert test that the new sleep-window tests fail against the pre-fix code and pass against the fix
- [x] Updated `tests/ui/status-divergence.spec.js` (Playwright) to assert the nat-vent info appears in the Status card and no standalone "Natural Vent" card exists — 4/4 passing
- [x] Full suite: 3018 passed, 0 failed
- [x] `ruff check` / `ruff format` clean
- [x] Version bumped 0.4.61 → 0.4.63 in `const.py` + `manifest.json`; `RELEASE_NOTES` and `KNOWN_FIXES[407]` updated
- [x] Deployed to production HA instance for manual verification