### PR TITLE
Fix #428: next_human_action gave backwards window/fan advice when outdoor was hotter than indoor

### DIFF
--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,17 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.4.72"
+VERSION = "0.4.73"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.4.73": [
+        "Fix #428: 'Your Next Action' could tell you to open a window or turn on a fan to cool"
+        " down even when it was hotter outside than inside — advice that would have made things"
+        " worse. It now checks live outdoor temperature (the same free-cooling direction guard"
+        " already used by the economizer/nat-vent logic) before ever suggesting a window or fan,"
+        " covers the mirrored heating-direction case, and won't repeat advice that's redundant"
+        " with what you've already done or what automation is already doing.",
+    ],
     "0.4.72": [
         "Fix #424: fan mode 'Both' (whole house fan + HVAC fan simultaneously) is no longer"
         " selectable during setup or in options — a proper per-device redesign for two"
@@ -794,6 +802,38 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    428: {
+        "version_fixed": "0.4.73",
+        "title": "next_human_action gives backwards window/fan advice when outdoor is hotter than indoor",
+        "scope_covered": (
+            "temperature.py: added free_cooling_direction_ok(outdoor_temp, indoor_temp), mirroring"
+            " automation.py's existing economizer direction_ok gate (~line 4360, Issue #327)."
+            " coordinator.py: _compute_next_action() rewritten to accept outdoor_temp,"
+            " windows_physically_open, and the AutomationEngine reference; every window/fan"
+            " suggestion (both cooling-direction and the previously entirely-missing"
+            " heating-direction mirror) is now gated on the live direction check. Added checks for"
+            " physically-open windows (avoids redundant 'open windows' when already open),"
+            " automation-engine live state (nat_vent/economizer already active, manual override,"
+            " grace period, paused-by-door — checked early per the approved guard-ordering"
+            " decision), and GUEST occupancy parity with HOME. Added INFO logging at entry and"
+            " each decision outcome, WARNING when the direction guard suppresses what would"
+            " otherwise have been the wrong suggestion. tests/test_coordinator.py:"
+            " TestComputeNextAction now calls the real bound method via a coordinator stub instead"
+            " of a hand-copied replica (the replica is how the missing outdoor check went uncaught"
+            " through 20+ existing tests) — full matrix of new test cases added, including the"
+            " exact reported repro (indoor 75°F / outdoor 80°F)."
+        ),
+        "scope_not_covered": (
+            "Two related gaps were identified but deliberately deferred to separate tracked"
+            " issues rather than bundled here: (1) automation.py's existing duplicate direction-gate"
+            " copies (economizer ~line 4360, fan/nat-vent check ~line 2695) are not yet"
+            " consolidated onto the new shared free_cooling_direction_ok() — they remain their own"
+            " separate, already-correct, already-tested implementations. (2) briefing.py's daily"
+            " window-advice prose does not yet get a live-outdoor cross-check — it still relies"
+            " solely on forecast-time DayClassification data, which is lower-risk since the"
+            " briefing is a point-in-time narrative rather than a continuously-displayed sensor."
+        ),
+    },
     424: {
         "version_fixed": "0.4.72",
         "title": "Remove selectable 'Both' fan mode; migrate existing configs to whole house fan",

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -208,7 +208,7 @@ from .const import (
 )
 from .learning import DailyRecord, LearningEngine, compute_k_passive_blocks
 from .state import StatePersistence
-from .temperature import convert_delta, format_temp, from_fahrenheit, to_fahrenheit
+from .temperature import convert_delta, format_temp, free_cooling_direction_ok, from_fahrenheit, to_fahrenheit
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -1940,7 +1940,13 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             ATTR_TREND_MAGNITUDE: c.trend_magnitude if c else 0,
             ATTR_BRIEFING: self._last_briefing,
             ATTR_BRIEFING_SHORT: self._last_briefing_short,
-            ATTR_NEXT_ACTION: self._compute_next_action(c, self._get_indoor_temp()),
+            ATTR_NEXT_ACTION: self._compute_next_action(
+                c,
+                indoor_temp=_indoor_temp,
+                outdoor_temp=_outdoor_temp,
+                windows_physically_open=self._any_sensor_open(),
+                ae=self.automation_engine,
+            ),
             ATTR_AUTOMATION_STATUS: self._compute_automation_status(),
             ATTR_LEARNING_SUGGESTIONS: suggestions,
             ATTR_COMPLIANCE_SCORE: compliance.get("comfort_score", 1.0),
@@ -5339,43 +5345,179 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         obs["status"] = "committing"
         self.hass.async_create_task(self._commit_observation(obs_type, force_grade="low"))
 
-    def _compute_next_action(self, c: DayClassification | None, indoor_temp: float | None = None) -> str:
-        """Compute the next recommended human action for display."""
-        if not c:
-            return "Waiting for forecast data..."
+    def _compute_next_action(
+        self,
+        c: DayClassification | None,
+        *,
+        indoor_temp: float | None = None,
+        outdoor_temp: float | None = None,
+        windows_physically_open: bool = False,
+        ae: AutomationEngine | None = None,
+    ) -> str:
+        """Compute the next recommended human action for display.
 
-        if self._occupancy_mode == OCCUPANCY_VACATION:
-            return "On vacation — deep energy-saving setback active."
-        if self._occupancy_mode == OCCUPANCY_AWAY:
-            return "You're away — automation managing temperature."
-
-        now = dt_util.now().time()
+        Every window/fan cooling (or heating) suggestion is gated on
+        free_cooling_direction_ok() — the same live outdoor-vs-indoor direction
+        guard already enforced in automation.py's economizer/nat-vent gates
+        (Issue #327) — so this display text can never recommend an action that
+        would work against the occupant's actual comfort goal (Issue #428).
+        """
         unit = self.config.get("temp_unit", "fahrenheit")
         comfort_cool = self.config.get("comfort_cool", 75)
+        comfort_heat = self.config.get("comfort_heat", 70)
+        fan_mode = self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED)
+        fan_enabled = fan_mode != FAN_MODE_DISABLED
+
+        _LOGGER.info(
+            "Next-action evaluation: day_type=%s indoor=%s outdoor=%s windows_open=%s"
+            " nat_vent=%s economizer=%s override=%s grace=%s paused_by_door=%s occupancy=%s",
+            c.day_type if c else "none",
+            f"{indoor_temp:.1f}" if indoor_temp is not None else "?",
+            f"{outdoor_temp:.1f}" if outdoor_temp is not None else "?",
+            windows_physically_open,
+            ae._natural_vent_active if ae else "?",
+            ae._economizer_active if ae else "?",
+            ae._manual_override_active if ae else "?",
+            ae._grace_active if ae else "?",
+            ae.is_paused_by_door if ae else "?",
+            self._occupancy_mode,
+        )
+
+        def _decide(msg: str, *, warn: bool = False, **ctx: Any) -> str:
+            ctx_str = " ".join(f"{k}={v}" for k, v in ctx.items())
+            (_LOGGER.warning if warn else _LOGGER.info)("Next-action: %s (%s)", msg, ctx_str)
+            return msg
+
+        if not c:
+            return _decide("Waiting for forecast data...")
+
+        if self._occupancy_mode == OCCUPANCY_VACATION:
+            return _decide("On vacation — deep energy-saving setback active.")
+        if self._occupancy_mode == OCCUPANCY_AWAY:
+            return _decide("You're away — automation managing temperature.")
+
+        # Automation-state guards checked early/globally: if the system isn't in its
+        # normal control loop right now, that fact is more relevant to the occupant
+        # than a scheduled reminder that ignores it (see plan's "Guard ordering"
+        # decision, Issue #428).
+        if ae is not None:
+            if ae._manual_override_active:
+                return _decide("Manual override active — automation is standing by.")
+            if ae._grace_active:
+                return _decide("Grace period active — automation will resume shortly.")
+            if ae.is_paused_by_door:
+                return _decide("Automation paused — a door or window is open.")
+
+        now = dt_util.now().time()
+        direction_ok = free_cooling_direction_ok(outdoor_temp, indoor_temp)
 
         if c.windows_recommended:
             if c.window_open_time and now < c.window_open_time:
-                return f"Open windows at {c.window_open_time.strftime('%I:%M %p')}"
+                return _decide(f"Open windows at {c.window_open_time.strftime('%I:%M %p')}")
             elif c.window_close_time and now < c.window_close_time:
-                return f"Close windows by {c.window_close_time.strftime('%I:%M %p')}"
+                return _decide(f"Close windows by {c.window_close_time.strftime('%I:%M %p')}")
             elif now >= time(ECONOMIZER_EVENING_START_HOUR, 0):
-                return "Open windows to cool down — outdoor air may be cooler now."
+                if windows_physically_open:
+                    if outdoor_temp is not None and indoor_temp is not None and not direction_ok:
+                        return _decide(
+                            f"Windows are open, but outdoor ({format_temp(outdoor_temp, unit)}) isn't cooler"
+                            f" than indoor ({format_temp(indoor_temp, unit)}) — consider closing them so the"
+                            f" AC/fan can help.",
+                            warn=True,
+                            outdoor=outdoor_temp,
+                            indoor=indoor_temp,
+                        )
+                    return _decide("Windows are open — you're all set.")
+                if outdoor_temp is not None and indoor_temp is not None:
+                    if direction_ok:
+                        return _decide(
+                            f"Open windows to cool down — outdoor ({format_temp(outdoor_temp, unit)}) is"
+                            f" now cooler than indoor ({format_temp(indoor_temp, unit)}).",
+                            outdoor=outdoor_temp,
+                            indoor=indoor_temp,
+                        )
+                    return _decide(
+                        f"Outdoor ({format_temp(outdoor_temp, unit)}) isn't cooler than indoor"
+                        f" ({format_temp(indoor_temp, unit)}) yet — keep windows closed for now.",
+                        warn=True,
+                        outdoor=outdoor_temp,
+                        indoor=indoor_temp,
+                    )
+                return _decide("Open windows to cool down — outdoor air may be cooler now.")
 
         if c.day_type == DAY_TYPE_HOT:
             threshold = comfort_cool + ECONOMIZER_TEMP_DELTA
             if c.window_opportunity_morning and now < time(ECONOMIZER_MORNING_END_HOUR, 0):
                 end_t = time(ECONOMIZER_MORNING_END_HOUR, 0).strftime("%I:%M %p").lstrip("0")
-                return f"Open windows if outdoor temp is below {format_temp(threshold, unit)} (until {end_t})"
+                return _decide(f"Open windows if outdoor temp is below {format_temp(threshold, unit)} (until {end_t})")
             elif c.window_opportunity_evening and now >= time(ECONOMIZER_EVENING_START_HOUR, 0):
-                return f"Open windows if outdoor temp is below {format_temp(threshold, unit)}"
-            return "Keep windows and blinds closed. AC is handling it."
+                return _decide(f"Open windows if outdoor temp is below {format_temp(threshold, unit)}")
+            if ae is not None and (ae._natural_vent_active or ae._economizer_active):
+                return _decide("AC and free cooling are both working on it.")
+            return _decide("Keep windows and blinds closed. AC is handling it.")
         elif c.day_type == DAY_TYPE_COLD:
-            return "Keep doors closed — help the heater out."
+            if windows_physically_open:
+                return _decide("Keep doors closed — help the heater out.")
+            return _decide("Doors are closed — heater is handling it.")
 
-        if indoor_temp is not None and indoor_temp > comfort_cool:
-            return f"Indoor temp is {format_temp(indoor_temp, unit)} — open windows or turn on a fan to cool down."
+        # WARM/MILD/COOL fallback: symmetric cooling-direction and heating-direction
+        # checks, both gated on live outdoor-vs-indoor direction (Issue #428).
+        cooling_needed = indoor_temp is not None and indoor_temp > comfort_cool
+        heating_needed = indoor_temp is not None and indoor_temp < comfort_heat
 
-        return "No action needed right now. Automation is handling it."
+        if cooling_needed:
+            if ae is not None and (ae._natural_vent_active or ae._economizer_active):
+                return _decide("Free cooling is already active.")
+            if windows_physically_open:
+                if outdoor_temp is not None and not direction_ok:
+                    return _decide(
+                        f"Windows are open, but outdoor ({format_temp(outdoor_temp, unit)}) isn't cooler"
+                        f" than indoor ({format_temp(indoor_temp, unit)}) — consider closing them so the"
+                        f" AC/fan can help.",
+                        warn=True,
+                        outdoor=outdoor_temp,
+                        indoor=indoor_temp,
+                    )
+                return _decide("Windows are open and outdoor air is helping.")
+            if outdoor_temp is None:
+                return _decide(
+                    f"Indoor is {format_temp(indoor_temp, unit)} — outdoor reading unavailable,"
+                    f" automation is handling it conservatively.",
+                    indoor=indoor_temp,
+                )
+            if direction_ok:
+                fan_clause = " or turn on the fan" if fan_enabled else ""
+                return _decide(
+                    f"Indoor temp is {format_temp(indoor_temp, unit)} — open windows{fan_clause} to cool"
+                    f" down; outdoor ({format_temp(outdoor_temp, unit)}) is cooler now.",
+                    outdoor=outdoor_temp,
+                    indoor=indoor_temp,
+                )
+            return _decide(
+                f"Indoor is {format_temp(indoor_temp, unit)} — outdoor ({format_temp(outdoor_temp, unit)})"
+                f" isn't cooler, so windows/fan won't help right now. Automation is handling it.",
+                warn=True,
+                outdoor=outdoor_temp,
+                indoor=indoor_temp,
+            )
+
+        if heating_needed:
+            if windows_physically_open:
+                return _decide("Windows are open — close them to help the heater.")
+            if outdoor_temp is not None and outdoor_temp > indoor_temp:
+                return _decide(
+                    f"Indoor is {format_temp(indoor_temp, unit)} — outdoor ({format_temp(outdoor_temp, unit)})"
+                    f" is warmer; opening windows briefly could help warm the home.",
+                    outdoor=outdoor_temp,
+                    indoor=indoor_temp,
+                )
+            return _decide(
+                f"Indoor is {format_temp(indoor_temp, unit)} — keep windows and doors closed to hold heat."
+                f" Automation is handling it.",
+                indoor=indoor_temp,
+            )
+
+        return _decide("No action needed right now. Automation is handling it.")
 
     def _emit_event(self, event_type: str, data: dict) -> None:
         """Append a timestamped event to the in-memory event log ring buffer (Issue #76)."""

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.4.72"
+  "version": "0.4.73"
 }

