### PR TITLE
Fix #420: detect and surface AI investigation report truncation

### DIFF
--- a/custom_components/climate_advisor/ai_skills.py
+++ b/custom_components/climate_advisor/ai_skills.py
@@ -126,6 +126,7 @@ class AISkillRegistry:
                     "error": None,
                     "input_context": context,
                     "raw_response": response.content,
+                    "truncated": response.truncated,
                 }
             except Exception:
                 _LOGGER.exception("Failed to parse AI response for skill '%s'", name)
@@ -211,6 +212,7 @@ class AISkillRegistry:
         override_reasoning = cfg.get(skill.config_key_reasoning) if skill.config_key_reasoning else None
 
         full_text = ""
+        stop_reason: str | None = None
         try:
             async for event in claude_client.async_request_streaming(
                 system_prompt=skill.system_prompt,
@@ -227,6 +229,8 @@ class AISkillRegistry:
                 elif event_type == "text":
                     full_text += event_text
                     yield {"type": "chunk", "text": event_text}
+                elif event_type == "stop":
+                    stop_reason = event.get("stop_reason")
         except Exception as exc:
             _LOGGER.error("Streaming request failed for skill '%s': %s", name, exc)
             yield {"type": "error", "message": str(exc)}
@@ -246,6 +250,7 @@ class AISkillRegistry:
             "error": None,
             "input_context": context,
             "raw_response": full_text,
+            "truncated": stop_reason == "max_tokens",
         }
 
 

--- a/custom_components/climate_advisor/api.py
+++ b/custom_components/climate_advisor/api.py
@@ -820,7 +820,13 @@ class ClimateAdvisorInvestigateView(HomeAssistantView):
                         "error": None,
                         "input_context": event.get("input_context", ""),
                         "raw_response": event.get("raw_response", ""),
+                        "truncated": event.get("truncated", False),
                     }
+                    if final_result["truncated"]:
+                        _LOGGER.warning(
+                            "Investigation report truncated: hit max_tokens limit; "
+                            "consider raising Investigator Max Response Length"
+                        )
 
             if final_result and final_result.get("success"):
                 coordinator.claude_client.increment_investigator_counter()
@@ -840,6 +846,11 @@ class ClimateAdvisorInvestigateView(HomeAssistantView):
         )
 
         if result.get("success") or result.get("source") == "fallback":
+            if result.get("truncated"):
+                _LOGGER.warning(
+                    "Investigation report truncated: hit max_tokens limit; "
+                    "consider raising Investigator Max Response Length"
+                )
             coordinator.claude_client.increment_investigator_counter()
             await coordinator.async_store_investigation_report(result)
             _LOGGER.info("Investigation complete: source=%s", result.get("source", "unknown"))

--- a/custom_components/climate_advisor/claude_api.py
+++ b/custom_components/climate_advisor/claude_api.py
@@ -80,6 +80,8 @@ class ClaudeResponse:
     rate_limited: bool = False
     circuit_open: bool = False
     budget_exceeded: bool = False
+    stop_reason: str | None = None
+    truncated: bool = False
 
 
 @dataclass
@@ -402,6 +404,24 @@ class ClaudeAPIClient:
             input_tokens: int = getattr(final_msg.usage, "input_tokens", 0)
             output_tokens: int = getattr(final_msg.usage, "output_tokens", 0)
             estimated_cost = self._estimate_cost(resolved_model, input_tokens, output_tokens)
+
+            stop_reason = getattr(final_msg, "stop_reason", None)
+            truncated = stop_reason == "max_tokens"
+            skill_name = self._extract_skill_name(system_prompt)
+            _LOGGER.debug(
+                "Claude streaming response finished: skill=%s stop_reason=%s output_tokens=%d",
+                skill_name,
+                stop_reason,
+                output_tokens,
+            )
+            if truncated:
+                _LOGGER.warning(
+                    "Response truncated: skill=%s stop_reason=max_tokens output_tokens=%d max_tokens=%d",
+                    skill_name,
+                    output_tokens,
+                    kwargs["max_tokens"],
+                )
+            yield {"type": "stop", "stop_reason": stop_reason}
 
             # Update counters on success
             self._circuit_breaker.consecutive_failures = 0
@@ -801,6 +821,23 @@ class ClaudeAPIClient:
                     if hasattr(block, "text"):
                         content_text += block.text
 
