### PR TITLE
Fix #409: streamline Status card nat-vent display (v0.4.64)

### DIFF
--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,16 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.4.63"
+VERSION = "0.4.64"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.4.64": [
+        "Fix #409: streamlined the Status card's nat-vent display — removed the duplicate"
+        " target temperature (previously shown twice), removed the redundant 'Natural"
+        " ventilation'/'nat-vent' double-naming, and dropped the unverified 'windows open'"
+        " prefix (nat-vent can be active without any window physically open; real window"
+        " state is already shown by the dedicated Doors/Windows card).",
+    ],
     "0.4.63": [
         "Fix #407 follow-up: removed the standalone 'Natural Vent' dashboard card — its"
         " cycling-band and AC-assist info is now shown as a supplemental line on the main"
@@ -720,6 +727,29 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    409: {
+        "version_fixed": "0.4.64",
+        "title": "Status card nat-vent display duplicated target/naming and claimed unverified 'windows open'",
+        "scope_covered": (
+            "coordinator.py: _compute_automation_status()'s nat-vent branch no longer prefixes"
+            " its return string with 'windows open · ' — natural_vent_active does not imply a"
+            " contact sensor is open (it can activate purely on temperature/idle-HVAC"
+            " conditions per automation.py's idle-reeval path, and door/window sensors are"
+            " optional config), and real window state is already shown by the dedicated"
+            " Doors/Windows status card, so restating it here was both potentially inaccurate"
+            " and duplicative. frontend/index.html: the supplemental nat-vent line under the"
+            " Status card no longer repeats the target temperature (already shown once in"
+            " automation_status) or the 'Natural ventilation' name (already named 'nat-vent'"
+            " in automation_status) — it now shows only the mode qualifier (AC assist / savings"
+            " mode) and the cycling band."
+        ),
+        "scope_not_covered": (
+            "Does not touch the other branches of _compute_automation_status() that"
+            " legitimately reference window/door state (e.g. 'windows open (as planned)',"
+            " 'paused — door/window open') — those describe genuinely door/window-driven"
+            " states. Does not touch automation.py or api.py, both already correct."
+        ),
+    },
     407: {
         "version_fixed": "0.4.63",
         "title": "Dashboard Status card showed stale nat-vent target + redundant Natural Vent card",

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -5468,8 +5468,13 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             # sleep window, and never migrated to compute_nat_vent_cycling_band() (the Issue #402
             # follow-up single source of truth for this exact value) — see that method's docstring
             # for the fix-one-duplicate-miss-the-sibling history this repeats (#374, #400, #402).
+            # Issue #409: dropped the "windows open · " prefix — natural_vent_active does not
+            # imply a sensor is open (it can activate on temperature/idle-HVAC conditions alone,
+            # see automation.py's idle-reeval path, and door/window sensors are optional config),
+            # and real window state is already shown by the dedicated Doors/Windows status card.
+            # Restating it here was both potentially inaccurate and duplicative.
             _nt = self.compute_nat_vent_cycling_band()["nat_vent_target"]
-            return f"windows open · nat-vent (target {_nt:.0f}°F)"
+            return f"nat-vent (target {_nt:.0f}°F)"
         if self.automation_engine.is_paused_by_door:
             if self._occupancy_mode == OCCUPANCY_AWAY:
                 return "paused — away (setback deferred: windows open)"

--- a/custom_components/climate_advisor/frontend/index.html
+++ b/custom_components/climate_advisor/frontend/index.html
@@ -951,13 +951,9 @@
           <div class="label">Status</div>
           <div class="value">${data.automation_status || 'unknown'}</div>
           ${data.pause_suppressed_classification ? `<div class="value">Classification suppressed — HVAC held off until windows close</div>` : ''}
-          ${data.nat_vent_active ? `
+          ${data.nat_vent_active && data.nat_vent_off_threshold != null && data.nat_vent_on_threshold != null ? `
           <div class="value" style="font-size:0.8rem;opacity:0.85">
-            ${escapeHtml(data.nat_vent_ac_assist ? 'Natural ventilation + AC assist' : 'Natural ventilation (savings mode — fan only)')}${
-              data.nat_vent_off_threshold != null && data.nat_vent_on_threshold != null
-                ? `<br>cycling ${Math.round(data.nat_vent_off_threshold)}${unitSym}–${Math.round(data.nat_vent_on_threshold)}${unitSym}${data.nat_vent_target != null ? ` (target ${Math.round(data.nat_vent_target)}${unitSym})` : ''}`
-                : ''
-            }
+            ${escapeHtml(data.nat_vent_ac_assist ? 'AC assist' : 'savings mode')} · cycling ${Math.round(data.nat_vent_off_threshold)}${unitSym}–${Math.round(data.nat_vent_on_threshold)}${unitSym}
           </div>
           ` : ''}
         </div>

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.4.63"
+  "version": "0.4.64"
 }

--- a/tests/test_nat_vent_dashboard_target.py
+++ b/tests/test_nat_vent_dashboard_target.py
@@ -197,6 +197,11 @@ class TestComputeAutomationStatusNatVentTarget:
     contradicting the already-correct Natural Vent card (e.g. 65-66°F), repeating the
     exact "fix one duplicate implementation, miss the sibling" pattern documented on
     compute_nat_vent_cycling_band() from #374/#400/#402.
+
+    Issue #409: the "windows open · " prefix was dropped — natural_vent_active does
+    not imply a sensor is open, and real window state is already shown by the
+    dedicated Doors/Windows status card, so restating it here was both potentially
+    inaccurate and duplicative.
     """
 
     def _config(self):
@@ -216,7 +221,7 @@ class TestComputeAutomationStatusNatVentTarget:
         with patch(_PATCH_DT_NOW, return_value=datetime(2026, 7, 2, 14, 0, 0)):
             status = coord._compute_automation_status()
 
-        assert status == "windows open · nat-vent (target 71°F)"
+        assert status == "nat-vent (target 71°F)"
 
     def test_sleep_window_status_uses_sleep_heat_not_daytime_midpoint(self):
         """During the sleep window, the status string must show the sleep-window target
@@ -231,7 +236,7 @@ class TestComputeAutomationStatusNatVentTarget:
         with patch(_PATCH_DT_NOW, return_value=datetime(2026, 7, 2, 2, 0, 0)):
             status = coord._compute_automation_status()
 
-        assert status == "windows open · nat-vent (target 66°F)"
+        assert status == "nat-vent (target 66°F)"
         assert "71" not in status
 
     def test_status_and_cycling_band_agree(self):
@@ -246,5 +251,19 @@ class TestComputeAutomationStatusNatVentTarget:
             status = coord._compute_automation_status()
             band = coord.compute_nat_vent_cycling_band()
 
-        expected = f"windows open · nat-vent (target {band['nat_vent_target']:.0f}°F)"
+        expected = f"nat-vent (target {band['nat_vent_target']:.0f}°F)"
         assert status == expected
+
+    def test_status_does_not_claim_windows_open(self):
+        """Issue #409: natural_vent_active does not imply a window/door sensor is open
+
+        (it can activate purely on temperature/idle-HVAC conditions, and contact sensors
+        are optional config), so the nat-vent status string must not assert "windows open"
+        — that fact belongs solely to the dedicated Doors/Windows status card.
+        """
+        coord = _make_nat_vent_coord_stub(config=self._config())
+
+        with patch(_PATCH_DT_NOW, return_value=datetime(2026, 7, 2, 14, 0, 0)):
+            status = coord._compute_automation_status()
+
+        assert "windows open" not in status

--- a/tests/ui/status-divergence.spec.js
+++ b/tests/ui/status-divergence.spec.js
@@ -74,12 +74,18 @@ test.describe('Status card CA-target divergence indicator (Issue #402)', () => {
 // Issue #407: the "Natural Vent" info previously rendered as its own separate
 // status-item card, duplicating (and drifting from) the main Status card's own
 // nat-vent target text — a UI the user never asked for (a byproduct of the #402
-// follow-up fix). Merged the cycling band (off/on threshold + target) and
-// AC-assist/savings-mode label back into the Status card as a supplemental line,
-// and removed the standalone card. This still guards against "target 71°F but
-// indoor is 69°F, why is the fan still on" by showing the band makes clear 69°F
-// is within the fan's normal cycling range, not a contradiction.
-test.describe('Natural Vent info merged into Status card (Issue #407)', () => {
+// follow-up fix). Merged the cycling band (off/on threshold) and AC-assist/savings-mode
+// label back into the Status card as a supplemental line, and removed the standalone
+// card. This still guards against "target 71°F but indoor is 69°F, why is the fan
+// still on" by showing the band makes clear 69°F is within the fan's normal cycling
+// range, not a contradiction.
+//
+// Issue #409 follow-up: the merged card still duplicated the target number (once in
+// automation_status, once in the supplemental line) and used two names ("Natural
+// ventilation" / "nat-vent") for the same concept. The supplemental line now shows
+// only the mode qualifier + cycling band, not the target — the target lives solely in
+// automation_status.
+test.describe('Natural Vent info merged into Status card (Issue #407, #409)', () => {
 
   test('Status card shows the cycling band when nat-vent is active', async ({ page }) => {
     await page.route('**/api/climate_advisor/status', (route) => {
@@ -93,7 +99,7 @@ test.describe('Natural Vent info merged into Status card (Issue #407)', () => {
           outdoor_temp: 65,
           automation_enabled: true,
           occupancy_mode: 'home',
-          automation_status: 'active',
+          automation_status: 'nat-vent (target 71°F)',
           compliance_score: 1.0,
           nat_vent_active: true,
           nat_vent_ac_assist: false,
@@ -117,6 +123,11 @@ test.describe('Natural Vent info merged into Status card (Issue #407)', () => {
     expect(html).toContain('72');
     expect(html).toContain('71');
     expect(html).toContain('savings mode');
+    // Issue #409: no duplicate naming — "Natural ventilation" must not appear
+    // (the concept is named once, as "nat-vent", in automation_status).
+    expect(html).not.toContain('Natural ventilation');
+    // Issue #409: the nat-vent branch must not assert an unverified "windows open" fact.
+    expect(html).not.toContain('windows open');
   });
 
   test('Status card shows no nat-vent line when nat-vent is not active', async ({ page }) => {


### PR DESCRIPTION
## Summary
Direct continuation of #407/#408. The user confirmed the merged card is "better but not great" — it repeated the nat-vent target twice and used two names for the same concept, and shaping analysis surfaced a deeper tension: the "windows open" prefix asserts a fact that isn't guaranteed.

- **Backend** (`coordinator.py::_compute_automation_status()`, nat-vent branch only): dropped the "windows open · " prefix. `natural_vent_active` does not imply a contact sensor is open — door/window sensors are optional config, and nat-vent can activate purely on temperature/idle-HVAC conditions. Real window state is already shown by the dedicated "Doors/Windows" card, so restating it here was both potentially inaccurate and duplicative.
- **Frontend** (`frontend/index.html`): the supplemental nat-vent line under the Status card now shows only the mode qualifier (`AC assist` / `savings mode`) + cycling band — dropped the duplicate target number (already in the primary line) and the redundant "Natural ventilation" naming (already "nat-vent" in the primary line).

Result: `nat-vent (target 65°F)` / `savings mode · cycling 64°F–66°F` — two compact lines instead of three wrapped, repetitive ones.

Fixes #409.

## Test plan
- [x] Updated 3 existing regression tests in `tests/test_nat_vent_dashboard_target.py` for the new string format; added a new test asserting the string never contains "windows open"
- [x] Updated `tests/ui/status-divergence.spec.js` to assert "Natural ventilation" and "windows open" are both absent
- [x] Full suite: 3019 passed, 0 failed; ruff clean
- [x] Playwright UI suite: 4/4 passed
- [x] Version bumped 0.4.63 → 0.4.64; `RELEASE_NOTES` and `KNOWN_FIXES[409]` added
- [x] Independent Opus verification pass confirmed scope, no defects