--- a/custom_components/climate_advisor/temperature.py
+++ b/custom_components/climate_advisor/temperature.py
@@ -68,6 +68,15 @@ def format_temp_delta(delta_fahrenheit: float, unit: str, decimals: int = 0) -> 
     return f"{delta:.{decimals}f}{symbol}"
 
 
+def free_cooling_direction_ok(outdoor_temp: float | None, indoor_temp: float | None) -> bool:
+    """True if outdoor air is actually cooler than indoor — the precondition for any
+    window/fan cooling advice or economizer/nat-vent action. Mirrors the direction
+    guard already enforced in automation.py's economizer and nat-vent gates (Issue #327).
+    Unknown readings default to True (caller decides whether to act on an unknown).
+    """
+    return indoor_temp is None or outdoor_temp is None or outdoor_temp < indoor_temp
+
+
 def convert_delta(value_fahrenheit: float, unit: str) -> float:
     """Convert a temperature delta from °F to the display unit (scale only, no offset).
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import datetime
+import importlib
 import sys
 from datetime import time
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -22,13 +23,18 @@ if "homeassistant" not in sys.modules:
 
 from custom_components.climate_advisor.classifier import DayClassification
 from custom_components.climate_advisor.const import (
+    CONF_FAN_MODE,
     DAY_TYPE_COLD,
     DAY_TYPE_HOT,
     DAY_TYPE_MILD,
     DAY_TYPE_WARM,
     ECONOMIZER_EVENING_START_HOUR,
-    ECONOMIZER_MORNING_END_HOUR,
-    ECONOMIZER_TEMP_DELTA,
+    FAN_MODE_DISABLED,
+    FAN_MODE_HVAC,
+    OCCUPANCY_AWAY,
+    OCCUPANCY_GUEST,
+    OCCUPANCY_HOME,
+    OCCUPANCY_VACATION,
     WARM_WINDOW_CLOSE_HOUR,
 )
 
@@ -63,41 +69,66 @@ def _make_classification(**overrides):
     return c
 
 
+def _get_coordinator_class():
+    """Return the current ClimateAdvisorCoordinator class.
+
+    Always import fresh via importlib (rather than holding a module-level
+    reference) — test_occupancy.py deletes and re-imports the coordinator
+    module, and a stale reference would have __globals__ pointing at the old
+    module, silently missing patches applied to the new one.
+    """
+    mod = importlib.import_module("custom_components.climate_advisor.coordinator")
+    return mod.ClimateAdvisorCoordinator
+
+
+def _make_ae_stub(**overrides):
+    """Automation-engine-like stub with every live-state flag explicitly False.
+
+    Unset MagicMock attributes are truthy by default — leaving any of these
+    unset would make _compute_next_action's guard branches fire unconditionally.
+    """
+    ae = MagicMock()
+    ae._natural_vent_active = False
+    ae._economizer_active = False
+    ae._manual_override_active = False
+    ae._grace_active = False
+    ae.is_paused_by_door = False
+    for key, value in overrides.items():
+        setattr(ae, key, value)
+    return ae
+
+
 def _compute_next_action(
     c: DayClassification | None,
     config: dict,
     now_time: time,
     indoor_temp: float | None = None,
+    outdoor_temp: float | None = None,
+    windows_physically_open: bool = False,
+    ae=None,
+    occupancy_mode: str = OCCUPANCY_HOME,
 ) -> str:
-    """Replicate _compute_next_action from coordinator.py."""
-    if not c:
-        return "Waiting for forecast data..."
+    """Call the real ClimateAdvisorCoordinator._compute_next_action (Issue #428).
 
-    comfort_cool = config.get("comfort_cool", 75)
-
-    if c.windows_recommended:
-        if c.window_open_time and now_time < c.window_open_time:
-            return f"Open windows at {c.window_open_time.strftime('%I:%M %p')}"
-        elif c.window_close_time and now_time < c.window_close_time:
-            return f"Close windows by {c.window_close_time.strftime('%I:%M %p')}"
-        elif now_time >= time(ECONOMIZER_EVENING_START_HOUR, 0):
-            return "Open windows to cool down — outdoor air may be cooler now."
-
-    if c.day_type == DAY_TYPE_HOT:
-        threshold = comfort_cool + ECONOMIZER_TEMP_DELTA
-        if c.window_opportunity_morning and now_time < time(ECONOMIZER_MORNING_END_HOUR, 0):
-            end_t = time(ECONOMIZER_MORNING_END_HOUR, 0).strftime("%I:%M %p").lstrip("0")
-            return f"Open windows if outdoor temp is below {threshold:.0f}°F (until {end_t})"
-        elif c.window_opportunity_evening and now_time >= time(ECONOMIZER_EVENING_START_HOUR, 0):
-            return f"Open windows if outdoor temp is below {threshold:.0f}°F"
-        return "Keep windows and blinds closed. AC is handling it."
-    elif c.day_type == DAY_TYPE_COLD:
-        return "Keep doors closed — help the heater out."
-
-    if indoor_temp is not None and indoor_temp > comfort_cool:
-        return f"Indoor temp is {indoor_temp:.0f}°F — open windows or turn on a fan to cool down."
-
-    return "No action needed right now. Automation is handling it."
+    Previously this test file hand-copied the function's logic — a replica that
+    could silently diverge from production and is exactly how the missing
+    outdoor-temp check went uncaught through 20+ existing tests. This now
+    exercises the real method against a minimal coordinator stub instead.
+    """
+    ClimateAdvisorCoordinator = _get_coordinator_class()
+    coord = object.__new__(ClimateAdvisorCoordinator)
+    coord.config = config
+    coord._occupancy_mode = occupancy_mode
+    fixed_dt = datetime.datetime(2026, 6, 1, now_time.hour, now_time.minute, now_time.second)
+    with patch("custom_components.climate_advisor.coordinator.dt_util.now", return_value=fixed_dt):
+        return ClimateAdvisorCoordinator._compute_next_action(
+            coord,
+            c,
+            indoor_temp=indoor_temp,
+            outdoor_temp=outdoor_temp,
+            windows_physically_open=windows_physically_open,
+            ae=ae,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -112,6 +143,22 @@ class TestComputeNextAction:
         """When classification is None → 'Waiting for forecast data...'."""
         result = _compute_next_action(None, {}, time(8, 0))
         assert result == "Waiting for forecast data..."
+
+    def test_next_action_vacation_occupancy_short_circuits(self):
+        """VACATION occupancy → status message, bypassing all thermal/window logic."""
+        c = _make_classification(day_type=DAY_TYPE_MILD)
+        result = _compute_next_action(
+            c, {}, time(8, 0), indoor_temp=78.0, outdoor_temp=80.0, occupancy_mode=OCCUPANCY_VACATION
+        )
+        assert "vacation" in result.lower()
+
+    def test_next_action_away_occupancy_short_circuits(self):
+        """AWAY occupancy → status message, bypassing all thermal/window logic."""
+        c = _make_classification(day_type=DAY_TYPE_MILD)
+        result = _compute_next_action(
+            c, {}, time(8, 0), indoor_temp=78.0, outdoor_temp=80.0, occupancy_mode=OCCUPANCY_AWAY
+        )
+        assert "away" in result.lower()
 
     def test_next_action_hot_morning_shows_threshold(self):
         """HOT day, morning opportunity, before 9 AM → threshold and cutoff time shown."""
@@ -196,11 +243,17 @@ class TestComputeNextAction:
         result = _compute_next_action(c, config, time(8, 0))
         assert "75" in result
 
-    def test_next_action_cold_day(self):
-        """COLD day → keep-doors-closed message."""
+    def test_next_action_cold_day_doors_open(self):
+        """COLD day, doors physically open → keep-doors-closed message."""
         c = _make_classification(day_type=DAY_TYPE_COLD)
-        result = _compute_next_action(c, {}, time(12, 0))
+        result = _compute_next_action(c, {}, time(12, 0), windows_physically_open=True)
         assert "Keep doors closed" in result
+
+    def test_next_action_cold_day_doors_already_closed(self):
+        """COLD day, doors already physically closed → confirms heater is handling it, no redundant ask."""
+        c = _make_classification(day_type=DAY_TYPE_COLD)
+        result = _compute_next_action(c, {}, time(12, 0), windows_physically_open=False)
+        assert "Doors are closed" in result
 
     def test_next_action_mild_day(self):
         """Mild day (not hot/cold) → no action needed message."""
@@ -241,10 +294,197 @@ class TestComputeNextAction:
         result = _compute_next_action(c, {}, time(20, 0))
         assert "Open windows" in result
 
-    def test_next_action_indoor_above_comfort_shows_guidance(self):
-        """Indoor temp above comfort_cool → actionable guidance, not 'no action'."""
+    def test_next_action_indoor_above_comfort_outdoor_cooler_shows_guidance(self):
+        """Indoor above comfort_cool, outdoor cooler → correct window/fan guidance with live outdoor shown."""
         c = _make_classification(day_type=DAY_TYPE_MILD, windows_recommended=False)
-        result = _compute_next_action(c, {"comfort_cool": 75}, time(14, 0), indoor_temp=78.0)
+        result = _compute_next_action(c, {"comfort_cool": 75}, time(14, 0), indoor_temp=78.0, outdoor_temp=70.0)
+        assert "78" in result
+        assert "70" in result
+        assert "open windows" in result.lower()
+        assert "No action needed" not in result
+
+    def test_next_action_indoor_above_comfort_outdoor_hotter_suppresses_bug(self):
+        """Regression test for Issue #428 — indoor 75/outdoor 80 must NOT suggest opening windows."""
+        c = _make_classification(day_type=DAY_TYPE_MILD, windows_recommended=False)
+        result = _compute_next_action(c, {"comfort_cool": 75}, time(14, 0), indoor_temp=75.5, outdoor_temp=80.0)
+        assert "won't help" in result
+        assert "open windows" not in result.lower()
+        assert "turn on the fan" not in result.lower()
+
+    def test_next_action_indoor_above_comfort_outdoor_hotter_logs_warning(self, caplog):
+        """The direction guard suppressing the naive suggestion must log at WARNING (Issue #428)."""
+        import logging
+
+        c = _make_classification(day_type=DAY_TYPE_MILD, windows_recommended=False)
+        with caplog.at_level(logging.WARNING, logger="custom_components.climate_advisor.coordinator"):
+            _compute_next_action(c, {"comfort_cool": 75}, time(14, 0), indoor_temp=75.5, outdoor_temp=80.0)
+        assert any(r.levelno == logging.WARNING for r in caplog.records)
+
+    def test_next_action_indoor_above_comfort_outdoor_unavailable(self):
+        """Outdoor reading unavailable → conservative message, never a guessed suggestion."""
+        c = _make_classification(day_type=DAY_TYPE_MILD, windows_recommended=False)
+        result = _compute_next_action(c, {"comfort_cool": 75}, time(14, 0), indoor_temp=78.0, outdoor_temp=None)
+        assert "unavailable" in result.lower()
+        assert "open windows" not in result.lower()
+
+    def test_next_action_indoor_above_comfort_fan_disabled_no_fan_mention(self):
+        """Fan config disabled → advice never suggests an action the config doesn't support."""
+        c = _make_classification(day_type=DAY_TYPE_MILD, windows_recommended=False)
+        result = _compute_next_action(
+            c,
+            {"comfort_cool": 75, CONF_FAN_MODE: FAN_MODE_DISABLED},
+            time(14, 0),
+            indoor_temp=78.0,
+            outdoor_temp=70.0,
+        )
+        assert "fan" not in result.lower()
+        assert "open windows" in result.lower()
+
+    def test_next_action_indoor_above_comfort_fan_enabled_mentions_fan(self):
+        """Fan config enabled → advice may mention the fan as an alternative."""
+        c = _make_classification(day_type=DAY_TYPE_MILD, windows_recommended=False)
+        result = _compute_next_action(
+            c,
+            {"comfort_cool": 75, CONF_FAN_MODE: FAN_MODE_HVAC},
+            time(14, 0),
+            indoor_temp=78.0,
+            outdoor_temp=70.0,
+        )
+        assert "fan" in result.lower()
+
+    def test_next_action_cooling_needed_free_cooling_already_active(self):
+        """Nat-vent/economizer already active → don't suggest a duplicate action."""
+        c = _make_classification(day_type=DAY_TYPE_MILD, windows_recommended=False)
+        ae = _make_ae_stub(_natural_vent_active=True)
+        result = _compute_next_action(c, {"comfort_cool": 75}, time(14, 0), indoor_temp=78.0, outdoor_temp=70.0, ae=ae)
+        assert "already active" in result.lower()
+
+    def test_next_action_cooling_needed_windows_open_direction_favorable(self):
+        """Cooling needed, windows already open, outdoor favorable → confirm, don't repeat the ask."""
+        c = _make_classification(day_type=DAY_TYPE_MILD, windows_recommended=False)
+        result = _compute_next_action(
+            c,
+            {"comfort_cool": 75},
+            time(14, 0),
+            indoor_temp=78.0,
+            outdoor_temp=70.0,
+            windows_physically_open=True,
+        )
+        assert "windows are open" in result.lower()
+        assert "helping" in result.lower()
+
+    def test_next_action_cooling_needed_windows_open_direction_unfavorable(self):
+        """Cooling needed, windows already open, outdoor NOT favorable → suggest closing them."""
+        c = _make_classification(day_type=DAY_TYPE_MILD, windows_recommended=False)
+        result = _compute_next_action(
+            c,
+            {"comfort_cool": 75},
+            time(14, 0),
+            indoor_temp=75.5,
+            outdoor_temp=80.0,
+            windows_physically_open=True,
+        )
+        assert "closing them" in result.lower()
+
+    def test_next_action_heating_needed_outdoor_warmer_suggests_windows(self):
+        """Heating needed (indoor below comfort_heat), outdoor warmer → new heating-direction mirror."""
+        c = _make_classification(day_type=DAY_TYPE_MILD, windows_recommended=False)
+        result = _compute_next_action(
+            c,
+            {"comfort_cool": 75, "comfort_heat": 70},
+            time(14, 0),
+            indoor_temp=65.0,
+            outdoor_temp=72.0,
+        )
+        assert "warmer" in result.lower()
+        assert "opening windows" in result.lower()
+
+    def test_next_action_heating_needed_outdoor_not_warmer_keep_closed(self):
+        """Heating needed, outdoor not warmer than indoor → keep closed, hold heat."""
+        c = _make_classification(day_type=DAY_TYPE_MILD, windows_recommended=False)
+        result = _compute_next_action(
+            c,
+            {"comfort_cool": 75, "comfort_heat": 70},
+            time(14, 0),
+            indoor_temp=65.0,
+            outdoor_temp=60.0,
+        )
+        assert "keep windows and doors closed" in result.lower()
+
+    def test_next_action_heating_needed_windows_already_open(self):
+        """Heating needed, windows already open → suggest closing them to help the heater."""
+        c = _make_classification(day_type=DAY_TYPE_MILD, windows_recommended=False)
+        result = _compute_next_action(
+            c,
+            {"comfort_cool": 75, "comfort_heat": 70},
+            time(14, 0),
+            indoor_temp=65.0,
+            outdoor_temp=72.0,
+            windows_physically_open=True,
+        )
+        assert "close them" in result.lower()
+
+    def test_next_action_manual_override_active_preempts_schedule(self):
+        """Manual override active → surfaced before any scheduled window message (guard-ordering decision)."""
+        c = _make_classification(
+            day_type=DAY_TYPE_WARM,
+            windows_recommended=True,
+            window_open_time=time(9, 0),
+        )
+        ae = _make_ae_stub(_manual_override_active=True)
+        result = _compute_next_action(c, {}, time(7, 0), ae=ae)
+        assert "manual override" in result.lower()
+
+    def test_next_action_grace_active_preempts_schedule(self):
+        """Grace period active → surfaced before any scheduled window message."""
+        c = _make_classification(
+            day_type=DAY_TYPE_WARM,
+            windows_recommended=True,
+            window_open_time=time(9, 0),
+        )
+        ae = _make_ae_stub(_grace_active=True)
+        result = _compute_next_action(c, {}, time(7, 0), ae=ae)
+        assert "grace period" in result.lower()
+
+    def test_next_action_paused_by_door_preempts_schedule(self):
+        """Paused by an open door → surfaced before any scheduled window message."""
+        c = _make_classification(
+            day_type=DAY_TYPE_WARM,
+            windows_recommended=True,
+            window_open_time=time(9, 0),
+        )
+        ae = _make_ae_stub(is_paused_by_door=True)
+        result = _compute_next_action(c, {}, time(7, 0), ae=ae)
+        assert "paused" in result.lower()
+
+    def test_next_action_hot_no_opportunity_free_cooling_active(self):
+        """HOT day, no scheduled opportunity, but nat-vent/economizer already active — don't contradict it."""
+        c = _make_classification(
+            day_type=DAY_TYPE_HOT,
+            window_opportunity_morning=False,
+            window_opportunity_evening=False,
+        )
+        ae = _make_ae_stub(_economizer_active=True)
+        result = _compute_next_action(c, {}, time(13, 0), ae=ae)
+        assert "both working on it" in result.lower()
+
+    def test_next_action_guest_occupancy_behaves_like_home(self):
+        """GUEST occupancy mode is not short-circuited — full comfort logic applies same as HOME."""
+        c = _make_classification(day_type=DAY_TYPE_MILD, windows_recommended=False)
+        result = _compute_next_action(
+            c,
+            {"comfort_cool": 75},
+            time(14, 0),
+            indoor_temp=78.0,
+            outdoor_temp=70.0,
+            occupancy_mode=OCCUPANCY_GUEST,
+        )
+        assert "open windows" in result.lower()
+
+    def test_next_action_indoor_above_comfort_shows_guidance(self):
+        """Indoor temp above comfort_cool, outdoor cooler → actionable guidance, not 'no action'."""
+        c = _make_classification(day_type=DAY_TYPE_MILD, windows_recommended=False)
+        result = _compute_next_action(c, {"comfort_cool": 75}, time(14, 0), indoor_temp=78.0, outdoor_temp=70.0)
         assert "78" in result
         assert "No action needed" not in result
 
@@ -261,14 +501,14 @@ class TestComputeNextAction:
         assert "No action needed" in result
 
     def test_next_action_warm_day_midday_indoor_above_comfort(self):
-        """WARM day mid-day with indoor above comfort — comfort guidance wins over 'no action'."""
+        """WARM day mid-day with indoor above comfort, outdoor cooler — comfort guidance wins over 'no action'."""
         c = _make_classification(
             day_type=DAY_TYPE_WARM,
             windows_recommended=True,
             window_open_time=time(6, 0),
             window_close_time=time(WARM_WINDOW_CLOSE_HOUR, 0),
         )
-        result = _compute_next_action(c, {"comfort_cool": 75}, time(13, 0), indoor_temp=79.0)
+        result = _compute_next_action(c, {"comfort_cool": 75}, time(13, 0), indoor_temp=79.0, outdoor_temp=72.0)
         assert "79" in result
         assert "No action needed" not in result
 

--- a/tests/test_temperature.py
+++ b/tests/test_temperature.py
@@ -10,6 +10,7 @@ from custom_components.climate_advisor.temperature import (
     UNIT_SYMBOL,
     format_temp,
     format_temp_delta,
+    free_cooling_direction_ok,
     from_fahrenheit,
     to_fahrenheit,
 )
@@ -163,3 +164,24 @@ class TestUnitSymbols:
 
     def test_celsius_constant_value(self):
         assert CELSIUS == "celsius"
+
+
+class TestFreeCoolingDirectionOk:
+    """Tests for free_cooling_direction_ok() — the shared free-cooling direction gate (Issue #428)."""
+
+    def test_outdoor_cooler_than_indoor_is_ok(self):
+        assert free_cooling_direction_ok(outdoor_temp=70.0, indoor_temp=78.0) is True
+
+    def test_outdoor_hotter_than_indoor_is_not_ok(self):
+        """The exact reported scenario: indoor 75, outdoor 80 — free cooling doesn't help."""
+        assert free_cooling_direction_ok(outdoor_temp=80.0, indoor_temp=75.0) is False
+
+    def test_outdoor_equal_to_indoor_is_not_ok(self):
+        assert free_cooling_direction_ok(outdoor_temp=75.0, indoor_temp=75.0) is False
+
+    def test_outdoor_none_defaults_to_ok(self):
+        """Unknown outdoor reading doesn't itself block — the caller decides how to act on unknown."""
+        assert free_cooling_direction_ok(outdoor_temp=None, indoor_temp=78.0) is True
+
+    def test_indoor_none_defaults_to_ok(self):
+        assert free_cooling_direction_ok(outdoor_temp=70.0, indoor_temp=None) is True


### PR DESCRIPTION
## Summary
- `_compute_next_action()`'s fallback branch suggested opening windows/fan whenever indoor > comfort_cool with zero outdoor-temperature check — it could (and did) tell the occupant to open windows while it was hotter outside than in.
- Extracts `free_cooling_direction_ok()` into `temperature.py`, mirroring automation.py's existing economizer/nat-vent direction gate (#327), and gates every window/fan suggestion — both cooling and the previously-missing heating-direction mirror — on live outdoor temp, physical window/door state, and automation-engine live state (nat_vent/economizer active, manual override, grace period, paused-by-door).
- Adds INFO/WARNING logging per CLAUDE.md's Observability Requirements.
- Replaces `test_coordinator.py`'s hand-copied `_compute_next_action()` replica (root cause of why 20+ existing tests never caught the missing check) with calls to the real method, plus new coverage for every branch including the exact reported repro (indoor 75°F / outdoor 80°F).
- Bumps version to 0.4.73 with release notes and a KNOWN_FIXES entry.
- Follow-ups deferred to #429 (consolidate automation.py's duplicate direction-gate copies) and #430 (same live-check for briefing.py).

Closes #428

## Test plan
- [x] `pytest tests/test_coordinator.py tests/test_temperature.py` — 142/142 pass
- [x] `pytest tests/` — 3125/3125 pass
- [x] `python tools/simulate.py` — 51/51 golden scenarios pass
- [x] `python -m ruff check` / `ruff format` clean
- [x] `test_version_sync.py` confirms const.py/manifest.json match