+                stop_reason = getattr(api_response, "stop_reason", None)
+                truncated = stop_reason == "max_tokens"
+                skill_name = self._extract_skill_name(system_prompt)
+                _LOGGER.debug(
+                    "Claude response finished: skill=%s stop_reason=%s output_tokens=%d",
+                    skill_name,
+                    stop_reason,
+                    output_tokens,
+                )
+                if truncated:
+                    _LOGGER.warning(
+                        "Response truncated: skill=%s stop_reason=max_tokens output_tokens=%d max_tokens=%d",
+                        skill_name,
+                        output_tokens,
+                        kwargs["max_tokens"],
+                    )
+
                 return ClaudeResponse(
                     success=True,
                     content=content_text,
@@ -808,6 +845,8 @@ class ClaudeAPIClient:
                     output_tokens=output_tokens,
                     estimated_cost=estimated_cost,
                     latency_ms=latency_ms,
+                    stop_reason=stop_reason,
+                    truncated=truncated,
                 )
 
             except RateLimitError as exc:

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,16 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.4.68"
+VERSION = "0.4.69"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.4.69": [
+        "Fix #420: AI Investigation reports now flag when a report was cut off before"
+        " Claude finished writing it (hit the configured max response length), instead of"
+        " silently showing an incomplete report as if it were 'Completed'. The dashboard"
+        " now shows a clear truncation warning and a log WARNING is emitted so you know to"
+        " raise 'Investigator Max Response Length' in AI settings and re-run.",
+    ],
     "0.4.68": [
         "Fix #417: overnight nat-vent no longer flickers between 'nat-vent' and"
         " 'paused — door/window open' every few minutes while the window stays open the"
@@ -758,6 +765,37 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    420: {
+        "version_fixed": "0.4.69",
+        "title": "AI Investigation report streamed text stops mid-way with no error shown",
+        "scope_covered": (
+            "claude_api.py: ClaudeResponse gained truncated/stop_reason fields;"
+            " _async_call_with_retry() (non-streaming) and async_request_streaming()"
+            " (streaming) both now read the Anthropic API's stop_reason on every request,"
+            " log it unconditionally at DEBUG, and log a WARNING plus set truncated=True"
+            " when stop_reason == 'max_tokens'. ai_skills.py: async_execute() and"
+            " async_execute_streaming() propagate truncated into their result/'done' dicts."
+            " api.py: ClimateAdvisorInvestigateView.post() logs a WARNING and stores"
+            " truncated in the persisted investigation report for both the streaming and"
+            " non-streaming branches. frontend/index.html: _runAIInvestigation() shows a"
+            " truncation warning instead of 'Completed' status; renderReportInPreview()"
+            " and the history list both show a truncation banner/badge when reopening a"
+            " truncated report; _formatInvestigationReport() notes it in markdown exports."
+            " Root cause: stop_reason was never inspected anywhere in the stack, so a"
+            " response cut off at the configured max_tokens cap was indistinguishable from"
+            " a normal completion — no exception, no log line, UI showed 'Completed'."
+        ),
+        "scope_not_covered": (
+            "Does not change the actual token budget or system-prompt verbosity — a"
+            " Investigator Max Response Length that is genuinely too low for the report"
+            " content will still truncate the report; it is now visibly flagged instead of"
+            " silent. Does not distinguish an early legitimate stop_reason == 'end_turn'"
+            " from a complete report — that case was not observed and could not be"
+            " confirmed without production log evidence (none was retrievable during this"
+            " investigation), but is now always logged at DEBUG so a future occurrence is"
+            " diagnosable."
+        ),
+    },
     417: {
         "version_fixed": "0.4.68",
         "title": "Overnight nat-vent flapped between nat-vent and paused-by-door every ~5min",

--- a/custom_components/climate_advisor/frontend/index.html
+++ b/custom_components/climate_advisor/frontend/index.html
@@ -2741,6 +2741,7 @@
               error: event.error || null,
               raw_response: event.raw_response || accumulated,
               input_context: event.input_context || '',
+              truncated: !!event.truncated,
             };
             _currentReport = {
               reportType: 'investigation',
@@ -2748,9 +2749,11 @@
               result,
               focus,
             };
-            console.log('[CA] Done event received, total=' + accumulated.length + ' chars');
+            console.log('[CA] Done event received, total=' + accumulated.length + ' chars, truncated=' + result.truncated);
             renderReportInPreview(_currentReport);
-            status.textContent = 'Completed at ' + new Date().toLocaleTimeString() + ' (source: ' + (result.source || 'ai') + ')';
+            status.textContent = result.truncated
+              ? '⚠ Report truncated — hit max response length. Increase ‘Investigator Max Response Length’ in AI settings and re-run.'
+              : 'Completed at ' + new Date().toLocaleTimeString() + ' (source: ' + (result.source || 'ai') + ')';
             loadUnifiedHistory();
             break;
 
@@ -2864,11 +2867,15 @@
       ? ' <span style="background:var(--primary);color:#fff;font-size:0.7rem;padding:1px 6px;border-radius:10px;vertical-align:middle;">refined</span>'
       : '';
     const tsSpan = ts ? '<div style="color:var(--text-secondary);font-size:0.82rem;margin-bottom:8px;">' + escapeHtml(ts) + refinedBadge + '</div>' : '';
+    const truncatedBanner = result.truncated
+      ? '<div style="background:var(--warning);color:#000;font-size:0.82rem;padding:6px 10px;border-radius:4px;margin-bottom:8px;">'
+        + '⚠ Report truncated — hit max response length. Increase ‘Investigator Max Response Length’ in AI settings and re-run.</div>'
+      : '';
     const data = result.data || {};
     const sourceLabel = result.source === 'fallback'
       ? '<span style="color:var(--warning);font-size:0.8rem">(fallback \u2014 AI unavailable)</span>'
       : '<span style="color:var(--success);font-size:0.8rem">(AI-generated)</span>';
-    let html = tsSpan + '<div style="margin-bottom:8px">' + sourceLabel + '</div>';
+    let html = tsSpan + truncatedBanner + '<div style="margin-bottom:8px">' + sourceLabel + '</div>';
     if (entry.reportType === 'activity') {
       const sections = ['summary', 'timeline', 'decisions', 'anomalies', 'diagnostics'];
       const sectionLabels = { summary: 'Summary', timeline: 'Timeline', decisions: 'Decisions', anomalies: 'Anomalies', diagnostics: 'Diagnostics' };
@@ -3089,6 +3096,9 @@
         : '<span style="background:var(--success);color:#fff;font-size:0.7rem;padding:1px 6px;border-radius:10px;">Activity</span>';
       const result = entry.result || {};
       const source = result.source || 'unknown';
+      const truncatedBadge = result.truncated
+        ? '<span title="Report was cut off — hit max response length" style="background:var(--warning);color:#000;font-size:0.7rem;padding:1px 6px;border-radius:10px;">⚠ truncated</span>'
+        : '';
       const summary = (result.data && result.data.summary)
         ? result.data.summary.replace(/\s+/g, ' ').trim().substring(0, 110) + (result.data.summary.length > 110 ? '…' : '')
         : '';
@@ -3099,6 +3109,7 @@
         + '<div style="display:flex;gap:6px;align-items:center;flex-wrap:wrap;">'
         + '<span style="font-size:0.82rem;font-weight:500;">' + escapeHtml(ts) + '</span>'
         + typeBadge
+        + truncatedBadge
         + '<span style="font-size:0.75rem;color:var(--text-secondary);">' + escapeHtml(source) + '</span>'
         + '</div>'
         + (summary ? '<div style="font-size:0.78rem;color:var(--text-secondary);margin-top:3px;line-height:1.4;">' + escapeHtml(summary) + '</div>' : '')
@@ -3165,6 +3176,7 @@
     out += '| **Date** | ' + ts + ' |\n';
     out += '| **Source** | ' + source + ' |\n';
     if (focus) out += '| **Focus** | ' + focus + ' |\n';
+    if (result.truncated) out += '| **Truncated** | ⚠ Yes — hit max response length |\n';
     out += '\n---\n\n';
     for (const { key, label } of sections) {
       const content = (data[key] || '').trim();

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.4.68"
+  "version": "0.4.69"
 }

--- a/docs/ai-skills-spec.md
+++ b/docs/ai-skills-spec.md
@@ -19,6 +19,7 @@
 | What rules govern the AI investigator's thermal pipeline health diagnosis? | Three THERMAL PIPELINE HEALTH rules in the system prompt: flag 0 committed HVAC obs as pipeline failure; flag `k_active_cool=NEVER LEARNED` with recent AC history as failure; flag ≥ 3 `new_session_started` abandonments as short-cycling. | [§THERMAL PIPELINE HEALTH System Prompt Rules](#thermal-pipeline-health-system-prompt-rules) |
 | Does the registry cache skill responses? | No. The registry has no response cache. Every `async_execute()` call builds a fresh context, calls Claude, and parses a new response. | [Caching](#caching) |
 | What invariant holds for `async_execute()` with respect to exceptions? | `async_execute()` never raises to the caller. Every exception inside context building, Claude call, parsing, and fallback invocation is caught and surfaced as a structured error dict. | [Invariants](#invariants) |
+| How does a caller know a report was cut off before Claude finished writing it? | `ClaudeAPIClient` inspects the Anthropic API's `stop_reason` on every request; `truncated=True` (present only on the AI success path) iff `stop_reason == "max_tokens"`. A stream ending on `max_tokens` is otherwise indistinguishable from a normal completion — no exception is raised (Issue #420). | [Return contract](#return-contract) |
 
 ---
 
@@ -106,7 +107,8 @@ No type enforcement is performed on callable signatures at registration time.
 4. **Claude call:** `await claude_client.async_request(system_prompt=skill.system_prompt, user_message=context, triggered_by=skill.triggered_by, model=..., max_tokens=..., reasoning_effort=...)`.
 5. **Success path:** If `response.success=True`:
    - Call `skill.response_parser(response.content)`. If the parser raises, fall through to step 6.
-   - Return `{success: True, source: "ai", data: parsed, error: None, input_context: context, raw_response: response.content}`.
+   - Return `{success: True, source: "ai", data: parsed, error: None, input_context: context, raw_response: response.content, truncated: response.truncated}`.
+   - `response.truncated` (and `response.stop_reason`) come from the Anthropic API's `stop_reason` field, which `ClaudeAPIClient` now inspects on every request (both `async_request` and `async_request_streaming`). `truncated=True` iff `stop_reason == "max_tokens"` — the model was cut off before finishing, not because it chose to stop. This is always logged (DEBUG for any stop_reason, WARNING when truncated) so a cut-off report is diagnosable instead of silently indistinguishable from a complete one (Issue #420).
 6. **Fallback path:** `response.success=False` or parser raised. Log WARNING. If `skill.fallback` is defined → `_run_fallback(skill, coordinator, context=context, **kwargs)`. Else → `_error_result(response.error or "AI request failed...", input_context=context)`.
 
 ### Fallback Trigger Conditions
@@ -133,10 +135,13 @@ Every `async_execute()` call returns exactly this shape:
     "error": str | None,      # error message string; None on success
     "input_context": str,     # assembled context string; "" if context build failed early
     "raw_response": str,      # Claude's raw text; "" on failure/fallback
+    "truncated": bool,        # True iff Claude's stop_reason was "max_tokens" (AI success path only)
 }
 ```
 
-All six keys are always present. `async_execute()` never raises.
+The first six keys are always present. `truncated` is only present on the AI success path
+(step 5) — fallback and error results omit it, and callers should treat a missing key as
+`False`. `async_execute()` never raises.
 
 ### `_run_fallback()` contract
 

--- a/tests/test_ai_investigator.py
+++ b/tests/test_ai_investigator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import datetime
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 # ── HA module stubs must be in place before importing climate_advisor modules ──
 if "homeassistant" not in sys.modules:
@@ -732,16 +732,23 @@ class TestInvestigatorRateLimit:
 # ---------------------------------------------------------------------------
 
 
-def _simulate_investigate_post(
+async def _simulate_investigate_post(
     coordinator: MagicMock,
     focus: str | None = None,
     hours: int = 48,
+    run_skill: bool = False,
 ) -> tuple[int, str]:
     """Replicate the logic of ClimateAdvisorInvestigateView.post() as a plain function.
 
     Returns (status_code, body_text) for assertions.
     This avoids instantiating HomeAssistantView which has metaclass constraints.
+
+    When *run_skill* is True, also replicates the non-streaming execution branch
+    (calls coordinator.ai_skills.async_execute(), logs a WARNING and stores the
+    report on success — mirroring api.py's truncation handling, Issue #420).
     """
+    import logging
+
     from custom_components.climate_advisor.const import (
         CONF_AI_ENABLED,
         CONF_AI_INVESTIGATOR_ENABLED,
@@ -762,7 +769,29 @@ def _simulate_investigate_post(
     if not allowed:
         return 429, reason
 
-    return 200, "ok"
+    if not run_skill:
+        return 200, "ok"
+
+    result = await coordinator.ai_skills.async_execute(
+        "investigator",
+        coordinator.hass,
+        coordinator,
+        coordinator.claude_client,
+        focus=focus or "",
+        hours=hours,
+    )
+
+    if result.get("success") or result.get("source") == "fallback":
+        if result.get("truncated"):
+            logging.getLogger("custom_components.climate_advisor.api").warning(
+                "Investigation report truncated: hit max_tokens limit; "
+                "consider raising Investigator Max Response Length"
+            )
+        coordinator.claude_client.increment_investigator_counter()
+        await coordinator.async_store_investigation_report(result)
+        return 200, "ok"
+
+    return 500, result.get("error", "Investigation failed")
 
 
 def _simulate_investigation_reports_get(coordinator: MagicMock) -> list[dict]:
@@ -791,7 +820,7 @@ class TestAPIEndpointLogic:
         """POST returns 403 when ai_enabled is False."""
         coord = self._make_api_coordinator(ai_enabled=False)
 
-        status, body = _simulate_investigate_post(coord)
+        status, body = asyncio.run(_simulate_investigate_post(coord))
 
         assert status == 403
         assert "AI features are not enabled" in body
@@ -800,7 +829,7 @@ class TestAPIEndpointLogic:
         """POST returns 403 when ai_investigator_enabled is False."""
         coord = self._make_api_coordinator(ai_investigator_enabled=False)
 
-        status, body = _simulate_investigate_post(coord)
+        status, body = asyncio.run(_simulate_investigate_post(coord))
 
         assert status == 403
         assert "Investigative agent is not enabled" in body
@@ -810,7 +839,7 @@ class TestAPIEndpointLogic:
         coord = self._make_api_coordinator()
         coord.claude_client = None
 
-        status, body = _simulate_investigate_post(coord)
+        status, body = asyncio.run(_simulate_investigate_post(coord))
 
         assert status == 503
 
@@ -819,7 +848,7 @@ class TestAPIEndpointLogic:
         coord = self._make_api_coordinator()
         coord.claude_client.check_investigator_rate_limit.return_value = (False, "limit reached")
 
-        status, body = _simulate_investigate_post(coord)
+        status, body = asyncio.run(_simulate_investigate_post(coord))
 
         assert status == 429
         assert "limit reached" in body
@@ -828,9 +857,61 @@ class TestAPIEndpointLogic:
         """POST returns 200 when all pre-conditions are satisfied."""
         coord = self._make_api_coordinator()
 
-        status, _ = _simulate_investigate_post(coord)
+        status, _ = asyncio.run(_simulate_investigate_post(coord))
 
         assert status == 200
+
+    def test_post_truncated_result_logs_warning_and_stores_flag(self, caplog):
+        """A truncated skill result logs a WARNING and stores truncated=True (Issue #420)."""
+        coord = self._make_api_coordinator()
+        coord.hass = MagicMock()
+        coord.ai_skills = MagicMock()
+        coord.ai_skills.async_execute = AsyncMock(
+            return_value={
+                "success": True,
+                "source": "ai",
+                "data": {},
+                "error": None,
+                "input_context": "ctx",
+                "raw_response": "cut off",
+                "truncated": True,
+            }
+        )
+        coord.async_store_investigation_report = AsyncMock()
+
+        with caplog.at_level("WARNING"):
+            status, _ = asyncio.run(_simulate_investigate_post(coord, run_skill=True))
+
+        assert status == 200
+        assert any("truncated" in rec.message.lower() for rec in caplog.records)
+        stored = coord.async_store_investigation_report.call_args[0][0]
+        assert stored["truncated"] is True
+
+    def test_post_normal_result_does_not_warn(self, caplog):
+        """A normal (non-truncated) result stores truncated=False and logs no warning."""
+        coord = self._make_api_coordinator()
+        coord.hass = MagicMock()
+        coord.ai_skills = MagicMock()
+        coord.ai_skills.async_execute = AsyncMock(
+            return_value={
+                "success": True,
+                "source": "ai",
+                "data": {},
+                "error": None,
+                "input_context": "ctx",
+                "raw_response": "complete report",
+                "truncated": False,
+            }
+        )
+        coord.async_store_investigation_report = AsyncMock()
+
+        with caplog.at_level("WARNING"):
+            status, _ = asyncio.run(_simulate_investigate_post(coord, run_skill=True))
+
+        assert status == 200
+        assert not any("truncated" in rec.message.lower() for rec in caplog.records)
+        stored = coord.async_store_investigation_report.call_args[0][0]
+        assert stored["truncated"] is False
 
     def test_get_reports_returns_coordinator_history(self):
         """GET returns the list from get_investigation_report_history()."""

--- a/tests/test_ai_skills.py
+++ b/tests/test_ai_skills.py
@@ -13,7 +13,7 @@ from custom_components.climate_advisor.claude_api import ClaudeResponse
 # ---------------------------------------------------------------------------
 
 
-def _success_response(content: str = "test response") -> ClaudeResponse:
+def _success_response(content: str = "test response", truncated: bool = False) -> ClaudeResponse:
     """Build a successful ClaudeResponse for use in tests."""
     return ClaudeResponse(
         success=True,
@@ -22,6 +22,8 @@ def _success_response(content: str = "test response") -> ClaudeResponse:
         output_tokens=20,
         estimated_cost=0.001,
         latency_ms=100.0,
+        stop_reason="max_tokens" if truncated else "end_turn",
+        truncated=truncated,
     )
 
 
@@ -158,6 +160,35 @@ class TestAISkillRegistryExecute:
         assert result["data"]["extra"] == "value"
         assert result["raw_response"] == "Great analysis here"
         assert result["input_context"] == "test context"
+
+    def test_execute_propagates_truncated_flag(self):
+        """A response that hit max_tokens propagates truncated=True into the result dict."""
+        registry = AISkillRegistry()
+        skill = _make_skill(name="truncated_skill")
+        registry.register(skill)
+
+        client = _make_claude_client(_success_response(content="cut off mid-sen", truncated=True))
+        hass = MagicMock()
+        coordinator = MagicMock()
+
+        result = asyncio.run(registry.async_execute("truncated_skill", hass, coordinator, client))
+
+        assert result["success"] is True
+        assert result["truncated"] is True
+
+    def test_execute_not_truncated_by_default(self):
+        """A normal completion has truncated=False."""
+        registry = AISkillRegistry()
+        skill = _make_skill(name="normal_skill")
+        registry.register(skill)
+
+        client = _make_claude_client(_success_response(content="complete"))
+        hass = MagicMock()
+        coordinator = MagicMock()
+
+        result = asyncio.run(registry.async_execute("normal_skill", hass, coordinator, client))
+
+        assert result["truncated"] is False
 
     def test_execute_with_fallback_on_ai_failure(self):
         """When AI fails and a fallback is registered, result comes from fallback."""
@@ -354,11 +385,14 @@ def _make_streaming_client(
     chunks: list[str],
     raise_on_stream: Exception | None = None,
     thinking_chunks: list[str] | None = None,
+    stop_reason: str | None = "end_turn",
 ) -> MagicMock:
     """Build a mock client whose async_request_streaming yields typed event dicts.
 
     Yields ``{"type": "thinking", ...}`` events for each entry in *thinking_chunks*
-    (if provided) before yielding ``{"type": "text", ...}`` events for *chunks*.
+    (if provided) before yielding ``{"type": "text", ...}`` events for *chunks*, then
+    a trailing ``{"type": "stop", "stop_reason": ...}`` event (unless *stop_reason* is
+    None, mimicking a client that predates the "stop" event).
     """
 
     async def _streaming_gen(*_args, **_kwargs):
@@ -368,6 +402,8 @@ def _make_streaming_client(
             yield {"type": "thinking", "text": t}
         for chunk in chunks:
             yield {"type": "text", "text": chunk}
+        if stop_reason is not None:
+            yield {"type": "stop", "stop_reason": stop_reason}
 
     client = MagicMock()
     client.async_request_streaming = _streaming_gen
@@ -488,3 +524,47 @@ class TestAISkillRegistryStreaming:
         assert chunk_events[0]["text"] == "Result"
         # Thinking content must NOT appear in raw_response (only text tokens)
         assert done_events[0]["raw_response"] == "Result"
+
+    def test_streaming_max_tokens_stop_marks_done_truncated(self):
+        """A 'stop' event with stop_reason='max_tokens' sets truncated=True on the done event."""
+        registry = AISkillRegistry()
+        skill = _make_skill(name="truncated_stream_skill")
+        registry.register(skill)
+
+        client = _make_streaming_client(["cut off"], stop_reason="max_tokens")
+        hass = MagicMock()
+        coordinator = MagicMock()
+
+        async def _collect():
+            events = []
+            async for ev in registry.async_execute_streaming("truncated_stream_skill", hass, coordinator, client):
+                events.append(ev)
+            return events
+
+        events = asyncio.run(_collect())
+        done_events = [e for e in events if e.get("type") == "done"]
+
+        assert len(done_events) == 1
+        assert done_events[0]["truncated"] is True
+
+    def test_streaming_end_turn_stop_marks_done_not_truncated(self):
+        """A 'stop' event with stop_reason='end_turn' leaves truncated=False on the done event."""
+        registry = AISkillRegistry()
+        skill = _make_skill(name="complete_stream_skill")
+        registry.register(skill)
+
+        client = _make_streaming_client(["all done"], stop_reason="end_turn")
+        hass = MagicMock()
+        coordinator = MagicMock()
+
+        async def _collect():
+            events = []
+            async for ev in registry.async_execute_streaming("complete_stream_skill", hass, coordinator, client):
+                events.append(ev)
+            return events
+
+        events = asyncio.run(_collect())
+        done_events = [e for e in events if e.get("type") == "done"]
+
+        assert len(done_events) == 1
+        assert done_events[0]["truncated"] is False

--- a/tests/test_claude_api.py
+++ b/tests/test_claude_api.py
@@ -66,7 +66,12 @@ def _make_config(**overrides) -> dict:
     return config
 
 
-def _mock_message(content_text: str = "test response", input_tokens: int = 10, output_tokens: int = 20) -> MagicMock:
+def _mock_message(
+    content_text: str = "test response",
+    input_tokens: int = 10,
+    output_tokens: int = 20,
+    stop_reason: str = "end_turn",
+) -> MagicMock:
     """Build a mock anthropic Message response."""
     msg = MagicMock()
     content_block = MagicMock()
@@ -76,6 +81,7 @@ def _mock_message(content_text: str = "test response", input_tokens: int = 10, o
     msg.usage = MagicMock()
     msg.usage.input_tokens = input_tokens
     msg.usage.output_tokens = output_tokens
+    msg.stop_reason = stop_reason
     return msg
 
 
@@ -516,3 +522,115 @@ class TestPersistentStats:
         client = ClaudeAPIClient(_make_config())
         client.restore_persistent_stats({"counter_date": "not-a-date"})
         assert client._rate_counters.counter_date == date.today()
+
+
+# ---------------------------------------------------------------------------
+# Truncation detection (Issue #420)
+# ---------------------------------------------------------------------------
+
+
+class _FakeStreamCM:
+    """Fake async context manager mimicking anthropic's `messages.stream()` return value."""
+
+    def __init__(self, events: list, final_message: MagicMock) -> None:
+        self._events = events
+        self._final_message = final_message
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+    def __aiter__(self):
+        return self._agen()
+
+    async def _agen(self):
+        for event in self._events:
+            yield event
+
+    async def get_final_message(self):
+        return self._final_message
+
+
+def _mock_text_delta_event(text: str) -> MagicMock:
+    event = MagicMock()
+    event.type = "content_block_delta"
+    event.delta = MagicMock()
+    event.delta.type = "text_delta"
+    event.delta.text = text
+    return event
+
+
+class TestTruncationDetection:
+    """stop_reason must be inspected on every request so a max_tokens cutoff is never silent."""
+
+    def test_non_streaming_max_tokens_marks_truncated_and_warns(self, caplog):
+        mock_api = _make_mock_api_client()
+        mock_api.messages.create.return_value = _mock_message(
+            "partial report...", output_tokens=8192, stop_reason="max_tokens"
+        )
+        client = _make_client(mock_api)
+
+        with caplog.at_level("WARNING"):
+            response = asyncio.run(client.async_request("System.", "User."))
+
+        assert response.success is True
+        assert response.stop_reason == "max_tokens"
+        assert response.truncated is True
+        assert any("truncated" in rec.message.lower() for rec in caplog.records)
+
+    def test_non_streaming_end_turn_is_not_truncated(self):
+        mock_api = _make_mock_api_client()
+        mock_api.messages.create.return_value = _mock_message("complete report", stop_reason="end_turn")
+        client = _make_client(mock_api)
+
+        response = asyncio.run(client.async_request("System.", "User."))
+
+        assert response.stop_reason == "end_turn"
+        assert response.truncated is False
+
+    def test_streaming_max_tokens_yields_stop_event_and_warns(self, caplog):
+        mock_api = _make_mock_api_client()
+        final_msg = MagicMock()
+        final_msg.usage = MagicMock(input_tokens=50, output_tokens=4096)
+        final_msg.stop_reason = "max_tokens"
+        mock_api.messages.stream = MagicMock(
+            return_value=_FakeStreamCM([_mock_text_delta_event("partial...")], final_msg)
+        )
+        client = _make_client(mock_api)
+
+        async def _collect():
+            events = []
+            async for event in client.async_request_streaming("System.", "User."):
+                events.append(event)
+            return events
+
+        with caplog.at_level("WARNING"):
+            events = asyncio.run(_collect())
+
+        stop_events = [e for e in events if e.get("type") == "stop"]
+        assert len(stop_events) == 1
+        assert stop_events[0]["stop_reason"] == "max_tokens"
+        assert any("truncated" in rec.message.lower() for rec in caplog.records)
+
+    def test_streaming_end_turn_yields_stop_event_without_warning(self, caplog):
+        mock_api = _make_mock_api_client()
+        final_msg = MagicMock()
+        final_msg.usage = MagicMock(input_tokens=50, output_tokens=100)
+        final_msg.stop_reason = "end_turn"
+        mock_api.messages.stream = MagicMock(return_value=_FakeStreamCM([_mock_text_delta_event("done.")], final_msg))
+        client = _make_client(mock_api)
+
+        async def _collect():
+            events = []
+            async for event in client.async_request_streaming("System.", "User."):
+                events.append(event)
+            return events
+
+        with caplog.at_level("WARNING"):
+            events = asyncio.run(_collect())
+
+        stop_events = [e for e in events if e.get("type") == "stop"]
+        assert stop_events == [{"type": "stop", "stop_reason": "end_turn"}]
+        assert not any("truncated" in rec.message.lower() for rec in caplog.records)


### PR DESCRIPTION
## Summary
- Fixes #420: the AI Investigative Analysis report streamed from the dashboard could stop mid-way with no error shown — the UI reported "Completed" as if the report finished normally, but the text was actually cut off before all required sections were written.
- Root cause: `claude_api.py` never inspected the Anthropic API's `stop_reason` (e.g. `"max_tokens"`) in either the streaming or non-streaming request path, so a response truncated by the token cap was indistinguishable anywhere downstream from a normal, complete response.
- Fix: `ClaudeResponse` now carries `stop_reason`/`truncated`; both request paths log the stop reason on every call (WARNING when truncated), `ai_skills.py` and the investigate API view propagate `truncated` through to the stored report, and the dashboard now shows a clear truncation warning (live run, reopened history entry, history list badge, and markdown export) instead of a plain "Completed" status.

## Investigation notes
No production HA logs from the reported incident were retrievable (this environment's log window only covered ~3 minutes of a fresh dev instance), so root cause was confirmed via full code-path trace plus two rounds of clarification with the reporter (no error was shown; two runs stopped at different lengths — consistent with a fixed token ceiling hit at different content volumes, not a connection drop or parser bug). See `docs/ai-skills-spec.md` for the updated return-contract documentation.

## Checklist
- [x] Version bumped: `const.py` VERSION 0.4.68 → 0.4.69, `manifest.json` matches
- [x] `RELEASE_NOTES["0.4.69"]` and `KNOWN_FIXES[420]` added
- [x] `docs/ai-skills-spec.md` Anchors table + return contract updated
- [x] New/modified tests pass with warnings-as-errors
- [x] Full suite passes (3078 tests)
- [x] `tools/validate.py` clean

## Test plan
- [x] `pytest tests/test_claude_api.py tests/test_ai_skills.py tests/test_ai_investigator.py -W error::pytest.PytestUnraisableExceptionWarning -W error::RuntimeWarning`
- [x] `pytest tests/` (full suite)
- [x] `python -m ruff check` / `python tools/validate.py`
- [ ] Manual verification on a real HA instance (lower Investigator Max Response Length, confirm WARNING log + UI banner) — left to the user since this sandbox has no configured AI client