### PR TITLE
Architecture reset: extract nat-vent decision surface into pure, tested core (v0.5.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,12 @@ id_rsa
 id_ed25519
 id_ecdsa
 
+# Real chart_log / telemetry samples pulled locally for replay/debugging — home data,
+# never a committed test fixture (see tools/sim_harness/chart_log_driver.py)
+scratch_chart_log.json
+*chart_log*.json
+!tools/simulations/**/*.json
+
 # Claude Code workspace
 /.claude/
 

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -43,11 +43,15 @@ from .const import (
     CONF_WELCOME_HOME_DEBOUNCE,
     DAY_TYPE_HOT,
     DEFAULT_AUTOMATION_GRACE_SECONDS,
+    DEFAULT_COMFORT_COOL,
+    DEFAULT_COMFORT_HEAT,
     DEFAULT_FAN_MIN_RUNTIME_PER_HOUR,
     DEFAULT_MANUAL_GRACE_SECONDS,
     DEFAULT_NATURAL_VENT_DELTA,
     DEFAULT_OVERRIDE_CONFIRM_SECONDS,
     DEFAULT_SENSOR_DEBOUNCE_SECONDS,
+    DEFAULT_SETBACK_COOL,
+    DEFAULT_SETBACK_HEAT,
     DEFAULT_SLEEP_COOL,
     DEFAULT_SLEEP_HEAT,
     DEFAULT_WELCOME_HOME_DEBOUNCE_SECONDS,
@@ -73,7 +77,36 @@ from .const import (
     TEMP_SOURCE_SENSOR,
     VACATION_SETBACK_EXTRA,
 )
-from .temperature import convert_delta, format_temp, format_temp_delta, from_fahrenheit, to_fahrenheit
+from .desired_state import (
+    FanCycleOutcome,
+    SetpointRetryAction,
+    decide_fan_cycle_off,
+    decide_fan_cycle_on,
+    decide_fan_thermo_backstop,
+    decide_grace_start,
+    decide_override_confirm,
+    decide_revisit,
+    decide_scheduled_write_seq_current,
+    decide_setpoint_retry_action,
+)
+from .fan_drift_reconciliation import FanDriftInputs, FanDriftOutcome, decide_fan_drift_reconciliation
+from .fan_thermostat_decision import (
+    FanThermostatInputs,
+    FanThermostatOutcome,
+    _resolve_vent_floor,
+    decide_fan_thermostat_check,
+)
+from .nat_vent_gate import NatVentGateInputs, decide_nat_vent_gate
+from .nat_vent_reactivation_lockout import is_reactivation_locked_out
+from .setpoint_verify_decision import SetpointVerifyOutcome, decide_setpoint_verify
+from .temperature import (
+    convert_delta,
+    format_temp,
+    format_temp_delta,
+    free_cooling_direction_ok,
+    from_fahrenheit,
+    to_fahrenheit,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -176,10 +209,10 @@ def select_comfort_band(
     ``aggressive_savings`` widens BOTH comfort edges by ``CEILING_ESCALATION_SAVINGS_MARGIN_F``
     (floor down, ceiling up) so the system runs less; setback/sleep bands are unaffected.
     """
-    comfort_heat = float(config.get("comfort_heat", 70))
-    comfort_cool = float(config.get("comfort_cool", 75))
-    setback_heat = float(config.get("setback_heat", 60))
-    setback_cool = float(config.get("setback_cool", 80))
+    comfort_heat = float(config.get("comfort_heat", DEFAULT_COMFORT_HEAT))
+    comfort_cool = float(config.get("comfort_cool", DEFAULT_COMFORT_COOL))
+    setback_heat = float(config.get("setback_heat", DEFAULT_SETBACK_HEAT))
+    setback_cool = float(config.get("setback_cool", DEFAULT_SETBACK_COOL))
     sleep_heat = float(config.get(CONF_SLEEP_HEAT, DEFAULT_SLEEP_HEAT))
     sleep_cool = float(config.get(CONF_SLEEP_COOL, DEFAULT_SLEEP_COOL))
     margin = CEILING_ESCALATION_SAVINGS_MARGIN_F if aggressive_savings else 0.0
@@ -216,6 +249,31 @@ def select_comfort_band(
         f"{', aggressive' if aggressive_savings else ''})"
     )
     return ComfortBand(floor=floor, ceiling=ceiling, active=active, reason=reason)
+
+
+def compute_pre_cool_target(config: dict, setback_modifier: float) -> float:
+    """Compute the overnight pre-cool AC ceiling that banks cold thermal mass on a warming-trend
+    night (Issue #258, floor formula revised — architecture-reset session).
+
+    ``raw_target = sleep_cool + setback_modifier`` (modifier is negative on a warming trend, so
+    this lowers the ceiling below the normal sleep target). The result is floored at
+    ``sleep_heat + hysteresis`` — the same "+1 above the floor" convention
+    ``nat_vent_temperature_check()`` already uses for sleep-window fan cycling — so pre-cool can
+    travel the full ``[sleep_heat, sleep_cool]`` range instead of being clamped near daytime
+    ``comfort_heat`` (the original formula's floor, which left little to no headroom once
+    ``sleep_cool`` was reformatted to a flat, cooler-than-daytime default).
+
+    This is the single source of truth for the pre-cool target — every one of its 5 call sites
+    (the real AC trigger in ``handle_pre_cool()``, trigger-time scheduling, the chart's target-band
+    dip, and the ODE predicted-indoor curve) must call this, not re-derive the formula, so the
+    chart and the control path can never diverge (Issue #436).
+    """
+    sleep_cool = float(config.get(CONF_SLEEP_COOL, DEFAULT_SLEEP_COOL))
+    sleep_heat = float(config.get(CONF_SLEEP_HEAT, DEFAULT_SLEEP_HEAT))
+    hysteresis = float(config.get(CONF_NAT_VENT_HYSTERESIS_F, NAT_VENT_HYSTERESIS_F))
+    raw_target = sleep_cool + setback_modifier
+    floor = sleep_heat + hysteresis
+    return max(raw_target, floor)
 
 
 def _in_sleep_window(now: datetime, config: dict) -> bool:
@@ -293,8 +351,8 @@ def compute_bedtime_setback(
     hvac_mode = c.hvac_mode
 
     if hvac_mode == "heat":
-        comfort = config.get("comfort_heat", 70)
-        floor = config.get("setback_heat", 60)
+        comfort = config.get("comfort_heat", DEFAULT_COMFORT_HEAT)
+        floor = config.get("setback_heat", DEFAULT_SETBACK_HEAT)
         rate = (thermal_model or {}).get("heating_rate_f_per_hour")
         default_depth = DEFAULT_SETBACK_DEPTH_F
         # Explicit sleep temp takes priority over adaptive calculation
@@ -302,8 +360,8 @@ def compute_bedtime_setback(
         if _explicit is not None:
             return max(float(_explicit), floor)
     elif hvac_mode == "cool":
-        comfort = config.get("comfort_cool", 75)
-        floor = config.get("setback_cool", 80)
+        comfort = config.get("comfort_cool", DEFAULT_COMFORT_COOL)
+        floor = config.get("setback_cool", DEFAULT_SETBACK_COOL)
         rate = (thermal_model or {}).get("cooling_rate_f_per_hour")
         default_depth = DEFAULT_SETBACK_DEPTH_COOL_F
         # Explicit sleep temp takes priority over adaptive calculation
@@ -313,7 +371,7 @@ def compute_bedtime_setback(
         if _explicit is not None:
             return min(float(_explicit), floor)
     else:
-        return config.get("comfort_heat", 70)
+        return config.get("comfort_heat", DEFAULT_COMFORT_HEAT)
 
     if not config.get("learning_enabled", True) or not config.get(CONF_ADAPTIVE_SETBACK, True):
         _LOGGER.debug(
@@ -614,12 +672,23 @@ class AutomationEngine:
         self._schedule_revisit()
 
     def _schedule_revisit(self) -> None:
-        """Schedule a follow-up re-evaluation after an HVAC action."""
+        """Schedule a follow-up re-evaluation after an HVAC action.
+
+        Architecture-reset Step 2 (session state machine slice): the
+        decision (should a revisit be scheduled, and when) now lives in
+        ``desired_state.decide_revisit()``. This method still owns cancelling
+        any prior timer and scheduling the real ``async_call_later``.
+        """
         if self._revisit_cancel:
             self._revisit_cancel()
             self._revisit_cancel = None
 
-        if not self._revisit_callback:
+        revisit = decide_revisit(
+            has_revisit_callback=bool(self._revisit_callback),
+            delay_seconds=REVISIT_DELAY_SECONDS,
+            now=dt_util.now(),
+        )
+        if revisit is None:
             return
 
         revisit_cb = self._revisit_callback
@@ -853,45 +922,63 @@ class AutomationEngine:
         self._fan_min_runtime_active = False
 
     async def _fan_cycle_on(self) -> None:
-        """Fan 'on' phase: activate fan, schedule off after min_runtime minutes."""
+        """Fan 'on' phase: activate fan, schedule off after min_runtime minutes.
+
+        Architecture-reset Step 2: the decision now lives in
+        desired_state.decide_fan_cycle_on() — this method owns actually calling
+        _activate_fan() and scheduling the real async_call_later.
+        """
         min_runtime = self.config.get(CONF_FAN_MIN_RUNTIME_PER_HOUR, DEFAULT_FAN_MIN_RUNTIME_PER_HOUR)
-        if min_runtime <= 0 or self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED) == FAN_MODE_DISABLED:
-            return  # Feature disabled — stop cycling
+        outcome, delay = decide_fan_cycle_on(
+            min_runtime_minutes=min_runtime,
+            fan_mode=self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED),
+            fan_override_active=self._fan_override_active,
+            fan_active=self._fan_active,
+        )
 
-        if self._fan_override_active:
-            return  # User has control; cycle suspended until override cleared
+        if outcome in (FanCycleOutcome.DISABLED, FanCycleOutcome.OVERRIDE_SUSPENDED):
+            return
 
-        if not self._fan_active:
+        if outcome is FanCycleOutcome.ACTIVATE_ALWAYS_ON:
             await self._activate_fan(reason="min_runtime_cycle")
             self._fan_min_runtime_active = True
+            return
 
-            if min_runtime >= 60:
-                return  # Always-on: fan stays on, no further scheduling
+        if outcome is FanCycleOutcome.ACTIVATE_WITH_OFF_TIMER:
+            await self._activate_fan(reason="min_runtime_cycle")
+            self._fan_min_runtime_active = True
 
             @callback
             def _turn_off(_now: Any) -> None:
                 self._fan_min_cycle_cancel = None
                 self.hass.async_create_task(self._fan_cycle_off())
 
-            self._fan_min_cycle_cancel = async_call_later(self.hass, min_runtime * 60, _turn_off)
-        else:
-            # Fan already running for another reason — skip, retry in 60 minutes
-            @callback
-            def _retry(_now: Any) -> None:
-                self._fan_min_cycle_cancel = None
-                self.hass.async_create_task(self._fan_cycle_on())
+            self._fan_min_cycle_cancel = async_call_later(self.hass, delay, _turn_off)
+            return
 
-            self._fan_min_cycle_cancel = async_call_later(self.hass, 60 * 60, _retry)
+        # outcome is RETRY_LATER — fan already running for another reason
+        @callback
+        def _retry(_now: Any) -> None:
+            self._fan_min_cycle_cancel = None
+            self.hass.async_create_task(self._fan_cycle_on())
+
+        self._fan_min_cycle_cancel = async_call_later(self.hass, delay, _retry)
 
     async def _fan_cycle_off(self) -> None:
-        """Fan 'off' phase: deactivate fan, schedule next on after wait period."""
-        min_runtime = self.config.get(CONF_FAN_MIN_RUNTIME_PER_HOUR, DEFAULT_FAN_MIN_RUNTIME_PER_HOUR)
+        """Fan 'off' phase: deactivate fan, schedule next on after wait period.
 
-        if self._fan_min_runtime_active:
+        Architecture-reset Step 2: the decision now lives in
+        desired_state.decide_fan_cycle_off().
+        """
+        min_runtime = self.config.get(CONF_FAN_MIN_RUNTIME_PER_HOUR, DEFAULT_FAN_MIN_RUNTIME_PER_HOUR)
+        should_deactivate, wait_sec = decide_fan_cycle_off(
+            fan_min_runtime_active=self._fan_min_runtime_active,
+            min_runtime_minutes=min_runtime,
+        )
+
+        if should_deactivate:
             self._fan_min_runtime_active = False
             await self._deactivate_fan(reason="min_runtime_cycle_complete")
-
-        wait_sec = max(0, (60 - min_runtime) * 60)
 
         @callback
         def _turn_on(_now: Any) -> None:
@@ -961,7 +1048,13 @@ class AutomationEngine:
         detected_mode = state.state if state else "unknown"
         confirm_seconds = int(self.config.get(CONF_OVERRIDE_CONFIRM_PERIOD, DEFAULT_OVERRIDE_CONFIRM_SECONDS))
 
-        if confirm_seconds <= 0:
+        # Architecture-reset Step 2 (session state machine slice): the disabled-vs-pending
+        # branch now lives in desired_state.decide_override_confirm() — this method still
+        # owns the immediate-accept side effect and the real async_call_later scheduling.
+        _override_pending = decide_override_confirm(
+            confirm_seconds=confirm_seconds, detected_mode=detected_mode, now=dt_util.now()
+        )
+        if _override_pending is None:
             # Confirmation disabled — accept override immediately (legacy behaviour)
             self._confirm_override(detected_mode)
             return
@@ -1265,7 +1358,7 @@ class AutomationEngine:
                 and classification.pre_condition_target < 0
                 and indoor_temp is not None
             ):
-                _absolute_target = float(self.config.get("comfort_cool", 75)) + float(
+                _absolute_target = float(self.config.get("comfort_cool", DEFAULT_COMFORT_COOL)) + float(
                     classification.pre_condition_target
                 )
                 if indoor_temp <= _absolute_target:
@@ -1621,7 +1714,7 @@ class AutomationEngine:
             )
             return
         # Check setpoint is appropriate for commanded mode
-        if mode == "cool" and temperature < (self.config.get("comfort_heat", 70) - 1.0):
+        if mode == "cool" and temperature < (self.config.get("comfort_heat", DEFAULT_COMFORT_HEAT) - 1.0):
             _LOGGER.error(
                 "SETPOINT INCONSISTENCY: cool mode but target %.1fF is below comfort_heat threshold",
                 temperature,
@@ -1634,11 +1727,11 @@ class AutomationEngine:
                         "incident_id": dt_util.now().isoformat(),
                         "hvac_mode": mode,
                         "setpoint_f": temperature,
-                        "comfort_heat": self.config.get("comfort_heat", 70),
-                        "comfort_cool": self.config.get("comfort_cool", 76),
+                        "comfort_heat": self.config.get("comfort_heat", DEFAULT_COMFORT_HEAT),
+                        "comfort_cool": self.config.get("comfort_cool", DEFAULT_COMFORT_COOL),
                     },
                 )
-        elif mode == "heat" and temperature > (self.config.get("comfort_cool", 76) + 1.0):
+        elif mode == "heat" and temperature > (self.config.get("comfort_cool", DEFAULT_COMFORT_COOL) + 1.0):
             _LOGGER.error(
                 "SETPOINT INCONSISTENCY: heat mode but target %.1fF is above comfort_cool threshold",
                 temperature,
@@ -1651,8 +1744,8 @@ class AutomationEngine:
                         "incident_id": dt_util.now().isoformat(),
                         "hvac_mode": mode,
                         "setpoint_f": temperature,
-                        "comfort_heat": self.config.get("comfort_heat", 70),
-                        "comfort_cool": self.config.get("comfort_cool", 76),
+                        "comfort_heat": self.config.get("comfort_heat", DEFAULT_COMFORT_HEAT),
+                        "comfort_cool": self.config.get("comfort_cool", DEFAULT_COMFORT_COOL),
                     },
                 )
         # Set state tracking BEFORE the write so the validation callback always
@@ -1687,16 +1780,32 @@ class AutomationEngine:
             self._temp_command_pending = False
 
         async def _check_single_setpoint_accepted() -> None:
-            if self._write_seq != _my_seq:
-                return
+            # Architecture-reset Step 2: reuses the SAME pure decision already built for
+            # the post-fan setpoint verify (setpoint_verify_decision.decide_setpoint_verify) —
+            # this is structurally the identical stale/no-reading/tolerance check (0.6°F),
+            # just without the no-setpoint/override-active branches, which never apply here
+            # (pending_setpoint_single/_mode are always set by this point, and this check
+            # doesn't consider manual override).
             state = self.hass.states.get(self.climate_entity)
-            if state is None:
+            reported: float | None = None
+            if state is not None:
+                _reported_raw = state.attributes.get("temperature")
+                if _reported_raw is not None:
+                    try:
+                        reported = float(_reported_raw)
+                    except (ValueError, TypeError):
+                        reported = None
+            outcome = decide_setpoint_verify(
+                current_write_seq=self._write_seq,
+                verify_write_seq=_my_seq,
+                expected_temp=self._pending_setpoint_single,
+                expected_mode=self._pending_setpoint_mode,
+                manual_override_active=False,
+                actual_temp=reported,
+            )
+            if outcome in (SetpointVerifyOutcome.STALE, SetpointVerifyOutcome.NO_READING):
                 return
-            reported = state.attributes.get("temperature")
-            if reported is None:
-                return
-            _TOLERANCE = 0.6
-            if abs(float(reported) - self._pending_setpoint_single) > _TOLERANCE:
+            if outcome is SetpointVerifyOutcome.REASSERT:
                 self._setpoint_reject_streak += 1
                 _LOGGER.error(
                     "Setpoint validation FAILED: commanded=%.1f (%s mode), "
@@ -1711,24 +1820,36 @@ class AutomationEngine:
                         "setpoint_rejected",
                         {
                             "commanded": self._pending_setpoint_single,
-                            "reported": float(reported),
+                            "reported": reported,
                         },
                     )
                 # Retry after 15 minutes if no newer command has superseded this one.
+                # Architecture-reset Step 3 (last of the 9 DesiredState mechanisms): the
+                # write_seq/nudge BRANCHING decision is now pure (decide_setpoint_retry_action
+                # below). The delay itself stays a literal constant, not derived from
+                # dt_util.now() arithmetic — this code path has never depended on the wall
+                # clock (unlike grace/revisit), and introducing that dependency here would
+                # repeat the exact decide_fan_cycle_on/off pitfall from earlier this session:
+                # dt_util is a bare, unpatched MagicMock in these tests, so a mocked
+                # `(at - now).total_seconds()` returns a MagicMock, not a real float.
                 _retry_seq = _my_seq
                 _retry_temp = service_temp
                 _retry_mode = mode
-                # Issue #411: on the 2nd+ consecutive rejection for this commanded value,
-                # nudge the setpoint by ±1°F first — some thermostat integrations dedup a
-                # repeated identical set_temperature payload, so retrying with the exact
-                # same value can never succeed. A brief nudge forces the device to
-                # recognize a real change before the actual target is sent 30s later.
-                _do_nudge = self._setpoint_reject_streak >= 2
 
                 async def _retry_callback(_now: Any) -> None:
-                    if self._write_seq != _retry_seq:
+                    # Issue #411: on the 2nd+ consecutive rejection for this commanded value,
+                    # nudge the setpoint by ±1°F first — some thermostat integrations dedup a
+                    # repeated identical set_temperature payload, so retrying with the exact
+                    # same value can never succeed. A brief nudge forces the device to
+                    # recognize a real change before the actual target is sent 30s later.
+                    _action = decide_setpoint_retry_action(
+                        current_write_seq=self._write_seq,
+                        retry_write_seq=_retry_seq,
+                        reject_streak=self._setpoint_reject_streak,
+                    )
+                    if _action is SetpointRetryAction.SUPERSEDED:
                         return  # newer command superseded; skip retry
-                    if _do_nudge:
+                    if _action is SetpointRetryAction.NUDGE_THEN_TARGET:
                         _nudge_delta = convert_delta(1.0, unit)
                         _nudge_temp = (
                             _retry_temp + _nudge_delta if _retry_mode == "cool" else _retry_temp - _nudge_delta
@@ -1762,7 +1883,9 @@ class AutomationEngine:
                         )
 
                         async def _send_real_target(_later: Any) -> None:
-                            if self._write_seq != _retry_seq:
+                            if not decide_scheduled_write_seq_current(
+                                current_write_seq=self._write_seq, target_write_seq=_retry_seq
+                            ):
                                 return  # newer command superseded; skip
                             _LOGGER.info(
                                 "Sending real target after nudge: %.1f %s",
@@ -1942,7 +2065,7 @@ class AutomationEngine:
 
             if self._grace_active:
                 outdoor = self._last_outdoor_temp
-                comfort_cool = float(self.config.get("comfort_cool", 75))
+                comfort_cool = float(self.config.get("comfort_cool", DEFAULT_COMFORT_COOL))
                 nat_vent_delta = float(self.config.get(CONF_NATURAL_VENT_DELTA, DEFAULT_NATURAL_VENT_DELTA))
                 nat_vent_threshold = comfort_cool + nat_vent_delta
                 if outdoor is not None and outdoor < nat_vent_threshold:
@@ -1966,7 +2089,7 @@ class AutomationEngine:
 
             # Check for natural ventilation opportunity before falling through to pause
             outdoor = self._last_outdoor_temp
-            comfort_cool = float(self.config.get("comfort_cool", 75))
+            comfort_cool = float(self.config.get("comfort_cool", DEFAULT_COMFORT_COOL))
             nat_vent_delta = float(self.config.get(CONF_NATURAL_VENT_DELTA, DEFAULT_NATURAL_VENT_DELTA))
             nat_vent_threshold = comfort_cool + nat_vent_delta
             indoor = self._get_indoor_temp_f()
@@ -1991,7 +2114,7 @@ class AutomationEngine:
                 indoor=indoor,
                 comfort_heat=comfort_heat,
                 comfort_cool=comfort_cool,
-                threshold=nat_vent_threshold,
+                nat_vent_delta=nat_vent_delta,
             )
             if _nat_vent_gate_entered:
                 _skip_nat_vent = False
@@ -2197,7 +2320,7 @@ class AutomationEngine:
                 # risen above comfort_cool, allow re-evaluation so nat-vent can engage.
                 # Grace still blocks rapid door-open/close cycling below the comfort ceiling.
                 _indoor = self._get_indoor_temp_f()
-                _cool = float(self.config.get("comfort_cool", 75))
+                _cool = float(self.config.get("comfort_cool", DEFAULT_COMFORT_COOL))
                 # Issue #244: a contact sensor open while HVAC is idle (door opened with
                 # nothing to pause) must still be re-evaluated so nat-vent can engage when
                 # outdoor later cools below indoor — otherwise the occupant misses free
@@ -2227,7 +2350,7 @@ class AutomationEngine:
                     return
 
             outdoor = self._last_outdoor_temp
-            comfort_cool = float(self.config.get("comfort_cool", 75))
+            comfort_cool = float(self.config.get("comfort_cool", DEFAULT_COMFORT_COOL))
             nat_vent_delta = float(self.config.get(CONF_NATURAL_VENT_DELTA, DEFAULT_NATURAL_VENT_DELTA))
             threshold = comfort_cool + nat_vent_delta
 
@@ -2245,7 +2368,7 @@ class AutomationEngine:
                     indoor=_indoor,
                     comfort_heat=_comfort_heat,
                     comfort_cool=comfort_cool,
-                    threshold=threshold,
+                    nat_vent_delta=nat_vent_delta,
                     hysteresis=_hysteresis,
                 ):
                     # Band stays armed — just activate the fan; the compressor self-arbitrates.
@@ -2285,7 +2408,7 @@ class AutomationEngine:
             # transitions. If indoor drops to comfort_heat, stop fan and restore heat.
             # Do NOT enter pause — the house needs to warm up, not wait for nat vent re-evaluation.
             if self._natural_vent_active:
-                comfort_heat = float(self.config.get("comfort_heat", 70))
+                comfort_heat = float(self.config.get("comfort_heat", DEFAULT_COMFORT_HEAT))
                 indoor = self._get_indoor_temp_f()
                 if (
                     self._natural_vent_active
@@ -2482,17 +2605,26 @@ class AutomationEngine:
                 )
                 comfort_heat = self._nat_vent_reactivation_floor()
 
-                # Enforce lockout after outdoor-warm exit
-                if self._nat_vent_outdoor_exit_time is not None:
-                    elapsed = (dt_util.now() - self._nat_vent_outdoor_exit_time).total_seconds()
-                    if elapsed < lockout_s:
-                        _LOGGER.debug(
-                            "Nat vent paused-by-door: lockout active — %.0fs elapsed of %.0fs (%.0fs remaining)",
-                            elapsed,
-                            lockout_s,
-                            lockout_s - elapsed,
-                        )
-                        return
+                # Enforce lockout after outdoor-warm exit. Architecture-reset Step 2: the
+                # decision itself now lives in
+                # nat_vent_reactivation_lockout.is_reactivation_locked_out() — deliberately
+                # NOT spread to the other 4 reactivation-gate call sites, each of which is
+                # structurally unreachable in the immediate aftermath of an outdoor-warm
+                # exit-with-pause (see that module's docstring).
+                _lockout_check_now = dt_util.now()
+                if is_reactivation_locked_out(
+                    outdoor_exit_time=self._nat_vent_outdoor_exit_time,
+                    now=_lockout_check_now,
+                    lockout_seconds=lockout_s,
+                ):
+                    elapsed = (_lockout_check_now - self._nat_vent_outdoor_exit_time).total_seconds()
+                    _LOGGER.debug(
+                        "Nat vent paused-by-door: lockout active — %.0fs elapsed of %.0fs (%.0fs remaining)",
+                        elapsed,
+                        lockout_s,
+                        lockout_s - elapsed,
+                    )
+                    return
 
                 _floor_ok = indoor > comfort_heat
                 _ceiling_ok = outdoor < threshold
@@ -2502,7 +2634,7 @@ class AutomationEngine:
                     indoor=indoor,
                     comfort_heat=comfort_heat,
                     comfort_cool=comfort_cool,
-                    threshold=threshold,
+                    nat_vent_delta=nat_vent_delta,
                     hysteresis=hysteresis,
                 )
                 if _may_reactivate:
@@ -2553,8 +2685,8 @@ class AutomationEngine:
             if not self._natural_vent_active:
                 return
 
-            comfort_heat = float(self.config.get("comfort_heat", 70))
-            comfort_cool = float(self.config.get("comfort_cool", 75))
+            comfort_heat = float(self.config.get("comfort_heat", DEFAULT_COMFORT_HEAT))
+            comfort_cool = float(self.config.get("comfort_cool", DEFAULT_COMFORT_COOL))
             hysteresis = float(self.config.get(CONF_NAT_VENT_HYSTERESIS_F, NAT_VENT_HYSTERESIS_F))
             if _in_sleep_window(dt_util.now(), self.config):
                 sleep_heat = float(self.config.get(CONF_SLEEP_HEAT, comfort_heat))
@@ -2614,7 +2746,14 @@ class AutomationEngine:
                 # emit_event=False: this transition is reported via nat_vent_fan_off below.
                 await self._deactivate_fan(reason="nat_vent_cycling_off", restore_hvac=False, emit_event=False)
                 # _natural_vent_active intentionally left True — session continues
-                if self._emit_event_callback:
+                # Issue #435: only report the cycling transition if there's an actual device
+                # to control — _deactivate_fan() is a no-op when fan_mode is disabled (a
+                # supported manual-window-only nat-vent configuration), and emitting
+                # unconditionally previously claimed device "none" turned off in that config.
+                # Checked directly against fan_mode (the real root cause) rather than a
+                # self._fan_active before/after comparison, since several existing tests
+                # mock _deactivate_fan() itself and don't simulate its state mutation.
+                if self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED) != FAN_MODE_DISABLED and self._emit_event_callback:
                     self._emit_event_callback(
                         "nat_vent_fan_off",
                         {
@@ -2651,7 +2790,14 @@ class AutomationEngine:
                 )
                 # emit_event=False: this transition is reported via nat_vent_fan_on below.
                 await self._activate_fan(reason="nat_vent_cycling_on", emit_event=False)
-                if self._emit_event_callback:
+                # Issue #435: only report the cycling transition if there's an actual device
+                # to control — _activate_fan() is a no-op when fan_mode is disabled (a
+                # supported manual-window-only nat-vent configuration), and emitting
+                # unconditionally previously claimed device "none" turned on in that config.
+                # Checked directly against fan_mode (the real root cause) rather than a
+                # self._fan_active before/after comparison, since several existing tests
+                # mock _activate_fan() itself and don't simulate its state mutation.
+                if self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED) != FAN_MODE_DISABLED and self._emit_event_callback:
                     self._emit_event_callback(
                         "nat_vent_fan_on",
                         {
@@ -2704,43 +2850,76 @@ class AutomationEngine:
             )
             return
 
-        comfort_heat = float(self.config.get("comfort_heat", 70))
+        comfort_heat = float(self.config.get("comfort_heat", DEFAULT_COMFORT_HEAT))
+        hysteresis_ftc = float(self.config.get(CONF_NAT_VENT_HYSTERESIS_F, NAT_VENT_HYSTERESIS_F))
+        in_sleep_window = _in_sleep_window(dt_util.now(), self.config)
+        sleep_heat_ftc = float(self.config.get(CONF_SLEEP_HEAT, comfort_heat))
 
-        # --- Check 1: free-cooling direction guard ---
-        # Free cooling requires outdoor cooler than indoor. Once outdoor >= indoor the
-        # airflow no longer cools (neutral or reversed) — stop. NOTE: NO hysteresis on the
-        # STOP side; the anti-flap hysteresis lives on nat-vent RE-activation
-        # (check_natural_vent_conditions). Subtracting it here would kill free cooling ~1°F
-        # early — e.g. stop at outdoor 71 / indoor 72 while a favorable gradient remains.
-        if outdoor is not None and indoor is not None and outdoor >= indoor:
-            if self._natural_vent_active:
-                # Issue #418: actually routed through the canonical nat-vent outdoor-rise
-                # exit now (previously this comment claimed it did, but the code hand-rolled
-                # _natural_vent_active/_paused_by_door/_deactivate_fan itself — which set
-                # _paused_by_door=True while still restoring HVAC via _deactivate_fan()'s
-                # default restore_hvac=True, contradicting the pause semantics, and never
-                # captured _pre_pause_mode or checked whether a sensor was genuinely still
-                # open). _exit_nat_vent() gets all three right, mirroring
-                # check_natural_vent_conditions()'s equivalent outdoor-rise-exit call site.
-                stop_reason = f"outdoor {outdoor:.1f}°F >= indoor {indoor:.1f}°F — airflow reversed"
-                _LOGGER.debug(
-                    "Fan thermostat check: trigger=%s indoor=%s outdoor=%s active=%s decision=%s",
-                    trigger,
-                    f"{indoor:.1f}",
-                    f"{outdoor:.1f}",
-                    True,
-                    f"stop:{stop_reason}",
+        # Issue #435 follow-up (architecture-reset Step 2): Check 1 + Check 2's decision
+        # logic now lives in one pure, independently-tested function
+        # (fan_thermostat_decision.decide_fan_thermostat_check) — shadow + substitution
+        # differential-tested against this exact dispatch (see
+        # tools/fan_thermostat_decision_diff.py, tools/sim_harness/fan_thermostat_decision_compare.py).
+        # This method now only reconstructs the same reason strings/log lines/side effects
+        # the pre-extraction inline code produced — no decision logic here.
+        inputs = FanThermostatInputs(
+            indoor=indoor,
+            outdoor=outdoor,
+            comfort_heat_raw=comfort_heat,
+            sleep_heat=sleep_heat_ftc,
+            in_sleep_window=in_sleep_window,
+            hysteresis=hysteresis_ftc,
+            natural_vent_active=self._natural_vent_active,
+        )
+        outcome = decide_fan_thermostat_check(inputs)
+
+        if outcome is FanThermostatOutcome.KEEP:
+            _LOGGER.debug(
+                "Fan thermostat check: trigger=%s indoor=%s outdoor=%s active=%s decision=keep",
+                trigger,
+                f"{indoor:.1f}" if indoor is not None else "unavailable",
+                f"{outdoor:.1f}" if outdoor is not None else "unavailable",
+                True,
+            )
+            return
+
+        if outcome is FanThermostatOutcome.STOP_VIA_NAT_VENT_EXIT:
+            # Issue #418: actually routed through the canonical nat-vent outdoor-rise
+            # exit now (previously this comment claimed it did, but the code hand-rolled
+            # _natural_vent_active/_paused_by_door/_deactivate_fan itself — which set
+            # _paused_by_door=True while still restoring HVAC via _deactivate_fan()'s
+            # default restore_hvac=True, contradicting the pause semantics, and never
+            # captured _pre_pause_mode or checked whether a sensor was genuinely still
+            # open). _exit_nat_vent() gets all three right, mirroring
+            # check_natural_vent_conditions()'s equivalent outdoor-rise-exit call site.
+            stop_reason = f"outdoor {outdoor:.1f}°F >= indoor {indoor:.1f}°F — airflow reversed"
+            _LOGGER.debug(
+                "Fan thermostat check: trigger=%s indoor=%s outdoor=%s active=%s decision=%s",
+                trigger,
+                f"{indoor:.1f}",
+                f"{outdoor:.1f}",
+                True,
+                f"stop:{stop_reason}",
+            )
+            if self._emit_event_callback:
+                self._emit_event_callback(
+                    "nat_vent_outdoor_rise_exit",
+                    {"outdoor": outdoor, "indoor": indoor, "fan_device": _fan_device_label(self.config)},
                 )
-                if self._emit_event_callback:
-                    self._emit_event_callback(
-                        "nat_vent_outdoor_rise_exit",
-                        {"outdoor": outdoor, "indoor": indoor, "fan_device": _fan_device_label(self.config)},
-                    )
-                await self._exit_nat_vent(
-                    reason=f"nat vent exit (fast loop): {stop_reason}",
-                    set_outdoor_exit_time=True,
-                )
-                return
+            await self._exit_nat_vent(
+                reason=f"nat vent exit (fast loop): {stop_reason}",
+                set_outdoor_exit_time=True,
+            )
+            return
+
+        if outcome is FanThermostatOutcome.STOP_DEACTIVATE:
+            # --- Check 1's non-nat-vent stop branch: free-cooling direction guard ---
+            # Free cooling requires outdoor cooler than indoor. Once outdoor >= indoor the
+            # airflow no longer cools (neutral or reversed) — stop. NOTE: NO hysteresis on
+            # the STOP side; the anti-flap hysteresis lives on nat-vent RE-activation
+            # (check_natural_vent_conditions). Subtracting it here would kill free cooling
+            # ~1°F early — e.g. stop at outdoor 71 / indoor 72 while a favorable gradient
+            # remains.
             stop_reason = f"outdoor {outdoor:.1f}°F >= indoor {indoor:.1f}°F (free cooling gone)"
             _LOGGER.debug(
                 "Fan thermostat check: trigger=%s indoor=%s outdoor=%s active=%s decision=%s",
@@ -2753,6 +2932,7 @@ class AutomationEngine:
             await self._deactivate_fan(reason=f"fan thermostat check — {stop_reason}")
             return
 
+        # outcome is STOP_COOLED_TO_FLOOR
         # --- Check 2: cooled to target ---
         # A CA fan only runs while outdoor < indoor (Check 1 stops it otherwise), so it is ALWAYS
         # cooling. Stop once indoor has cooled to the comfort floor, to avoid overcooling. Do NOT
@@ -2767,34 +2947,19 @@ class AutomationEngine:
         # always preempt nat_vent_temperature_check()'s correct sleep-window cycling (off at
         # sleep_heat, on at sleep_heat+2*hysteresis) before that logic ever got a chance to run,
         # permanently ending the nat-vent session at comfort_heat instead of letting it cycle.
-        _hysteresis_ftc = float(self.config.get(CONF_NAT_VENT_HYSTERESIS_F, NAT_VENT_HYSTERESIS_F))
-        if _in_sleep_window(dt_util.now(), self.config):
-            _sleep_heat_ftc = float(self.config.get(CONF_SLEEP_HEAT, comfort_heat))
-            _vent_floor_ftc = _sleep_heat_ftc - _hysteresis_ftc
-        else:
-            _vent_floor_ftc = comfort_heat
-        if indoor is not None and indoor <= _vent_floor_ftc:
-            stop_reason = f"indoor {indoor:.1f}°F ≤ comfort floor {_vent_floor_ftc:.1f}°F (cooled to floor)"
-            _LOGGER.debug(
-                "Fan thermostat check: trigger=%s indoor=%s outdoor=%s active=%s decision=%s",
-                trigger,
-                f"{indoor:.1f}",
-                f"{outdoor:.1f}" if outdoor is not None else "unavailable",
-                True,
-                f"stop:{stop_reason}",
-            )
-            if self._natural_vent_active:
-                self._natural_vent_active = False
-            await self._deactivate_fan(reason=f"fan thermostat check — {stop_reason}")
-            return
-
+        vent_floor_ftc = _resolve_vent_floor(inputs)
+        stop_reason = f"indoor {indoor:.1f}°F ≤ comfort floor {vent_floor_ftc:.1f}°F (cooled to floor)"
         _LOGGER.debug(
-            "Fan thermostat check: trigger=%s indoor=%s outdoor=%s active=%s decision=keep",
+            "Fan thermostat check: trigger=%s indoor=%s outdoor=%s active=%s decision=%s",
             trigger,
-            f"{indoor:.1f}" if indoor is not None else "unavailable",
+            f"{indoor:.1f}",
             f"{outdoor:.1f}" if outdoor is not None else "unavailable",
             True,
+            f"stop:{stop_reason}",
         )
+        if self._natural_vent_active:
+            self._natural_vent_active = False
+        await self._deactivate_fan(reason=f"fan thermostat check — {stop_reason}")
 
     async def reconcile_fan_on_startup(
         self,
@@ -2864,9 +3029,8 @@ class AutomationEngine:
         # Evaluate nat-vent eligibility
         hysteresis = float(self.config.get(CONF_NAT_VENT_HYSTERESIS_F, NAT_VENT_HYSTERESIS_F))
         nat_vent_delta = float(self.config.get(CONF_NATURAL_VENT_DELTA, DEFAULT_NATURAL_VENT_DELTA))
-        comfort_cool = float(self.config.get("comfort_cool", 75))
+        comfort_cool = float(self.config.get("comfort_cool", DEFAULT_COMFORT_COOL))
         comfort_heat = self._nat_vent_reactivation_floor()
-        nat_vent_threshold = comfort_cool + nat_vent_delta
 
         # Issue #417: folded into the shared _nat_vent_may_reactivate() gate instead of a
         # 5th hand-rolled copy — this hand-rolled version was also missing the sleep-aware
@@ -2879,7 +3043,7 @@ class AutomationEngine:
                 indoor=indoor,
                 comfort_heat=comfort_heat,
                 comfort_cool=comfort_cool,
-                threshold=nat_vent_threshold,
+                nat_vent_delta=nat_vent_delta,
                 hysteresis=hysteresis,
             )
         )
@@ -3012,23 +3176,36 @@ class AutomationEngine:
         Args:
             source: "manual" for user-initiated overrides,
                     "automation" for Climate Advisor resumptions.
+
+        Architecture-reset Step 2 (session state machine slice): the
+        duration/should_notify RESOLUTION now lives in
+        ``desired_state.decide_grace_start()`` — the first real production
+        wiring of a DesiredState type, not just a schema. This method still
+        owns everything decide_grace_start() doesn't cover: cancelling prior
+        timers, scheduling the real ``async_call_later``, setting instance
+        flags, and emitting the ``grace_started`` event.
         """
         self._cancel_grace_timers()
 
-        if source == "manual":
-            duration = self.config.get(CONF_MANUAL_GRACE_PERIOD, DEFAULT_MANUAL_GRACE_SECONDS)
-            should_notify = self.config.get(CONF_MANUAL_GRACE_NOTIFY, True)
-        else:
-            duration = self.config.get(CONF_AUTOMATION_GRACE_PERIOD, DEFAULT_AUTOMATION_GRACE_SECONDS)
-            should_notify = self.config.get(CONF_AUTOMATION_GRACE_NOTIFY, True)
-
-        if duration <= 0:
+        now = dt_util.now()
+        grace = decide_grace_start(
+            source=source,
+            manual_duration_seconds=self.config.get(CONF_MANUAL_GRACE_PERIOD, DEFAULT_MANUAL_GRACE_SECONDS),
+            manual_should_notify=self.config.get(CONF_MANUAL_GRACE_NOTIFY, True),
+            automation_duration_seconds=self.config.get(CONF_AUTOMATION_GRACE_PERIOD, DEFAULT_AUTOMATION_GRACE_SECONDS),
+            automation_should_notify=self.config.get(CONF_AUTOMATION_GRACE_NOTIFY, True),
+            now=now,
+        )
+        if grace is None:
             return  # Grace period disabled
+
+        duration = int((grace.at - now).total_seconds())
+        should_notify = grace.should_notify
 
         self._grace_active = True
         self._last_resume_source = source
         self._grace_duration_seconds = duration
-        self._grace_end_time = (dt_util.now() + timedelta(seconds=duration)).isoformat()
+        self._grace_end_time = grace.at.isoformat()
 
         @callback
         def _grace_expired(_now: Any) -> None:
@@ -3173,7 +3350,7 @@ class AutomationEngine:
                 return
             # Check nat-vent conditions before blindly re-pausing
             outdoor = self._last_outdoor_temp
-            comfort_cool = float(self.config.get("comfort_cool", 75))
+            comfort_cool = float(self.config.get("comfort_cool", DEFAULT_COMFORT_COOL))
             nat_vent_delta = float(self.config.get(CONF_NATURAL_VENT_DELTA, DEFAULT_NATURAL_VENT_DELTA))
             indoor = self._get_indoor_temp_f()
             comfort_heat = self._nat_vent_reactivation_floor()
@@ -3186,7 +3363,7 @@ class AutomationEngine:
                 indoor=indoor,
                 comfort_heat=comfort_heat,
                 comfort_cool=comfort_cool,
-                threshold=nat_vent_threshold,
+                nat_vent_delta=nat_vent_delta,
             ):
                 nat_vent_reason = (
                     f"grace expired — nat-vent: outdoor {outdoor:.1f}°F < indoor {indoor:.1f}°F,"
@@ -3506,11 +3683,13 @@ class AutomationEngine:
             # Skipped ever got populated on the majority of nights in a mild climate).
             if _sleep_band.active == "floor":
                 self._today_record.setback_heat_applied_f = _sleep_band.floor
-                self._today_record.setback_depth_f = abs(self.config.get("comfort_heat", 70) - _sleep_band.floor)
+                _comfort_heat_f = self.config.get("comfort_heat", DEFAULT_COMFORT_HEAT)
+                self._today_record.setback_depth_f = abs(_comfort_heat_f - _sleep_band.floor)
                 self._today_record.setback_was_adaptive = False
             elif _sleep_band.active == "ceiling":
                 self._today_record.setback_cool_applied_f = _sleep_band.ceiling
-                self._today_record.setback_depth_f = abs(self.config.get("comfort_cool", 75) - _sleep_band.ceiling)
+                _comfort_cool_f = self.config.get("comfort_cool", DEFAULT_COMFORT_COOL)
+                self._today_record.setback_depth_f = abs(_comfort_cool_f - _sleep_band.ceiling)
                 self._today_record.setback_was_adaptive = False
         await self._apply_comfort_band(
             _sleep_band,
@@ -3524,8 +3703,6 @@ class AutomationEngine:
         Suppressed when nat-vent already brought indoor to or below the target.
         Returns a short status string for logging.
         """
-        from .const import CONF_SLEEP_COOL, PRE_COOL_MIN_HEADROOM_F
-
         c = self._current_classification
         if not c or c.setback_modifier >= 0:
             _LOGGER.info(
@@ -3546,11 +3723,12 @@ class AutomationEngine:
             )
             return "skipped: manual override"
 
-        sleep_cool = float(self.config.get(CONF_SLEEP_COOL) or self.config.get("sleep_cool", 78.0))
-        comfort_heat = float(self.config.get("comfort_heat", 70.0))
+        sleep_cool = float(self.config.get(CONF_SLEEP_COOL, DEFAULT_SLEEP_COOL))
+        sleep_heat_floor = float(self.config.get(CONF_SLEEP_HEAT, DEFAULT_SLEEP_HEAT))
+        hysteresis = float(self.config.get(CONF_NAT_VENT_HYSTERESIS_F, NAT_VENT_HYSTERESIS_F))
         raw_target = sleep_cool + c.setback_modifier  # setback_modifier is negative for warming trend
-        floor = comfort_heat + PRE_COOL_MIN_HEADROOM_F
-        pre_cool_target = max(raw_target, floor)
+        floor = sleep_heat_floor + hysteresis
+        pre_cool_target = compute_pre_cool_target(self.config, c.setback_modifier)
 
         _LOGGER.info(
             "Pre-cool trigger fired: indoor=%s°F, target=%.1f°F, modifier=%.1f (sleep_cool=%.1f, floor=%.1f)",
@@ -3563,11 +3741,11 @@ class AutomationEngine:
 
         if raw_target < floor:
             _LOGGER.warning(
-                "Pre-cool target %.1f°F below floor %.1f°F (comfort_heat=%.1f + headroom=%.1f); clamped to %.1f°F",
+                "Pre-cool target %.1f°F below floor %.1f°F (sleep_heat=%.1f + hysteresis=%.1f); clamped to %.1f°F",
                 raw_target,
                 floor,
-                comfort_heat,
-                PRE_COOL_MIN_HEADROOM_F,
+                sleep_heat_floor,
+                hysteresis,
                 pre_cool_target,
             )
 
@@ -3657,7 +3835,7 @@ class AutomationEngine:
 
         # Morning pre-cool overshoot guard: warn if indoor is below comfort_heat (heat may fire)
         _current_indoor = indoor_temp
-        _comfort_heat = float(self.config.get("comfort_heat", 70.0))
+        _comfort_heat = float(self.config.get("comfort_heat", DEFAULT_COMFORT_HEAT))
         if _current_indoor is not None:
             if _current_indoor < _comfort_heat:
                 _LOGGER.warning(
@@ -3760,7 +3938,7 @@ class AutomationEngine:
         failure mode already fixed once for the cycling functions under Issue #402;
         this closes the gap on the reactivation-gate side.
         """
-        comfort_heat = float(self.config.get("comfort_heat", 70))
+        comfort_heat = float(self.config.get("comfort_heat", DEFAULT_COMFORT_HEAT))
         if _in_sleep_window(dt_util.now(), self.config):
             return float(self.config.get(CONF_SLEEP_HEAT, comfort_heat))
         return comfort_heat
@@ -3772,7 +3950,7 @@ class AutomationEngine:
         indoor: float | None,
         comfort_heat: float,
         comfort_cool: float,
-        threshold: float,
+        nat_vent_delta: float,
         hysteresis: float = 0.0,
     ) -> bool:
         """Shared 4-part reactivation gate for nat-vent (Issue #411, Pass 4).
@@ -3788,23 +3966,44 @@ class AutomationEngine:
         applying nat-vent HVAC state) — this function returns only the shared boolean
         gate, mirroring how ``_ceiling_threshold()`` is scoped as a value helper.
 
+        Architecture-reset Step 2 follow-up: the decision itself now lives in
+        ``nat_vent_gate.decide_nat_vent_gate()`` — differential + substitution
+        tested against this exact call (see tools/nat_vent_gate_diff.py,
+        tools/nat_vent_gate_substitution_diff.py). This method only reconstructs
+        the ``NatVentGateInputs`` from already-caller-resolved values (``comfort_heat``
+        is already sleep-window-resolved by every caller via
+        ``_nat_vent_reactivation_floor()``, so ``in_sleep_window=False`` here is not a
+        second resolution — it's a pass-through that keeps the pure core's own
+        sleep-window branch a no-op, since that resolution already happened once).
+
         Args:
             outdoor: Current outdoor temperature (°F), or None if unavailable.
             indoor: Current indoor temperature (°F), or None if unavailable.
-            comfort_heat: Comfort floor (°F) — indoor must be above this.
+            comfort_heat: Comfort floor (°F) — indoor must be above this. Already
+                sleep-window-resolved by the caller (via ``_nat_vent_reactivation_floor()``).
             comfort_cool: Comfort ceiling (°F) — used for the archetype-aware ceiling check.
-            threshold: Outdoor must be below this (typically comfort_cool + nat_vent_delta).
-                Passed in rather than recomputed here so this stays a pure boolean gate.
+            nat_vent_delta: Added to comfort_cool to form the outdoor threshold —
+                every real call site already holds this as a separate local before
+                summing it into a threshold, so passing it through unchanged (instead
+                of the pre-summed threshold) avoids re-deriving it via subtraction.
             hysteresis: Subtracted from indoor in the outdoor/indoor delta check. Callers
                 that don't apply hysteresis (handle_door_window_open, _re_pause_for_open_sensor)
                 pass 0.0 (the default); the paused-by-door reactivation block passes the
                 configured nat-vent hysteresis.
         """
-        if outdoor is None or indoor is None:
-            return False
-        ceiling_threshold = self._ceiling_threshold(comfort_cool)
-        ceiling_ok = ceiling_threshold is None or indoor <= ceiling_threshold
-        return outdoor < indoor - hysteresis and indoor > comfort_heat and outdoor < threshold and ceiling_ok
+        inputs = NatVentGateInputs(
+            outdoor=outdoor,
+            indoor=indoor,
+            comfort_heat_raw=comfort_heat,
+            sleep_heat=comfort_heat,
+            in_sleep_window=False,
+            comfort_cool=comfort_cool,
+            nat_vent_delta=nat_vent_delta,
+            hysteresis=hysteresis,
+            fan_mode=self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED),
+            aggressive_savings=bool(self.config.get("aggressive_savings", False)),
+        )
+        return decide_nat_vent_gate(inputs)
 
     def _ceiling_threshold(self, comfort_cool: float | None) -> float | None:
         """Ceiling above which the compressor should take over from fan-assisted cooling.
@@ -3862,8 +4061,8 @@ class AutomationEngine:
             return
 
         aggressive_savings = bool(self.config.get("aggressive_savings", False))
-        comfort_heat = float(self.config.get("comfort_heat", 70))
-        comfort_cool = float(self.config.get("comfort_cool", 75))
+        comfort_heat = float(self.config.get("comfort_heat", DEFAULT_COMFORT_HEAT))
+        comfort_cool = float(self.config.get("comfort_cool", DEFAULT_COMFORT_COOL))
 
         if not aggressive_savings:
             # Sleep window: skip the full-band setpoint call — apply_classification() will arm
@@ -4009,33 +4208,35 @@ class AutomationEngine:
             _expected_mode = self._last_commanded_hvac_mode
 
             async def _do_verify_after_fan_on() -> None:
-                if self._write_seq != _verify_seq:
-                    return  # newer command issued — skip
-                if _expected_temp is None or _expected_mode is None:
-                    return  # no active setpoint
-                if self._manual_override_active:
-                    return  # genuine confirmed override — don't fight it
+                # Architecture-reset Step 2: the decision now lives in
+                # setpoint_verify_decision.decide_setpoint_verify() — shared with
+                # _do_verify_after_fan_off(), which had byte-for-byte identical logic
+                # before this consolidation (found during the #429 dedup sweep).
                 current_state = self.hass.states.get(self.climate_entity)
-                if current_state is None:
-                    return
-                actual = current_state.attributes.get("temperature")
-                if actual is None:
-                    return
-                try:
-                    if (
-                        abs(float(actual) - _expected_temp) > 0.6
-                    ):  # 0.6°F — same tolerance as _check_single_setpoint_accepted
-                        _LOGGER.info(
-                            "Post-fan setpoint verify: thermostat %.1f°F != expected %.1f°F — re-asserting %s mode",
-                            float(actual),
-                            _expected_temp,
-                            _expected_mode,
-                        )
-                        await self._set_temperature(
-                            _expected_temp, reason="post-fan-verify/repair", mode=_expected_mode
-                        )
-                except (ValueError, TypeError):
-                    pass
+                actual_temp: float | None = None
+                if current_state is not None:
+                    _actual_raw = current_state.attributes.get("temperature")
+                    if _actual_raw is not None:
+                        try:
+                            actual_temp = float(_actual_raw)
+                        except (ValueError, TypeError):
+                            actual_temp = None
+                outcome = decide_setpoint_verify(
+                    current_write_seq=self._write_seq,
+                    verify_write_seq=_verify_seq,
+                    expected_temp=_expected_temp,
+                    expected_mode=_expected_mode,
+                    manual_override_active=self._manual_override_active,
+                    actual_temp=actual_temp,
+                )
+                if outcome is SetpointVerifyOutcome.REASSERT:
+                    _LOGGER.info(
+                        "Post-fan setpoint verify: thermostat %.1f°F != expected %.1f°F — re-asserting %s mode",
+                        actual_temp,
+                        _expected_temp,
+                        _expected_mode,
+                    )
+                    await self._set_temperature(_expected_temp, reason="post-fan-verify/repair", mode=_expected_mode)
 
             @callback
             def _verify_setpoint_after_fan_on(_now: Any) -> None:
@@ -4088,8 +4289,11 @@ class AutomationEngine:
         # timer to also re-evaluate cycling while nat-vent is active.
         if self._natural_vent_active and indoor is not None:
             await self.nat_vent_temperature_check(indoor)
-        # Re-arm only if the fan is still active after the check
-        if self._fan_running:
+        # Re-arm only if the fan is still active after the check. Architecture-reset
+        # Step 2: the decision now lives in desired_state.decide_fan_thermo_backstop() —
+        # this method still owns actually calling _start_fan_thermo_backstop() to
+        # schedule the real timer.
+        if decide_fan_thermo_backstop(fan_running=self._fan_running, delay_seconds=5 * 60, now=dt_util.now()):
             self._start_fan_thermo_backstop()
 
     def _cancel_fan_thermo_backstop(self) -> None:
@@ -4125,43 +4329,55 @@ class AutomationEngine:
         with `preserve_nat_vent_session=True` — the nat-vent session survives so the
         immediately-following `nat_vent_temperature_check()` call in `_thermo_backstop_task()`
         can re-fire `_activate_fan()` on the same tick if conditions still warrant it.
+
+        Architecture-reset Step 2 (session state machine slice): the decision itself now
+        lives in `fan_drift_reconciliation.decide_fan_drift_reconciliation()` — this method
+        only reconstructs the pure inputs and applies the returned outcome's side effects.
         """
-        if not self._fan_active:
-            self._fan_drift_tick_count = 0
-            return
-
         fan_mode = self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED)
-        if fan_mode not in (FAN_MODE_WHOLE_HOUSE, FAN_MODE_BOTH):
+        recent_fan_command = bool(
+            self._is_recent_fan_command_callback and self._is_recent_fan_command_callback(threshold_seconds=30.0)
+        )
+        physical_state_available = bool(self._get_fan_physical_state_callback)
+        # Mirrors the original code's laziness: only actually read live physical state
+        # once every cheaper guard (fan active, applicable archetype, no recent CA
+        # command echo) has already passed — avoids an unnecessary state read otherwise.
+        physical_on = None
+        if (
+            self._fan_active
+            and fan_mode in (FAN_MODE_WHOLE_HOUSE, FAN_MODE_BOTH)
+            and not recent_fan_command
+            and physical_state_available
+        ):
+            physical_on = self._get_fan_physical_state_callback()
+
+        inputs = FanDriftInputs(
+            fan_active=self._fan_active,
+            fan_mode=fan_mode,
+            recent_fan_command=recent_fan_command,
+            physical_state_available=physical_state_available,
+            physical_on=physical_on,
+            tick_count=self._fan_drift_tick_count,
+        )
+        outcome, next_tick_count = decide_fan_drift_reconciliation(inputs)
+        self._fan_drift_tick_count = next_tick_count
+
+        if outcome in (FanDriftOutcome.RESET, FanDriftOutcome.NOOP):
             return
 
-        if self._is_recent_fan_command_callback and self._is_recent_fan_command_callback(threshold_seconds=30.0):
-            self._fan_drift_tick_count = 0
-            return
-
-        if not self._get_fan_physical_state_callback:
-            return
-        physical_on = self._get_fan_physical_state_callback()
-        if physical_on is None:
-            return  # command-only mode — no ground truth, nothing to reconcile
-        if physical_on:
-            self._fan_drift_tick_count = 0  # agrees — reset
-            return
-
-        # physical_on is False but _fan_active is True — disagreement.
-        self._fan_drift_tick_count += 1
-        if self._fan_drift_tick_count < 2:
+        if outcome is FanDriftOutcome.AWAITING:
             _LOGGER.info(
                 "Fan physical-state drift detected (tick %d/2): _fan_active=True but physical"
                 " state=off — awaiting confirmation tick before correcting",
-                self._fan_drift_tick_count,
+                next_tick_count,
             )
             return
 
+        # outcome is CORRECT
         _LOGGER.warning(
             "Fan physical-state drift confirmed over 2 backstop ticks: _fan_active=True but"
             " physical state=off — self-correcting stale flag (Issue #423)"
         )
-        self._fan_drift_tick_count = 0
         if self._emit_event_callback:
             self._emit_event_callback(
                 "fan_cancel",
@@ -4284,33 +4500,35 @@ class AutomationEngine:
             _expected_mode = self._last_commanded_hvac_mode
 
             async def _do_verify_after_fan_off() -> None:
-                if self._write_seq != _verify_seq:
-                    return  # newer command issued — skip
-                if _expected_temp is None or _expected_mode is None:
-                    return  # no active setpoint
-                if self._manual_override_active:
-                    return  # genuine confirmed override — don't fight it
+                # Architecture-reset Step 2: the decision now lives in
+                # setpoint_verify_decision.decide_setpoint_verify() — shared with
+                # _do_verify_after_fan_on(), which had byte-for-byte identical logic
+                # before this consolidation (found during the #429 dedup sweep).
                 current_state = self.hass.states.get(self.climate_entity)
-                if current_state is None:
-                    return
-                actual = current_state.attributes.get("temperature")
-                if actual is None:
-                    return
-                try:
-                    if (
-                        abs(float(actual) - _expected_temp) > 0.6
-                    ):  # 0.6°F — same tolerance as _check_single_setpoint_accepted
-                        _LOGGER.info(
-                            "Post-fan setpoint verify: thermostat %.1f°F != expected %.1f°F — re-asserting %s mode",
-                            float(actual),
-                            _expected_temp,
-                            _expected_mode,
-                        )
-                        await self._set_temperature(
-                            _expected_temp, reason="post-fan-verify/repair", mode=_expected_mode
-                        )
-                except (ValueError, TypeError):
-                    pass
+                actual_temp: float | None = None
+                if current_state is not None:
+                    _actual_raw = current_state.attributes.get("temperature")
+                    if _actual_raw is not None:
+                        try:
+                            actual_temp = float(_actual_raw)
+                        except (ValueError, TypeError):
+                            actual_temp = None
+                outcome = decide_setpoint_verify(
+                    current_write_seq=self._write_seq,
+                    verify_write_seq=_verify_seq,
+                    expected_temp=_expected_temp,
+                    expected_mode=_expected_mode,
+                    manual_override_active=self._manual_override_active,
+                    actual_temp=actual_temp,
+                )
+                if outcome is SetpointVerifyOutcome.REASSERT:
+                    _LOGGER.info(
+                        "Post-fan setpoint verify: thermostat %.1f°F != expected %.1f°F — re-asserting %s mode",
+                        actual_temp,
+                        _expected_temp,
+                        _expected_mode,
+                    )
+                    await self._set_temperature(_expected_temp, reason="post-fan-verify/repair", mode=_expected_mode)
 
             @callback
             def _verify_setpoint_after_fan_off(_now: Any) -> None:
@@ -4353,7 +4571,7 @@ class AutomationEngine:
             return False
 
         unit = self.config.get("temp_unit", "fahrenheit")
-        comfort_cool = self.config.get("comfort_cool", 75)
+        comfort_cool = self.config.get("comfort_cool", DEFAULT_COMFORT_COOL)
         delta = self.config.get("economizer_temp_delta", ECONOMIZER_TEMP_DELTA)
         aggressive_savings = self.config.get("aggressive_savings", False)
 
@@ -4371,7 +4589,10 @@ class AutomationEngine:
         # nat-vent's gate at check_natural_vent_conditions. Without this guard the economizer
         # could start the fan while it is warmer outside than in (e.g. on a hot evening), pulling
         # warmer outdoor air into the house and working against comfort.
-        direction_ok = indoor_temp is None or outdoor_temp < indoor_temp
+        # Architecture-reset (Issue #429 consolidation): routed through temperature.py's shared
+        # free_cooling_direction_ok() — the exact same strict-<, fail-open-on-None variant
+        # already used by coordinator.py's next_human_action(), instead of a third hand-copy.
+        direction_ok = free_cooling_direction_ok(outdoor_temp, indoor_temp)
         if not direction_ok:
             _LOGGER.debug(
                 "Economizer gate: direction rejected — outdoor %.1f°F >= indoor %.1f°F"

--- a/custom_components/climate_advisor/briefing.py
+++ b/custom_components/climate_advisor/briefing.py
@@ -26,8 +26,10 @@ from .const import (
     DEFAULT_AUTOMATION_GRACE_SECONDS,
     DEFAULT_MANUAL_GRACE_SECONDS,
     DEFAULT_SENSOR_DEBOUNCE_SECONDS,
+    DEFAULT_SETBACK_COOL,
     DEFAULT_SETBACK_DEPTH_COOL_F,
     DEFAULT_SETBACK_DEPTH_F,
+    DEFAULT_SETBACK_HEAT,
     ECONOMIZER_TEMP_DELTA,
     FAN_MODE_DISABLED,
     OCCUPANCY_SETBACK_MINUTES,
@@ -264,8 +266,8 @@ def _generate_tldr_table(
     day_type_val = f"{c.day_type.title()} ({format_temp(c.today_high, temp_unit)})"
 
     # --- HVAC Mode row (Issue #85: show setback temps when away/vacation) ---
-    setback_heat = config.get("setback_heat", 62)
-    setback_cool = config.get("setback_cool", 80)
+    setback_heat = config.get("setback_heat", DEFAULT_SETBACK_HEAT)
+    setback_cool = config.get("setback_cool", DEFAULT_SETBACK_COOL)
     if occupancy_mode in ("away", "vacation"):
         if c.hvac_mode == "cool":
             hvac_val = f"Cool at {format_temp(setback_cool, temp_unit)} (setback — {occupancy_mode})"
@@ -445,6 +447,18 @@ def _hot_day_plan(
 
 _CEILING_PRECOOL_FALLBACK_MIN = 120  # default lead time when k_active_cool is unavailable
 
+_NAT_VENT_CUTOFF_MARGIN_F = 1.0  # forecast-hour margin — distinct from the live-control gates'
+# own boundary choices (nat_vent_gate.py's strict <, fan_thermostat_decision.py's non-strict >=);
+# this is a PREDICTIVE identification of "the hour nat-vent stops being viable", not a live
+# control decision, so a small conservative buffer is appropriate here specifically.
+
+
+def _nat_vent_cutoff_reached(outdoor_temp: float, indoor_temp: float) -> bool:
+    """Architecture-reset (Issue #429 consolidation): the shared predicate both
+    _derive_warm_day_events() and _derive_natural_vent_events() independently
+    hand-rolled as `outdoor >= indoor - 1.0` — now a single shared definition."""
+    return outdoor_temp >= indoor_temp - _NAT_VENT_CUTOFF_MARGIN_F
+
 
 def _derive_warm_day_events(
     predicted_indoor: list[dict] | None,
@@ -494,7 +508,7 @@ def _derive_warm_day_events(
 
     # nat_vent_cutoff: first entry where outdoor >= indoor - 1 F
     for ts, i_temp, o_temp in pairs:
-        if o_temp >= i_temp - 1.0:
+        if _nat_vent_cutoff_reached(o_temp, i_temp):
             result["nat_vent_cutoff"] = ts
             break
 
@@ -573,7 +587,7 @@ def _derive_natural_vent_events(
 
     # nat_vent_cutoff: first hour where outdoor >= indoor - 1.0 °F
     for h in range(n):
-        if predicted_outdoor_future[h] >= predicted_indoor_future[h] - 1.0:
+        if _nat_vent_cutoff_reached(predicted_outdoor_future[h], predicted_indoor_future[h]):
             result["nat_vent_cutoff"] = h
             break
 

--- a/custom_components/climate_advisor/config_flow.py
+++ b/custom_components/climate_advisor/config_flow.py
@@ -161,6 +161,47 @@ def _entity_selector_for_source(source: str) -> selector.EntitySelector:
     return selector.EntitySelector(selector.EntitySelectorConfig(domain="sensor", device_class="temperature"))
 
 
+def setpoint_slider_ranges(is_celsius: bool) -> dict[str, tuple[float, float, float, float]]:
+    """Slider (min, max, default, step) for the 6 setpoints on the INITIAL setup wizard
+    (async_step_setpoints), keyed by field name.
+
+    Celsius defaults are derived from the same DEFAULT_* Fahrenheit constants (rounded
+    to the 0.5 step) rather than a second set of hand-picked literals, so the two unit
+    branches — and any future reformat of the DEFAULT_* constants — can never drift
+    apart again. This closes a real bug: DEFAULT_SLEEP_HEAT/DEFAULT_SLEEP_COOL were
+    reformatted from 66/78 to 64/72 (architecture-reset session, #438), but this
+    wizard's own hardcoded defaults were never updated, so every brand-new install
+    (Fahrenheit sleep fields, and ALL SIX Celsius fields) had the stale values
+    explicitly written into its config on first setup.
+
+    The options/edit flow (async_step_setpoints in ClimateAdvisorOptionsFlow) is
+    intentionally NOT built from this function — it displays the CURRENT configured
+    value (`current.get(key, DEFAULT_X)`), not a fresh-install default, so its ranges
+    dicts stay separate.
+    """
+
+    def _c_default(f_value: float) -> float:
+        return round(from_fahrenheit(f_value, CELSIUS) * 2) / 2
+
+    if is_celsius:
+        return {
+            "comfort_heat": (13, 27, _c_default(DEFAULT_COMFORT_HEAT), 0.5),
+            "comfort_cool": (20, 29, _c_default(DEFAULT_COMFORT_COOL), 0.5),
+            "setback_heat": (7, 18, _c_default(DEFAULT_SETBACK_HEAT), 0.5),
+            "setback_cool": (24, 32, _c_default(DEFAULT_SETBACK_COOL), 0.5),
+            "sleep_heat": (13, 26, _c_default(DEFAULT_SLEEP_HEAT), 0.5),
+            "sleep_cool": (21, 32, _c_default(DEFAULT_SLEEP_COOL), 0.5),
+        }
+    return {
+        "comfort_heat": (55, 80, DEFAULT_COMFORT_HEAT, 1),
+        "comfort_cool": (68, 85, DEFAULT_COMFORT_COOL, 1),
+        "setback_heat": (45, 65, DEFAULT_SETBACK_HEAT, 1),
+        "setback_cool": (75, 90, DEFAULT_SETBACK_COOL, 1),
+        "sleep_heat": (55, 79, DEFAULT_SLEEP_HEAT, 1),
+        "sleep_cool": (69, 89, DEFAULT_SLEEP_COOL, 1),
+    }
+
+
 class ClimateAdvisorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Climate Advisor."""
 
@@ -245,27 +286,9 @@ class ClimateAdvisorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self._data.update(converted)
                 return await self.async_step_temperature_sources()
 
-        # Slider ranges and defaults depend on chosen unit
-        if is_celsius:
-            ranges = {
-                "comfort_heat": (13, 27, 21, 0.5),
-                "comfort_cool": (20, 29, 24, 0.5),
-                "setback_heat": (7, 18, 16, 0.5),
-                "setback_cool": (24, 32, 27, 0.5),
-                "sleep_heat": (13, 26, 19, 0.5),
-                "sleep_cool": (21, 32, 26, 0.5),
-            }
-            unit_label = "°C"
-        else:
-            ranges = {
-                "comfort_heat": (55, 80, DEFAULT_COMFORT_HEAT, 1),
-                "comfort_cool": (68, 85, DEFAULT_COMFORT_COOL, 1),
-                "setback_heat": (45, 65, DEFAULT_SETBACK_HEAT, 1),
-                "setback_cool": (75, 90, DEFAULT_SETBACK_COOL, 1),
-                "sleep_heat": (55, 79, 66, 1),
-                "sleep_cool": (69, 89, 78, 1),
-            }
-            unit_label = "°F"
+        # Slider ranges and defaults depend on chosen unit — see setpoint_slider_ranges().
+        ranges = setpoint_slider_ranges(is_celsius)
+        unit_label = "°C" if is_celsius else "°F"
 
         def _num(key: str) -> selector.NumberSelector:
             mn, mx, default, step = ranges[key]

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,46 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.4.74"
+VERSION = "0.5.1"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.1": [
+        "Fix #439: the initial setup wizard could write stale sleep-temperature"
+        " defaults into a brand-new install — Fahrenheit sleep fields, and all six"
+        " Celsius setpoints, were hardcoded and never picked up the household-matched"
+        " defaults shipped in 0.5.0. Every unit now derives its default directly from"
+        " the same shared constants, so new installs get the intended values.",
+        "Fix #440: on a warming-trend night, if natural ventilation ended earlier than"
+        " its originally scheduled close time — for any reason, including the window"
+        " simply being closed — the overnight pre-cool AC trigger stayed on the old"
+        " schedule instead of stepping in right away. It now reacts to nat-vent"
+        " actually ending and moves the AC trigger earlier when that saves time,"
+        " never later.",
+    ],
+    "0.5.0": [
+        "Feat #438: the default comfort/setback/sleep temperatures shipped for fresh installs"
+        " (and any config relying on an unconfigured fallback) now match a real, tuned household"
+        " configuration instead of arbitrary round numbers — comfort 68°F/74°F, setback 63°F/79°F,"
+        " and a flat sleep target of 64°F/72°F that's cooler than daytime comfort, not warmer."
+        " Fixed 3 latent bugs found along the way where a hardcoded fallback had silently drifted"
+        " from the value it was supposed to mirror (a setpoint-inconsistency check, the chart's"
+        " fan-activity prediction, and the away/vacation display in the daily briefing).",
+        "Fix #437: on a warming-trend night, the overnight pre-cool phase (which lowers the AC"
+        " ceiling to bank cold thermal mass before the next hot day) could silently become a"
+        " no-op — it computed a target but immediately clamped it back up near daytime comfort,"
+        " so no extra cooling ever happened even though the system reported pre-cool as active."
+        " The clamp now anchors to the sleep temperature range instead of the daytime one, so"
+        " pre-cool can use its full intended range. This also closes #436: the chart's target-band"
+        " display and the real overnight setpoint can no longer show different pre-cool numbers,"
+        " since both now compute the target the same single way.",
+    ],
+    "0.4.75": [
+        "Fix #435: if you run natural ventilation with no whole-house fan or HVAC-fan device"
+        " configured (relying on manually-opened windows instead), the activity report could"
+        " show a confusing 'Nat-vent fan on/off' entry claiming device \"none\" turned on or"
+        " off — even though nothing happened, since there's no fan to control in that setup."
+        " The cycling check now only reports a fan transition when one actually occurred.",
+    ],
     "0.4.74": [
         "Fix #427: overnight whole-house-fan nat-vent sessions were being torn down and"
         " re-adopted every 5-15 minutes for hours, showing repeated 'fan running (untracked)'"
@@ -814,6 +851,149 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    440: {
+        "version_fixed": "0.5.1",
+        "title": "Pre-cool AC trigger stuck on stale schedule when nat-vent exits ahead of its scheduled close",
+        "scope_covered": (
+            "coordinator.py: _compute_pre_cool_trigger_time() computes the pre-cool AC trigger ONCE at"
+            " classification time (window_close_time + PRE_COOL_POST_NAT_VENT_DELAY_MINUTES, or a"
+            " wake_time-4h fallback) and _maybe_schedule_pre_cool() only ever runs it once per day"
+            " (idempotent via _pre_cool_trigger_scheduled). If nat-vent exited for real well before"
+            " that scheduled time — the reactivation gate firing, a sensor closing, outdoor rising, an"
+            " away/vacation ceiling exit, or a startup reconcile — the trigger stayed on the stale"
+            " schedule, wasting the AC-vs-free-cooling decision gap in between. Fixed by detecting a"
+            " genuine natural_vent_active True->False transition inside _emit_event() (deliberately not"
+            " enumerating the 6 real exit event-type strings, which would silently miss a future exit"
+            " path) and, via new pure function _decide_pre_cool_reschedule(), pulling the pending"
+            " trigger to now + PRE_COOL_POST_NAT_VENT_DELAY_MINUTES whenever that is earlier than what's"
+            " already scheduled — never later, so an exit close to (or after) the scheduled time cannot"
+            " accidentally push pre-cool back. New coordinator method"
+            " _maybe_reschedule_pre_cool_on_nat_vent_exit() owns cancelling/rescheduling the real timer."
+            " 9 new tests (tests/test_pre_cool_reschedule.py): pure-function boundaries plus a"
+            " coordinator-level load-bearing positive control proving the _emit_event() transition"
+            " detection genuinely drives the reschedule."
+        ),
+        "scope_not_covered": (
+            "Does not add any mechanism to actively EXTEND a nat-vent session (e.g. delaying an"
+            " already-favorable exit to bank more free cooling before pre-cool would fire) — only pulls"
+            " the AC trigger earlier when a real exit already happened ahead of schedule."
+            " handle_pre_cool()'s own nat-vent bypass check (whether indoor already reached the target"
+            " at fire time) is unchanged."
+        ),
+    },
+    439: {
+        "version_fixed": "0.5.1",
+        "title": "Initial setup wizard wrote stale sleep-temperature defaults into brand-new installs",
+        "scope_covered": (
+            "config_flow.py: async_step_setpoints() (the INITIAL setup wizard, distinct from the"
+            " options/edit flow which already read current.get(key, DEFAULT_X) correctly). Fahrenheit"
+            " branch: comfort_heat/comfort_cool/setback_heat/setback_cool already referenced the"
+            " DEFAULT_* named constants, but sleep_heat/sleep_cool were hardcoded literals 66/78 — the"
+            " pre-0.5.0 values, never updated when those constants were reformatted to 64/72. Celsius"
+            " branch: ALL SIX fields were hardcoded literal Celsius numbers hand-converted from the OLD"
+            " Fahrenheit defaults and never updated. Since these are vol.Required fields with the stale"
+            " value pre-filled, submitting the form unchanged wrote the stale numbers explicitly into"
+            " the new install's config — not merely a display glitch. Fixed by extracting"
+            " setpoint_slider_ranges(is_celsius) — derives every default (both unit branches) from the"
+            " DEFAULT_* Fahrenheit constants directly, converting to Celsius via from_fahrenheit()"
+            " rounded to the 0.5 step. 4 new regression tests in test_config_flow.py pin both branches'"
+            " defaults against the named constants."
+        ),
+        "scope_not_covered": (
+            "Only the INITIAL setup wizard's setpoint defaults were touched. The options/edit flow was"
+            " already correct and was not modified. Slider min/max bounds (not the defaults) were not"
+            " audited for staleness."
+        ),
+    },
+    437: {
+        "version_fixed": "0.5.0",
+        "title": "Overnight pre-cool thermal-mass banking silently became a no-op on many configs",
+        "scope_covered": (
+            "automation.py: handle_pre_cool()'s target floor was comfort_heat + PRE_COOL_MIN_HEADROOM_F"
+            " (a fixed 2°F above the DAYTIME comfort floor) — correct when DEFAULT_SLEEP_COOL was a"
+            " warmer economizer-style 78°F (plenty of headroom below it), but once sleep_cool was"
+            " reformatted to a flatter, cooler-than-daytime household default (74->closer to comfort_heat),"
+            " the same floor left little to no room: pre-cool clamped its target right back up near the"
+            " normal sleep ceiling, banking nothing while still emitting pre_cool_applied as if it worked."
+            " Root-caused after the user recalled an existing '+1 above the floor' convention"
+            " (nat_vent_temperature_check()'s sleep_heat + hysteresis sleep-window cycling target) and"
+            " asked whether pre-cool should reuse it. New compute_pre_cool_target() in automation.py"
+            " floors the target at sleep_heat + hysteresis instead, letting pre-cool travel the full"
+            " [sleep_heat, sleep_cool] range regardless of the comfort_heat/comfort_cool configuration."
+            " The same formula (plus a stale literal 78.0 sleep_cool fallback, same bug class as #435)"
+            " was independently duplicated across 5 call sites (handle_pre_cool, trigger-time scheduling,"
+            " status text, the chart target-band dip, and the ODE predicted-indoor curve) — all 5 now"
+            " route through the one shared function. PRE_COOL_MIN_HEADROOM_F removed (dead)."
+        ),
+        "scope_not_covered": (
+            "The nat-vent-preference behavior itself (pre-cool is a single scheduled trigger that"
+            " checks after the fact whether nat-vent already reached the target, not an actively"
+            " extended/preferred free-cooling window before falling back to AC) was not changed —"
+            " only the target/floor computation."
+        ),
+    },
+    438: {
+        "version_fixed": "0.5.0",
+        "title": "Shipped default comfort/setback/sleep temperatures reformatted to a real household config",
+        "scope_covered": (
+            "const.py: DEFAULT_COMFORT_HEAT/DEFAULT_COMFORT_COOL/DEFAULT_SETBACK_HEAT/"
+            "DEFAULT_SETBACK_COOL changed from arbitrary round numbers (70/75/60/80) to a real, tuned"
+            " installation's own configured values (68/74/63/79). DEFAULT_SLEEP_HEAT/DEFAULT_SLEEP_COOL"
+            " changed from a derived-from-comfort_cool formula (66/78, implicitly warmer-at-night) to"
+            " independent flat values (64/72) reflecting a deliberate 'sleep cooler than daytime,"
+            " not warmer' household preference. Dozens of scattered literal fallbacks in"
+            " automation.py/coordinator.py/briefing.py were swept to reference these named constants"
+            " instead of duplicated literals, surfacing and fixing 3 genuine latent drift bugs: the"
+            " setpoint-mode-inconsistency incident detector's stray comfort_cool fallback of 76 (vs"
+            " 75/74 everywhere else), coordinator.py's chart fan-activity prediction using a stray"
+            " natural_vent_delta fallback of 5.0 (vs the real default 3.0), and briefing.py's"
+            " away/vacation display using a stray setback_heat fallback of 62 (vs 60/63 elsewhere)."
+            " 5 locked golden scenarios depending on the old default values were reviewed and re-signed."
+        ),
+        "scope_not_covered": (
+            "config_flow.py's UI slider bounds and initial-setup default tuple (still a separate"
+            " hardcoded (69, 89, 78, 1) for sleep_cool's first-run slider) were not audited or changed"
+            " as part of this sweep."
+        ),
+    },
+    435: {
+        "version_fixed": "0.4.75",
+        "title": (
+            "Nat-vent activity report showed 'fan on/off' events for device \"none\" when no fan device was configured"
+        ),
+        "scope_covered": (
+            "automation.py: nat_vent_temperature_check()'s two thermostatic-cycling branches"
+            " called _activate_fan()/_deactivate_fan() and then unconditionally emitted the"
+            " nat_vent_fan_on/nat_vent_fan_off event regardless of whether the call actually"
+            " changed self._fan_active. Both helpers correctly no-op when fan_mode is disabled"
+            " (a supported manual-window-only nat-vent configuration), but the event still fired,"
+            ' and _fan_device_label() returns "none" in that config — so the rendered activity'
+            " report line (ai_skills_activity.py _render_nat_vent_fan_on/_off) read 'Nat-vent fan"
+            " on -- indoor X >= Y' / 'none: auto->on', claiming a nonexistent device transitioned."
+            " Found via architecture-reset Step 2: fixing a sim-harness fidelity gap in"
+            " tools/sim_harness/run_production.py (the harness never dispatched to"
+            " nat_vent_temperature_check()/fan_thermostat_check() on an ordinary temp_update tick,"
+            " missing the real _async_thermostat_changed state-listener path from"
+            " coordinator.py:2837-2862) let 3 golden scenarios reach this code path for the first"
+            " time and fail. Fixed by guarding both emissions on whether self._fan_active actually"
+            " changed as a result of the call, rather than duplicating the fan_mode check — robust"
+            " against any other no-op condition inside _activate_fan()/_deactivate_fan() (override"
+            " active, dry_run, idempotency guard). Golden scenarios mild_all_day_nat_vent_only,"
+            " nat_vent_active_indoor_in_band_guard_dormant, and nat_vent_ceiling_breach_hvac_escalation"
+            " now pass without the spurious event. A 4th golden, whole_house_fan_hvac_suppression"
+            " (which DOES configure a real fan_mode), was separately updated (not a bug — its"
+            " assertion predated this code path being reachable and didn't anticipate the fan"
+            " legitimately cycling off mid-session) to expect nat_vent_fan_off at the point indoor"
+            " reaches the cycling off-threshold."
+        ),
+        "scope_not_covered": (
+            "Only the two cycling branches in nat_vent_temperature_check() were touched. Other"
+            " event emissions elsewhere in automation.py (fan_activated, fan_deactivated,"
+            " nat_vent_outdoor_rise_exit, nat_vent_comfort_floor_exit, etc.) were not audited for"
+            " the same class of unconditional-emit-after-no-op-call pattern — this fix does not"
+            " claim they're safe, only that this specific pair was found and fixed."
+        ),
+    },
     427: {
         "version_fixed": "0.4.74",
         "title": (
@@ -3092,11 +3272,17 @@ CONF_GITHUB_TOKEN = "github_token"
 CONF_GITHUB_REPO = "github_repo"
 API_SUBMIT_GITHUB_ISSUE = "/api/climate_advisor/submit_github_issue"
 
-# Default setpoints (°F)
-DEFAULT_COMFORT_HEAT = 70
-DEFAULT_COMFORT_COOL = 75
-DEFAULT_SETBACK_HEAT = 60
-DEFAULT_SETBACK_COOL = 80
+# Default setpoints (°F) — reformatted to match a real, tuned installation's own
+# configured values (architecture-reset session, user-requested) rather than
+# arbitrary round numbers. Does NOT affect the version 14->15 migration in
+# __init__.py, which intentionally preserves the OLD historical defaults
+# (70/75/60/80) as its own literal fallbacks for backfilling PRE-EXISTING
+# installs that upgrade through that specific version transition — that is
+# backward-compatibility logic, not a "new install" default, and must not change.
+DEFAULT_COMFORT_HEAT = 68
+DEFAULT_COMFORT_COOL = 74
+DEFAULT_SETBACK_HEAT = 63
+DEFAULT_SETBACK_COOL = 79
 
 # Day type classifications
 DAY_TYPE_HOT = "hot"
@@ -4048,8 +4234,13 @@ THERMAL_PASSIVE_CONF_HIGH = 30
 # Sleep temperature config keys (Issue #101)
 CONF_SLEEP_HEAT = "sleep_heat"
 CONF_SLEEP_COOL = "sleep_cool"
-DEFAULT_SLEEP_HEAT = 66.0  # comfort_heat(70) - DEFAULT_SETBACK_DEPTH_F(4)
-DEFAULT_SLEEP_COOL = 78.0  # comfort_cool(75) + DEFAULT_SETBACK_DEPTH_COOL_F(3)
+DEFAULT_SLEEP_HEAT = 64.0  # comfort_heat(68) - DEFAULT_SETBACK_DEPTH_F(4) — still holds
+DEFAULT_SLEEP_COOL = 72.0  # a real, tuned installation's own value — NOT derived from
+# comfort_cool + DEFAULT_SETBACK_DEPTH_COOL_F (that formula assumes a warmer/looser
+# overnight setback for economizing; this household's real preference is the opposite
+# direction — cooler for sleep, not warmer — so this is now an independent flat default,
+# matching the confirmed-correct P3 bedtime-application behavior (Issue #435/#436
+# investigation found production already applies this flat value, not the formula).
 MAX_SETBACK_DEPTH_F = 8.0  # never set back more than this
 SETBACK_RECOVERY_BUFFER_MINUTES = 30  # pre-heat leads wake_time by this much
 
@@ -4059,7 +4250,11 @@ SETBACK_RECOVERY_BUFFER_MINUTES = 30  # pre-heat leads wake_time by this much
 # ---------------------------------------------------------------------------
 PRE_COOL_POST_NAT_VENT_DELAY_MINUTES: int = 30  # delay after nat-vent window closes before AC pre-cool fires
 PRE_COOL_WAKE_OFFSET_HOURS: float = 4.0  # fallback trigger: this many hours before wake_time
-PRE_COOL_MIN_HEADROOM_F: float = 2.0  # pre-cool target floor = comfort_heat + this (prevents morning heat firing)
+# Pre-cool target floor is sleep_heat + nat_vent hysteresis (compute_pre_cool_target() in
+# automation.py) — the same "+1 above the floor" convention nat_vent_temperature_check() uses
+# for sleep-window fan cycling. Replaces the old comfort_heat + 2F floor (architecture-reset
+# session), which left little to no headroom once DEFAULT_SLEEP_COOL was reformatted to a flat,
+# cooler-than-daytime default (Issue #436).
 THERMAL_OBS_CAP = 200  # max observations in LearningState
 
 # ---------------------------------------------------------------------------

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -32,7 +32,7 @@ from homeassistant.helpers.event import (
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
 
-from .automation import AutomationEngine, _in_sleep_window, compute_bedtime_setback
+from .automation import AutomationEngine, _in_sleep_window, compute_bedtime_setback, compute_pre_cool_target
 from .briefing import generate_briefing
 from .chart_log import ChartStateLog
 from .classifier import DayClassification, ForecastSnapshot, classify_day
@@ -97,10 +97,15 @@ from .const import (
     DAY_TYPE_COLD,
     DAY_TYPE_HOT,
     DEFAULT_AUTOMATION_GRACE_SECONDS,
+    DEFAULT_COMFORT_COOL,
+    DEFAULT_COMFORT_HEAT,
     DEFAULT_MANUAL_GRACE_SECONDS,
+    DEFAULT_NATURAL_VENT_DELTA,
     DEFAULT_SENSOR_DEBOUNCE_SECONDS,
+    DEFAULT_SETBACK_COOL,
     DEFAULT_SETBACK_DEPTH_COOL_F,
     DEFAULT_SETBACK_DEPTH_F,
+    DEFAULT_SETBACK_HEAT,
     DEFAULT_THRESHOLD_COOL,
     DEFAULT_THRESHOLD_HOT,
     DEFAULT_THRESHOLD_MILD,
@@ -207,6 +212,7 @@ from .const import (
     VERSION,
 )
 from .learning import DailyRecord, LearningEngine, compute_k_passive_blocks
+from .nat_vent_gate import NatVentGateInputs, decide_nat_vent_gate
 from .state import StatePersistence
 from .temperature import convert_delta, format_temp, free_cooling_direction_ok, from_fahrenheit, to_fahrenheit
 
@@ -326,6 +332,11 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         self._pre_cool_status: str | None = None  # surfaced in status API
         self._pre_cool_trigger_dt: datetime | None = None  # full tz-aware trigger datetime
         self._pre_cool_target: float | None = None  # pre-cool ceiling target temp
+        # #437 follow-up: tracks natural_vent_active across _emit_event() calls so a
+        # True->False transition (nat-vent genuinely exiting, any of its 6 real exit
+        # paths) can pull a pending pre-cool trigger earlier instead of leaving it on
+        # the STATIC classification-time schedule.
+        self._nat_vent_was_active: bool = False
 
         # Startup coalescing (Issue #321): suppress override detection for 5 min after restart
         self._startup_coalesce_active: bool = True
@@ -1296,8 +1307,8 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         if outdoor is None:
             return  # No current data — keep classifier's recommendation
 
-        comfort_cool = float(self.config.get("comfort_cool", 75))
-        comfort_heat = float(self.config.get("comfort_heat", 70))
+        comfort_cool = float(self.config.get("comfort_cool", DEFAULT_COMFORT_COOL))
+        comfort_heat = float(self.config.get("comfort_heat", DEFAULT_COMFORT_HEAT))
 
         if outdoor > comfort_cool:
             _LOGGER.debug(
@@ -1333,11 +1344,31 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         hvac_commanded = False
 
         if open_sensors and outdoor is not None and indoor is not None:
-            comfort_heat = float(self.config.get("comfort_heat", 70))
-            comfort_cool = float(self.config.get("comfort_cool", 75))
-            nat_vent_delta = float(self.config.get("natural_vent_delta", 3.0))
+            comfort_heat = float(self.config.get("comfort_heat", DEFAULT_COMFORT_HEAT))
+            comfort_cool = float(self.config.get("comfort_cool", DEFAULT_COMFORT_COOL))
+            nat_vent_delta = float(self.config.get("natural_vent_delta", DEFAULT_NATURAL_VENT_DELTA))
             nat_vent_threshold = comfort_cool + nat_vent_delta
-            if outdoor < indoor and indoor > comfort_heat and outdoor < nat_vent_threshold:
+            # Architecture-reset (Issue #429 consolidation): this pre-check used to hand-roll
+            # the same 3-part gate (direction/floor/ceiling) that _nat_vent_may_reactivate()
+            # already consolidates — risking exactly the site-drift #429/#411 warns about
+            # (e.g. this copy never considered fan_mode archetype or aggressive_savings for
+            # the ceiling check, unlike the real gate). No hysteresis and no sleep-window
+            # floor resolution here, matching this call site's original (pre-consolidation)
+            # scope exactly — comfort_heat is passed through as-is, not sleep-aware, since
+            # startup coalescing has never resolved that here.
+            _startup_gate_inputs = NatVentGateInputs(
+                outdoor=outdoor,
+                indoor=indoor,
+                comfort_heat_raw=comfort_heat,
+                sleep_heat=comfort_heat,
+                in_sleep_window=False,
+                comfort_cool=comfort_cool,
+                nat_vent_delta=nat_vent_delta,
+                hysteresis=0.0,
+                fan_mode=self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED),
+                aggressive_savings=bool(self.config.get("aggressive_savings", False)),
+            )
+            if decide_nat_vent_gate(_startup_gate_inputs):
                 _LOGGER.info(
                     "Startup coalescing: nat-vent conditions met"
                     " (outdoor %.1f°F < indoor %.1f°F, indoor > comfort_heat %.1f°F,"
@@ -1353,13 +1384,14 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 _LOGGER.debug("[coalesce-diag] after handle_door_window_open(%s)", first_sensor)
                 nat_vent_activated = True
             else:
+                _nat_vent_delta_log = float(self.config.get("natural_vent_delta", DEFAULT_NATURAL_VENT_DELTA))
                 _LOGGER.info(
                     "Startup coalescing: nat-vent conditions not met"
                     " (outdoor=%.1f, indoor=%.1f, comfort_heat=%.1f, threshold=%.1f)",
                     outdoor or 0,
                     indoor or 0,
-                    float(self.config.get("comfort_heat", 70)),
-                    float(self.config.get("comfort_cool", 75)) + float(self.config.get("natural_vent_delta", 3.0)),
+                    float(self.config.get("comfort_heat", DEFAULT_COMFORT_HEAT)),
+                    float(self.config.get("comfort_cool", DEFAULT_COMFORT_COOL)) + _nat_vent_delta_log,
                 )
 
         if not nat_vent_activated and c:
@@ -1686,8 +1718,8 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
 
                 # Track comfort violations (elapsed minutes since last check, capped at 30)
                 if self._today_record:
-                    comfort_low = self.config.get("comfort_heat", 70)
-                    comfort_high = self.config.get("comfort_cool", 75)
+                    comfort_low = self.config.get("comfort_heat", DEFAULT_COMFORT_HEAT)
+                    comfort_high = self.config.get("comfort_cool", DEFAULT_COMFORT_COOL)
                     now = dt_util.now()
                     if self._last_violation_check is not None:
                         elapsed_minutes = min((now - self._last_violation_check).total_seconds() / 60, 30.0)
@@ -2570,7 +2602,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         """
         from .const import (
             CONF_SLEEP_COOL,
-            PRE_COOL_MIN_HEADROOM_F,
+            DEFAULT_SLEEP_COOL,
             PRE_COOL_POST_NAT_VENT_DELAY_MINUTES,
             PRE_COOL_WAKE_OFFSET_HOURS,
         )
@@ -2580,9 +2612,8 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             return None
 
         # Verify the pre-cool target would actually differ from sleep_cool
-        sleep_cool = float(self.config.get(CONF_SLEEP_COOL) or self.config.get("sleep_cool", 78.0))
-        comfort_heat = float(self.config.get("comfort_heat", 70.0))
-        pre_cool_target = max(sleep_cool + c.setback_modifier, comfort_heat + PRE_COOL_MIN_HEADROOM_F)
+        sleep_cool = float(self.config.get(CONF_SLEEP_COOL, DEFAULT_SLEEP_COOL))
+        pre_cool_target = compute_pre_cool_target(self.config, c.setback_modifier)
         if pre_cool_target >= sleep_cool:
             _LOGGER.info(
                 "Pre-cool scheduling: clamped target (%.1f°F) == sleep_cool (%.1f°F); skipping",
@@ -2640,12 +2671,8 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             return
 
         # Build the pre-cool target for status display
-        from .const import CONF_SLEEP_COOL, PRE_COOL_MIN_HEADROOM_F
-
         c = self._current_classification
-        sleep_cool = float(self.config.get(CONF_SLEEP_COOL) or self.config.get("sleep_cool", 78.0))
-        comfort_heat = float(self.config.get("comfort_heat", 70.0))
-        pre_cool_target = max(sleep_cool + c.setback_modifier, comfort_heat + PRE_COOL_MIN_HEADROOM_F)
+        pre_cool_target = compute_pre_cool_target(self.config, c.setback_modifier)
 
         self._pre_cool_trigger_cancel = async_track_point_in_time(self.hass, self._async_pre_cool_trigger, trigger_time)
         self._pre_cool_trigger_scheduled = True
@@ -2670,6 +2697,42 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         elif "applied" in result:
             self._pre_cool_status = result.replace("applied: ", "pre-cool active (").rstrip() + ")"
         await self.async_refresh()
+
+    def _maybe_reschedule_pre_cool_on_nat_vent_exit(self) -> None:
+        """Pull a pending pre-cool trigger earlier when nat-vent exits for real, ahead
+        of its originally-scheduled window_close_time (#437 follow-up).
+
+        Occupant impact without this: a nat-vent session that ends early — the
+        reactivation gate exiting, a sensor closing, outdoor rising, an away/vacation
+        ceiling exit, or a startup reconcile — leaves pre-cool waiting on the STATIC
+        classification-time schedule (window_close_time + 30 min, computed once at
+        classification time), wasting the AC-vs-free-cooling decision gap between the
+        real exit and the stale trigger time. Called from _emit_event() on every
+        natural_vent_active True->False transition.
+        """
+        from .const import PRE_COOL_POST_NAT_VENT_DELAY_MINUTES
+
+        if not self._current_classification:
+            return
+        new_trigger = _decide_pre_cool_reschedule(
+            current_trigger_at=self._pre_cool_trigger_dt,
+            setback_modifier=self._current_classification.setback_modifier,
+            nat_vent_close_delay_minutes=PRE_COOL_POST_NAT_VENT_DELAY_MINUTES,
+            now=dt_util.now(),
+        )
+        if new_trigger is None:
+            return
+        if self._pre_cool_trigger_cancel is not None:
+            self._pre_cool_trigger_cancel()
+        self._pre_cool_trigger_cancel = async_track_point_in_time(self.hass, self._async_pre_cool_trigger, new_trigger)
+        self._pre_cool_trigger_dt = new_trigger
+        self._pre_cool_status = (
+            f"Pre-cool rescheduled ({new_trigger.strftime('%I:%M %p').lstrip('0')}) — nat-vent exited early"
+        )
+        _LOGGER.info(
+            "Pre-cool trigger pulled earlier to %s — nat-vent exited ahead of its scheduled window close",
+            new_trigger.strftime("%H:%M"),
+        )
 
     async def _async_end_of_day(self, now: datetime) -> None:
         """Finalize the day's record and reset for tomorrow."""
@@ -5363,8 +5426,8 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         would work against the occupant's actual comfort goal (Issue #428).
         """
         unit = self.config.get("temp_unit", "fahrenheit")
-        comfort_cool = self.config.get("comfort_cool", 75)
-        comfort_heat = self.config.get("comfort_heat", 70)
+        comfort_cool = self.config.get("comfort_cool", DEFAULT_COMFORT_COOL)
+        comfort_heat = self.config.get("comfort_heat", DEFAULT_COMFORT_HEAT)
         fan_mode = self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED)
         fan_enabled = fan_mode != FAN_MODE_DISABLED
 
@@ -5537,6 +5600,17 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         self._event_log.append(entry)
         if len(self._event_log) > EVENT_LOG_CAP:
             self._event_log.pop(0)
+
+        # #437 follow-up: detect a genuine nat-vent True->False exit transition (any of
+        # the 6 real exit paths — comfort-floor, away-ceiling, predicted-floor,
+        # outdoor-rise, reconcile, or all-sensors-closed — this deliberately does NOT
+        # enumerate event-type strings, which would silently miss a future exit path)
+        # and pull a pending pre-cool trigger earlier if it's still on the stale
+        # classification-time schedule.
+        _nat_vent_active_now = bool(self.automation_engine._natural_vent_active) if self.automation_engine else False
+        if getattr(self, "_nat_vent_was_active", False) and not _nat_vent_active_now:
+            self._maybe_reschedule_pre_cool_on_nat_vent_exit()
+        self._nat_vent_was_active = _nat_vent_active_now
 
     def _emit_incident(self, incident_class: str, incident_id: str, extra: dict | None = None) -> None:
         """Emit an incident_detected event into the event log."""
@@ -6225,14 +6299,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             _pc_trigger_time = self._compute_pre_cool_trigger_time()
             if _pc_trigger_time is not None:
                 _pc_trigger_h = _pc_trigger_time.hour + _pc_trigger_time.minute / 60.0
-                from .const import CONF_SLEEP_COOL, PRE_COOL_MIN_HEADROOM_F
-
-                _pc_sleep_cool = float(self.config.get(CONF_SLEEP_COOL) or self.config.get("sleep_cool", 78.0))
-                _pc_comfort_heat = float(self.config.get("comfort_heat", 70.0))
-                _pc_target = max(
-                    _pc_sleep_cool + self._current_classification.setback_modifier,
-                    _pc_comfort_heat + PRE_COOL_MIN_HEADROOM_F,
-                )
+                _pc_target = compute_pre_cool_target(self.config, self._current_classification.setback_modifier)
 
         _raw_band = list(
             _compute_target_band_schedule(
@@ -6384,8 +6451,8 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         hysteresis = float(self.config.get(CONF_NAT_VENT_HYSTERESIS_F, NAT_VENT_HYSTERESIS_F))
         if not ae._natural_vent_active:
             return {"nat_vent_target": None, "nat_vent_on_threshold": None, "nat_vent_off_threshold": None}
-        comfort_heat = float(self.config.get("comfort_heat", 70))
-        comfort_cool = float(self.config.get("comfort_cool", 75))
+        comfort_heat = float(self.config.get("comfort_heat", DEFAULT_COMFORT_HEAT))
+        comfort_cool = float(self.config.get("comfort_cool", DEFAULT_COMFORT_COOL))
         if _in_sleep_window(dt_util.now(), self.config):
             sleep_heat = float(self.config.get(CONF_SLEEP_HEAT, comfort_heat))
             target = sleep_heat + hysteresis
@@ -6568,6 +6635,37 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         self._unsub_listeners.clear()
         self._unsubscribe_door_window_listeners()
         self.automation_engine.cleanup()
+
+
+def _decide_pre_cool_reschedule(
+    *,
+    current_trigger_at: datetime | None,
+    setback_modifier: float,
+    nat_vent_close_delay_minutes: float,
+    now: datetime,
+) -> datetime | None:
+    """Pure decision for _maybe_reschedule_pre_cool_on_nat_vent_exit() (#437 follow-up):
+    should a pending pre-cool trigger be pulled earlier because nat-vent just exited
+    for real, ahead of its originally-scheduled window_close_time?
+
+    Returns the new (earlier) trigger time, or None when no reschedule should happen:
+      - no trigger is currently pending (already fired today, or none was ever needed —
+        `current_trigger_at is None`)
+      - no warming trend is active (`setback_modifier >= 0` — pre-cool wouldn't have
+        been scheduled in the first place)
+      - the candidate time (now + the same nat-vent-close delay the original schedule
+        uses) is NOT earlier than what's already scheduled — this only ever pulls the
+        trigger EARLIER, never later, so a nat-vent exit that happens to occur close to
+        (or after) the already-scheduled time can't accidentally push pre-cool back.
+    """
+    if current_trigger_at is None:
+        return None
+    if setback_modifier >= 0:
+        return None
+    candidate = now + timedelta(minutes=nat_vent_close_delay_minutes)
+    if candidate >= current_trigger_at:
+        return None
+    return candidate
 
 
 def _compute_ramp_hours(temp_delta: float, hvac_mode: str, thermal_model: dict | None) -> float:
@@ -6996,10 +7094,10 @@ def _compute_target_band_schedule(
     When thermal_model and classification are both provided, sleep_heat is derived
     via compute_bedtime_setback() — matching automation.py's adaptive setpoint logic.
     """
-    comfort_heat = float(config.get("comfort_heat", 70))
-    comfort_cool = float(config.get("comfort_cool", 75))
-    setback_heat = float(config.get("setback_heat", 60))
-    setback_cool = float(config.get("setback_cool", 80))
+    comfort_heat = float(config.get("comfort_heat", DEFAULT_COMFORT_HEAT))
+    comfort_cool = float(config.get("comfort_cool", DEFAULT_COMFORT_COOL))
+    setback_heat = float(config.get("setback_heat", DEFAULT_SETBACK_HEAT))
+    setback_cool = float(config.get("setback_cool", DEFAULT_SETBACK_COOL))
     sleep_heat = float(config.get("sleep_heat", comfort_heat - DEFAULT_SETBACK_DEPTH_F))
     sleep_cool = float(config.get("sleep_cool", comfort_cool + DEFAULT_SETBACK_DEPTH_COOL_F))
 
@@ -7170,10 +7268,10 @@ def _build_predicted_indoor_future(
         now.isoformat() if hasattr(now, "isoformat") else now,
     )
 
-    comfort_heat = float(config.get("comfort_heat", 70))
-    comfort_cool = float(config.get("comfort_cool", 75))
-    setback_heat = float(config.get("setback_heat", 60))  # absolute floor for heat
-    setback_cool = float(config.get("setback_cool", 80))  # absolute ceiling for cool
+    comfort_heat = float(config.get("comfort_heat", DEFAULT_COMFORT_HEAT))
+    comfort_cool = float(config.get("comfort_cool", DEFAULT_COMFORT_COOL))
+    setback_heat = float(config.get("setback_heat", DEFAULT_SETBACK_HEAT))  # absolute floor for heat
+    setback_cool = float(config.get("setback_cool", DEFAULT_SETBACK_COOL))  # absolute ceiling for cool
 
     # Mirror automation engine (automation.py compute_setback_temp) and
     # compute_predicted_temps (coordinator.py ~line 2678) — use sleep_heat/sleep_cool if
@@ -7334,8 +7432,6 @@ def _build_predicted_indoor_future(
     _setback_mod = getattr(classification, "setback_modifier", None)
     if isinstance(_setback_mod, (int, float)) and _setback_mod < 0:
         from .const import (
-            CONF_SLEEP_COOL,
-            PRE_COOL_MIN_HEADROOM_F,
             PRE_COOL_POST_NAT_VENT_DELAY_MINUTES,
             PRE_COOL_WAKE_OFFSET_HOURS,
         )
@@ -7347,12 +7443,7 @@ def _build_predicted_indoor_future(
             _wake_str = config.get("wake_time", "06:30")
             _wake_h_raw = int(_wake_str.split(":")[0]) + int(_wake_str.split(":")[1]) / 60.0
             _ode_pc_trigger_h = _wake_h_raw - PRE_COOL_WAKE_OFFSET_HOURS
-        _ode_sc = float(config.get(CONF_SLEEP_COOL) or config.get("sleep_cool", 78.0))
-        _ode_ch = float(config.get("comfort_heat", 70.0))
-        _ode_pc_target = max(
-            _ode_sc + classification.setback_modifier,
-            _ode_ch + PRE_COOL_MIN_HEADROOM_F,
-        )
+        _ode_pc_target = compute_pre_cool_target(config, classification.setback_modifier)
 
     _band_schedule = _compute_target_band_schedule(
         _future_timestamps_for_band,
@@ -7576,21 +7667,24 @@ def compute_predicted_temps(
 
     # --- HVAC floor and ceiling for this day type ---
     if c.hvac_mode == "heat":
-        hvac_floor = config.get("comfort_heat", 70)
+        hvac_floor = config.get("comfort_heat", DEFAULT_COMFORT_HEAT)
         hvac_ceiling = None
     elif c.hvac_mode == "cool":
-        hvac_floor = config.get("setback_cool", 80) + c.setback_modifier
-        hvac_ceiling = config.get("comfort_cool", 75)
+        hvac_floor = config.get("setback_cool", DEFAULT_SETBACK_COOL) + c.setback_modifier
+        hvac_ceiling = config.get("comfort_cool", DEFAULT_COMFORT_COOL)
     else:  # "off" / mild
-        hvac_floor = config.get("setback_heat", 60) + c.setback_modifier
+        hvac_floor = config.get("setback_heat", DEFAULT_SETBACK_HEAT) + c.setback_modifier
         hvac_ceiling = None
 
     # --- Schedule timing (for heat/cool days where HVAC actively ramps) ---
-    comfort = config.get("comfort_heat", 70) if c.hvac_mode != "cool" else config.get("comfort_cool", 75)
+    if c.hvac_mode != "cool":
+        comfort = config.get("comfort_heat", DEFAULT_COMFORT_HEAT)
+    else:
+        comfort = config.get("comfort_cool", DEFAULT_COMFORT_COOL)
     if c.hvac_mode == "heat":
-        setback = config.get("setback_heat", 60) + c.setback_modifier
+        setback = config.get("setback_heat", DEFAULT_SETBACK_HEAT) + c.setback_modifier
     elif c.hvac_mode == "cool":
-        setback = config.get("setback_cool", 80) + c.setback_modifier
+        setback = config.get("setback_cool", DEFAULT_SETBACK_COOL) + c.setback_modifier
     else:
         setback = hvac_floor
 
@@ -7887,7 +7981,7 @@ def _compute_predicted_activity(
     indoor_by_ts = {e["ts"]: e.get("temp") for e in predicted_indoor if e.get("ts")}
     hvac_mode = getattr(classification, "hvac_mode", "off") if classification is not None else "off"
     fan_mode = str(config.get("fan_mode", "auto"))
-    natural_vent_delta = float(config.get("natural_vent_delta", 5.0))
+    natural_vent_delta = float(config.get("natural_vent_delta", DEFAULT_NATURAL_VENT_DELTA))
 
     result = []
     for band_entry in target_band:

--- a/custom_components/climate_advisor/desired_state.py
+++ b/custom_components/climate_advisor/desired_state.py
@@ -1,0 +1,422 @@
+"""DesiredState — explicit temporal-intention schema (architecture-reset Step 3).
+
+Per the plan's design correction: a pure `decide()` core can't just express
+instantaneous HVAC/fan state — today's automation.py schedules 9 distinct
+timer mechanisms (revisit, fan min-runtime cycling, override confirm, setpoint
+accept-check, setpoint retry/nudge, grace period + restart restore, fan
+thermostat backstop, post-fan-on/off setpoint verify) as scattered
+`async_call_later` callbacks with their own cancel-flag bookkeeping. Under the
+functional-core model, these become DATA the pure core returns — "please
+re-evaluate at T", "please retry this setpoint at T", "please hold grace until
+T", "please send this notification" — and the shell (still `automation.py`,
+still scheduling real timers) becomes a uniform interpreter of that data
+instead of 9 bespoke schedulers.
+
+This module started as a DESIGN deliverable (Step 3), not a production
+migration — every field traces to one of the 9 real mechanisms enumerated in
+the Step-3 status report, nothing invented. All 9 now have their real
+BRANCHING decision wired: grace (`decide_grace_start`), revisit-after-action
+(`decide_revisit`), the fan thermostat backstop re-arm
+(`decide_fan_thermo_backstop`), the override confirm disabled/pending branch
+(`decide_override_confirm`), fan min-runtime cycling
+(`decide_fan_cycle_on`/`decide_fan_cycle_off`), and — the last of the 9 — the
+setpoint accept-check/retry/nudge/backoff family
+(`decide_setpoint_retry_action`/`decide_scheduled_write_seq_current`). The
+post-fan setpoint verify pair is wired too, via the sibling
+`setpoint_verify_decision.py` module (same DATA-not-side-effect pattern, kept
+separate since it isn't itself a temporal-schedule type). Scheduling the real
+timer, cancelling prior ones, and emitting events always stay the shell's job
+— only the branching DECISION moves into pure data.
+
+One deliberate exception: `decide_setpoint_retry_schedule()` (constructing a
+`PendingSetpointRetry` with a resolved `at: datetime`) is schema-validated by
+`TestDecideSetpointRetrySchedule` but NOT called from automation.py's actual
+scheduling. The real retry/nudge delays (900s / 30s) have never depended on
+`dt_util.now()` — they are fixed constants, unlike grace/revisit which already
+read the wall clock in the pre-refactor code. Deriving the delay via
+`(at - now).total_seconds()` here would introduce a new `dt_util.now()` call
+into a path that never had one, repeating the exact `decide_fan_cycle_on`/
+`decide_fan_cycle_off` pitfall found earlier this session: `dt_util` is a bare,
+unpatched `MagicMock` in the tests covering this exact retry/nudge path, so
+mocked datetime arithmetic silently returns a `MagicMock`, not a real float,
+breaking `async_call_later`'s delay argument. `PendingSetpointRetry` remains a
+validated, correctly-shaped schema for this intention; the shell simply keeps
+using its own literal delay constants rather than round-tripping them through
+a datetime it doesn't otherwise need.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from enum import Enum
+
+
+@dataclass(frozen=True)
+class ScheduledReevaluation:
+    """ "Please call me back at this time" — covers revisit, fan min-runtime
+    cycling, and the fan thermostat backstop (self-rescheduling: the shell
+    re-issues a new ScheduledReevaluation each time it handles one).
+
+    Field-by-field correspondence:
+      at     -> the real code's `async_call_later(hass, delay_seconds, cb)` delay,
+                already resolved to an absolute time by the pure core (which has
+                no wall-clock access) — the shell computes `delay = at - now()`.
+      reason -> a stable tag identifying WHICH mechanism this is
+                ("revisit" | "fan_min_runtime_on" | "fan_min_runtime_off" |
+                "fan_min_runtime_retry" | "fan_thermo_backstop"), so the shell
+                knows which handler to invoke when it fires — replaces today's
+                9 separately-named callback closures with one data-driven dispatch.
+    """
+
+    at: datetime
+    reason: str
+
+
+@dataclass(frozen=True)
+class PendingSetpointRetry:
+    """ "Please verify/retry this setpoint" — covers the setpoint accept-check
+    (10s), the nudge-then-retry escalation (30s), and the repeated-rejection
+    backoff (900s). All three are really the same underlying intention at
+    different delays/attempt counts, currently implemented as 3 separately
+    scheduled closures sharing `_write_seq`/`_setpoint_reject_streak` state.
+
+      at              -> resolved absolute retry time
+      temperature      -> the setpoint to (re)assert
+      mode             -> the hvac_mode to (re)assert it under
+      write_seq        -> replaces `self._write_seq` — the shell still needs to
+                           know "is this retry stale" (a newer command superseded
+                           it), but that comparison becomes a data check against
+                           the DesiredState's own sequence number, not an
+                           instance-attribute a closure captured at schedule time.
+      reject_streak    -> replaces `self._setpoint_reject_streak` — how many
+                           consecutive rejections have occurred, so the shell can
+                           decide nudge-vs-immediate-retry-vs-give-up without its
+                           own separate counter.
+    """
+
+    at: datetime
+    temperature: float
+    mode: str
+    write_seq: int
+    reject_streak: int
+
+
+@dataclass(frozen=True)
+class GraceUntil:
+    """ "Please hold grace until this time, then re-check." Covers both grace
+    starting fresh (_start_grace_period) and restoring after an HA restart
+    (_reschedule_grace_timer) — the restart case is just this same value
+    reconstructed from persisted state, not a different mechanism.
+
+      at             -> absolute grace-expiry time (the real code stores
+                         self._grace_end_time as an ISO string for the SAME
+                         purpose — this is that value, typed as datetime)
+      source         -> "manual" | "automation" — which grace budget/notify
+                         config applies (mirrors _start_grace_period's own arg)
+      should_notify  -> whether expiry should send a notification (the real
+                         code reads this from config at grace-START time and
+                         must remember it until expiry — currently an inner
+                         closure captures it; here it's plain data)
+    """
+
+    at: datetime
+    source: str
+    should_notify: bool
+
+
+def decide_grace_start(
+    *,
+    source: str,
+    manual_duration_seconds: float,
+    manual_should_notify: bool,
+    automation_duration_seconds: float,
+    automation_should_notify: bool,
+    now: datetime,
+) -> GraceUntil | None:
+    """Pure reimplementation of _start_grace_period()'s duration/should_notify resolution.
+
+    Architecture-reset Step 2 (session state machine slice) — the first real
+    wiring of a DesiredState type into production, not just a paper design.
+    Returns None when the resolved duration is <= 0 (grace disabled for that
+    source), mirroring the real method's early return in that case. The shell
+    (``_start_grace_period()``) still owns all the side effects this decision
+    doesn't cover: cancelling prior timers, scheduling the real
+    ``async_call_later``, setting instance flags, and emitting the
+    ``grace_started`` event.
+    """
+    if source == "manual":
+        duration = manual_duration_seconds
+        should_notify = manual_should_notify
+    else:
+        duration = automation_duration_seconds
+        should_notify = automation_should_notify
+
+    if duration <= 0:
+        return None
+
+    return GraceUntil(at=now + timedelta(seconds=duration), source=source, should_notify=should_notify)
+
+
+@dataclass(frozen=True)
+class OverrideConfirmPending:
+    """ "Please confirm/reject this detected override at this time." Covers
+    _override_confirm_cancel — the window during which a detected thermostat
+    change might be transient (reverted) or a real user override.
+
+      at     -> absolute confirm-expiry time
+      mode   -> the mode that was detected, to compare against at expiry
+    """
+
+    at: datetime
+    mode: str
+
+
+@dataclass(frozen=True)
+class SetpointVerify:
+    """ "Please re-assert this setpoint at this time." Covers the two 30s
+    post-fan-on/off verify timers — Ecobee-class thermostats may revert to
+    their own comfort program right after a fan command, so CA re-asserts its
+    setpoint shortly after to make sure the correction sticks.
+
+      at            -> absolute verify time
+      expected_temp -> the setpoint that should be in effect
+      expected_mode -> the hvac_mode that should be in effect
+      write_seq     -> same staleness-check purpose as PendingSetpointRetry.write_seq
+    """
+
+    at: datetime
+    expected_temp: float | None
+    expected_mode: str | None
+    write_seq: int
+
+
+@dataclass(frozen=True)
+class NotificationRequest:
+    """ "Please send this notification." Every _notify() call already IS this
+    shape at the call site (message, title, notification_type) — this makes
+    that shape a first-class part of DesiredState instead of a side effect
+    fired inline mid-decision, so a pure core could express "this decision
+    also wants to tell the occupant X" without calling hass.services directly.
+    """
+
+    message: str
+    title: str
+    notification_type: str
+
+
+@dataclass(frozen=True)
+class DesiredState:
+    """The full intended state a decision produces — instantaneous AND temporal.
+
+    Instantaneous fields mirror what today's action_log already records
+    (climate.set_temperature / set_hvac_mode / fan turn_on/off calls).
+    Temporal fields mirror the 9 real timer mechanisms enumerated in the
+    Step-3 status report — every one of the dataclasses above traces to a
+    specific existing `async_call_later` call site, not an invented concept.
+
+    A None temporal field means "no change to that pending intention" (e.g.
+    a decision that doesn't touch grace leaves grace_until unset, rather than
+    the shell having to guess whether to cancel an existing timer). The shell
+    reconciles DesiredState against actual pending timers the same way it
+    already reconciles instantaneous state against the actual thermostat.
+    """
+
+    hvac_mode: str | None = None
+    setpoint: float | None = None
+    setpoint_low: float | None = None
+    setpoint_high: float | None = None
+    fan_command: str | None = None  # "on" | "off" | None (no change)
+
+    scheduled_reevaluations: tuple[ScheduledReevaluation, ...] = field(default_factory=tuple)
+    pending_setpoint_retry: PendingSetpointRetry | None = None
+    grace_until: GraceUntil | None = None
+    override_confirm_pending: OverrideConfirmPending | None = None
+    setpoint_verify: SetpointVerify | None = None
+    notifications: tuple[NotificationRequest, ...] = field(default_factory=tuple)
+
+
+def decide_revisit(*, has_revisit_callback: bool, delay_seconds: float, now: datetime) -> ScheduledReevaluation | None:
+    """Pure reimplementation of _schedule_revisit()'s decision: whether to schedule
+    a follow-up re-evaluation after an HVAC action, and when.
+
+    Returns None when no revisit callback is registered (mirrors the real
+    method's `if not self._revisit_callback: return` early exit) — the shell
+    still owns cancelling any prior timer and scheduling the real
+    `async_call_later`.
+    """
+    if not has_revisit_callback:
+        return None
+    return ScheduledReevaluation(at=now + timedelta(seconds=delay_seconds), reason="revisit")
+
+
+def decide_override_confirm(
+    *, confirm_seconds: float, detected_mode: str, now: datetime
+) -> OverrideConfirmPending | None:
+    """Pure reimplementation of start_override_confirmation()'s disabled-vs-pending branch.
+
+    Returns None when confirm_seconds <= 0 (confirmation disabled) — the shell
+    interprets None as "accept the override immediately" (calls
+    _confirm_override(detected_mode) right away), mirroring the real method's
+    own early-return branch. Otherwise returns the pending window to schedule.
+    """
+    if confirm_seconds <= 0:
+        return None
+    return OverrideConfirmPending(at=now + timedelta(seconds=confirm_seconds), mode=detected_mode)
+
+
+def decide_fan_thermo_backstop(
+    *, fan_running: bool, delay_seconds: float, now: datetime
+) -> ScheduledReevaluation | None:
+    """Pure reimplementation of _thermo_backstop_task()'s re-arm decision: the
+    backstop timer only reschedules itself while a CA-owned fan is still active.
+
+    Returns None when the fan is no longer running (mirrors the real method's
+    `if self._fan_running: self._start_fan_thermo_backstop()` — only re-arms in
+    that case). The shell still owns scheduling the real `async_call_later` and
+    invoking `fan_thermostat_check()`/`nat_vent_temperature_check()`.
+    """
+    if not fan_running:
+        return None
+    return ScheduledReevaluation(at=now + timedelta(seconds=delay_seconds), reason="fan_thermo_backstop")
+
+
+_FAN_MODE_DISABLED = "disabled"  # mirrors const.FAN_MODE_DISABLED — duplicated locally per the
+# same import-independence convention nat_vent_gate.py/fan_thermostat_decision.py already use.
+
+
+class FanCycleOutcome(Enum):
+    """The real outcomes _fan_cycle_on() can produce."""
+
+    DISABLED = "disabled"  # feature disabled (min_runtime<=0 or fan_mode disabled) — no-op
+    OVERRIDE_SUSPENDED = "override_suspended"  # user has manual control — cycle suspended
+    ACTIVATE_ALWAYS_ON = "activate_always_on"  # min_runtime>=60 — activate, never schedule off
+    ACTIVATE_WITH_OFF_TIMER = "activate_with_off_timer"  # activate, schedule off at min_runtime
+    RETRY_LATER = "retry_later"  # fan already active for another reason — retry in 60min
+
+
+def decide_fan_cycle_on(
+    *,
+    min_runtime_minutes: float,
+    fan_mode: str,
+    fan_override_active: bool,
+    fan_active: bool,
+) -> tuple[FanCycleOutcome, float | None]:
+    """Pure reimplementation of _fan_cycle_on()'s decision (min-runtime cycling "on" phase).
+
+    Returns (outcome, delay_seconds). delay_seconds is a raw duration (not an
+    absolute time) — this mechanism only ever needs a relative re-check delay,
+    never wall-clock alignment, so it deliberately does NOT take a `now`
+    parameter (unlike decide_grace_start/decide_revisit/etc.) — avoiding a
+    dependency on `dt_util.now()` that existing tests mock as a bare
+    MagicMock in this specific code path (the original code never called
+    dt_util.now() here either, just raw arithmetic on min_runtime).
+
+    delay_seconds is None for DISABLED/OVERRIDE_SUSPENDED/ACTIVATE_ALWAYS_ON
+    (nothing further to schedule); for ACTIVATE_WITH_OFF_TIMER it's the
+    off-phase re-check delay; for RETRY_LATER it's the 60-minute retry delay.
+    The shell owns actually calling _activate_fan() when the outcome starts
+    with ACTIVATE, and converting delay_seconds into a real async_call_later.
+    """
+    if min_runtime_minutes <= 0 or fan_mode == _FAN_MODE_DISABLED:
+        return FanCycleOutcome.DISABLED, None
+    if fan_override_active:
+        return FanCycleOutcome.OVERRIDE_SUSPENDED, None
+    if not fan_active:
+        if min_runtime_minutes >= 60:
+            return FanCycleOutcome.ACTIVATE_ALWAYS_ON, None
+        return FanCycleOutcome.ACTIVATE_WITH_OFF_TIMER, min_runtime_minutes * 60.0
+    return FanCycleOutcome.RETRY_LATER, 60.0 * 60.0
+
+
+def decide_fan_cycle_off(*, fan_min_runtime_active: bool, min_runtime_minutes: float) -> tuple[bool, float]:
+    """Pure reimplementation of _fan_cycle_off()'s decision (min-runtime cycling "off" phase).
+
+    Returns (should_deactivate, wait_seconds) — wait_seconds is a raw duration,
+    same rationale as decide_fan_cycle_on (no `now` parameter needed).
+    should_deactivate mirrors the real method's `if self._fan_min_runtime_active:`
+    guard — the shell calls _deactivate_fan() only when True. wait_seconds (the
+    "on" phase re-check delay) is ALWAYS returned, matching the real method's
+    unconditional final `async_call_later` call.
+    """
+    wait_seconds = max(0.0, (60.0 - min_runtime_minutes) * 60.0)
+    return fan_min_runtime_active, wait_seconds
+
+
+def decide_setpoint_retry_schedule(
+    *,
+    temperature: float,
+    mode: str,
+    write_seq: int,
+    reject_streak: int,
+    delay_seconds: float,
+    now: datetime,
+) -> PendingSetpointRetry:
+    """Pure construction of the PendingSetpointRetry intention that WOULD represent
+    the 900s backoff (`_check_single_setpoint_accepted()`'s REASSERT outcome) or
+    the 30s nudge-then-target follow-up (`_retry_callback()`'s NUDGE_THEN_TARGET
+    branch) — the same triple (`_retry_seq`/`_retry_temp`/`_retry_mode` in the
+    real code) those two real call sites capture before scheduling
+    `async_call_later`.
+
+    NOT called from production automation.py — see the module docstring's
+    "One deliberate exception" note. Both real delays are literal constants that
+    never depended on `dt_util.now()`; this function exists as validated schema
+    (proving `PendingSetpointRetry` fits the real data) rather than as a
+    production dependency, avoiding a `dt_util.now()`-mocking pitfall.
+
+    Always returns a value (no None case): an unlimited-retry backoff is the
+    current, unchanged behavior — this function does not add a give-up path.
+    """
+    return PendingSetpointRetry(
+        at=now + timedelta(seconds=delay_seconds),
+        temperature=temperature,
+        mode=mode,
+        write_seq=write_seq,
+        reject_streak=reject_streak,
+    )
+
+
+class SetpointRetryAction(Enum):
+    """The real outcomes _retry_callback() can produce."""
+
+    SUPERSEDED = "superseded"  # a newer command replaced this one; skip entirely
+    DIRECT_RETRY = "direct_retry"  # re-send the target setpoint immediately
+    NUDGE_THEN_TARGET = "nudge_then_target"  # send a 1-degree nudge now, real target in 30s
+
+
+def decide_setpoint_retry_action(
+    *, current_write_seq: int, retry_write_seq: int, reject_streak: int
+) -> SetpointRetryAction:
+    """Pure reimplementation of _retry_callback()'s decision: is this retry
+    stale, and if not, nudge-first or retry directly.
+
+    Mirrors the real method's `if self._write_seq != _retry_seq: return`
+    staleness guard, then `_do_nudge = self._setpoint_reject_streak >= 2`
+    (Issue #411: some thermostat integrations dedup a repeated identical
+    set_temperature payload, so retrying with the exact same value can never
+    succeed — a brief nudge forces the device to recognize a real change
+    before the actual target is sent 30s later). The original code precomputed
+    `_do_nudge` once at verify time and captured it in the closure; here it is
+    re-derived from `reject_streak` at the moment of firing instead, since
+    `PendingSetpointRetry` already carries `reject_streak` as data — one fewer
+    piece of captured closure state.
+    """
+    if current_write_seq != retry_write_seq:
+        return SetpointRetryAction.SUPERSEDED
+    if reject_streak >= 2:
+        return SetpointRetryAction.NUDGE_THEN_TARGET
+    return SetpointRetryAction.DIRECT_RETRY
+
+
+def decide_scheduled_write_seq_current(*, current_write_seq: int, target_write_seq: int) -> bool:
+    """Pure staleness check shared by every write_seq-tagged scheduled action.
+
+    True means "no newer command has superseded this one, proceed" — used by
+    `_send_real_target()`'s own `if self._write_seq != _retry_seq: return`
+    guard (the second-stage check after a NUDGE_THEN_TARGET decision), the
+    same staleness concept `decide_setpoint_retry_action` checks for the first
+    stage, kept as a standalone one-line function since the send-real-target
+    site has no nudge/reject_streak branching of its own to combine it with.
+    """
+    return current_write_seq == target_write_seq

--- a/custom_components/climate_advisor/fan_drift_reconciliation.py
+++ b/custom_components/climate_advisor/fan_drift_reconciliation.py
@@ -1,0 +1,86 @@
+"""Pure decision core for fan physical-state drift reconciliation (Issue #423).
+
+Architecture-reset Step 2 (session state machine slice): pure reimplementation
+of ``_reconcile_fan_physical_drift()``'s decision logic — the 2-tick-confirm
+self-healing check that detects a stale ``_fan_active=True`` with no matching
+physical fan and corrects it. Mirrors the same pattern as
+``nat_vent_gate.py``/``fan_thermostat_decision.py``: every field on
+``FanDriftInputs`` traces to a real read in the production method, and this
+function returns only the decision (outcome + next tick count) — the shell
+still owns applying the side effects (clearing flags, starting grace, emitting
+the event).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+FAN_MODE_WHOLE_HOUSE = "whole_house_fan"
+FAN_MODE_BOTH = "both"
+
+_DRIFT_CONFIRM_TICKS = 2
+
+
+class FanDriftOutcome(Enum):
+    """The three real outcomes _reconcile_fan_physical_drift() can produce."""
+
+    RESET = "reset"  # tick count -> 0, no correction (fan inactive / command echo / agrees)
+    NOOP = "noop"  # tick count unchanged, no correction (not-applicable archetype / no ground truth)
+    AWAITING = "awaiting"  # tick count incremented, not yet at the 2-tick confirmation threshold
+    CORRECT = "correct"  # confirmed drift over 2 ticks -> tick count resets to 0, correction fires
+
+
+@dataclass(frozen=True)
+class FanDriftInputs:
+    """Every input the drift-reconciliation check may read — explicit, nothing hidden.
+
+    Field-by-field correspondence to the real code:
+      fan_active               -> self._fan_active
+      fan_mode                 -> config CONF_FAN_MODE
+      recent_fan_command       -> self._is_recent_fan_command_callback(threshold_seconds=30.0)
+      physical_state_available -> whether self._get_fan_physical_state_callback is set
+      physical_on              -> self._get_fan_physical_state_callback() — None means
+                                   command-only mode (no ground truth to compare against)
+      tick_count                -> self._fan_drift_tick_count (persisted across backstop ticks)
+    """
+
+    fan_active: bool
+    fan_mode: str
+    recent_fan_command: bool
+    physical_state_available: bool
+    physical_on: bool | None
+    tick_count: int
+
+
+def decide_fan_drift_reconciliation(inputs: FanDriftInputs) -> tuple[FanDriftOutcome, int]:
+    """Pure reimplementation of _reconcile_fan_physical_drift()'s decision logic.
+
+    Returns (outcome, next_tick_count). The shell applies outcome-specific side
+    effects (RESET/NOOP/AWAITING have none besides the tick-count update;
+    CORRECT additionally clears fan flags, starts grace, and emits fan_cancel).
+    """
+    if not inputs.fan_active:
+        return FanDriftOutcome.RESET, 0
+
+    if inputs.fan_mode not in (FAN_MODE_WHOLE_HOUSE, FAN_MODE_BOTH):
+        return FanDriftOutcome.NOOP, inputs.tick_count
+
+    if inputs.recent_fan_command:
+        return FanDriftOutcome.RESET, 0
+
+    if not inputs.physical_state_available:
+        return FanDriftOutcome.NOOP, inputs.tick_count
+
+    if inputs.physical_on is None:
+        return FanDriftOutcome.NOOP, inputs.tick_count
+
+    if inputs.physical_on:
+        return FanDriftOutcome.RESET, 0
+
+    # physical_on is False but fan_active is True — disagreement.
+    next_count = inputs.tick_count + 1
+    if next_count < _DRIFT_CONFIRM_TICKS:
+        return FanDriftOutcome.AWAITING, next_count
+
+    return FanDriftOutcome.CORRECT, 0

--- a/custom_components/climate_advisor/fan_thermostat_decision.py
+++ b/custom_components/climate_advisor/fan_thermostat_decision.py
@@ -1,0 +1,105 @@
+"""Pure decision core for the tick-level fan thermostatic stop check (architecture-reset Step 2).
+
+Second proof slice, expanding outward from the reactivation gate
+(``nat_vent_gate.py``) per the roadmap's Step 2. Pure reimplementation of
+``automation.py``'s ``fan_thermostat_check()`` Check 1 (free-cooling-direction
+stop, Issue #327) and Check 2 (cooled-to-target stop, sleep-aware per Issue
+#402) — the tick-level safety check that fires on every indoor/outdoor
+temperature change plus a 5-min backstop, historically the site of #327 and
+#402's original bugs.
+
+Scope: unlike the boolean reactivation gate, this decision has FOUR real
+outcomes (keep / stop-via-nat-vent-exit / stop-deactivate / stop-cooled-to-floor),
+each with a different action shape in production — captured here as an enum,
+the smallest step toward the plan's `DesiredState` design without building the
+full general schema yet (that's Step 3). This function does NOT decide whether
+the fan is active or overridden — those are cheap precondition checks the shell
+keeps, mirroring `_nat_vent_may_reactivate()`'s own precedent ("callers keep
+their own additional guards; this function returns only the shared gate").
+
+Every field on ``FanThermostatInputs`` traces to a real production read; in
+particular ``in_sleep_window`` replaces the real code's internal
+``dt_util.now()`` read, exactly as in ``nat_vent_gate.py``.
+
+Validated via shadow + substitution differential replay against the real
+production method — see ``tools/fan_thermostat_decision_diff.py`` and the
+Step-2 status report.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class FanThermostatOutcome(Enum):
+    """The four real outcomes fan_thermostat_check() can produce."""
+
+    KEEP = "keep"
+    STOP_VIA_NAT_VENT_EXIT = "stop_via_nat_vent_exit"
+    STOP_DEACTIVATE = "stop_deactivate"
+    STOP_COOLED_TO_FLOOR = "stop_cooled_to_floor"
+
+
+@dataclass(frozen=True)
+class FanThermostatInputs:
+    """Every input the tick-level fan stop check may read — explicit, nothing hidden.
+
+    Field-by-field correspondence to the real code:
+      indoor, outdoor      -> fan_thermostat_check(indoor=, outdoor=)
+      comfort_heat_raw     -> config comfort_heat (Check 2's awake-branch floor, unmodified)
+      sleep_heat           -> config CONF_SLEEP_HEAT, falls back to comfort_heat_raw
+      in_sleep_window      -> replaces _in_sleep_window(dt_util.now(), config)
+      hysteresis           -> config CONF_NAT_VENT_HYSTERESIS_F — used ONLY in Check 2's
+                               sleep-branch floor (_sleep_heat - hysteresis); Check 1's
+                               direction-reversal stop deliberately uses NO hysteresis
+                               (see the real code's comment: subtracting it there would
+                               kill free cooling ~1F early)
+      natural_vent_active  -> self._natural_vent_active — determines whether Check 1's
+                               stop routes through the nat-vent exit path or a plain
+                               deactivate
+    """
+
+    indoor: float | None
+    outdoor: float | None
+    comfort_heat_raw: float
+    sleep_heat: float
+    in_sleep_window: bool
+    hysteresis: float
+    natural_vent_active: bool
+
+
+def _resolve_vent_floor(inputs: FanThermostatInputs) -> float:
+    """Pure reimplementation of Check 2's floor resolution.
+
+    Deliberately asymmetric, matching production exactly: the sleep-window
+    branch subtracts hysteresis from sleep_heat; the awake branch does NOT
+    subtract hysteresis from comfort_heat_raw. This is not a simplification
+    opportunity — it's what the real code does, and the two floors are allowed
+    to have different boundary shapes.
+    """
+    if inputs.in_sleep_window:
+        return inputs.sleep_heat - inputs.hysteresis
+    return inputs.comfort_heat_raw
+
+
+def decide_fan_thermostat_check(inputs: FanThermostatInputs) -> FanThermostatOutcome:
+    """Pure reimplementation of fan_thermostat_check()'s Check 1 + Check 2.
+
+    Preconditions (fan active, not overridden) are the shell's responsibility,
+    not this function's — mirrors decide_nat_vent_gate()'s scoping.
+    """
+    # --- Check 1: free-cooling direction guard (Issue #327) ---
+    # Non-strict >=, NO hysteresis — this boundary is deliberately different
+    # from the reactivation gate's strict < with configurable hysteresis.
+    if inputs.outdoor is not None and inputs.indoor is not None and inputs.outdoor >= inputs.indoor:
+        if inputs.natural_vent_active:
+            return FanThermostatOutcome.STOP_VIA_NAT_VENT_EXIT
+        return FanThermostatOutcome.STOP_DEACTIVATE
+
+    # --- Check 2: cooled to target, sleep-aware (Issue #402) ---
+    vent_floor = _resolve_vent_floor(inputs)
+    if inputs.indoor is not None and inputs.indoor <= vent_floor:
+        return FanThermostatOutcome.STOP_COOLED_TO_FLOOR
+
+    return FanThermostatOutcome.KEEP

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.4.74"
+  "version": "0.5.1"
 }

--- a/custom_components/climate_advisor/nat_vent_gate.py
+++ b/custom_components/climate_advisor/nat_vent_gate.py
@@ -1,0 +1,109 @@
+"""Pure decision core for the nat-vent reactivation gate (architecture-reset Step 2).
+
+This is the first proof slice of the functional-core approach: a pure
+reimplementation of the exact boolean gate already unified across 5 production
+call sites in ``automation.py`` (``_nat_vent_may_reactivate()``,
+``_ceiling_threshold()``, ``_nat_vent_reactivation_floor()`` — consolidated by
+Issues #411/#417 after the site-drift bug class documented in project memory).
+
+Scope: this module answers exactly one question — "given current conditions,
+should nat-vent (re)activate right now?" — as a pure function of an explicit
+``NatVentGateInputs`` value. It does NOT model the surrounding session state
+machine (grace periods, reactivation lockout timers, physical fan drift
+reconciliation) — those stay in ``automation.py`` for now; expanding the pure
+core to cover them is a later step (see the architecture-reset plan's Step 3).
+
+Every field on ``NatVentGateInputs`` corresponds to a value the real
+``_nat_vent_may_reactivate()`` call chain reads (directly, or via
+``self.config``/``dt_util.now()``) — nothing is hidden or implicit. In
+particular ``in_sleep_window`` replaces the real code's internal
+``dt_util.now()`` read: the caller resolves wall-clock time once, the pure core
+never touches it.
+
+Validated via differential replay against the real production method — see
+``tools/nat_vent_gate_diff.py`` and the Step-2 status report for results.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Mirrors custom_components.climate_advisor.const.CEILING_ESCALATION_SAVINGS_MARGIN_F —
+# duplicated here (a plain float constant, not logic) rather than imported, to keep this
+# module import-independent of the rest of the integration during the proof-slice phase.
+# TODO(step 3+): import from const.py once this module is wired into production.
+_CEILING_ESCALATION_SAVINGS_MARGIN_F = 2.0
+
+FAN_MODE_DISABLED = "disabled"
+FAN_MODE_WHOLE_HOUSE = "whole_house_fan"
+FAN_MODE_HVAC = "hvac_fan"
+FAN_MODE_BOTH = "both"
+
+
+@dataclass(frozen=True)
+class NatVentGateInputs:
+    """Every input the reactivation gate may read — explicit, nothing hidden.
+
+    Field-by-field correspondence to the real code:
+      outdoor, indoor          -> _nat_vent_may_reactivate(outdoor=, indoor=)
+      comfort_heat_raw         -> the caller's raw config comfort_heat (before sleep adjustment)
+      sleep_heat               -> config CONF_SLEEP_HEAT, falls back to comfort_heat_raw
+      in_sleep_window          -> replaces _in_sleep_window(dt_util.now(), config) — resolved
+                                   by the caller, never read from the wall clock in here
+      comfort_cool             -> _nat_vent_may_reactivate(comfort_cool=) / _ceiling_threshold(comfort_cool)
+      nat_vent_delta           -> used to compute threshold = comfort_cool + nat_vent_delta
+                                   (every real call site computes this identically)
+      hysteresis               -> _nat_vent_may_reactivate(hysteresis=) — 0.0 at 2 call sites
+                                   (handle_door_window_open, _re_pause_for_open_sensor),
+                                   the configured value at the other 3
+      fan_mode                 -> _ceiling_threshold()'s archetype branch
+      aggressive_savings       -> _ceiling_threshold()'s savings-margin branch
+    """
+
+    outdoor: float | None
+    indoor: float | None
+    comfort_heat_raw: float
+    sleep_heat: float
+    in_sleep_window: bool
+    comfort_cool: float
+    nat_vent_delta: float
+    hysteresis: float
+    fan_mode: str
+    aggressive_savings: bool
+
+
+def _resolve_comfort_heat(inputs: NatVentGateInputs) -> float:
+    """Pure reimplementation of _nat_vent_reactivation_floor() (Issue #417)."""
+    return inputs.sleep_heat if inputs.in_sleep_window else inputs.comfort_heat_raw
+
+
+def _resolve_ceiling_threshold(inputs: NatVentGateInputs) -> float | None:
+    """Pure reimplementation of _ceiling_threshold()."""
+    if inputs.fan_mode in (FAN_MODE_WHOLE_HOUSE, FAN_MODE_BOTH):
+        return None
+    if inputs.aggressive_savings:
+        return inputs.comfort_cool + _CEILING_ESCALATION_SAVINGS_MARGIN_F
+    return inputs.comfort_cool
+
+
+def decide_nat_vent_gate(inputs: NatVentGateInputs) -> bool:
+    """Pure reimplementation of _nat_vent_may_reactivate() (Issue #411 Pass 4).
+
+    Same 4-part gate, same boundary semantics (strict '<', '<=' on the ceiling
+    check) as production — this function exists to be differentially validated
+    against the real method, not to introduce new behavior.
+    """
+    if inputs.outdoor is None or inputs.indoor is None:
+        return False
+
+    comfort_heat = _resolve_comfort_heat(inputs)
+    threshold = inputs.comfort_cool + inputs.nat_vent_delta
+    ceiling_threshold = _resolve_ceiling_threshold(inputs)
+    ceiling_ok = ceiling_threshold is None or inputs.indoor <= ceiling_threshold
+
+    return (
+        inputs.outdoor < inputs.indoor - inputs.hysteresis
+        and inputs.indoor > comfort_heat
+        and inputs.outdoor < threshold
+        and ceiling_ok
+    )

--- a/custom_components/climate_advisor/nat_vent_reactivation_lockout.py
+++ b/custom_components/climate_advisor/nat_vent_reactivation_lockout.py
@@ -1,0 +1,43 @@
+"""Pure decision core for the nat-vent reactivation lockout (architecture-reset Step 2).
+
+Guards against rapid re-activation flapping right after an outdoor-warm exit:
+once nat-vent exits because outdoor rose above indoor (the ONLY exit reason
+that records `_nat_vent_outdoor_exit_time`, per `_exit_nat_vent()`'s
+docstring), the paused-by-door reactivation check inside
+`check_natural_vent_conditions()` must wait out a configured lockout window
+before considering reactivation again.
+
+Verified narrowly and deliberately scoped to this ONE call site, not a gap to
+spread to the other 4 reactivation-gate call sites (`handle_door_window_open`,
+the Priority-0 grace+ceiling re-entry check, `reconcile_fan_on_startup`,
+`_re_pause_for_open_sensor`): each of those is structurally unreachable in the
+immediate aftermath of an outdoor-warm exit-with-pause, because they're each
+guarded by a `not self._paused_by_door` (or equivalent) condition that is
+already False at that moment — `_paused_by_door` and `_natural_vent_active`
+being True is exactly what a pause/reactivation cycle means, and none of the
+other 4 sites can even be entered while paused. Applying the lockout there
+too would be dead code, not a fix.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+
+def is_reactivation_locked_out(
+    *,
+    outdoor_exit_time: datetime | None,
+    now: datetime,
+    lockout_seconds: float,
+) -> bool:
+    """Pure reimplementation of the lockout check inside check_natural_vent_conditions().
+
+    Returns True (locked out — do not reactivate yet) only when a prior
+    outdoor-warm exit was recorded AND the configured lockout window hasn't
+    elapsed since then. Returns False (no lockout in effect) when no such
+    exit has happened yet, or the window has elapsed.
+    """
+    if outdoor_exit_time is None:
+        return False
+    elapsed = (now - outdoor_exit_time).total_seconds()
+    return elapsed < lockout_seconds

--- a/custom_components/climate_advisor/setpoint_verify_decision.py
+++ b/custom_components/climate_advisor/setpoint_verify_decision.py
@@ -1,0 +1,51 @@
+"""Pure decision core for the post-fan setpoint verify check (architecture-reset Step 2).
+
+`_activate_fan()` and `_deactivate_fan()` each scheduled a 30-second post-fan
+setpoint-verify callback with byte-for-byte IDENTICAL decision logic (found
+during the #429 direction-gate consolidation sweep — this isn't a direction
+gate, but the exact same copy-paste-drift risk the sweep was looking for).
+Both re-assert the last commanded setpoint if the thermostat (e.g. an Ecobee
+reverting to its own comfort program) doesn't match it within tolerance.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+_TOLERANCE_F = 0.6  # same tolerance as _check_single_setpoint_accepted()
+
+
+class SetpointVerifyOutcome(Enum):
+    """The outcomes the post-fan setpoint verify decision can produce."""
+
+    STALE = "stale"  # a newer command superseded this verify — skip
+    NO_SETPOINT = "no_setpoint"  # no active setpoint captured at schedule time
+    OVERRIDE_ACTIVE = "override_active"  # genuine confirmed override — don't fight it
+    NO_READING = "no_reading"  # no current thermostat state/temperature attribute
+    WITHIN_TOLERANCE = "within_tolerance"  # matches expected setpoint — no action
+    REASSERT = "reassert"  # mismatch beyond tolerance — re-assert the setpoint
+
+
+def decide_setpoint_verify(
+    *,
+    current_write_seq: int,
+    verify_write_seq: int,
+    expected_temp: float | None,
+    expected_mode: str | None,
+    manual_override_active: bool,
+    actual_temp: float | None,
+) -> SetpointVerifyOutcome:
+    """Pure reimplementation of _do_verify_after_fan_on()/_do_verify_after_fan_off()'s
+    (identical) decision logic. The shell owns actually calling _set_temperature()
+    when the outcome is REASSERT."""
+    if current_write_seq != verify_write_seq:
+        return SetpointVerifyOutcome.STALE
+    if expected_temp is None or expected_mode is None:
+        return SetpointVerifyOutcome.NO_SETPOINT
+    if manual_override_active:
+        return SetpointVerifyOutcome.OVERRIDE_ACTIVE
+    if actual_temp is None:
+        return SetpointVerifyOutcome.NO_READING
+    if abs(actual_temp - expected_temp) > _TOLERANCE_F:
+        return SetpointVerifyOutcome.REASSERT
+    return SetpointVerifyOutcome.WITHIN_TOLERANCE

--- a/docs/08-COMPUTATION-REFERENCE.md
+++ b/docs/08-COMPUTATION-REFERENCE.md
@@ -25,7 +25,7 @@ The automation logic table and all threshold constants in this document are expr
 | How is the setback modifier computed and what values can it take? | `avg_delta = ((tomorrow_high − today_high) + (tomorrow_low − today_low)) / 2`; modifier ranges from −3.0 (strong warming) to +3.0 (significant cold front); stable trend → 0. | [§3. Setback Modifier](08-COMPUTATION-REFERENCE.md#3-setback-modifier) |
 | What is the bedtime setpoint formula and when does the thermal model change it? | Default: `comfort_heat − 4°F` (heat) / `comfort_cool + 3°F` (cool). When thermal model confidence ≥ "low", `compute_bedtime_setback()` scales depth from `heating_rate_f_per_hour × recovery_window_hours`, clamped to `[MIN_SETBACK_DEPTH, MAX_SETBACK_DEPTH]`. | [§5a. Adaptive Bedtime Setback](08-COMPUTATION-REFERENCE.md#5a-adaptive-bedtime-setback-compute_bedtime_setback) |
 | When does nat-vent continue past bedtime instead of stopping, and what stops it afterward? | When nat-vent is active, the fan is CA-owned, and `outdoor < sleep_cool`, bedtime emits `nat_vent_bedtime_continue` and keeps the fan running. Through the sleep window the fan cycles on/off around `sleep_heat + hysteresis` (`nat_vent_temperature_check()`); the session itself only ends via the Priority 2 comfort-floor exit (`indoor ≤ sleep_heat − hysteresis`, event `nat_vent_comfort_floor_exit`) — the old Priority 0 `nat_vent_sleep_ceiling_reached` exit was removed in Issue #371. | [§5a nat-vent continuation gate](08-COMPUTATION-REFERENCE.md#5a-adaptive-bedtime-setback-compute_bedtime_setback) · [Exit Hierarchy](08-COMPUTATION-REFERENCE.md#exit-hierarchy) |
-| When and how does CA pre-cool the home on warming-trend nights? | Mid-night trigger (nat-vent close + 30 min, or wake − 4 h fallback); target = `sleep_cool + setback_modifier` floored at `comfort_heat + 2°F`. AC suppressed if nat-vent already reached target. Morning guard emits `pre_cool_overshoot` if indoor < `comfort_heat` at wake-up. | [§5a-i. Overnight Pre-Cool Phase](08-COMPUTATION-REFERENCE.md#5a-i-overnight-pre-cool-phase-issue-258) |
+| When and how does CA pre-cool the home on warming-trend nights? | Mid-night trigger (nat-vent close + 30 min, or wake − 4 h fallback); target = `sleep_cool + setback_modifier` floored at `sleep_heat + hysteresis` (`compute_pre_cool_target()`, single source of truth for all 5 call sites). AC suppressed if nat-vent already reached target. Morning guard emits `pre_cool_overshoot` if indoor < `comfort_heat` at wake-up. | [§5a-i. Overnight Pre-Cool Phase](08-COMPUTATION-REFERENCE.md#5a-i-overnight-pre-cool-phase-issue-258) |
 | How does the physics ODE predict future indoor temperature? | `T(t+dt) = T_outdoor + (T − T_outdoor) × exp(k_p × dt) + (Q/k_p) × (exp(k_p × dt) − 1)`, where Q switches between k_active_heat, k_active_cool, and 0 per schedule period. | [§5c. Predicted Temperature Graph — Physics Path](08-COMPUTATION-REFERENCE.md#5c-predicted-temperature-graph--physics-path) |
 | What is the dynamic target band and how does occupancy mode change it? | `_compute_target_band_schedule()` returns `[{ts, lower, upper}]` per forecast hour; away = setback today only, vacation = deep setback all days, home/guest = comfort with sleep/wake ramps. | [§5d. Dynamic Target Band](08-COMPUTATION-REFERENCE.md#5d-dynamic-target-band--_compute_target_band_schedule) |
 | How does comfort score accumulate and what triggers a suggestion? | `comfort_score = 1 − (total_violation_minutes / (days_recorded × 1440))`; more than 5 days with > 30 violation minutes triggers the `comfort_violations` suggestion. | [§Metric Definitions — Comfort Score](05-LEARNING-ENGINE-DESIGN.md#comfort-score-comfort_score) |
@@ -182,15 +182,16 @@ On warming-trend nights (`setback_modifier < 0`), the coordinator schedules a se
 | No nat-vent config | `wake_time − PRE_COOL_WAKE_OFFSET_HOURS (4 h)` — fallback |
 | `setback_modifier >= 0` | No trigger scheduled (no warming trend) |
 
-**Target formula** (`handle_pre_cool()` in `automation.py`):
+**Target formula** (`compute_pre_cool_target()` in `automation.py` — the single source of truth, called by all 5 sites that need this value: the real AC trigger in `handle_pre_cool()`, `_compute_pre_cool_trigger_time()`, `_maybe_schedule_pre_cool()`'s status text, the chart target-band dip, and the ODE predicted-indoor curve):
 
 ```
-raw_target  = sleep_cool + setback_modifier          # modifier is negative → lower ceiling
-floor       = comfort_heat + PRE_COOL_MIN_HEADROOM_F  # default: comfort_heat + 2°F
-pre_cool_target = max(raw_target, floor)              # clamp prevents morning heating
+raw_target  = sleep_cool + setback_modifier   # modifier is negative → lower ceiling
+floor       = sleep_heat + hysteresis         # same "+1 above the floor" convention as
+                                               # nat_vent_temperature_check()'s sleep-window cycling
+pre_cool_target = max(raw_target, floor)      # clamp prevents dropping below the sleep floor
 ```
 
-The floor guard prevents the home from dropping so far below `comfort_heat` that the heat fires at wake-up (doubly wasteful: night AC + morning heat).
+The floor guard prevents the home from dropping below the sleep band's own floor (`sleep_heat`), so pre-cool can travel the full `[sleep_heat, sleep_cool]` range on a strong warming trend instead of being clamped near daytime `comfort_heat` (the pre-Issue-#436 formula, whose floor left little to no headroom once `sleep_cool` was reformatted to a flat, cooler-than-daytime household default).
 
 **Nat-vent bypass condition:** If the pre-cool trigger fires with `nat_vent_just_closed=True` AND `indoor_temp ≤ pre_cool_target`, the AC service call is suppressed — free cooling via open windows already achieved the target. Event `pre_cool_suppressed_nat_vent` is emitted.
 

--- a/tests/test_automation_celsius.py
+++ b/tests/test_automation_celsius.py
@@ -882,3 +882,162 @@ class TestSetpointNudgeStreak:
             self._fire_validation_cb(engine, validation_cb, captured_call_later)
 
         assert engine._setpoint_reject_streak == 0, "streak must reset to 0 once the thermostat confirms the setpoint"
+
+
+class TestSetpointRetryActionLoadBearing:
+    """Positive control (architecture-reset session, last of the 9 DesiredState
+    mechanisms): proves _retry_callback() actually dispatches on
+    decide_setpoint_retry_action()'s outcome rather than the wiring being dead
+    code — corrupt the pure function at its source module (patched at
+    `automation.decide_setpoint_retry_action`, the name automation.py imports
+    at module scope, mirroring every other positive control this session) and
+    confirm production behavior changes.
+    """
+
+    def _make_engine_stub(self) -> AutomationEngine:
+        hass = MagicMock()
+        hass.services.async_call = AsyncMock()
+        hass.async_create_task = MagicMock(side_effect=lambda coro: coro.close())
+        config: dict = {
+            "climate_entity": "climate.test_thermostat",
+            "temp_unit": "fahrenheit",
+            "comfort_heat": 68.0,
+            "comfort_cool": 76.0,
+            "setback_heat": 60.0,
+            "setback_cool": 80.0,
+            "notify_service": "notify.notify",
+        }
+        return AutomationEngine(
+            hass=hass,
+            climate_entity=config["climate_entity"],
+            weather_entity="weather.forecast_home",
+            door_window_sensors=[],
+            notify_service=config["notify_service"],
+            config=config,
+        )
+
+    def test_forcing_superseded_suppresses_the_real_retry(self):
+        """With decide_setpoint_retry_action() patched to always return SUPERSEDED,
+        firing the 900s retry callback must NOT re-send the setpoint — proving the
+        real _retry_callback() genuinely branches on this function's answer instead
+        of always retrying regardless."""
+        from custom_components.climate_advisor.desired_state import SetpointRetryAction
+
+        engine = self._make_engine_stub()
+        wrong_state = MagicMock()
+        wrong_state.state = "cool"
+        wrong_state.attributes = {"temperature": 72.0, "hvac_action": "idle", "fan_mode": "auto"}
+        engine.hass.states.get = MagicMock(return_value=wrong_state)
+
+        captured_call_later: list = []
+
+        def fake_call_later(hass, delay, callback):
+            captured_call_later.append((delay, callback))
+            return MagicMock()
+
+        with (
+            patch("custom_components.climate_advisor.automation.async_call_later", side_effect=fake_call_later),
+            patch("custom_components.climate_advisor.automation.callback", side_effect=lambda fn: fn),
+        ):
+            asyncio.run(engine._set_temperature(75.0, reason="test", mode="cool"))
+            validation_cb = captured_call_later[0][1]
+            captured_call_later.clear()
+
+            coros: list = []
+            engine.hass.async_create_task = MagicMock(side_effect=lambda coro: coros.append(coro))
+            validation_cb(None)
+            asyncio.run(coros[0])
+
+        assert engine._setpoint_reject_streak == 1
+        retry_delay, retry_lambda = captured_call_later[0]
+        assert retry_delay == 900
+
+        engine.hass.services.async_call.reset_mock()
+        retry_coros: list = []
+        engine.hass.async_create_task = MagicMock(side_effect=lambda coro: retry_coros.append(coro))
+
+        with (
+            patch("custom_components.climate_advisor.automation.async_call_later", side_effect=fake_call_later),
+            patch("custom_components.climate_advisor.automation.callback", side_effect=lambda fn: fn),
+            patch(
+                "custom_components.climate_advisor.automation.decide_setpoint_retry_action",
+                return_value=SetpointRetryAction.SUPERSEDED,
+            ),
+        ):
+            retry_lambda(None)
+            assert len(retry_coros) == 1
+            asyncio.run(retry_coros[0])
+
+        assert engine.hass.services.async_call.call_count == 0, (
+            "forcing SUPERSEDED must suppress the retry entirely — load-bearing confirmed"
+        )
+
+    def test_forcing_nudge_then_target_sends_a_nudge_on_the_first_rejection(self):
+        """With decide_setpoint_retry_action() patched to always return
+        NUDGE_THEN_TARGET, even a FIRST rejection (reject_streak=1, which would
+        normally be a plain direct retry) must nudge — proving the real code
+        dispatches on the function's return value, not its own separate
+        reject_streak>=2 check baked back in as a shadow copy."""
+        from custom_components.climate_advisor.desired_state import SetpointRetryAction
+
+        engine = self._make_engine_stub()
+        wrong_state = MagicMock()
+        wrong_state.state = "cool"
+        wrong_state.attributes = {"temperature": 72.0, "hvac_action": "idle", "fan_mode": "auto"}
+        engine.hass.states.get = MagicMock(return_value=wrong_state)
+
+        captured_call_later: list = []
+
+        def fake_call_later(hass, delay, callback):
+            captured_call_later.append((delay, callback))
+            return MagicMock()
+
+        with (
+            patch("custom_components.climate_advisor.automation.async_call_later", side_effect=fake_call_later),
+            patch("custom_components.climate_advisor.automation.callback", side_effect=lambda fn: fn),
+        ):
+            asyncio.run(engine._set_temperature(75.0, reason="test", mode="cool"))
+            validation_cb = captured_call_later[0][1]
+            captured_call_later.clear()
+
+            coros: list = []
+            engine.hass.async_create_task = MagicMock(side_effect=lambda coro: coros.append(coro))
+            validation_cb(None)
+            asyncio.run(coros[0])
+
+        assert engine._setpoint_reject_streak == 1, "this is deliberately a FIRST rejection"
+        _, retry_lambda = captured_call_later[0]
+
+        engine.hass.services.async_call.reset_mock()
+        retry_coros: list = []
+        engine.hass.async_create_task = MagicMock(side_effect=lambda coro: retry_coros.append(coro))
+        nested_call_later: list = []
+
+        def fake_call_later_nested(hass, delay, callback):
+            nested_call_later.append((delay, callback))
+            return MagicMock()
+
+        with (
+            patch(
+                "custom_components.climate_advisor.automation.async_call_later",
+                side_effect=fake_call_later_nested,
+            ),
+            patch("custom_components.climate_advisor.automation.callback", side_effect=lambda fn: fn),
+            patch(
+                "custom_components.climate_advisor.automation.decide_setpoint_retry_action",
+                return_value=SetpointRetryAction.NUDGE_THEN_TARGET,
+            ),
+        ):
+            retry_lambda(None)
+            assert len(retry_coros) == 1
+            asyncio.run(retry_coros[0])
+
+        nudge_calls = engine.hass.services.async_call.call_args_list
+        assert len(nudge_calls) == 1, (
+            f"forcing NUDGE_THEN_TARGET on a first rejection must still nudge — load-bearing confirmed;"
+            f" got {nudge_calls}"
+        )
+        nudge_temp = nudge_calls[0][0][2]["temperature"]
+        assert abs(nudge_temp - 76.0) < 0.01, "cool mode nudges +1.0F"
+        thirty_s_calls = [(d, cb) for d, cb in nested_call_later if d == 30]
+        assert len(thirty_s_calls) == 1, "must also schedule the 30s real-target follow-up"

--- a/tests/test_bedtime_setback.py
+++ b/tests/test_bedtime_setback.py
@@ -466,8 +466,9 @@ class TestHandleBedtimeCoolApplied:
         asyncio.run(engine.handle_bedtime())
 
         assert engine._today_record.setback_cool_applied_f is not None
-        # Target must be above comfort_cool (75) — it's a setback
-        assert engine._today_record.setback_cool_applied_f > 75
+        # Overnight sleep target is a flat, cooler-than-daytime default (DEFAULT_SLEEP_COOL=72),
+        # below comfort_cool (75) — this household sleeps cooler, not warmer (Issue #435/#436).
+        assert engine._today_record.setback_cool_applied_f < 75
 
     def test_cool_writes_setback_depth_f(self):
         """cool mode: _today_record.setback_depth_f must be positive (target minus comfort)."""

--- a/tests/test_chart_log_driver.py
+++ b/tests/test_chart_log_driver.py
@@ -1,0 +1,88 @@
+"""Tests for the chart_log input-trajectory driver (architecture-reset Step 1).
+
+Uses a small SYNTHETIC fixture, not real chart_log data — chart_log files are real
+home telemetry and are never committed to the test suite. The driver's contract
+(discard recorded decisions, keep only indoor/outdoor/ts, skip nulls, respect
+max_entries/stride) is what's under test here; it was additionally validated
+manually against a real ~5700-entry chart_log with zero old-vs-old divergence
+(see the differential-replay Step-1 status report).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TOOLS = REPO_ROOT / "tools"
+for _p in (str(REPO_ROOT), str(TOOLS)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from tools.sim_harness.chart_log_driver import (  # noqa: E402
+    build_scenario_from_chart_log,
+    load_chart_log,
+)
+from tools.sim_harness.differential import old_vs_old  # noqa: E402
+
+_SYNTHETIC_ENTRIES = [
+    {"ts": "2026-06-01T08:00:00-07:00", "hvac": "off", "fan": False, "indoor": 72.0, "outdoor": 65.0},
+    # A "decision" field present in the real log (hvac/fan) — must be discarded, not replayed.
+    {"ts": "2026-06-01T08:30:00-07:00", "hvac": "cool", "fan": True, "indoor": 73.0, "outdoor": 68.0},
+    # Null indoor — must be skipped, not crash.
+    {"ts": "2026-06-01T09:00:00-07:00", "hvac": "cool", "fan": True, "indoor": None, "outdoor": 70.0},
+    # Null outdoor — must be skipped.
+    {"ts": "2026-06-01T09:30:00-07:00", "hvac": "cool", "fan": True, "indoor": 74.0, "outdoor": None},
+    {"ts": "2026-06-01T10:00:00-07:00", "hvac": "cool", "fan": True, "indoor": 75.0, "outdoor": 72.0},
+]
+
+
+def test_build_scenario_discards_recorded_decisions_and_skips_nulls() -> None:
+    scen = build_scenario_from_chart_log(_SYNTHETIC_ENTRIES, name="unit_test")
+    # 5 entries in, 2 null-skipped -> 3 usable events.
+    assert len(scen["events"]) == 3
+    for ev in scen["events"]:
+        assert ev["type"] == "temp_update"
+        assert set(ev.keys()) == {"type", "time", "indoor_f", "outdoor_f"}
+        # No hvac/fan/windows_* keys ever carried through — inputs only.
+    assert scen["events"][0]["indoor_f"] == 72.0
+    assert scen["events"][0]["outdoor_f"] == 65.0
+
+
+def test_build_scenario_respects_max_entries_and_stride() -> None:
+    scen = build_scenario_from_chart_log(_SYNTHETIC_ENTRIES, max_entries=2)
+    assert len(scen["events"]) == 2
+    # max_entries takes the most recent usable entries (from the end).
+    assert scen["events"][-1]["indoor_f"] == 75.0
+
+    scen_strided = build_scenario_from_chart_log(_SYNTHETIC_ENTRIES, stride=2)
+    assert len(scen_strided["events"]) == 2  # 3 usable -> indices 0,2
+
+
+def test_build_scenario_skips_malformed_timestamps() -> None:
+    entries = [*_SYNTHETIC_ENTRIES, {"ts": "not-a-timestamp", "indoor": 70.0, "outdoor": 60.0}]
+    scen = build_scenario_from_chart_log(entries)
+    assert len(scen["events"]) == 3  # malformed ts entry excluded
+
+
+def test_load_chart_log_missing_file_returns_empty() -> None:
+    assert load_chart_log("/nonexistent/path/does_not_exist.json") == []
+
+
+def test_load_chart_log_round_trips_entries_key(tmp_path: Path) -> None:
+    p = tmp_path / "sample.json"
+    p.write_text(json.dumps({"entries": _SYNTHETIC_ENTRIES}), encoding="utf-8")
+    loaded = load_chart_log(p)
+    assert loaded == _SYNTHETIC_ENTRIES
+
+
+def test_chart_log_driven_old_vs_old_is_clean() -> None:
+    """The synthetic trajectory, replayed through the real engine, must diff to zero."""
+    scen = build_scenario_from_chart_log(_SYNTHETIC_ENTRIES, name="unit_test_replay")
+    diff = old_vs_old(scen, scenario_name="unit_test_replay")
+    assert not diff.a_error and not diff.b_error, (diff.a_error, diff.b_error)
+    assert diff.is_clean, (
+        f"old-vs-old divergence on synthetic chart_log replay: "
+        f"{len(diff.event_divergences)} event, {len(diff.action_divergences)} action divergences"
+    )

--- a/tests/test_chart_setpoint.py
+++ b/tests/test_chart_setpoint.py
@@ -539,6 +539,33 @@ class TestComputePredictedActivity:
         )
         assert result[0]["fan_active"] is True
 
+    def test_natural_vent_delta_default_matches_automation_default(self) -> None:
+        """Architecture-reset latent-bug fix: when natural_vent_delta isn't explicitly
+        configured, the chart prediction's fallback must match DEFAULT_NATURAL_VENT_DELTA
+        (3.0F), the same default the real automation engine uses -- not a stray 5.0F that
+        would let the chart predict fan activity the real engine wouldn't actually produce.
+
+        band_upper=76, outdoor=78.5: with the old buggy 5.0F default, 78.5 < 76+5=81 is
+        True (fan predicted active); with the fixed 3.0F default, 78.5 < 76+3=79 is still
+        True but 79.5 would flip to False -- pinning the boundary at exactly the real
+        engine's threshold, not the wider stray one.
+        """
+        fn = self._import_helper()
+        ts = "2026-05-18T16:00:00+00:00"
+        config_without_delta = {"comfort_heat": 68.0, "comfort_cool": 76.0, "fan_mode": "auto"}
+        result = fn(
+            self._make_band(ts, lower=68.0, upper=76.0),
+            self._make_forecast(ts, 79.5),  # outdoor 79.5: below the buggy 81 threshold,
+            # ABOVE the fixed 79 threshold -- distinguishes the two defaults
+            self._make_predicted_indoor(ts, 85.0),  # indoor well above outdoor and band_upper
+            self._make_classification("off"),
+            config_without_delta,
+        )
+        assert result[0]["fan_active"] is False, (
+            "with the fixed 3.0F default (threshold=79), outdoor=79.5 must NOT predict fan "
+            "activity -- if this is True, the stray 5.0F default (threshold=81) regressed"
+        )
+
     def test_fan_not_active_when_outdoor_warmer_than_indoor(self) -> None:
         """Fan off when outdoor >= indoor (no benefit from ventilation)."""
         fn = self._import_helper()

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -309,7 +309,7 @@ class TestRecommendations:
         assert result.window_close_time == time(10, 0)
 
     def test_warm_windows_not_recommended_when_low_too_high(self):
-        # today_low=74 > 72 → gate fails, windows_recommended=False
+        # today_low=74 > boundary(71) → gate fails, windows_recommended=False
         # but the times should still be populated
         result = self._classify(today_high=80, today_low=74)
         assert result.windows_recommended is False
@@ -317,13 +317,14 @@ class TestRecommendations:
         assert result.window_close_time == time(10, 0)
 
     def test_warm_windows_recommended_when_low_is_cool(self):
-        # today_low=60 <= 72 → gate passes, windows_recommended=True
+        # today_low=60 <= boundary(71) → gate passes, windows_recommended=True
         result = self._classify(today_high=80, today_low=60)
         assert result.windows_recommended is True
 
     def test_warm_windows_recommended_at_boundary(self):
-        # today_low=72 == 72 → exactly at boundary (<=), windows_recommended=True
-        result = self._classify(today_high=80, today_low=72)
+        # Boundary = DEFAULT_COMFORT_COOL(74) - ECONOMIZER_TEMP_DELTA(3) = 71.
+        # today_low=71 == boundary → exactly at boundary (<=), windows_recommended=True
+        result = self._classify(today_high=80, today_low=71)
         assert result.windows_recommended is True
 
     # --- MILD ---

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -464,6 +464,87 @@ class TestConfigFlowStepUserFields:
         assert 75 <= DEFAULT_SETBACK_COOL <= 90
 
 
+class TestSetpointSliderRangesRegression:
+    """Regression guard (architecture-reset session, #438 follow-up): the initial
+    setup wizard's Fahrenheit sleep_heat/sleep_cool defaults, and ALL SIX Celsius
+    defaults, were hardcoded literals that silently went stale when
+    DEFAULT_SLEEP_HEAT/DEFAULT_SLEEP_COOL were reformatted from 66/78 to 64/72 —
+    every brand-new install got the OLD values explicitly written into its config,
+    bypassing the reformat entirely. setpoint_slider_ranges() now derives every
+    default from the DEFAULT_* constants directly, so this can't drift again.
+    """
+
+    def test_fahrenheit_defaults_match_named_constants_exactly(self):
+        from custom_components.climate_advisor.config_flow import setpoint_slider_ranges
+        from custom_components.climate_advisor.const import (
+            DEFAULT_COMFORT_COOL,
+            DEFAULT_COMFORT_HEAT,
+            DEFAULT_SETBACK_COOL,
+            DEFAULT_SETBACK_HEAT,
+            DEFAULT_SLEEP_COOL,
+            DEFAULT_SLEEP_HEAT,
+        )
+
+        ranges = setpoint_slider_ranges(is_celsius=False)
+        assert ranges["comfort_heat"][2] == DEFAULT_COMFORT_HEAT
+        assert ranges["comfort_cool"][2] == DEFAULT_COMFORT_COOL
+        assert ranges["setback_heat"][2] == DEFAULT_SETBACK_HEAT
+        assert ranges["setback_cool"][2] == DEFAULT_SETBACK_COOL
+        assert ranges["sleep_heat"][2] == DEFAULT_SLEEP_HEAT, (
+            "sleep_heat was the specific field found still hardcoded to the stale 66"
+        )
+        assert ranges["sleep_cool"][2] == DEFAULT_SLEEP_COOL, (
+            "sleep_cool was the specific field found still hardcoded to the stale 78"
+        )
+
+    def test_celsius_defaults_are_the_fahrenheit_defaults_converted(self):
+        """Each Celsius default must equal from_fahrenheit(DEFAULT_X, CELSIUS),
+        rounded to the nearest 0.5 — not an independently hand-picked literal that
+        can silently stop matching the Fahrenheit constant it's supposed to mirror."""
+        from custom_components.climate_advisor.config_flow import setpoint_slider_ranges
+        from custom_components.climate_advisor.const import (
+            DEFAULT_COMFORT_COOL,
+            DEFAULT_COMFORT_HEAT,
+            DEFAULT_SETBACK_COOL,
+            DEFAULT_SETBACK_HEAT,
+            DEFAULT_SLEEP_COOL,
+            DEFAULT_SLEEP_HEAT,
+        )
+        from custom_components.climate_advisor.temperature import CELSIUS, from_fahrenheit
+
+        ranges = setpoint_slider_ranges(is_celsius=True)
+        for key, f_default in (
+            ("comfort_heat", DEFAULT_COMFORT_HEAT),
+            ("comfort_cool", DEFAULT_COMFORT_COOL),
+            ("setback_heat", DEFAULT_SETBACK_HEAT),
+            ("setback_cool", DEFAULT_SETBACK_COOL),
+            ("sleep_heat", DEFAULT_SLEEP_HEAT),
+            ("sleep_cool", DEFAULT_SLEEP_COOL),
+        ):
+            expected = round(from_fahrenheit(f_default, CELSIUS) * 2) / 2
+            assert ranges[key][2] == expected, f"{key}: expected {expected}, got {ranges[key][2]}"
+
+    def test_celsius_sleep_cool_default_is_not_the_old_stale_26(self):
+        """Concrete regression pin: the old hardcoded Celsius sleep_cool default (26,
+        matching the pre-#438 78F) must not reappear."""
+        from custom_components.climate_advisor.config_flow import setpoint_slider_ranges
+
+        ranges = setpoint_slider_ranges(is_celsius=True)
+        assert ranges["sleep_cool"][2] != 26, "26C is the stale pre-#438 default (78F) — must not reappear"
+        assert ranges["sleep_cool"][2] == 22.0
+
+    def test_all_defaults_within_their_own_slider_bounds(self):
+        """Every default (both unit branches) must fall within its own (min, max)."""
+        from custom_components.climate_advisor.config_flow import setpoint_slider_ranges
+
+        for is_celsius in (False, True):
+            ranges = setpoint_slider_ranges(is_celsius)
+            for key, (mn, mx, default, _step) in ranges.items():
+                assert mn <= default <= mx, (
+                    f"{key} ({'C' if is_celsius else 'F'}): default {default} not in [{mn}, {mx}]"
+                )
+
+
 # ---------------------------------------------------------------------------
 # v1→v2 migration
 # ---------------------------------------------------------------------------

--- a/tests/test_desired_state.py
+++ b/tests/test_desired_state.py
@@ -1,0 +1,377 @@
+"""Validation tests for the DesiredState schema (architecture-reset Step 3).
+
+Most of these are NOT production integration tests — most of desired_state.py
+isn't wired into automation.py (deliberately deferred, see the module
+docstring). Each test constructs a DesiredState value from a REAL example
+already present in automation.py/const.py (a real grace duration, a real
+backstop interval, a real notification message) and asserts the schema
+round-trips that information losslessly — proving the design fits actual
+mechanisms, not just a plausible-looking shape.
+
+The grace-period mechanism IS now wired for real: TestDecideGraceStart below
+tests decide_grace_start() directly, and
+tests/test_grace_period_desired_state_integration.py proves
+_start_grace_period() actually calls it.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from custom_components.climate_advisor.const import (
+    DEFAULT_AUTOMATION_GRACE_SECONDS,
+    DEFAULT_MANUAL_GRACE_SECONDS,
+    REVISIT_DELAY_SECONDS,
+)
+from custom_components.climate_advisor.desired_state import (
+    DesiredState,
+    FanCycleOutcome,
+    GraceUntil,
+    NotificationRequest,
+    OverrideConfirmPending,
+    PendingSetpointRetry,
+    ScheduledReevaluation,
+    SetpointRetryAction,
+    SetpointVerify,
+    decide_fan_cycle_off,
+    decide_fan_cycle_on,
+    decide_fan_thermo_backstop,
+    decide_grace_start,
+    decide_override_confirm,
+    decide_revisit,
+    decide_scheduled_write_seq_current,
+    decide_setpoint_retry_action,
+    decide_setpoint_retry_schedule,
+)
+
+_NOW = datetime(2026, 7, 10, 12, 0, 0, tzinfo=UTC)
+
+
+def test_grace_until_represents_automation_grace_start():
+    """Mirrors _start_grace_period("automation", ...): real duration
+    (DEFAULT_AUTOMATION_GRACE_SECONDS=300s), source, and should_notify."""
+    grace = GraceUntil(
+        at=_NOW + timedelta(seconds=DEFAULT_AUTOMATION_GRACE_SECONDS),
+        source="automation",
+        should_notify=True,
+    )
+    assert grace.at == _NOW + timedelta(seconds=300)
+    assert grace.source == "automation"
+    assert grace.should_notify is True
+
+
+def test_grace_until_represents_manual_grace_start():
+    """Mirrors _start_grace_period("manual", ...): DEFAULT_MANUAL_GRACE_SECONDS."""
+    grace = GraceUntil(
+        at=_NOW + timedelta(seconds=DEFAULT_MANUAL_GRACE_SECONDS),
+        source="manual",
+        should_notify=True,
+    )
+    assert grace.source == "manual"
+    assert (grace.at - _NOW).total_seconds() == DEFAULT_MANUAL_GRACE_SECONDS
+
+
+def test_scheduled_reevaluation_represents_revisit_after_action():
+    """Mirrors _schedule_revisit(): fires REVISIT_DELAY_SECONDS (300s) after any action."""
+    revisit = ScheduledReevaluation(at=_NOW + timedelta(seconds=REVISIT_DELAY_SECONDS), reason="revisit")
+    assert revisit.reason == "revisit"
+    assert (revisit.at - _NOW).total_seconds() == 300
+
+
+def test_scheduled_reevaluation_represents_fan_thermo_backstop():
+    """Mirrors _start_fan_thermo_backstop(): self-rescheduling every 5 minutes
+    while a CA-owned fan is active."""
+    backstop = ScheduledReevaluation(at=_NOW + timedelta(minutes=5), reason="fan_thermo_backstop")
+    assert backstop.reason == "fan_thermo_backstop"
+    assert (backstop.at - _NOW).total_seconds() == 300
+
+
+def test_pending_setpoint_retry_represents_nudge_then_real_target():
+    """Mirrors the real 30s nudge-then-retry escalation in _set_temperature():
+    a rejected setpoint gets a small nudge immediately, then the real target
+    is retried 30s later, gated on write_seq matching (a newer command must
+    supersede a stale retry) and reject_streak (how many consecutive
+    rejections have occurred so far)."""
+    retry = PendingSetpointRetry(
+        at=_NOW + timedelta(seconds=30),
+        temperature=72.0,
+        mode="cool",
+        write_seq=5,
+        reject_streak=1,
+    )
+    assert retry.temperature == 72.0
+    assert retry.write_seq == 5
+    assert retry.reject_streak == 1
+
+
+def test_override_confirm_pending_represents_detected_mode_change():
+    """Mirrors handle_manual_override()'s confirm window: a detected mode
+    change is held pending until confirm_seconds elapses, to distinguish a
+    transient thermostat blip from a real user override."""
+    pending = OverrideConfirmPending(at=_NOW + timedelta(seconds=120), mode="heat")
+    assert pending.mode == "heat"
+
+
+def test_setpoint_verify_represents_post_fan_on_reassert():
+    """Mirrors _verify_setpoint_after_fan_on(): re-assert the setpoint 30s
+    after a fan command, in case the thermostat reverted to its own program."""
+    verify = SetpointVerify(at=_NOW + timedelta(seconds=30), expected_temp=75.0, expected_mode="cool", write_seq=3)
+    assert verify.expected_temp == 75.0
+    assert verify.write_seq == 3
+
+
+def test_notification_request_represents_grace_repause_message():
+    """Mirrors _re_pause_for_open_sensor()'s real notification text (verified
+    against automation.py in the grace-expiry-repause-sensor-still-open golden)."""
+    notice = NotificationRequest(
+        message="Grace period expired but a door/window is still open. HVAC has been paused again.",
+        title="Climate Advisor",
+        notification_type="grace_repause",
+    )
+    assert "still open" in notice.message
+    assert notice.notification_type == "grace_repause"
+
+
+def test_desired_state_combines_instantaneous_and_temporal_fields():
+    """A single decision can express BOTH an instantaneous action (deactivate
+    the fan, matching automation.py's real _deactivate_fan side effects) AND
+    multiple temporal intentions (start grace, request a notification) —
+    the exact shape a converted nat-vent-exit decision would need to return."""
+    state = DesiredState(
+        hvac_mode="cool",
+        fan_command="off",
+        grace_until=GraceUntil(at=_NOW + timedelta(seconds=300), source="automation", should_notify=True),
+        notifications=(
+            NotificationRequest(
+                message="Nat-vent ended — HVAC restored.",
+                title="Climate Advisor",
+                notification_type="nat_vent_exit",
+            ),
+        ),
+    )
+    assert state.hvac_mode == "cool"
+    assert state.fan_command == "off"
+    assert state.grace_until is not None
+    assert len(state.notifications) == 1
+    # Fields not touched by this decision stay unset, not guessed at.
+    assert state.scheduled_reevaluations == ()
+    assert state.pending_setpoint_retry is None
+
+
+class TestDecideGraceStart:
+    """decide_grace_start() — the first real production wiring of a DesiredState type.
+
+    Mirrors _start_grace_period()'s exact source-based resolution and the
+    duration<=0 (disabled) early return.
+    """
+
+    def test_manual_source_uses_manual_duration_and_notify(self):
+        grace = decide_grace_start(
+            source="manual",
+            manual_duration_seconds=180,
+            manual_should_notify=True,
+            automation_duration_seconds=300,
+            automation_should_notify=False,
+            now=_NOW,
+        )
+        assert grace is not None
+        assert grace.source == "manual"
+        assert grace.at == _NOW + timedelta(seconds=180)
+        assert grace.should_notify is True
+
+    def test_automation_source_uses_automation_duration_and_notify(self):
+        grace = decide_grace_start(
+            source="automation",
+            manual_duration_seconds=180,
+            manual_should_notify=True,
+            automation_duration_seconds=300,
+            automation_should_notify=False,
+            now=_NOW,
+        )
+        assert grace is not None
+        assert grace.source == "automation"
+        assert grace.at == _NOW + timedelta(seconds=300)
+        assert grace.should_notify is False
+
+    def test_zero_duration_disables_grace(self):
+        """Mirrors _start_grace_period()'s `if duration <= 0: return` (grace disabled)."""
+        grace = decide_grace_start(
+            source="manual",
+            manual_duration_seconds=0,
+            manual_should_notify=True,
+            automation_duration_seconds=300,
+            automation_should_notify=True,
+            now=_NOW,
+        )
+        assert grace is None
+
+    def test_negative_duration_disables_grace(self):
+        grace = decide_grace_start(
+            source="automation",
+            manual_duration_seconds=300,
+            manual_should_notify=True,
+            automation_duration_seconds=-5,
+            automation_should_notify=True,
+            now=_NOW,
+        )
+        assert grace is None
+
+
+class TestDecideRevisit:
+    def test_schedules_when_callback_registered(self):
+        revisit = decide_revisit(has_revisit_callback=True, delay_seconds=REVISIT_DELAY_SECONDS, now=_NOW)
+        assert revisit is not None
+        assert revisit.reason == "revisit"
+        assert revisit.at == _NOW + timedelta(seconds=REVISIT_DELAY_SECONDS)
+
+    def test_none_when_no_callback_registered(self):
+        """Mirrors _schedule_revisit()'s `if not self._revisit_callback: return`."""
+        revisit = decide_revisit(has_revisit_callback=False, delay_seconds=REVISIT_DELAY_SECONDS, now=_NOW)
+        assert revisit is None
+
+
+class TestDecideFanThermoBackstop:
+    def test_re_arms_when_fan_still_running(self):
+        backstop = decide_fan_thermo_backstop(fan_running=True, delay_seconds=300, now=_NOW)
+        assert backstop is not None
+        assert backstop.reason == "fan_thermo_backstop"
+        assert backstop.at == _NOW + timedelta(seconds=300)
+
+    def test_none_when_fan_no_longer_running(self):
+        """Mirrors _thermo_backstop_task()'s `if self._fan_running:` re-arm guard."""
+        backstop = decide_fan_thermo_backstop(fan_running=False, delay_seconds=300, now=_NOW)
+        assert backstop is None
+
+
+class TestDecideOverrideConfirm:
+    def test_schedules_pending_window_when_enabled(self):
+        pending = decide_override_confirm(confirm_seconds=600, detected_mode="heat", now=_NOW)
+        assert pending is not None
+        assert pending.mode == "heat"
+        assert pending.at == _NOW + timedelta(seconds=600)
+
+    def test_none_when_confirmation_disabled(self):
+        """Mirrors start_override_confirmation()'s `if confirm_seconds <= 0:` immediate-accept branch."""
+        pending = decide_override_confirm(confirm_seconds=0, detected_mode="heat", now=_NOW)
+        assert pending is None
+
+    def test_none_when_confirm_seconds_negative(self):
+        pending = decide_override_confirm(confirm_seconds=-1, detected_mode="cool", now=_NOW)
+        assert pending is None
+
+
+class TestDecideFanCycleOn:
+    _BASE = {
+        "min_runtime_minutes": 20.0,
+        "fan_mode": "whole_house_fan",
+        "fan_override_active": False,
+        "fan_active": False,
+    }
+
+    def _inputs(self, **overrides):
+        return {**self._BASE, **overrides}
+
+    def test_disabled_when_min_runtime_zero(self):
+        outcome, delay = decide_fan_cycle_on(**self._inputs(min_runtime_minutes=0))
+        assert outcome == FanCycleOutcome.DISABLED
+        assert delay is None
+
+    def test_disabled_when_fan_mode_disabled(self):
+        outcome, delay = decide_fan_cycle_on(**self._inputs(fan_mode="disabled"))
+        assert outcome == FanCycleOutcome.DISABLED
+        assert delay is None
+
+    def test_override_suspended_when_user_has_control(self):
+        outcome, delay = decide_fan_cycle_on(**self._inputs(fan_override_active=True))
+        assert outcome == FanCycleOutcome.OVERRIDE_SUSPENDED
+        assert delay is None
+
+    def test_activate_always_on_when_min_runtime_at_least_60(self):
+        outcome, delay = decide_fan_cycle_on(**self._inputs(min_runtime_minutes=60))
+        assert outcome == FanCycleOutcome.ACTIVATE_ALWAYS_ON
+        assert delay is None
+
+    def test_activate_with_off_timer_when_min_runtime_under_60(self):
+        outcome, delay = decide_fan_cycle_on(**self._inputs(min_runtime_minutes=20))
+        assert outcome == FanCycleOutcome.ACTIVATE_WITH_OFF_TIMER
+        assert delay == 20 * 60.0
+
+    def test_retry_later_when_fan_already_active(self):
+        outcome, delay = decide_fan_cycle_on(**self._inputs(fan_active=True))
+        assert outcome == FanCycleOutcome.RETRY_LATER
+        assert delay == 60 * 60.0
+
+
+class TestDecideFanCycleOff:
+    def test_deactivates_when_runtime_active(self):
+        should_deactivate, wait_seconds = decide_fan_cycle_off(fan_min_runtime_active=True, min_runtime_minutes=20.0)
+        assert should_deactivate is True
+        assert wait_seconds == (60 - 20) * 60.0
+
+    def test_no_deactivate_when_runtime_not_active(self):
+        """Mirrors _fan_cycle_off()'s `if self._fan_min_runtime_active:` guard."""
+        should_deactivate, wait_seconds = decide_fan_cycle_off(fan_min_runtime_active=False, min_runtime_minutes=20.0)
+        assert should_deactivate is False
+        assert wait_seconds > 0  # next "on" phase is always scheduled regardless
+
+    def test_wait_seconds_clamped_to_zero_when_min_runtime_exceeds_60(self):
+        """max(0, ...) guard: an (invalid but possible) min_runtime > 60 must not produce
+        a negative wait."""
+        _, wait_seconds = decide_fan_cycle_off(fan_min_runtime_active=True, min_runtime_minutes=90.0)
+        assert wait_seconds == 0.0
+
+
+class TestDecideSetpointRetrySchedule:
+    """The last of the 9 DesiredState mechanisms (architecture-reset session)."""
+
+    def test_backoff_schedule_captures_the_retry_triple(self):
+        """Mirrors _check_single_setpoint_accepted()'s REASSERT branch capturing
+        _retry_seq/_retry_temp/_retry_mode before async_call_later(hass, 900, ...)."""
+        retry = decide_setpoint_retry_schedule(
+            temperature=72.0, mode="cool", write_seq=5, reject_streak=1, delay_seconds=900, now=_NOW
+        )
+        assert retry == PendingSetpointRetry(
+            at=_NOW + timedelta(seconds=900), temperature=72.0, mode="cool", write_seq=5, reject_streak=1
+        )
+
+    def test_nudge_followup_schedule_uses_30s_delay(self):
+        """Mirrors _retry_callback()'s NUDGE_THEN_TARGET branch scheduling
+        _send_real_target 30s out via async_call_later(hass, 30, ...)."""
+        retry = decide_setpoint_retry_schedule(
+            temperature=68.0, mode="heat", write_seq=7, reject_streak=2, delay_seconds=30, now=_NOW
+        )
+        assert retry.at == _NOW + timedelta(seconds=30)
+        assert retry.reject_streak == 2
+
+
+class TestDecideSetpointRetryAction:
+    def test_superseded_when_write_seq_changed(self):
+        """Mirrors _retry_callback()'s `if self._write_seq != _retry_seq: return`."""
+        action = decide_setpoint_retry_action(current_write_seq=6, retry_write_seq=5, reject_streak=0)
+        assert action == SetpointRetryAction.SUPERSEDED
+
+    def test_direct_retry_when_reject_streak_below_two(self):
+        """reject_streak=0 or 1 -> immediate retry, no nudge (Issue #411 threshold)."""
+        action = decide_setpoint_retry_action(current_write_seq=5, retry_write_seq=5, reject_streak=1)
+        assert action == SetpointRetryAction.DIRECT_RETRY
+
+    def test_nudge_then_target_when_reject_streak_at_least_two(self):
+        """reject_streak>=2 -> some thermostat integrations dedup an identical repeated
+        set_temperature payload, so nudge first (Issue #411)."""
+        action = decide_setpoint_retry_action(current_write_seq=5, retry_write_seq=5, reject_streak=2)
+        assert action == SetpointRetryAction.NUDGE_THEN_TARGET
+
+    def test_superseded_takes_priority_over_reject_streak(self):
+        """Matches real code's if/return order: staleness is checked before nudge branching."""
+        action = decide_setpoint_retry_action(current_write_seq=9, retry_write_seq=5, reject_streak=5)
+        assert action == SetpointRetryAction.SUPERSEDED
+
+
+class TestDecideScheduledWriteSeqCurrent:
+    def test_true_when_write_seq_unchanged(self):
+        """Mirrors _send_real_target()'s `if self._write_seq != _retry_seq: return` guard
+        (the True/proceed side)."""
+        assert decide_scheduled_write_seq_current(current_write_seq=5, target_write_seq=5) is True
+
+    def test_false_when_a_newer_command_superseded_it(self):
+        assert decide_scheduled_write_seq_current(current_write_seq=6, target_write_seq=5) is False

--- a/tests/test_differential_harness.py
+++ b/tests/test_differential_harness.py
@@ -1,0 +1,117 @@
+"""Tests for the differential-replay harness (architecture-reset Step 1).
+
+Covers:
+  - the diff engine's own sequence-diff logic (unit),
+  - the positive control ("test the test"): a mutated run MUST diverge, per log type,
+  - old-vs-old determinism: representative goldens diff to zero against themselves.
+
+Mirrors tests/test_production_harness.py's invocation pattern — the harness runner
+manages its own event loop via asyncio.run internally, so these are plain sync tests.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TOOLS = REPO_ROOT / "tools"
+for _p in (str(REPO_ROOT), str(TOOLS)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from tools.sim_harness.differential import (  # noqa: E402
+    LogDivergence,
+    _diff_sequences,
+    bump_setpoint_mutation,
+    diff_runs,
+    extra_event_mutation,
+    old_vs_old,
+)
+
+GOLDEN_DIR = TOOLS / "simulations" / "golden"
+
+# A scenario known to command at least one setpoint and emit classification events —
+# used to exercise both positive controls. Chosen because it applies a classification
+# and cycles occupancy (guaranteed set_temperature calls).
+_SETPOINT_SCENARIO = "away-mode-classification-cycle"
+
+# A small representative spread for old-vs-old determinism checks.
+_REPRESENTATIVE = [
+    "away-mode-classification-cycle",
+    "nat-vent-evening-activation",
+    "warm_day_ceiling_breach_ac_defense",
+    "2026-03-28-overnight",
+]
+
+
+def _load(name: str) -> dict:
+    path = GOLDEN_DIR / f"{name}.json"
+    if not path.exists():
+        pytest.skip(f"golden scenario {name!r} not present")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Diff-engine unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_diff_sequences_identical_is_empty() -> None:
+    assert _diff_sequences([1, 2, 3], [1, 2, 3]) == []
+
+
+def test_diff_sequences_detects_value_change() -> None:
+    divs = _diff_sequences([1, 2, 3], [1, 9, 3])
+    assert len(divs) == 1
+    assert divs[0] == LogDivergence(index=1, a=2, b=9)
+
+
+def test_diff_sequences_detects_length_mismatch() -> None:
+    divs = _diff_sequences([1, 2], [1, 2, 3])
+    assert len(divs) == 1
+    assert divs[0] == LogDivergence(index=2, a=None, b=3)
+
+
+# ---------------------------------------------------------------------------
+# Positive control — the diff engine MUST detect a real difference per log type
+# ---------------------------------------------------------------------------
+
+
+def test_positive_control_action_log_detects_setpoint_mutation() -> None:
+    scen = _load(_SETPOINT_SCENARIO)
+    diff = diff_runs(scen, mutate_b=lambda: bump_setpoint_mutation(5.0), scenario_name=_SETPOINT_SCENARIO)
+    assert not diff.a_error and not diff.b_error, (diff.a_error, diff.b_error)
+    assert diff.action_divergences, (
+        "positive control FAILED: a +5°F setpoint mutation produced no action_log divergence — "
+        "the diff engine cannot be trusted to detect action differences"
+    )
+
+
+def test_positive_control_event_log_detects_extra_event() -> None:
+    scen = _load(_SETPOINT_SCENARIO)
+    diff = diff_runs(scen, mutate_b=extra_event_mutation, scenario_name=_SETPOINT_SCENARIO)
+    assert not diff.a_error and not diff.b_error, (diff.a_error, diff.b_error)
+    assert diff.event_divergences, (
+        "positive control FAILED: the extra-event mutation produced no event_log divergence — "
+        "the diff engine cannot be trusted to detect event differences"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Old-vs-old determinism — identical code, identical inputs → zero divergence
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", _REPRESENTATIVE)
+def test_old_vs_old_is_clean(name: str) -> None:
+    scen = _load(name)
+    diff = old_vs_old(scen, scenario_name=name)
+    assert not diff.a_error and not diff.b_error, (diff.a_error, diff.b_error)
+    assert diff.is_clean, (
+        f"{name}: old-vs-old divergence (a hidden input the harness failed to control): "
+        f"{len(diff.event_divergences)} event, {len(diff.action_divergences)} action divergences"
+    )

--- a/tests/test_enumerator.py
+++ b/tests/test_enumerator.py
@@ -1,0 +1,82 @@
+"""Tests for the boundary-focused t-wise synthetic enumerator (architecture-reset Step 1).
+
+Keeps runtime small: full t=3 sweep (~5809 scenarios) is exercised manually via
+tools/synthetic_enumerate.py, not in the default test suite. These tests validate
+the generator's contract (t-wise coverage, scenario shape) and run a small capped
+sample through the real differential-replay engine.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TOOLS = REPO_ROOT / "tools"
+for _p in (str(REPO_ROOT), str(TOOLS)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from tools.sim_harness.differential import old_vs_old  # noqa: E402
+from tools.sim_harness.enumerator import (  # noqa: E402
+    DIMENSIONS,
+    CoverageStats,
+    assignment_to_scenario,
+    build_enumerated_scenarios,
+    generate_t_wise_assignments,
+)
+
+
+def test_generate_t_wise_covers_every_pair_of_dimensions_at_t2() -> None:
+    """At t=2, every (dim_a, dim_b) pair must have every value combination represented."""
+    assignments = generate_t_wise_assignments(t=2)
+    a, b = DIMENSIONS[0], DIMENSIONS[1]
+    seen = {(x[a.name], x[b.name]) for x in assignments if x[a.name] != a.baseline or x[b.name] != b.baseline}
+    # Every explicit (a,b) combination generated when a,b is the active pair.
+    expected = {(va, vb) for va in a.values for vb in b.values}
+    assert expected <= seen
+
+
+def test_generate_t_wise_count_matches_combinatorics() -> None:
+    import itertools
+    import math
+
+    n = len(DIMENSIONS)
+    t = 3
+    expected = 0
+    for combo in itertools.combinations(DIMENSIONS, t):
+        expected += math.prod(len(d.values) for d in combo)
+    assert len(generate_t_wise_assignments(t=t)) == expected
+    assert CoverageStats.compute(t).total_assignments == expected
+    assert n == len(DIMENSIONS)  # sanity: dimension set didn't shrink silently
+
+
+def test_assignment_to_scenario_produces_valid_scenario_shape() -> None:
+    assignments = generate_t_wise_assignments(t=3)
+    scen = assignment_to_scenario(assignments[0], name="unit_test")
+    assert scen["name"] == "unit_test"
+    assert "events" in scen and len(scen["events"]) >= 2
+    types = [e["type"] for e in scen["events"]]
+    assert "classification" in types
+    assert "temp_update" in types
+    temp_event = next(e for e in scen["events"] if e["type"] == "temp_update")
+    assert isinstance(temp_event["indoor_f"], float)
+    assert isinstance(temp_event["outdoor_f"], float)
+
+
+def test_build_enumerated_scenarios_respects_limit() -> None:
+    scenarios = build_enumerated_scenarios(t=3, limit=17)
+    assert len(scenarios) == 17
+    names = {s.name for s in scenarios}
+    assert len(names) == 17  # all unique
+
+
+def test_small_sample_old_vs_old_is_clean() -> None:
+    """A capped sample of real generated boundary scenarios must diff to zero."""
+    scenarios = build_enumerated_scenarios(t=3, limit=40)
+    bad = []
+    for es in scenarios:
+        d = old_vs_old(es.scenario, scenario_name=es.name)
+        if d.a_error or d.b_error or not d.is_clean:
+            bad.append((es.name, d))
+    assert not bad, f"{len(bad)} synthetic boundary scenario(s) diverged old-vs-old: {[n for n, _ in bad[:5]]}"

--- a/tests/test_fan_control.py
+++ b/tests/test_fan_control.py
@@ -2113,6 +2113,33 @@ class TestReconcileFanDriftIntegration:
         assert engine._fan_active is True, "cycling-on must have re-activated the real fan on the same tick"
 
 
+class TestReconcileFanDriftIntegrationLoadBearing:
+    """Architecture-reset Step 2: proves _reconcile_fan_physical_drift() genuinely calls
+    decide_fan_drift_reconciliation() to decide, not some other code path that happens
+    to agree. Patches the exact name automation.py imports at module scope."""
+
+    def test_forcing_reset_outcome_prevents_a_real_confirmed_correction(self):
+        engine = _make_automation_engine({CONF_FAN_MODE: FAN_MODE_WHOLE_HOUSE})
+        engine._get_fan_physical_state_callback = MagicMock(return_value=False)
+        engine._is_recent_fan_command_callback = MagicMock(return_value=False)
+        engine._clear_fan_flags_and_start_grace = MagicMock()
+        engine._fan_active = True
+
+        from custom_components.climate_advisor.fan_drift_reconciliation import FanDriftOutcome
+
+        with patch(
+            "custom_components.climate_advisor.automation.decide_fan_drift_reconciliation",
+            lambda inputs: (FanDriftOutcome.RESET, 0),
+        ):
+            # Two real drift ticks would normally confirm and correct — forcing RESET
+            # every time must prevent that, proving the real decision function is load-bearing.
+            engine._reconcile_fan_physical_drift()
+            engine._reconcile_fan_physical_drift()
+
+        engine._clear_fan_flags_and_start_grace.assert_not_called()
+        assert engine._fan_drift_tick_count == 0
+
+
 class TestReconcileFanOnStartup:
     """Startup fan reconciliation — no running fan is ever left in limbo (Issue #327)."""
 

--- a/tests/test_fan_drift_reconciliation.py
+++ b/tests/test_fan_drift_reconciliation.py
@@ -1,0 +1,86 @@
+"""Inline unit tests for the pure fan-drift-reconciliation core (architecture-reset Step 2).
+
+Direct tests of decide_fan_drift_reconciliation() — mirrors the
+test_nat_vent_gate.py / test_fan_thermostat_decision.py pattern. Each case
+traces to a real production test in tests/test_fan_control.py's
+TestReconcileFanPhysicalDrift, not an invented boundary.
+"""
+
+from __future__ import annotations
+
+from custom_components.climate_advisor.fan_drift_reconciliation import (
+    FAN_MODE_BOTH,
+    FAN_MODE_WHOLE_HOUSE,
+    FanDriftInputs,
+    FanDriftOutcome,
+    decide_fan_drift_reconciliation,
+)
+
+_BASE = {
+    "fan_active": True,
+    "fan_mode": FAN_MODE_WHOLE_HOUSE,
+    "recent_fan_command": False,
+    "physical_state_available": True,
+    "physical_on": False,
+    "tick_count": 0,
+}
+
+
+def _inputs(**overrides) -> FanDriftInputs:
+    return FanDriftInputs(**{**_BASE, **overrides})
+
+
+def test_reset_when_fan_not_active():
+    outcome, tick = decide_fan_drift_reconciliation(_inputs(fan_active=False, tick_count=1))
+    assert outcome == FanDriftOutcome.RESET
+    assert tick == 0
+
+
+def test_noop_for_hvac_mode_archetype():
+    """FAN_MODE_HVAC (not WHF/BOTH) has no separate physical entity — no-op, tick unchanged."""
+    outcome, tick = decide_fan_drift_reconciliation(_inputs(fan_mode="hvac_fan", tick_count=1))
+    assert outcome == FanDriftOutcome.NOOP
+    assert tick == 1
+
+
+def test_noop_for_both_archetype_reaches_physical_check():
+    """FAN_MODE_BOTH is a valid archetype for this check (not excluded like HVAC-only)."""
+    outcome, tick = decide_fan_drift_reconciliation(_inputs(fan_mode=FAN_MODE_BOTH, physical_on=True))
+    assert outcome == FanDriftOutcome.RESET
+    assert tick == 0
+
+
+def test_reset_on_recent_ca_command_echo():
+    outcome, tick = decide_fan_drift_reconciliation(_inputs(recent_fan_command=True, tick_count=1))
+    assert outcome == FanDriftOutcome.RESET
+    assert tick == 0
+
+
+def test_noop_when_no_physical_state_callback():
+    outcome, tick = decide_fan_drift_reconciliation(_inputs(physical_state_available=False, tick_count=1))
+    assert outcome == FanDriftOutcome.NOOP
+    assert tick == 1
+
+
+def test_noop_command_only_mode_physical_on_none():
+    outcome, tick = decide_fan_drift_reconciliation(_inputs(physical_on=None, tick_count=1))
+    assert outcome == FanDriftOutcome.NOOP
+    assert tick == 1
+
+
+def test_reset_when_physical_state_agrees():
+    outcome, tick = decide_fan_drift_reconciliation(_inputs(physical_on=True, tick_count=1))
+    assert outcome == FanDriftOutcome.RESET
+    assert tick == 0
+
+
+def test_first_drift_tick_awaits_confirmation():
+    outcome, tick = decide_fan_drift_reconciliation(_inputs(physical_on=False, tick_count=0))
+    assert outcome == FanDriftOutcome.AWAITING
+    assert tick == 1
+
+
+def test_second_consecutive_drift_tick_corrects():
+    outcome, tick = decide_fan_drift_reconciliation(_inputs(physical_on=False, tick_count=1))
+    assert outcome == FanDriftOutcome.CORRECT
+    assert tick == 0

--- a/tests/test_fan_thermostat_decision.py
+++ b/tests/test_fan_thermostat_decision.py
@@ -1,0 +1,130 @@
+"""Inline unit tests for the pure fan thermostatic stop check (architecture-reset Step 2).
+
+Direct tests of decide_fan_thermostat_check() and its boundaries — mirrors the
+test_nat_vent_gate.py pattern. Each boundary traces to the real production
+comment/incident that motivated it (#327, #402), not an invented value.
+"""
+
+from __future__ import annotations
+
+from custom_components.climate_advisor.fan_thermostat_decision import (
+    FanThermostatInputs,
+    FanThermostatOutcome,
+    _resolve_vent_floor,
+    decide_fan_thermostat_check,
+)
+
+_BASE = {
+    "indoor": 74.0,
+    "outdoor": 70.0,
+    "comfort_heat_raw": 70.0,
+    "sleep_heat": 64.0,
+    "in_sleep_window": False,
+    "hysteresis": 1.0,
+    "natural_vent_active": False,
+}
+
+
+def _inputs(**overrides) -> FanThermostatInputs:
+    return FanThermostatInputs(**{**_BASE, **overrides})
+
+
+class TestCheck1DirectionReversal:
+    def test_favorable_direction_keeps(self):
+        assert decide_fan_thermostat_check(_inputs(outdoor=70.0, indoor=74.0)) == FanThermostatOutcome.KEEP
+
+    def test_boundary_equal_temps_stops(self):
+        """Non-strict >=: outdoor == indoor already counts as reversed — unlike the
+        reactivation gate's strict '<', this is deliberately a different boundary."""
+        assert decide_fan_thermostat_check(_inputs(outdoor=74.0, indoor=74.0)) == FanThermostatOutcome.STOP_DEACTIVATE
+
+    def test_no_hysteresis_on_stop_side(self):
+        """Explicit production comment: subtracting hysteresis here would kill free
+        cooling ~1F early — e.g. outdoor=71/indoor=72 must still stop, not be
+        protected by the 1.0 hysteresis configured for the reactivation side."""
+        assert (
+            decide_fan_thermostat_check(_inputs(outdoor=71.0, indoor=72.0, hysteresis=1.0)) == FanThermostatOutcome.KEEP
+        )
+        assert (
+            decide_fan_thermostat_check(_inputs(outdoor=72.0, indoor=72.0, hysteresis=1.0))
+            == FanThermostatOutcome.STOP_DEACTIVATE
+        )
+
+    def test_reversal_during_nat_vent_routes_through_exit(self):
+        """Issue #418: must route through the nat-vent exit path, not a plain
+        deactivate, when a nat-vent session is active."""
+        result = decide_fan_thermostat_check(_inputs(outdoor=75.0, indoor=74.0, natural_vent_active=True))
+        assert result == FanThermostatOutcome.STOP_VIA_NAT_VENT_EXIT
+
+    def test_reversal_without_nat_vent_deactivates_plainly(self):
+        result = decide_fan_thermostat_check(_inputs(outdoor=75.0, indoor=74.0, natural_vent_active=False))
+        assert result == FanThermostatOutcome.STOP_DEACTIVATE
+
+    def test_none_outdoor_never_triggers_check1(self):
+        assert decide_fan_thermostat_check(_inputs(outdoor=None, indoor=74.0)) == FanThermostatOutcome.KEEP
+
+    def test_none_indoor_never_triggers_check1(self):
+        assert decide_fan_thermostat_check(_inputs(outdoor=70.0, indoor=None)) == FanThermostatOutcome.KEEP
+
+
+class TestCheck2CooledToFloor:
+    def test_above_floor_keeps(self):
+        assert (
+            decide_fan_thermostat_check(_inputs(indoor=71.0, outdoor=65.0, comfort_heat_raw=70.0))
+            == FanThermostatOutcome.KEEP
+        )
+
+    def test_boundary_at_floor_stops(self):
+        """Non-strict <=: indoor exactly at the floor already stops."""
+        assert (
+            decide_fan_thermostat_check(_inputs(indoor=70.0, outdoor=65.0, comfort_heat_raw=70.0))
+            == FanThermostatOutcome.STOP_COOLED_TO_FLOOR
+        )
+
+    def test_awake_floor_ignores_hysteresis(self):
+        """Deliberate asymmetry: the awake branch does NOT subtract hysteresis from
+        comfort_heat_raw (only the sleep branch subtracts it from sleep_heat)."""
+        assert _resolve_vent_floor(_inputs(comfort_heat_raw=70.0, hysteresis=1.0, in_sleep_window=False)) == 70.0
+
+    def test_sleep_window_uses_hysteresis_adjusted_sleep_floor(self):
+        """Issue #402: the tick-level check must be sleep-aware — indoor sitting
+        between sleep_heat and the flat daytime comfort_heat must NOT stop the fan
+        prematurely during the sleep window, or it preempts nat_vent_temperature_check()'s
+        correct sleep-window cycling before it ever runs."""
+        floor = _resolve_vent_floor(_inputs(sleep_heat=64.0, hysteresis=1.0, in_sleep_window=True))
+        assert floor == 63.0  # 64 - 1
+
+        # Indoor at 67F: above the sleep-aware floor (63F) -> must KEEP running.
+        assert (
+            decide_fan_thermostat_check(
+                _inputs(indoor=67.0, outdoor=60.0, sleep_heat=64.0, hysteresis=1.0, in_sleep_window=True)
+            )
+            == FanThermostatOutcome.KEEP
+        )
+        # Same indoor, same config, but AWAKE: comfort_heat_raw=70F floor -> must STOP.
+        assert (
+            decide_fan_thermostat_check(
+                _inputs(
+                    indoor=67.0,
+                    outdoor=60.0,
+                    comfort_heat_raw=70.0,
+                    sleep_heat=64.0,
+                    hysteresis=1.0,
+                    in_sleep_window=False,
+                )
+            )
+            == FanThermostatOutcome.STOP_COOLED_TO_FLOOR
+        )
+
+    def test_none_indoor_never_triggers_check2(self):
+        assert decide_fan_thermostat_check(_inputs(indoor=None, outdoor=65.0)) == FanThermostatOutcome.KEEP
+
+
+class TestCheckOrdering:
+    def test_check1_takes_priority_over_check2(self):
+        """If both a direction reversal AND a below-floor condition are true
+        simultaneously, Check 1 fires first (matches real code's if/return order)."""
+        result = decide_fan_thermostat_check(
+            _inputs(outdoor=80.0, indoor=65.0, comfort_heat_raw=70.0, natural_vent_active=False)
+        )
+        assert result == FanThermostatOutcome.STOP_DEACTIVATE  # Check 1's outcome, not Check 2's

--- a/tests/test_fan_thermostat_decision_compare.py
+++ b/tests/test_fan_thermostat_decision_compare.py
@@ -1,0 +1,129 @@
+"""Regression test for the fan-thermostat-check old-vs-new comparator (architecture-reset Step 2, slice 2).
+
+Full-scale shadow validation (51 goldens + full t=3 synthetic sweep) is run via
+tools/fan_thermostat_decision_diff.py and recorded in the Step-2 status report —
+too large for the default test suite. This keeps a small, fast regression check
+that the comparator itself still intercepts real calls and agrees.
+
+Coverage history (see the Step-2 status report): this comparator's calls only
+fire when self._fan_running (_fan_active or _natural_vent_active) is already
+True — this file's tests (goldens only) keep guarding that baseline. The
+former "synthetic contributes zero calls" gap is now CLOSED: a two-phase
+synthetic driver (tools/sim_harness/fan_thermostat_two_phase.py) wraps each t=3
+assignment with a real activation preamble (a nat-vent-session activation via
+sensor_open, or a real start_min_fan_runtime_cycles() call for a fan-only
+state) before the assignment's own boundary tick — see
+tests/test_fan_thermostat_two_phase.py and
+tools/fan_thermostat_decision_integration_check.py for that full-scale
+validation (7438 calls, all 4 outcomes genuinely exercised, 0 disagreements).
+
+A sim-harness fidelity fix (tools/sim_harness/run_production.py, adding the
+missing `_async_thermostat_changed`-equivalent dispatch on ordinary temp ticks)
+let 2 goldens (nat-vent-outdoor-rises-above-indoor-exit,
+warm_day_ceiling_breach_ac_defense) newly exercise a real STOP_VIA_NAT_VENT_EXIT
+outcome for the first time — previously every real call was KEEP. That fix also
+uncovered and fixed a real comparator bug: `_reconstruct_inputs` was capturing
+`natural_vent_active` AFTER the real check ran, reading state the STOP_VIA_NAT_VENT_EXIT
+branch itself had already cleared, producing a false disagreement. Fixed by
+capturing inputs before the real call.
+
+`fan_thermostat_check()` in automation.py now calls `decide_fan_thermostat_check()`
+directly (Issue #435 follow-up extraction) — this comparator's "new_outcome" is
+computed via a local import of the SOURCE module
+(`custom_components.climate_advisor.fan_thermostat_decision`), independent of
+automation.py's own top-level-bound import, so patching the source here still
+correctly breaks only the comparator's reconstruction, not real production —
+see tools/sim_harness/fan_thermostat_decision_integration.py for the separate
+positive control that breaks REAL production (patched at
+`automation.decide_fan_thermostat_check`, the name automation.py actually
+calls) to prove the extraction is load-bearing.
+
+Also includes a POSITIVE CONTROL: proves the comparator can actually detect a
+disagreement, not just that it hasn't found one. Forces STOP_DEACTIVATE, an
+outcome genuinely distinct from every real one observed (KEEP,
+STOP_VIA_NAT_VENT_EXIT) — forcing an outcome that already occurs naturally
+would trivially show zero disagreement regardless of whether detection works.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TOOLS = REPO_ROOT / "tools"
+for _p in (str(REPO_ROOT), str(TOOLS)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from tools.sim_harness.fan_thermostat_decision_compare import FanThermostatComparisonRun, compare_scenario  # noqa: E402
+
+GOLDEN_DIR = TOOLS / "simulations" / "golden"
+
+
+def _load_goldens() -> list[tuple[str, dict]]:
+    out = []
+    for path in sorted(GOLDEN_DIR.glob("*.json")):
+        if path.name == "MANIFEST.json":
+            continue
+        out.append((path.stem, json.loads(path.read_text(encoding="utf-8"))))
+    return out
+
+
+def test_comparator_intercepts_real_calls_and_agrees_on_goldens():
+    run = FanThermostatComparisonRun()
+    for name, scen in _load_goldens():
+        compare_scenario(scen, name, run)
+
+    assert run.n_calls > 0, "comparator intercepted zero fan_thermostat_check calls — instrumentation broke"
+    assert not run.errors, run.errors
+    assert not run.disagreements, [(c.scenario_name, c.real_outcome, c.new_outcome) for c in run.disagreements]
+
+
+def test_real_outcomes_never_include_stop_deactivate_or_stop_cooled_to_floor():
+    """Guards the exact premise the positive control below depends on: STOP_DEACTIVATE
+    must remain an outcome no real golden-driven call produces, or forcing it as the
+    positive control's broken value would no longer be a genuinely different outcome.
+    KEEP and STOP_VIA_NAT_VENT_EXIT are both real, observed outcomes (the latter since
+    the Step-2 harness fidelity fix); STOP_DEACTIVATE and STOP_COOLED_TO_FLOOR are not
+    yet exercised by any golden — a real, separate coverage gap, not asserted away here."""
+    from custom_components.climate_advisor.fan_thermostat_decision import FanThermostatOutcome
+
+    run = FanThermostatComparisonRun()
+    for name, scen in _load_goldens():
+        compare_scenario(scen, name, run)
+
+    outcomes = Counter(c.real_outcome for c in run.calls)
+    assert run.n_calls > 0
+    unexpected = {FanThermostatOutcome.STOP_DEACTIVATE, FanThermostatOutcome.STOP_COOLED_TO_FLOOR} & set(outcomes)
+    assert not unexpected, (
+        f"a golden now exercises {unexpected} — the positive control's forced STOP_DEACTIVATE value "
+        f"is no longer distinct from every real outcome; got full distribution {outcomes}"
+    )
+
+
+def test_comparator_positive_control_detects_a_broken_new_function():
+    """Test the test: force decide_fan_thermostat_check() to always return
+    STOP_DEACTIVATE (an outcome distinct from every real observed outcome, per
+    the coverage-gap test above) and confirm the comparator flags every call as
+    a disagreement.
+    """
+    from custom_components.climate_advisor.fan_thermostat_decision import FanThermostatOutcome
+
+    run = FanThermostatComparisonRun()
+    with patch(
+        "custom_components.climate_advisor.fan_thermostat_decision.decide_fan_thermostat_check",
+        lambda inputs: FanThermostatOutcome.STOP_DEACTIVATE,
+    ):
+        for name, scen in _load_goldens():
+            compare_scenario(scen, f"{name}_POSITIVE_CONTROL", run)
+
+    assert run.n_calls > 0, "positive control needs real calls to compare against"
+    assert len(run.disagreements) == run.n_calls, (
+        "positive control FAILED: forcing decide_fan_thermostat_check() to STOP_DEACTIVATE should make "
+        f"EVERY call disagree, but only {len(run.disagreements)}/{run.n_calls} did — "
+        "the comparator cannot be trusted to detect a real bug"
+    )

--- a/tests/test_fan_thermostat_decision_integration.py
+++ b/tests/test_fan_thermostat_decision_integration.py
@@ -1,0 +1,67 @@
+"""Regression test for the fan_thermostat_check production integration (Step 2, slice 2).
+
+automation.py's fan_thermostat_check() now calls decide_fan_thermostat_check()
+directly (Issue #435 follow-up extraction, mirroring Issue #411's precedent for
+the nat-vent gate) — there is no separate "old" implementation left to run
+shadow/substitution comparisons against; production simply IS the pure
+function's caller. What remains to prove is that the extraction is genuinely
+LOAD-BEARING: if decide_fan_thermostat_check() were broken, real production
+behavior (the full action_log/event_log) must actually change, not silently
+keep working via some other code path.
+
+Full-scale validation (all 51 goldens) is run via
+tools/fan_thermostat_decision_integration_check.py --positive-control and
+recorded in the Step-2 status report. This keeps a small, fast regression
+check on one known-good probe golden.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TOOLS = REPO_ROOT / "tools"
+for _p in (str(REPO_ROOT), str(TOOLS)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from tools.sim_harness.differential import diff_runs  # noqa: E402
+from tools.sim_harness.fan_thermostat_decision_integration import break_fan_thermostat_decision  # noqa: E402
+
+GOLDEN_DIR = TOOLS / "simulations" / "golden"
+
+# A long-running golden known to exercise fan_thermostat_check many times (76 calls).
+_PROBE_GOLDEN = "whf_reactivates_after_sleep_floor_exit"
+
+
+def _load(name: str) -> dict:
+    return json.loads((GOLDEN_DIR / f"{name}.json").read_text(encoding="utf-8"))
+
+
+def test_baseline_is_clean_old_vs_old():
+    """Sanity check: two untouched runs of the same scenario must be identical —
+    isolates any divergence found below to the deliberate corruption, not noise."""
+    scen = _load(_PROBE_GOLDEN)
+    diff = diff_runs(scen, scenario_name=_PROBE_GOLDEN)
+    assert not diff.a_error and not diff.b_error, (diff.a_error, diff.b_error)
+    assert diff.is_clean, (
+        f"untouched baseline diverged from itself: {len(diff.event_divergences)} event, "
+        f"{len(diff.action_divergences)} action divergences — hidden nondeterminism, not this test's concern"
+    )
+
+
+def test_corrupting_the_pure_function_changes_real_production_behavior():
+    """The actual load-bearing proof: rotating every decide_fan_thermostat_check()
+    outcome to a different one must cascade into a real, detectable full-scenario
+    divergence — proving automation.py's fan_thermostat_check() really does call
+    this function to decide, not some other code path that happens to agree.
+    """
+    scen = _load(_PROBE_GOLDEN)
+    diff = diff_runs(scen, mutate_b=break_fan_thermostat_decision, scenario_name=f"{_PROBE_GOLDEN}_BROKEN")
+    assert not diff.a_error and not diff.b_error, (diff.a_error, diff.b_error)
+    assert not diff.is_clean, (
+        "positive control FAILED: rotating decide_fan_thermostat_check()'s outcome produced no "
+        f"divergence on {_PROBE_GOLDEN} — the extraction may not be load-bearing in production"
+    )

--- a/tests/test_fan_thermostat_two_phase.py
+++ b/tests/test_fan_thermostat_two_phase.py
@@ -1,0 +1,67 @@
+"""Regression tests for the fan_thermostat_check two-phase synthetic driver (Step 2, slice 2).
+
+Full-scale sweep (51 goldens + full 6819-scenario two-phase synthetic set) is
+run via tools/fan_thermostat_decision_integration_check.py --synthetic all and
+recorded in the Step-2 status report — too large for the default test suite.
+This keeps a small, fast regression check that both preamble variants
+("nat_vent" and "fan_only") build correctly and genuinely reach the comparator,
+including outcomes the single-tick enumerator could never produce
+(STOP_DEACTIVATE, STOP_COOLED_TO_FLOOR, STOP_VIA_NAT_VENT_EXIT).
+"""
+
+from __future__ import annotations
+
+import sys
+from collections import Counter
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TOOLS = REPO_ROOT / "tools"
+for _p in (str(REPO_ROOT), str(TOOLS)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from tools.sim_harness.fan_thermostat_decision_compare import FanThermostatComparisonRun, compare_scenario  # noqa: E402
+from tools.sim_harness.fan_thermostat_two_phase import build_two_phase_scenarios  # noqa: E402
+
+
+def test_both_preamble_variants_are_built():
+    # limit=600: the first non-disabled fan_mode assignment appears at index 501 in the
+    # fixed t=3 generation order (most early combos hold fan_mode at its "disabled"
+    # baseline until it's one of the actively-varied t-wise dimensions) — 600 reliably
+    # includes at least one fan_only-eligible assignment without depending on luck.
+    two_phase = build_two_phase_scenarios(t=3, limit=600)
+    by_preamble = Counter(s.preamble for s in two_phase)
+    assert by_preamble["nat_vent"] > 0, "nat_vent preamble variant missing — every assignment should get one"
+    assert by_preamble["fan_only"] > 0, (
+        "fan_only preamble variant missing from a 600-assignment sample — "
+        "the reachability gate likely regressed (no fan_mode != 'disabled' assignment reached)"
+    )
+
+
+def test_fan_only_preamble_skipped_when_fan_mode_disabled():
+    from tools.sim_harness.enumerator import generate_t_wise_assignments
+    from tools.sim_harness.fan_thermostat_two_phase import build_two_phase_scenario
+
+    disabled_assignment = next(a for a in generate_t_wise_assignments(t=3) if a.get("fan_mode") == "disabled")
+    scen = build_two_phase_scenario(disabled_assignment, preamble="fan_only", name="probe")
+    assert scen is None, "fan_only preamble must be skipped (return None) when fan_mode is disabled"
+
+
+def test_two_phase_sweep_agrees_and_exercises_real_outcomes_beyond_keep():
+    from custom_components.climate_advisor.fan_thermostat_decision import FanThermostatOutcome
+
+    two_phase = build_two_phase_scenarios(t=3, limit=500)
+    run = FanThermostatComparisonRun()
+    for tp in two_phase:
+        compare_scenario(tp.scenario, tp.name, run)
+
+    assert run.n_calls > 0, "two-phase driver intercepted zero calls — instrumentation or preamble broke"
+    assert not run.errors, run.errors
+    assert not run.disagreements, [(c.scenario_name, c.real_outcome, c.new_outcome) for c in run.disagreements]
+
+    outcomes = set(c.real_outcome for c in run.calls)
+    assert outcomes != {FanThermostatOutcome.KEEP}, (
+        "two-phase driver only produced KEEP outcomes on this sample — the activation preambles "
+        "aren't genuinely exercising Check 1/Check 2's stop branches"
+    )

--- a/tests/test_full_surface_integration.py
+++ b/tests/test_full_surface_integration.py
@@ -1,0 +1,75 @@
+"""Regression test for the Step-4 full-surface simultaneous positive control.
+
+Every mechanism on the nat-vent decision surface already has its own dedicated
+positive control (test_nat_vent_gate_integration.py,
+test_fan_thermostat_decision_integration.py, and inline positive controls for
+fan drift reconciliation, reactivation lockout, grace, setpoint retry/verify,
+pre-cool target, pre-cool reschedule). Those each corrupt ONE function at a
+time. This test corrupts EVERY extracted decision point on the surface
+SIMULTANEOUSLY and confirms real production behavior still diverges — proving
+the surface holds together as a whole, not just each piece in isolation, per
+the architecture-reset plan's Step 4 ("full substitution across the whole
+nat-vent surface simultaneously... the actual point at which 'end-to-end' is
+validated").
+
+Full-scale validation (all 56 goldens) is run via
+tools/full_surface_integration_check.py --positive-control (51/56 diverge —
+substantially more than either individual control alone, 31/56 and 7/56
+respectively). This keeps a small, fast regression check on one known-good
+probe golden.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TOOLS = REPO_ROOT / "tools"
+for _p in (str(REPO_ROOT), str(TOOLS)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from tools.sim_harness.differential import diff_runs  # noqa: E402
+from tools.sim_harness.full_surface_integration import break_entire_nat_vent_surface  # noqa: E402
+
+GOLDEN_DIR = TOOLS / "simulations" / "golden"
+
+# Exercises the gate, the tick-level stop check, and grace — a rich probe for the
+# combined corruption (also used as the nat-vent-gate-only probe elsewhere).
+_PROBE_GOLDEN = "2026-03-28-overnight"
+
+
+def _load(name: str) -> dict:
+    return json.loads((GOLDEN_DIR / f"{name}.json").read_text(encoding="utf-8"))
+
+
+def test_baseline_is_clean_old_vs_old():
+    """Sanity check: two untouched runs of the same scenario must be identical —
+    isolates any divergence found below to the deliberate corruption, not noise."""
+    scen = _load(_PROBE_GOLDEN)
+    diff = diff_runs(scen, scenario_name=_PROBE_GOLDEN)
+    assert not diff.a_error and not diff.b_error, (diff.a_error, diff.b_error)
+    assert diff.is_clean, (
+        f"untouched baseline diverged from itself: {len(diff.event_divergences)} event, "
+        f"{len(diff.action_divergences)} action divergences — hidden nondeterminism, not this test's concern"
+    )
+
+
+def test_corrupting_the_entire_surface_simultaneously_changes_real_production_behavior():
+    """The actual Step-4 proof: corrupting every extracted decision point on the
+    nat-vent surface AT ONCE (gate, tick-level stop check, fan drift
+    reconciliation, reactivation lockout, grace start, setpoint retry action,
+    setpoint verify, pre-cool target, pre-cool reschedule) must still cascade
+    into a real, detectable full-scenario divergence — proving none of the
+    corruptions silently mask each other and the whole surface remains
+    genuinely load-bearing when combined, not just each piece alone.
+    """
+    scen = _load(_PROBE_GOLDEN)
+    diff = diff_runs(scen, mutate_b=break_entire_nat_vent_surface, scenario_name=f"{_PROBE_GOLDEN}_FULL_BROKEN")
+    assert not diff.a_error and not diff.b_error, (diff.a_error, diff.b_error)
+    assert not diff.is_clean, (
+        "positive control FAILED: corrupting the entire nat-vent decision surface simultaneously produced "
+        f"no divergence on {_PROBE_GOLDEN} — some corruption may be silently masking another"
+    )

--- a/tests/test_grace_period_desired_state_integration.py
+++ b/tests/test_grace_period_desired_state_integration.py
@@ -1,0 +1,32 @@
+"""Regression test proving _start_grace_period() genuinely calls decide_grace_start()
+to decide (architecture-reset Step 2 / Step 3 wiring), not some other code path
+that happens to agree.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from custom_components.climate_advisor.const import CONF_AUTOMATION_GRACE_PERIOD
+from tests.test_door_window import _make_automation_engine  # noqa: E402
+
+
+def test_forcing_grace_disabled_prevents_a_real_grace_start():
+    """decide_grace_start() forced to always return None (disabled) must prevent
+    _start_grace_period() from actually starting grace, even with a real nonzero
+    duration configured — proving the wiring is load-bearing."""
+    engine = _make_automation_engine({CONF_AUTOMATION_GRACE_PERIOD: 300})
+
+    with (
+        patch("custom_components.climate_advisor.automation.async_call_later") as mock_call_later,
+        patch("custom_components.climate_advisor.automation.callback", side_effect=lambda f: f),
+        patch("custom_components.climate_advisor.automation.decide_grace_start", return_value=None),
+    ):
+        mock_call_later.return_value = MagicMock()
+        engine._start_grace_period(source="automation", trigger="sensor_closed_resume")
+
+    assert engine._grace_active is False, (
+        "forcing decide_grace_start() to return None (disabled) should prevent grace from "
+        "starting even with a real nonzero duration configured — the wiring is load-bearing"
+    )
+    mock_call_later.assert_not_called()

--- a/tests/test_nat_vent_activation.py
+++ b/tests/test_nat_vent_activation.py
@@ -442,6 +442,38 @@ class TestReactivationLockout:
         assert engine._natural_vent_active is True
 
 
+class TestReactivationLockoutLoadBearing:
+    """Architecture-reset Step 2: proves check_natural_vent_conditions() genuinely calls
+    is_reactivation_locked_out() to decide, not some other code path that happens to agree."""
+
+    def test_forcing_never_locked_out_allows_reactivation_within_the_real_window(self):
+        """Same setup as test_reactivation_blocked_within_lockout (10s after exit, well
+        within the real 300s lockout) — but with the lockout function forced to always
+        return False. Reactivation must now proceed, proving the real check is load-bearing."""
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=76.0, nat_vent_delta=3.0, indoor_f=76.0)
+        engine._paused_by_door = True
+        engine._natural_vent_active = False
+        engine._last_outdoor_temp = 68.0
+
+        exit_time = datetime(2026, 4, 20, 20, 0, 0)
+        engine._nat_vent_outdoor_exit_time = exit_time
+        check_time = exit_time + timedelta(seconds=10)  # well within the real 300s lockout
+
+        with (
+            patch(_DT_NOW_PATH, return_value=check_time),
+            patch(
+                "custom_components.climate_advisor.automation.is_reactivation_locked_out",
+                return_value=False,
+            ),
+        ):
+            asyncio.run(engine.check_natural_vent_conditions())
+
+        assert engine._natural_vent_active is True, (
+            "forcing is_reactivation_locked_out() to always return False should let reactivation "
+            "proceed even 10s after an outdoor-warm exit — the real lockout function is load-bearing"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Row 6 — hysteresis: re-activation requires outdoor < indoor - 1.0F
 # ---------------------------------------------------------------------------
@@ -1653,8 +1685,8 @@ class TestNatVentSleepWindowBand:
         """Nat-vent active + sleep window → _apply_comfort_band called once (sleep band only).
 
         Occupant experience: after the fix, the thermostat receives one setpoint write per
-        30-minute cycle overnight — the sleep ceiling (78°F by default) — not two competing
-        writes at 75°F and 78°F that make the thermostat history look like the integration
+        30-minute cycle overnight — the sleep ceiling (72°F by default) — not two competing
+        writes at 74°F and 72°F that make the thermostat history look like the integration
         is malfunctioning.
         """
         engine = self._make_sleep_engine()
@@ -1669,9 +1701,9 @@ class TestNatVentSleepWindowBand:
             f"Expected 1 _apply_comfort_band call during sleep window; got {engine._apply_comfort_band.call_count}"
         )
         band = engine._apply_comfort_band.call_args[0][0]
-        # Sleep band uses DEFAULT_SLEEP_HEAT=66 / DEFAULT_SLEEP_COOL=78, not comfort band 70/75
-        assert band.floor == 66.0, f"Sleep band floor must be sleep_heat=66. Got: {band.floor}"
-        assert band.ceiling == 78.0, f"Sleep band ceiling must be sleep_cool=78. Got: {band.ceiling}"
+        # Sleep band uses DEFAULT_SLEEP_HEAT=64 / DEFAULT_SLEEP_COOL=72, not comfort band 68/74
+        assert band.floor == 64.0, f"Sleep band floor must be sleep_heat=64. Got: {band.floor}"
+        assert band.ceiling == 72.0, f"Sleep band ceiling must be sleep_cool=72. Got: {band.ceiling}"
 
     def test_sleep_window_nat_vent_ac_assist_event_still_emitted(self):
         """nat_vent_ac_assist_armed event fires during sleep window despite skipped setpoint.
@@ -2078,7 +2110,7 @@ class TestNatVentMayReactivateDirect:
         """All four sub-conditions satisfied -> True."""
         engine = _make_engine(comfort_heat=70.0, comfort_cool=75.0)
         result = engine._nat_vent_may_reactivate(
-            outdoor=68.0, indoor=74.0, comfort_heat=70.0, comfort_cool=75.0, threshold=78.0
+            outdoor=68.0, indoor=74.0, comfort_heat=70.0, comfort_cool=75.0, nat_vent_delta=3.0
         )
         assert result is True
 
@@ -2086,7 +2118,7 @@ class TestNatVentMayReactivateDirect:
         """outdoor is None -> False (short-circuit before any other check)."""
         engine = _make_engine(comfort_heat=70.0, comfort_cool=75.0)
         result = engine._nat_vent_may_reactivate(
-            outdoor=None, indoor=74.0, comfort_heat=70.0, comfort_cool=75.0, threshold=78.0
+            outdoor=None, indoor=74.0, comfort_heat=70.0, comfort_cool=75.0, nat_vent_delta=3.0
         )
         assert result is False
 
@@ -2094,7 +2126,7 @@ class TestNatVentMayReactivateDirect:
         """indoor is None -> False (short-circuit before any other check)."""
         engine = _make_engine(comfort_heat=70.0, comfort_cool=75.0)
         result = engine._nat_vent_may_reactivate(
-            outdoor=68.0, indoor=None, comfort_heat=70.0, comfort_cool=75.0, threshold=78.0
+            outdoor=68.0, indoor=None, comfort_heat=70.0, comfort_cool=75.0, nat_vent_delta=3.0
         )
         assert result is False
 
@@ -2105,7 +2137,7 @@ class TestNatVentMayReactivateDirect:
         """
         engine = _make_engine(comfort_heat=70.0, comfort_cool=75.0)
         result = engine._nat_vent_may_reactivate(
-            outdoor=74.0, indoor=74.0, comfort_heat=70.0, comfort_cool=75.0, threshold=78.0
+            outdoor=74.0, indoor=74.0, comfort_heat=70.0, comfort_cool=75.0, nat_vent_delta=3.0
         )
         assert result is False
 
@@ -2116,7 +2148,7 @@ class TestNatVentMayReactivateDirect:
         """
         engine = _make_engine(comfort_heat=70.0, comfort_cool=75.0)
         result = engine._nat_vent_may_reactivate(
-            outdoor=73.5, indoor=74.0, comfort_heat=70.0, comfort_cool=75.0, threshold=78.0, hysteresis=1.0
+            outdoor=73.5, indoor=74.0, comfort_heat=70.0, comfort_cool=75.0, nat_vent_delta=3.0, hysteresis=1.0
         )
         assert result is False
 
@@ -2127,7 +2159,7 @@ class TestNatVentMayReactivateDirect:
         """
         engine = _make_engine(comfort_heat=70.0, comfort_cool=75.0)
         result = engine._nat_vent_may_reactivate(
-            outdoor=65.0, indoor=70.0, comfort_heat=70.0, comfort_cool=75.0, threshold=78.0
+            outdoor=65.0, indoor=70.0, comfort_heat=70.0, comfort_cool=75.0, nat_vent_delta=3.0
         )
         assert result is False
 
@@ -2138,7 +2170,7 @@ class TestNatVentMayReactivateDirect:
         """
         engine = _make_engine(comfort_heat=70.0, comfort_cool=75.0)
         result = engine._nat_vent_may_reactivate(
-            outdoor=78.0, indoor=74.0, comfort_heat=70.0, comfort_cool=75.0, threshold=78.0
+            outdoor=78.0, indoor=74.0, comfort_heat=70.0, comfort_cool=75.0, nat_vent_delta=3.0
         )
         assert result is False
 
@@ -2149,7 +2181,7 @@ class TestNatVentMayReactivateDirect:
         """
         engine = _make_engine(comfort_heat=70.0, comfort_cool=75.0)
         result = engine._nat_vent_may_reactivate(
-            outdoor=65.0, indoor=76.0, comfort_heat=70.0, comfort_cool=75.0, threshold=78.0
+            outdoor=65.0, indoor=76.0, comfort_heat=70.0, comfort_cool=75.0, nat_vent_delta=3.0
         )
         assert result is False
 
@@ -2161,7 +2193,7 @@ class TestNatVentMayReactivateDirect:
         engine = _make_engine(comfort_heat=70.0, comfort_cool=75.0)
         engine.config[CONF_FAN_MODE] = FAN_MODE_WHOLE_HOUSE
         result = engine._nat_vent_may_reactivate(
-            outdoor=65.0, indoor=90.0, comfort_heat=70.0, comfort_cool=75.0, threshold=78.0
+            outdoor=65.0, indoor=90.0, comfort_heat=70.0, comfort_cool=75.0, nat_vent_delta=3.0
         )
         assert result is True, (
             "WHF archetype: _ceiling_threshold() returns None, so indoor far past comfort_cool "
@@ -2177,7 +2209,7 @@ class TestNatVentMayReactivateDirect:
         engine = _make_engine(comfort_heat=70.0, comfort_cool=75.0)
         engine.config[CONF_FAN_MODE] = FAN_MODE_WHOLE_HOUSE
         result = engine._nat_vent_may_reactivate(
-            outdoor=91.0, indoor=90.0, comfort_heat=70.0, comfort_cool=75.0, threshold=95.0
+            outdoor=91.0, indoor=90.0, comfort_heat=70.0, comfort_cool=75.0, nat_vent_delta=20.0
         )
         assert result is False, "WHF still requires outdoor < indoor - hysteresis"
 
@@ -2307,7 +2339,7 @@ class TestIssue402ClassOscillationPrevention:
 
         # Reactivation gate: must allow (ceiling exempt), pure direction-only.
         reactivate_ok = engine._nat_vent_may_reactivate(
-            outdoor=80.0, indoor=90.0, comfort_heat=70.0, comfort_cool=74.0, threshold=90.0
+            outdoor=80.0, indoor=90.0, comfort_heat=70.0, comfort_cool=74.0, nat_vent_delta=16.0
         )
         assert reactivate_ok is True
 
@@ -2335,7 +2367,7 @@ class TestIssue402ClassOscillationPrevention:
         # Default fan_mode is HVAC-fan archetype (not WHF/BOTH) in _make_engine.
 
         reactivate_ok = engine._nat_vent_may_reactivate(
-            outdoor=65.0, indoor=76.0, comfort_heat=70.0, comfort_cool=74.0, threshold=77.0
+            outdoor=65.0, indoor=76.0, comfort_heat=70.0, comfort_cool=74.0, nat_vent_delta=3.0
         )
         assert reactivate_ok is False, "HVAC-fan archetype: ceiling exceeded must block reactivation"
 
@@ -2484,3 +2516,93 @@ class TestDecisionLockHolderTracking:
         asyncio.run(_run_both())
 
         assert seen_holder_while_waiting["holder"] == "first_method"
+
+
+# ---------------------------------------------------------------------------
+# Issue #435: nat_vent_temperature_check() must not report a fan transition
+# that didn't actually happen (fan_mode disabled — no device to control)
+# ---------------------------------------------------------------------------
+
+
+class TestNoSpuriousFanCyclingEventWhenNoFanConfigured:
+    """Issue #435: with fan_mode disabled (manual-window-only nat-vent, a supported
+    configuration), _activate_fan()/_deactivate_fan() correctly no-op — but the
+    cycling branches used to emit nat_vent_fan_on/nat_vent_fan_off unconditionally
+    anyway. _fan_device_label() returns "none" in this config, so the occupant's
+    activity report showed a nonsensical "Nat-vent fan on -- ... / none: auto->on"
+    line claiming a nonexistent device transitioned. Found via the architecture-reset
+    Step 2 sim-harness fidelity fix (tools/sim_harness/run_production.py) that let 3
+    golden scenarios finally exercise this code path.
+
+    Occupant experience: the activity report only shows a fan transition when CA
+    actually commanded a real device — no more phantom "device none" entries.
+    """
+
+    def test_no_fan_on_event_when_indoor_crosses_on_threshold_with_fan_disabled(self):
+        # comfort_heat=70, comfort_cool=74 -> midpoint 72, hysteresis 1.0 -> on_threshold=73
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=74.0, nat_vent_delta=3.0)
+        engine._natural_vent_active = True
+        engine._fan_active = False  # natural resting state with no fan device configured
+        engine._last_outdoor_temp = 60.0  # well below indoor -> outdoor-warm guard doesn't skip
+        engine._async_save_state = AsyncMock()
+
+        emitted: list[tuple] = []
+        engine._emit_event_callback = lambda name, payload: emitted.append((name, payload))
+
+        with patch(_DT_NOW_PATH, return_value=_AWAKE_NOW):
+            asyncio.run(engine.nat_vent_temperature_check(73.0))  # >= on_threshold
+
+        assert engine._fan_active is False, "no fan device configured -- _activate_fan() must stay a no-op"
+        event_names = [e[0] for e in emitted]
+        assert "nat_vent_fan_on" not in event_names, (
+            f"nat_vent_fan_on must not fire when _activate_fan() was a no-op (fan_mode disabled); "
+            f"got events: {event_names}"
+        )
+
+    def test_no_fan_off_event_when_indoor_crosses_off_threshold_with_fan_disabled(self):
+        # comfort_heat=70, comfort_cool=74 -> midpoint 72, hysteresis 1.0 -> off_threshold=71
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=74.0, nat_vent_delta=3.0)
+        engine._natural_vent_active = True
+        # Edge state: _fan_active=True with fan_mode disabled shouldn't occur naturally
+        # (fan_mode disabled means _activate_fan() never sets it), but guards the branch
+        # entry condition (`if self._fan_active and current_temp <= off_threshold`) directly.
+        engine._fan_active = True
+        engine._async_save_state = AsyncMock()
+
+        emitted: list[tuple] = []
+        engine._emit_event_callback = lambda name, payload: emitted.append((name, payload))
+
+        with patch(_DT_NOW_PATH, return_value=_AWAKE_NOW):
+            asyncio.run(engine.nat_vent_temperature_check(71.0))  # <= off_threshold
+
+        assert engine._fan_active is True, "no fan device configured -- _deactivate_fan() must stay a no-op"
+        event_names = [e[0] for e in emitted]
+        assert "nat_vent_fan_off" not in event_names, (
+            f"nat_vent_fan_off must not fire when _deactivate_fan() was a no-op (fan_mode disabled); "
+            f"got events: {event_names}"
+        )
+
+    def test_fan_on_event_still_fires_when_a_real_fan_is_configured(self):
+        """Regression guard for the opposite direction: don't over-correct into never
+        emitting. When a real fan_mode is configured, the transition really happens and
+        the event must still fire — this is the whole_house_fan_hvac_suppression golden's
+        real-cycling case, exercised here at the unit level."""
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=74.0, nat_vent_delta=3.0)
+        engine.config["fan_mode"] = "whole_house_fan"
+        engine.config["fan_entity"] = "fan.whole_house"
+        engine._natural_vent_active = True
+        engine._fan_active = False
+        engine._last_outdoor_temp = 60.0
+        engine._async_save_state = AsyncMock()
+
+        emitted: list[tuple] = []
+        engine._emit_event_callback = lambda name, payload: emitted.append((name, payload))
+
+        with patch(_DT_NOW_PATH, return_value=_AWAKE_NOW):
+            asyncio.run(engine.nat_vent_temperature_check(73.0))  # >= on_threshold
+
+        assert engine._fan_active is True, "a real fan device must actually activate"
+        event_names = [e[0] for e in emitted]
+        assert "nat_vent_fan_on" in event_names, (
+            f"nat_vent_fan_on must still fire when the fan really turned on; got events: {event_names}"
+        )

--- a/tests/test_nat_vent_gate.py
+++ b/tests/test_nat_vent_gate.py
@@ -1,0 +1,122 @@
+"""Inline unit tests for the pure nat-vent reactivation gate (architecture-reset Step 2).
+
+Direct tests of decide_nat_vent_gate() and its helpers — the "proper inline code
+testing" the plan called for, as opposed to relying solely on the differential
+harness. Mirrors the existing test_temperature.py pattern for free_cooling_direction_ok().
+"""
+
+from __future__ import annotations
+
+from custom_components.climate_advisor.nat_vent_gate import (
+    FAN_MODE_BOTH,
+    FAN_MODE_DISABLED,
+    FAN_MODE_HVAC,
+    FAN_MODE_WHOLE_HOUSE,
+    NatVentGateInputs,
+    _resolve_ceiling_threshold,
+    _resolve_comfort_heat,
+    decide_nat_vent_gate,
+)
+
+_BASE = {
+    "outdoor": 70.0,
+    "indoor": 76.0,
+    "comfort_heat_raw": 70.0,
+    "sleep_heat": 64.0,
+    "in_sleep_window": False,
+    "comfort_cool": 76.0,
+    "nat_vent_delta": 3.0,
+    "hysteresis": 0.0,
+    "fan_mode": FAN_MODE_HVAC,
+    "aggressive_savings": False,
+}
+
+
+def _inputs(**overrides) -> NatVentGateInputs:
+    return NatVentGateInputs(**{**_BASE, **overrides})
+
+
+class TestDecideNatVentGate:
+    def test_activates_when_all_four_conditions_met(self):
+        assert decide_nat_vent_gate(_inputs(outdoor=70.0, indoor=76.0)) is True
+
+    def test_none_outdoor_blocks(self):
+        assert decide_nat_vent_gate(_inputs(outdoor=None)) is False
+
+    def test_none_indoor_blocks(self):
+        assert decide_nat_vent_gate(_inputs(indoor=None)) is False
+
+    def test_direction_boundary_equal_temps_blocks(self):
+        """Strict '<' — outdoor == indoor is not favorable (mirrors free_cooling_direction_ok)."""
+        assert decide_nat_vent_gate(_inputs(outdoor=76.0, indoor=76.0)) is False
+
+    def test_direction_boundary_one_tenth_degree_favorable(self):
+        assert decide_nat_vent_gate(_inputs(outdoor=75.9, indoor=76.0)) is True
+
+    def test_hysteresis_shifts_direction_boundary(self):
+        """outdoor < indoor - hysteresis: a 1F hysteresis requires outdoor 1F below indoor."""
+        assert decide_nat_vent_gate(_inputs(outdoor=75.5, indoor=76.0, hysteresis=1.0)) is False
+        assert decide_nat_vent_gate(_inputs(outdoor=74.9, indoor=76.0, hysteresis=1.0)) is True
+
+    def test_floor_boundary_indoor_at_comfort_heat_blocks(self):
+        """Strict '>' on the floor — indoor == comfort_heat is not above the floor."""
+        assert decide_nat_vent_gate(_inputs(indoor=70.0, outdoor=65.0)) is False
+
+    def test_floor_boundary_just_above_activates(self):
+        assert decide_nat_vent_gate(_inputs(indoor=70.1, outdoor=65.0)) is True
+
+    def test_sleep_window_uses_sleep_heat_floor(self):
+        """Issue #417 — indoor between sleep_heat and comfort_heat must activate during sleep."""
+        assert decide_nat_vent_gate(_inputs(indoor=67.0, outdoor=60.0, in_sleep_window=False)) is False
+        assert decide_nat_vent_gate(_inputs(indoor=67.0, outdoor=60.0, in_sleep_window=True)) is True
+
+    def test_threshold_boundary_outdoor_at_threshold_blocks(self):
+        """threshold = comfort_cool(76) + nat_vent_delta(3) = 79; strict '<'.
+        fan_mode=WHOLE_HOUSE isolates this from the (separate) ceiling gate."""
+        assert decide_nat_vent_gate(_inputs(outdoor=79.0, indoor=80.0, fan_mode=FAN_MODE_WHOLE_HOUSE)) is False
+
+    def test_threshold_boundary_just_under_activates(self):
+        assert decide_nat_vent_gate(_inputs(outdoor=78.9, indoor=80.0, fan_mode=FAN_MODE_WHOLE_HOUSE)) is True
+
+    def test_whole_house_fan_has_no_ceiling_gate(self):
+        """Issue #392 — WHF archetype: ceiling never blocks, only direction matters."""
+        assert decide_nat_vent_gate(_inputs(indoor=90.0, outdoor=70.0, fan_mode=FAN_MODE_WHOLE_HOUSE)) is True
+        assert decide_nat_vent_gate(_inputs(indoor=90.0, outdoor=70.0, fan_mode=FAN_MODE_BOTH)) is True
+
+    def test_hvac_fan_ceiling_blocks_above_comfort_cool(self):
+        assert decide_nat_vent_gate(_inputs(indoor=76.1, outdoor=70.0, fan_mode=FAN_MODE_HVAC)) is False
+
+    def test_hvac_fan_ceiling_boundary_at_comfort_cool_allows(self):
+        """Non-strict '<=' on the ceiling check."""
+        assert decide_nat_vent_gate(_inputs(indoor=76.0, outdoor=70.0, fan_mode=FAN_MODE_HVAC)) is True
+
+    def test_aggressive_savings_widens_ceiling(self):
+        assert decide_nat_vent_gate(_inputs(indoor=77.5, outdoor=70.0, aggressive_savings=False)) is False
+        assert decide_nat_vent_gate(_inputs(indoor=77.5, outdoor=70.0, aggressive_savings=True)) is True
+
+    def test_fan_disabled_does_not_affect_the_gate_itself(self):
+        """FAN_MODE_DISABLED isn't special-cased in the gate — the caller (_activate_fan)
+        is what no-ops for disabled; the gate is a pure eligibility question."""
+        assert decide_nat_vent_gate(_inputs(fan_mode=FAN_MODE_DISABLED)) is True
+
+
+class TestResolveComfortHeat:
+    def test_daytime_uses_raw_comfort_heat(self):
+        assert _resolve_comfort_heat(_inputs(in_sleep_window=False)) == 70.0
+
+    def test_sleep_window_uses_sleep_heat(self):
+        assert _resolve_comfort_heat(_inputs(in_sleep_window=True)) == 64.0
+
+
+class TestResolveCeilingThreshold:
+    def test_whole_house_fan_returns_none(self):
+        assert _resolve_ceiling_threshold(_inputs(fan_mode=FAN_MODE_WHOLE_HOUSE)) is None
+
+    def test_both_returns_none(self):
+        assert _resolve_ceiling_threshold(_inputs(fan_mode=FAN_MODE_BOTH)) is None
+
+    def test_hvac_fan_returns_comfort_cool(self):
+        assert _resolve_ceiling_threshold(_inputs(fan_mode=FAN_MODE_HVAC)) == 76.0
+
+    def test_aggressive_savings_adds_margin(self):
+        assert _resolve_ceiling_threshold(_inputs(fan_mode=FAN_MODE_HVAC, aggressive_savings=True)) == 78.0

--- a/tests/test_nat_vent_gate_compare.py
+++ b/tests/test_nat_vent_gate_compare.py
@@ -1,0 +1,100 @@
+"""Regression test for the nat-vent gate old-vs-new comparator (architecture-reset Step 2).
+
+Full-scale validation (51 goldens + full t=3 synthetic sweep, 1106+ gate calls,
+0 disagreements) is run via tools/nat_vent_gate_diff.py and recorded in the Step-2
+status report — too large for the default test suite. This keeps a small, fast
+regression check that the comparator itself still intercepts real calls and agrees.
+
+Uses the real `sensor_open` enumerator dimension (fixed at the source in
+enumerator.py after Step 2 found the original 9-dimension set couldn't reach any
+sensor-gated decision path) rather than a local event-injection workaround.
+
+Also includes a POSITIVE CONTROL: every "agrees" test above only proves the
+comparator hasn't found a disagreement — not that it CAN find one (the same gap
+the old-vs-old harness had before its own positive control was added, per
+tests/test_differential_harness.py). Deliberately breaks the new pure function
+and asserts the comparator flags every call as disagreeing.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TOOLS = REPO_ROOT / "tools"
+for _p in (str(REPO_ROOT), str(TOOLS)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from tools.sim_harness.enumerator import assignment_to_scenario, generate_t_wise_assignments  # noqa: E402
+from tools.sim_harness.nat_vent_gate_compare import GateComparisonRun, compare_scenario  # noqa: E402
+
+GOLDEN_DIR = TOOLS / "simulations" / "golden"
+_PROBE_GOLDEN = "away_natvent_activates_free_cooling"
+
+
+def test_comparator_intercepts_real_gate_calls_and_agrees_on_goldens():
+    run = GateComparisonRun()
+    for path in sorted(GOLDEN_DIR.glob("*.json")):
+        if path.name == "MANIFEST.json":
+            continue
+        import json  # noqa: PLC0415
+
+        scen = json.loads(path.read_text(encoding="utf-8"))
+        compare_scenario(scen, path.stem, run)
+
+    assert run.n_calls > 0, "comparator intercepted zero gate calls — instrumentation broke"
+    assert not run.errors, run.errors
+    assert not run.disagreements, [(c.scenario_name, c.real_result, c.new_result) for c in run.disagreements]
+
+
+def test_comparator_agrees_on_a_synthetic_sample_with_sensor_open():
+    """Without sensor_open=True, the gate is unreachable — the Step-2 finding this test guards.
+    Filters for assignments where sensor_open is the active dimension (rather than a fixed
+    --limit slice) so this stays correct regardless of dimension ordering in enumerator.py."""
+    run = GateComparisonRun()
+    assignments = [a for a in generate_t_wise_assignments(t=3) if a.get("sensor_open") is True][:100]
+    assert assignments, "no t=3 assignment has sensor_open=True — the dimension regressed"
+
+    for i, a in enumerate(assignments):
+        es = assignment_to_scenario(a, name=f"regression_sensor_open_{i:03d}")
+        compare_scenario(es, es["name"], run)
+
+    assert run.n_calls > 0, "sensor_open dimension regressed — gate unreachable again"
+    assert not run.errors, run.errors
+    assert not run.disagreements
+
+
+def test_comparator_positive_control_detects_a_broken_new_function():
+    """Test the test: deliberately invert decide_nat_vent_gate()'s answer and confirm
+    the comparator flags every call as a disagreement. A comparator that always
+    reports 'agrees' would also pass every test above — this proves it doesn't.
+
+    Patched at the SOURCE module (custom_components...nat_vent_gate), not at
+    nat_vent_gate_compare — the comparator imports decide_nat_vent_gate via a
+    LOCAL `from ... import` inside its wrapper function, re-resolved fresh on
+    every call, so patching the comparator module's own namespace is a no-op.
+    """
+    import json
+
+    scen = json.loads((GOLDEN_DIR / f"{_PROBE_GOLDEN}.json").read_text(encoding="utf-8"))
+
+    from custom_components.climate_advisor.nat_vent_gate import decide_nat_vent_gate as original_decide
+
+    def _inverted_decide(inputs):
+        return not original_decide(inputs)
+
+    run = GateComparisonRun()
+    with patch("custom_components.climate_advisor.nat_vent_gate.decide_nat_vent_gate", _inverted_decide):
+        compare_scenario(scen, f"{_PROBE_GOLDEN}_POSITIVE_CONTROL", run)
+
+    assert run.n_calls > 0, (
+        f"positive control needs {_PROBE_GOLDEN} to actually reach the gate — pick a different probe scenario"
+    )
+    assert len(run.disagreements) == run.n_calls, (
+        "positive control FAILED: inverting decide_nat_vent_gate() should make EVERY "
+        f"call disagree, but only {len(run.disagreements)}/{run.n_calls} did — "
+        "the comparator cannot be trusted to detect a real bug"
+    )

--- a/tests/test_nat_vent_gate_integration.py
+++ b/tests/test_nat_vent_gate_integration.py
@@ -1,0 +1,67 @@
+"""Regression test for the nat-vent gate production integration.
+
+automation.py's `_nat_vent_may_reactivate()` now calls `decide_nat_vent_gate()`
+directly (mirroring Issue #435's fan_thermostat_check extraction) — production
+simply IS the pure function's caller now, so the shadow/substitution
+distinction Step 1/2 built for this gate has collapsed into one. What remains
+to prove is that the extraction is genuinely LOAD-BEARING: if
+decide_nat_vent_gate() were broken, real production behavior (the full
+action_log/event_log) must actually change.
+
+Full-scale validation (all 56 goldens) is run via
+tools/nat_vent_gate_integration_check.py --positive-control and recorded in
+the Step-2 status report. This keeps a small, fast regression check on one
+known-good probe golden.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TOOLS = REPO_ROOT / "tools"
+for _p in (str(REPO_ROOT), str(TOOLS)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from tools.sim_harness.differential import diff_runs  # noqa: E402
+from tools.sim_harness.nat_vent_gate_integration import break_nat_vent_gate  # noqa: E402
+
+GOLDEN_DIR = TOOLS / "simulations" / "golden"
+
+# Reused as a probe elsewhere in this project too (genuinely exercises the gate).
+_PROBE_GOLDEN = "2026-03-28-overnight"
+
+
+def _load(name: str) -> dict:
+    return json.loads((GOLDEN_DIR / f"{name}.json").read_text(encoding="utf-8"))
+
+
+def test_baseline_is_clean_old_vs_old():
+    """Sanity check: two untouched runs of the same scenario must be identical —
+    isolates any divergence found below to the deliberate corruption, not noise."""
+    scen = _load(_PROBE_GOLDEN)
+    diff = diff_runs(scen, scenario_name=_PROBE_GOLDEN)
+    assert not diff.a_error and not diff.b_error, (diff.a_error, diff.b_error)
+    assert diff.is_clean, (
+        f"untouched baseline diverged from itself: {len(diff.event_divergences)} event, "
+        f"{len(diff.action_divergences)} action divergences — hidden nondeterminism, not this test's concern"
+    )
+
+
+def test_corrupting_the_pure_function_changes_real_production_behavior():
+    """The actual load-bearing proof: inverting decide_nat_vent_gate()'s outcome
+    (preserving its None-input safety guarantee, which downstream formatting code
+    relies on) must cascade into a real, detectable full-scenario divergence —
+    proving automation.py's _nat_vent_may_reactivate() really does call this
+    function to decide, not some other code path that happens to agree.
+    """
+    scen = _load(_PROBE_GOLDEN)
+    diff = diff_runs(scen, mutate_b=break_nat_vent_gate, scenario_name=f"{_PROBE_GOLDEN}_BROKEN")
+    assert not diff.a_error and not diff.b_error, (diff.a_error, diff.b_error)
+    assert not diff.is_clean, (
+        "positive control FAILED: inverting decide_nat_vent_gate()'s outcome produced no "
+        f"divergence on {_PROBE_GOLDEN} — the extraction may not be load-bearing in production"
+    )

--- a/tests/test_nat_vent_gate_substitution.py
+++ b/tests/test_nat_vent_gate_substitution.py
@@ -1,0 +1,70 @@
+"""Tests for substitution testing (architecture-reset Step 2, "real end-to-end" gap closed).
+
+Shadow-mode comparison (test_nat_vent_gate_compare.py) only proves "the new
+function WOULD have agreed" — it never lets the new function's answer drive
+real behavior. These tests prove the stronger claim: substituting the new
+function's answer into the live engine produces an IDENTICAL full scenario
+outcome (entire action_log/event_log, not just one function's boolean) to an
+untouched baseline. Full-scale validation (51 goldens + full t=3 synthetic
+sweep, 5860 scenarios, 0 divergences) is run via
+tools/nat_vent_gate_substitution_diff.py and recorded in the Step-2 status
+report — too large for the default test suite.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TOOLS = REPO_ROOT / "tools"
+for _p in (str(REPO_ROOT), str(TOOLS)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from tools.sim_harness.differential import diff_runs  # noqa: E402
+from tools.sim_harness.nat_vent_gate_compare import substitute_new_gate  # noqa: E402
+
+GOLDEN_DIR = TOOLS / "simulations" / "golden"
+
+# A scenario known to actually exercise the nat-vent reactivation gate at least
+# once — chosen because it's used as the positive-control probe elsewhere too.
+_PROBE_GOLDEN = "2026-03-28-overnight"
+
+
+def _load(name: str) -> dict:
+    return json.loads((GOLDEN_DIR / f"{name}.json").read_text(encoding="utf-8"))
+
+
+def test_substitution_produces_identical_full_scenario_on_real_golden():
+    """The real (unbroken) new function, actually driving behavior, must produce
+    a byte-identical action_log/event_log to the untouched baseline."""
+    scen = _load(_PROBE_GOLDEN)
+    diff = diff_runs(scen, mutate_b=substitute_new_gate, scenario_name=_PROBE_GOLDEN)
+    assert not diff.a_error and not diff.b_error, (diff.a_error, diff.b_error)
+    assert diff.is_clean, (
+        f"substitution diverged from baseline on a real scenario: "
+        f"{len(diff.event_divergences)} event, {len(diff.action_divergences)} action divergences — "
+        "letting the new function actually decide changed the outcome, not just its own boolean"
+    )
+
+
+def test_substitution_positive_control_detects_a_broken_new_function():
+    """Test the test: a deliberately broken new function (always False), substituted
+    in, MUST cascade into a real, detectable full-scenario divergence — not just
+    a shadow disagreement. Proves the substitution mechanism can catch downstream
+    effects (e.g. a nat-vent activation event never firing), not only the immediate
+    call site.
+    """
+    scen = _load(_PROBE_GOLDEN)
+    with patch("custom_components.climate_advisor.nat_vent_gate.decide_nat_vent_gate", lambda inputs: False):
+        diff = diff_runs(scen, mutate_b=substitute_new_gate, scenario_name=f"{_PROBE_GOLDEN}_POSITIVE_CONTROL")
+
+    assert not diff.a_error and not diff.b_error, (diff.a_error, diff.b_error)
+    assert not diff.is_clean, (
+        f"positive control FAILED: forcing decide_nat_vent_gate() to always return False "
+        f"produced no divergence on {_PROBE_GOLDEN} — the substitution mechanism cannot be "
+        "trusted to detect a real behavioral bug"
+    )

--- a/tests/test_nat_vent_reactivation_lockout.py
+++ b/tests/test_nat_vent_reactivation_lockout.py
@@ -1,0 +1,29 @@
+"""Inline unit tests for the pure nat-vent reactivation lockout core (architecture-reset Step 2)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from custom_components.climate_advisor.nat_vent_reactivation_lockout import is_reactivation_locked_out
+
+_NOW = datetime(2026, 7, 10, 12, 0, 0, tzinfo=UTC)
+
+
+def test_no_lockout_when_no_prior_exit():
+    assert is_reactivation_locked_out(outdoor_exit_time=None, now=_NOW, lockout_seconds=600) is False
+
+
+def test_locked_out_when_elapsed_less_than_lockout():
+    exit_time = _NOW - timedelta(seconds=100)
+    assert is_reactivation_locked_out(outdoor_exit_time=exit_time, now=_NOW, lockout_seconds=600) is True
+
+
+def test_boundary_elapsed_equal_to_lockout_is_not_locked_out():
+    """Non-strict '<': elapsed == lockout_seconds means the window just closed."""
+    exit_time = _NOW - timedelta(seconds=600)
+    assert is_reactivation_locked_out(outdoor_exit_time=exit_time, now=_NOW, lockout_seconds=600) is False
+
+
+def test_not_locked_out_when_elapsed_exceeds_lockout():
+    exit_time = _NOW - timedelta(seconds=601)
+    assert is_reactivation_locked_out(outdoor_exit_time=exit_time, now=_NOW, lockout_seconds=600) is False

--- a/tests/test_pre_cool.py
+++ b/tests/test_pre_cool.py
@@ -37,11 +37,10 @@ from custom_components.climate_advisor.automation import (  # noqa: E402
 )
 from custom_components.climate_advisor.classifier import DayClassification  # noqa: E402
 from custom_components.climate_advisor.const import (  # noqa: E402
-    DEFAULT_SLEEP_COOL,
+    NAT_VENT_HYSTERESIS_F,
     OCCUPANCY_AWAY,
     OCCUPANCY_HOME,
     OCCUPANCY_VACATION,
-    PRE_COOL_MIN_HEADROOM_F,
 )
 
 # ---------------------------------------------------------------------------
@@ -194,7 +193,14 @@ class TestComputeBedtimeSetbackCoolSignConvention:
 
 
 class TestHandlePreCoolTargetFormula:
-    """Verify the pre-cool target computation: sleep_cool + setback_modifier, floored at comfort_heat+2."""
+    """Verify the pre-cool target computation: sleep_cool + setback_modifier, floored at
+    sleep_heat + hysteresis (compute_pre_cool_target(), architecture-reset session).
+
+    The floor was moved off comfort_heat (a daytime concept) onto sleep_heat + hysteresis —
+    the same "+1 above the floor" convention nat_vent_temperature_check() already uses for
+    sleep-window fan cycling — so pre-cool can travel the full [sleep_heat, sleep_cool] range
+    instead of being clamped near daytime comfort_heat regardless of trend severity (Issue #436).
+    """
 
     def test_target_uses_sleep_cool_plus_modifier(self):
         """Target = sleep_cool(78) + modifier(-3) = 75 with no clamp needed."""
@@ -213,8 +219,19 @@ class TestHandlePreCoolTargetFormula:
         assert payload["target"] == pytest.approx(75.0), f"Expected target 78 + (-3) = 75°F, got {payload['target']}"
 
     def test_target_uses_default_sleep_cool_when_not_configured(self):
-        """Without explicit sleep_cool in config, falls back to DEFAULT_SLEEP_COOL(78)."""
-        engine = _make_engine()  # no sleep_cool in config
+        """Without explicit sleep_cool/sleep_heat in config, falls back to
+        DEFAULT_SLEEP_COOL (72°F) and DEFAULT_SLEEP_HEAT (64°F).
+
+        handle_pre_cool() was fixed (architecture-reset session) to read the same
+        DEFAULT_SLEEP_COOL the bedtime sleep band uses, instead of a stray literal
+        78.0 fallback — the literal was found to invert pre-cool's purpose once
+        DEFAULT_SLEEP_COOL was reformatted to 72 (a real tuned installation's own
+        flatter, cooler overnight default): it would have computed a target WARMER
+        than the new bedtime ceiling. The floor was also moved to sleep_heat + hysteresis
+        (64 + 1 = 65), so the raw target (72 - 3 = 69) is NOT clamped — pre-cool banks
+        the full modifier depth instead of being stuck near comfort_heat.
+        """
+        engine = _make_engine()  # no sleep_cool/sleep_heat in config
         emitted: list[tuple] = []
         engine._emit_event_callback = lambda e, d: emitted.append((e, d))
         engine.set_occupancy_mode(OCCUPANCY_HOME)
@@ -225,26 +242,28 @@ class TestHandlePreCoolTargetFormula:
         applied_events = [(e, d) for e, d in emitted if e == "pre_cool_applied"]
         assert len(applied_events) == 1
         _, payload = applied_events[0]
-        # DEFAULT_SLEEP_COOL=78 + (-3) = 75
-        assert payload["target"] == pytest.approx(DEFAULT_SLEEP_COOL + (-3.0))
+        # DEFAULT_SLEEP_COOL(72) + (-3) = 69, floor = DEFAULT_SLEEP_HEAT(64) + hysteresis(1) = 65
+        # raw(69) > floor(65) -> no clamp
+        assert payload["target"] == pytest.approx(69.0)
 
-    def test_floor_clamp_prevents_target_below_comfort_heat_plus_headroom(self):
-        """When target < comfort_heat + PRE_COOL_MIN_HEADROOM_F, clamp to floor."""
-        # sleep_cool=72, modifier=-5 → raw=67, floor=70+2=72, clamped to 72
-        engine = _make_engine({"sleep_cool": 72.0, "comfort_heat": 70.0})
+    def test_floor_clamp_prevents_target_below_sleep_heat_plus_hysteresis(self):
+        """When raw target < sleep_heat + hysteresis, clamp to that floor."""
+        # sleep_cool=66, sleep_heat defaults to 64, hysteresis defaults to 1 -> floor=65
+        # modifier=-3 -> raw=63, below floor(65) -> clamped to 65
+        engine = _make_engine({"sleep_cool": 66.0})
         emitted: list[tuple] = []
         engine._emit_event_callback = lambda e, d: emitted.append((e, d))
         engine.set_occupancy_mode(OCCUPANCY_HOME)
-        engine._current_classification = _make_classification(setback_modifier=-5.0)
+        engine._current_classification = _make_classification(setback_modifier=-3.0)
 
-        asyncio.run(engine.handle_pre_cool(indoor_temp=70.0, nat_vent_just_closed=False))
+        asyncio.run(engine.handle_pre_cool(indoor_temp=65.0, nat_vent_just_closed=False))
 
         applied_events = [(e, d) for e, d in emitted if e == "pre_cool_applied"]
         assert len(applied_events) == 1
         _, payload = applied_events[0]
-        floor = 70.0 + PRE_COOL_MIN_HEADROOM_F
+        floor = 64.0 + NAT_VENT_HYSTERESIS_F
         assert payload["target"] == pytest.approx(floor), (
-            f"Expected target clamped to comfort_heat(70)+headroom(2)=72°F, got {payload['target']}"
+            f"Expected target clamped to sleep_heat(64)+hysteresis(1)=65°F, got {payload['target']}"
         )
 
     def test_pre_cool_modifier_in_event_payload(self):

--- a/tests/test_pre_cool_reschedule.py
+++ b/tests/test_pre_cool_reschedule.py
@@ -1,0 +1,230 @@
+"""Tests for the pre-cool early-reschedule mechanism (#437 follow-up,
+architecture-reset session).
+
+Occupant impact this closes: on a warming-trend night, pre-cool's AC trigger was
+scheduled ONCE at classification time (window_close_time + 30min, or a wake-4h
+fallback), and never revisited. If nat-vent exited early — the reactivation gate
+firing, a sensor closing, outdoor rising, an away/vacation ceiling exit, or a
+startup reconcile — the occupant's AC still waited for the STATIC, now-stale
+schedule, wasting the gap between the real exit and the original trigger time.
+This mechanism detects the real natural_vent_active True->False transition (via
+_emit_event(), independent of which of the 6 real exit paths caused it) and pulls
+the pending trigger earlier, never later.
+
+Covers:
+  - _decide_pre_cool_reschedule() pure function boundaries
+  - _maybe_reschedule_pre_cool_on_nat_vent_exit() coordinator wiring
+  - _emit_event()'s True->False transition detection (the real production trigger)
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+if "homeassistant" not in sys.modules:
+    from conftest import install_ha_stubs
+
+    install_ha_stubs()
+
+_NOW = datetime(2026, 7, 16, 23, 0, 0, tzinfo=UTC)
+
+
+def _get_coordinator_class():
+    """Return current ClimateAdvisorCoordinator class — avoids stale __globals__."""
+    mod = importlib.import_module("custom_components.climate_advisor.coordinator")
+    return mod.ClimateAdvisorCoordinator
+
+
+from custom_components.climate_advisor.classifier import DayClassification  # noqa: E402
+from custom_components.climate_advisor.coordinator import _decide_pre_cool_reschedule  # noqa: E402
+
+
+def _make_classification(setback_modifier: float = -3.0) -> DayClassification:
+    c = object.__new__(DayClassification)
+    c.__dict__.update(
+        {
+            "day_type": "warm",
+            "trend_direction": "warming",
+            "trend_magnitude": 3.0,
+            "today_high": 88,
+            "today_low": 65,
+            "tomorrow_high": 96,
+            "tomorrow_low": 70,
+            "hvac_mode": "cool",
+            "pre_condition": False,
+            "pre_condition_target": None,
+            "windows_recommended": False,
+            "window_open_time": None,
+            "window_close_time": None,
+            "setback_modifier": setback_modifier,
+        }
+    )
+    return c
+
+
+# ---------------------------------------------------------------------------
+# Pure function: _decide_pre_cool_reschedule()
+# ---------------------------------------------------------------------------
+
+
+class TestDecidePreCoolReschedule:
+    def test_pulls_trigger_earlier_when_candidate_precedes_scheduled_time(self):
+        """Nat-vent exits at 23:00; scheduled trigger was 01:30 — pull it to 23:30."""
+        result = _decide_pre_cool_reschedule(
+            current_trigger_at=_NOW + timedelta(hours=2, minutes=30),
+            setback_modifier=-3.0,
+            nat_vent_close_delay_minutes=30,
+            now=_NOW,
+        )
+        assert result == _NOW + timedelta(minutes=30)
+
+    def test_none_when_no_trigger_pending(self):
+        """Mirrors 'already fired today, or never scheduled' — current_trigger_at is None."""
+        result = _decide_pre_cool_reschedule(
+            current_trigger_at=None,
+            setback_modifier=-3.0,
+            nat_vent_close_delay_minutes=30,
+            now=_NOW,
+        )
+        assert result is None
+
+    def test_none_when_no_warming_trend(self):
+        """setback_modifier >= 0 -> pre-cool wouldn't have been scheduled in the first place."""
+        result = _decide_pre_cool_reschedule(
+            current_trigger_at=_NOW + timedelta(hours=2),
+            setback_modifier=0.0,
+            nat_vent_close_delay_minutes=30,
+            now=_NOW,
+        )
+        assert result is None
+
+    def test_none_when_candidate_would_be_later_not_earlier(self):
+        """Only ever pulls the trigger EARLIER — a nat-vent exit close to (or after) the
+        already-scheduled time must not push pre-cool back."""
+        result = _decide_pre_cool_reschedule(
+            current_trigger_at=_NOW + timedelta(minutes=10),
+            setback_modifier=-3.0,
+            nat_vent_close_delay_minutes=30,
+            now=_NOW,
+        )
+        assert result is None
+
+    def test_none_at_exact_equality_boundary(self):
+        """candidate == current_trigger_at -> no reschedule (non-strict >= guard)."""
+        result = _decide_pre_cool_reschedule(
+            current_trigger_at=_NOW + timedelta(minutes=30),
+            setback_modifier=-3.0,
+            nat_vent_close_delay_minutes=30,
+            now=_NOW,
+        )
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Coordinator wiring: _emit_event() transition detection + reschedule
+# ---------------------------------------------------------------------------
+
+
+def _make_coord_stub():
+    ClimateAdvisorCoordinator = _get_coordinator_class()
+    coord = object.__new__(ClimateAdvisorCoordinator)
+    coord.hass = MagicMock()
+    coord.config = {"comfort_heat": 68, "comfort_cool": 74}
+    coord._event_log = []
+    coord._current_classification = _make_classification(setback_modifier=-3.0)
+    coord._pre_cool_trigger_dt = _NOW + timedelta(hours=2, minutes=30)
+    coord._pre_cool_trigger_cancel = None
+    coord._pre_cool_status = None
+    coord._get_indoor_temp = MagicMock(return_value=74.0)
+    coord._last_outdoor_temp = 65.0
+    coord._nat_vent_was_active = False
+
+    ae = MagicMock()
+    ae._natural_vent_active = False
+    coord.automation_engine = ae
+
+    coord._emit_event = types.MethodType(ClimateAdvisorCoordinator._emit_event, coord)
+    coord._maybe_reschedule_pre_cool_on_nat_vent_exit = types.MethodType(
+        ClimateAdvisorCoordinator._maybe_reschedule_pre_cool_on_nat_vent_exit, coord
+    )
+    coord._async_pre_cool_trigger = MagicMock()
+    return coord
+
+
+class TestMaybeReschedulePreCoolOnNatVentExitLoadBearing:
+    """Positive-control style: proves _emit_event()'s transition detection actually
+    drives the reschedule, not just that the pure function is correct in isolation."""
+
+    def test_true_to_false_transition_reschedules_the_real_timer(self):
+        coord = _make_coord_stub()
+
+        with (
+            patch("custom_components.climate_advisor.coordinator.async_track_point_in_time") as mock_track,
+            patch("custom_components.climate_advisor.coordinator.dt_util.now", return_value=_NOW),
+        ):
+            mock_track.return_value = "cancel-handle"
+
+            # First emit: nat-vent still active -> no transition, no reschedule.
+            coord.automation_engine._natural_vent_active = True
+            coord._emit_event("nat_vent_still_active", {})
+            assert mock_track.call_count == 0
+
+            # Second emit: nat-vent has exited -> True->False transition detected.
+            coord.automation_engine._natural_vent_active = False
+            coord._emit_event("nat_vent_comfort_floor_exit", {})
+
+        assert mock_track.call_count == 1, "the real timer must be rescheduled on the exit transition"
+        _, _, scheduled_at = mock_track.call_args[0]
+        assert scheduled_at == _NOW + timedelta(minutes=30)
+        assert coord._pre_cool_trigger_dt == _NOW + timedelta(minutes=30)
+        assert coord._pre_cool_trigger_cancel == "cancel-handle"
+        assert "rescheduled" in coord._pre_cool_status
+
+    def test_no_reschedule_when_nat_vent_never_transitions(self):
+        """Nat-vent inactive on both emits (no session ran at all) -> no false-positive reschedule."""
+        coord = _make_coord_stub()
+
+        with patch("custom_components.climate_advisor.coordinator.async_track_point_in_time") as mock_track:
+            coord.automation_engine._natural_vent_active = False
+            coord._emit_event("classification_applied", {})
+            coord._emit_event("bedtime_setback", {})
+
+        assert mock_track.call_count == 0
+
+    def test_no_reschedule_when_no_warming_trend(self):
+        """Nat-vent exits, but today has no warming trend -> pre-cool was never pending."""
+        coord = _make_coord_stub()
+        coord._current_classification = _make_classification(setback_modifier=0.0)
+
+        with (
+            patch("custom_components.climate_advisor.coordinator.async_track_point_in_time") as mock_track,
+            patch("custom_components.climate_advisor.coordinator.dt_util.now", return_value=_NOW),
+        ):
+            coord.automation_engine._natural_vent_active = True
+            coord._emit_event("nat_vent_still_active", {})
+            coord.automation_engine._natural_vent_active = False
+            coord._emit_event("nat_vent_comfort_floor_exit", {})
+
+        assert mock_track.call_count == 0
+
+    def test_forcing_decide_function_to_return_none_suppresses_the_reschedule(self):
+        """Load-bearing: patch _decide_pre_cool_reschedule (the name coordinator.py
+        imports/calls at module scope) to always return None; confirm the real
+        transition-triggered call site genuinely dispatches on its answer."""
+        coord = _make_coord_stub()
+
+        with (
+            patch("custom_components.climate_advisor.coordinator.async_track_point_in_time") as mock_track,
+            patch("custom_components.climate_advisor.coordinator.dt_util.now", return_value=_NOW),
+            patch("custom_components.climate_advisor.coordinator._decide_pre_cool_reschedule", return_value=None),
+        ):
+            coord.automation_engine._natural_vent_active = True
+            coord._emit_event("nat_vent_still_active", {})
+            coord.automation_engine._natural_vent_active = False
+            coord._emit_event("nat_vent_comfort_floor_exit", {})
+
+        assert mock_track.call_count == 0, "forcing None must suppress the reschedule — load-bearing confirmed"

--- a/tests/test_setpoint_incident_comfort_cool_default.py
+++ b/tests/test_setpoint_incident_comfort_cool_default.py
@@ -1,0 +1,68 @@
+"""Regression test: the setpoint-mode-inconsistency incident detector in
+_set_temperature() must use the SAME comfort_cool default (DEFAULT_COMFORT_COOL)
+as every other site in the codebase, not a stray literal (architecture-reset
+latent-bug fix).
+
+Before the fix, `mode == "heat" and temperature > (config.get("comfort_cool", 76) + 1.0)`
+used a fallback of 76 while every other comfort_cool default read in
+automation.py/coordinator.py used 75 — a 1F band difference that only mattered
+for installs relying on the default (comfort_cool not explicitly configured).
+The shared default was later reformatted to match a real tuned installation
+(DEFAULT_COMFORT_COOL=74); this test asserts against that named constant
+rather than a hardcoded literal so it can't drift again.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.climate_advisor.automation import AutomationEngine
+from custom_components.climate_advisor.const import DEFAULT_COMFORT_COOL
+
+
+def _make_engine_no_comfort_cool_configured():
+    hass = MagicMock()
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+    hass.async_create_task = MagicMock(side_effect=lambda coro: coro.close())
+    hass.states = MagicMock()
+    climate_state = MagicMock()
+    climate_state.state = "heat"
+    climate_state.attributes = {}
+    hass.states.get = MagicMock(return_value=climate_state)
+
+    config = {
+        "comfort_heat": 70,
+        # comfort_cool intentionally NOT configured -- exercises the default fallback.
+        "notify_service": "notify.notify",
+    }
+    return AutomationEngine(
+        hass=hass,
+        climate_entity="climate.thermostat",
+        weather_entity="weather.forecast_home",
+        door_window_sensors=["binary_sensor.front_door"],
+        notify_service="notify.notify",
+        config=config,
+    )
+
+
+def test_heat_mode_incident_threshold_uses_shared_default_not_a_stray_literal():
+    """temperature=76.5 in heat mode: with DEFAULT_COMFORT_COOL(74), threshold is
+    75 (74+1), so 76.5 > 75 SHOULD trigger the incident -- proving the incident
+    detector reads the same shared default every other comfort_cool site uses."""
+    engine = _make_engine_no_comfort_cool_configured()
+    events: list[tuple] = []
+    engine._emit_event_callback = lambda name, payload: events.append((name, payload))
+
+    asyncio.run(engine._set_temperature(76.5, reason="test", mode="heat"))
+
+    incident_events = [e for e in events if e[0] == "incident_detected"]
+    assert len(incident_events) == 1, (
+        f"expected the setpoint-mode-inconsistency incident to fire at 76.5F in heat mode "
+        f"with the shared comfort_cool default (threshold={DEFAULT_COMFORT_COOL + 1}); got events: {events}"
+    )
+    assert incident_events[0][1]["comfort_cool"] == DEFAULT_COMFORT_COOL, (
+        f"incident payload must report the same comfort_cool default ({DEFAULT_COMFORT_COOL}) other code paths use; "
+        f"got {incident_events[0][1]['comfort_cool']}"
+    )

--- a/tests/test_setpoint_verify_decision.py
+++ b/tests/test_setpoint_verify_decision.py
@@ -1,0 +1,75 @@
+"""Inline unit tests for the pure post-fan setpoint verify core (architecture-reset Step 2).
+
+Direct tests of decide_setpoint_verify() — each traces to the identical
+decision logic previously hand-duplicated in _do_verify_after_fan_on() and
+_do_verify_after_fan_off().
+"""
+
+from __future__ import annotations
+
+from custom_components.climate_advisor.setpoint_verify_decision import (
+    SetpointVerifyOutcome,
+    decide_setpoint_verify,
+)
+
+_BASE = {
+    "current_write_seq": 5,
+    "verify_write_seq": 5,
+    "expected_temp": 72.0,
+    "expected_mode": "cool",
+    "manual_override_active": False,
+    "actual_temp": 72.0,
+}
+
+
+def _inputs(**overrides):
+    return {**_BASE, **overrides}
+
+
+def test_stale_when_write_seq_changed():
+    outcome = decide_setpoint_verify(**_inputs(current_write_seq=6))
+    assert outcome == SetpointVerifyOutcome.STALE
+
+
+def test_no_setpoint_when_expected_temp_none():
+    outcome = decide_setpoint_verify(**_inputs(expected_temp=None))
+    assert outcome == SetpointVerifyOutcome.NO_SETPOINT
+
+
+def test_no_setpoint_when_expected_mode_none():
+    outcome = decide_setpoint_verify(**_inputs(expected_mode=None))
+    assert outcome == SetpointVerifyOutcome.NO_SETPOINT
+
+
+def test_override_active_skips_reassertion():
+    outcome = decide_setpoint_verify(**_inputs(manual_override_active=True, actual_temp=80.0))
+    assert outcome == SetpointVerifyOutcome.OVERRIDE_ACTIVE
+
+
+def test_no_reading_when_actual_temp_none():
+    outcome = decide_setpoint_verify(**_inputs(actual_temp=None))
+    assert outcome == SetpointVerifyOutcome.NO_READING
+
+
+def test_within_tolerance_no_action():
+    outcome = decide_setpoint_verify(**_inputs(actual_temp=72.5))  # 0.5F diff, within 0.6F tolerance
+    assert outcome == SetpointVerifyOutcome.WITHIN_TOLERANCE
+
+
+def test_boundary_exactly_at_tolerance_no_action():
+    """Non-strict boundary: abs(diff) > tolerance triggers reassert; == tolerance does not."""
+    outcome = decide_setpoint_verify(**_inputs(actual_temp=72.6))  # exactly 0.6F diff
+    assert outcome == SetpointVerifyOutcome.WITHIN_TOLERANCE
+
+
+def test_reassert_when_beyond_tolerance():
+    outcome = decide_setpoint_verify(**_inputs(actual_temp=73.0))  # 1.0F diff, beyond 0.6F tolerance
+    assert outcome == SetpointVerifyOutcome.REASSERT
+
+
+def test_stale_check_takes_priority_over_other_conditions():
+    """Matches real code's if/return order: staleness is checked first."""
+    outcome = decide_setpoint_verify(
+        **_inputs(current_write_seq=99, expected_temp=None, manual_override_active=True, actual_temp=None)
+    )
+    assert outcome == SetpointVerifyOutcome.STALE

--- a/tests/test_territory_map.py
+++ b/tests/test_territory_map.py
@@ -1,0 +1,40 @@
+"""Tests for the territory-map coverage instrument (architecture-reset Step 1).
+
+Verifies the map builds over the golden corpus and reports coverage in the shape
+downstream steps depend on. Not asserting the exact blind-spot list (that shifts as
+goldens are added) — only that the instrument runs, records real calls, and yields a
+well-formed coverage report.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TOOLS = REPO_ROOT / "tools"
+for _p in (str(REPO_ROOT), str(TOOLS)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from tools.territory_map import _DECISION_METHODS, build_map  # noqa: E402
+
+
+def test_territory_map_builds_and_records_calls() -> None:
+    m = build_map()
+    assert m["n_goldens"] >= 20, f"expected the full golden set, found {m['n_goldens']}"
+    # The map must report every catalogued decision function (fired or blind).
+    assert set(m["decision_calls"].keys()) == set(_DECISION_METHODS)
+    # The corpus must exercise the core nat-vent/classification paths heavily —
+    # if these are zero, the instrument is not actually wrapping the engine.
+    assert m["decision_calls"]["apply_classification"] > 0
+    assert m["decision_calls"]["check_natural_vent_conditions"] > 0
+    # Control primitives must fire (goldens command setpoints).
+    assert m["control_calls"]["_set_temperature"] > 0
+
+
+def test_territory_map_reports_blind_spots_as_list() -> None:
+    m = build_map()
+    # blind_spots is exactly the decision functions with zero calls.
+    expected = {meth for meth, c in m["decision_calls"].items() if c == 0}
+    assert set(m["blind_spots"]) == expected

--- a/tools/differential_replay.py
+++ b/tools/differential_replay.py
@@ -1,0 +1,253 @@
+"""differential_replay — CLI driver for the differential-replay harness (architecture-reset Step 1).
+
+Two jobs:
+
+  --positive-control   Run the "test the test" checks: a deliberately mutated run
+                       MUST diverge from the baseline, per log type (action + event).
+                       If these ever pass as "clean", the diff engine is broken and
+                       no zero result below can be trusted.
+
+  (default)            Old-vs-old hidden-input hunt: run every golden scenario twice
+                       through the REAL production engine and report any divergence.
+                       Divergence between two runs of identical code == a hidden input
+                       the harness failed to control (wall-clock, RNG, iteration order,
+                       un-snapshotted state). Zero divergence across all goldens is the
+                       Step-1 exit criterion.
+
+  --chart-log PATH     Same old-vs-old hunt, but driven by real (indoor, outdoor)
+                       trajectories from a CA chart_log file instead of the goldens.
+                       Recorded hvac/fan/windows decisions in the log are discarded —
+                       only the physical input trajectory is replayed (see
+                       tools/sim_harness/chart_log_driver.py). This is an INPUT
+                       source, never an output oracle.
+
+Pure test/tooling — imports the sim_harness and reads golden JSON. Touches no
+production code.
+
+Usage:
+  python tools/differential_replay.py                    # old-vs-old over all goldens
+  python tools/differential_replay.py --positive-control # test-the-test
+  python tools/differential_replay.py --limit 5 -v       # first 5 goldens, verbose
+  python tools/differential_replay.py --chart-log scratch_chart_log.json --chart-log-max-entries 500
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import sys
+from pathlib import Path
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_PROJECT_ROOT = os.path.dirname(_HERE)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from tools.sim_harness._loop import close_loop  # noqa: E402
+from tools.sim_harness.chart_log_driver import build_scenario_from_chart_log, load_chart_log  # noqa: E402
+from tools.sim_harness.differential import (  # noqa: E402
+    ScenarioDiff,
+    bump_setpoint_mutation,
+    diff_runs,
+    extra_event_mutation,
+    old_vs_old,
+)
+
+_GOLDEN_DIR = Path(_PROJECT_ROOT) / "tools" / "simulations" / "golden"
+
+
+def _load_goldens(limit: int | None = None) -> list[tuple[str, dict]]:
+    """Load golden scenario JSONs (name, dict), excluding MANIFEST.json."""
+    out: list[tuple[str, dict]] = []
+    for path in sorted(_GOLDEN_DIR.glob("*.json")):
+        if path.name == "MANIFEST.json":
+            continue
+        with path.open(encoding="utf-8") as fh:
+            try:
+                data = json.load(fh)
+            except json.JSONDecodeError as exc:
+                print(f"  SKIP {path.name}: invalid JSON ({exc})")
+                continue
+        out.append((path.stem, data))
+        if limit is not None and len(out) >= limit:
+            break
+    return out
+
+
+def _print_divergences(diff: ScenarioDiff, verbose: bool) -> None:
+    """Print the first few divergences of a non-clean diff."""
+    show = 3 if not verbose else 20
+    for label, divs in (("event", diff.event_divergences), ("action", diff.action_divergences)):
+        for d in divs[:show]:
+            print(f"    [{label} #{d.index}]")
+            print(f"      A: {d.a}")
+            print(f"      B: {d.b}")
+        if len(divs) > show:
+            print(f"    … +{len(divs) - show} more {label} divergences")
+
+
+def run_positive_control(verbose: bool) -> int:
+    """Prove the diff engine detects a real difference in each log type."""
+    goldens = _load_goldens()
+    if not goldens:
+        print("No golden scenarios found — cannot run positive control.")
+        return 1
+
+    print("=== POSITIVE CONTROL (test the test) ===")
+    print("A deliberately mutated run MUST diverge. If any check reports 'clean', the")
+    print("diff engine is broken and no old-vs-old zero result can be trusted.\n")
+
+    # ACTION-log positive control: find a golden whose baseline emits >=1 setpoint,
+    # then confirm the +5F setpoint mutation makes the action_log diverge.
+    action_ok = False
+    action_probe: str | None = None
+    for name, scen in goldens:
+        d = diff_runs(scen, mutate_b=lambda: bump_setpoint_mutation(5.0), scenario_name=name)
+        if d.a_error or d.b_error:
+            continue
+        if d.action_divergences:
+            action_ok = True
+            action_probe = name
+            print(
+                f"[action] DETECTED on '{name}': {len(d.action_divergences)} action divergence(s) "
+                f"under +5F setpoint mutation [OK]"
+            )
+            if verbose:
+                _print_divergences(d, verbose)
+            break
+    if not action_ok:
+        print("[action] FAILED — no golden showed an action_log divergence under setpoint mutation. [FAIL]")
+
+    # EVENT-log positive control: the extra-event mutation must add an event.
+    event_ok = False
+    event_probe: str | None = None
+    for name, scen in goldens:
+        d = diff_runs(scen, mutate_b=extra_event_mutation, scenario_name=name)
+        if d.a_error or d.b_error:
+            continue
+        if d.event_divergences:
+            event_ok = True
+            event_probe = name
+            print(
+                f"[event]  DETECTED on '{name}': {len(d.event_divergences)} event divergence(s) "
+                f"under extra-event mutation [OK]"
+            )
+            if verbose:
+                _print_divergences(d, verbose)
+            break
+    if not event_ok:
+        print("[event]  FAILED — extra-event mutation produced no event_log divergence. [FAIL]")
+
+    print()
+    if action_ok and event_ok:
+        print(
+            f"POSITIVE CONTROL PASSED — diff engine detects action (via '{action_probe}') "
+            f"and event (via '{event_probe}') differences."
+        )
+        return 0
+    print("POSITIVE CONTROL FAILED — do not trust any zero old-vs-old result until fixed.")
+    return 1
+
+
+def run_old_vs_old(limit: int | None, verbose: bool) -> int:
+    """Run every golden twice with identical code and report divergences."""
+    goldens = _load_goldens(limit)
+    print(f"=== OLD-vs-OLD hidden-input hunt ({len(goldens)} golden scenarios) ===")
+    print("Any divergence == a hidden input the harness failed to control.\n")
+
+    clean = 0
+    diverged: list[ScenarioDiff] = []
+    errored: list[ScenarioDiff] = []
+
+    for name, scen in goldens:
+        d = old_vs_old(scen, scenario_name=name)
+        if d.a_error or d.b_error:
+            errored.append(d)
+            print(f"  ERROR   {name}: a={d.a_error} b={d.b_error}")
+            continue
+        if d.is_clean:
+            clean += 1
+            if verbose:
+                print(f"  clean   {name}")
+        else:
+            diverged.append(d)
+            print(f"  DIVERGE {d.summary()}")
+            _print_divergences(d, verbose)
+
+    print("\n--- summary ---")
+    print(f"  clean:    {clean}")
+    print(f"  diverged: {len(diverged)}")
+    print(f"  errored:  {len(errored)}")
+    if diverged:
+        print("\nHidden inputs to capture (scenarios that diverged old-vs-old):")
+        for d in diverged:
+            print(f"  - {d.scenario_name}")
+    if not diverged and not errored:
+        print("\nEXIT CRITERION MET: zero old-vs-old divergence across all goldens.")
+        return 0
+    return 1
+
+
+def run_old_vs_old_chart_log(path: str, max_entries: int | None, stride: int, verbose: bool) -> int:
+    """Old-vs-old hunt driven by real chart_log input trajectories (input-only, no oracle)."""
+    entries = load_chart_log(path)
+    if not entries:
+        print(f"No usable chart_log entries found at {path!r}.")
+        return 1
+
+    scen = build_scenario_from_chart_log(entries, max_entries=max_entries, stride=stride)
+    n_events = len(scen["events"])
+    print(f"=== OLD-vs-OLD chart_log replay: {path} ({n_events} temp_update events) ===")
+    print("Input trajectories only — recorded hvac/fan/windows decisions in the log are")
+    print("discarded; any divergence == a hidden input the harness failed to control.\n")
+
+    if n_events == 0:
+        print("No usable (indoor, outdoor) pairs in this log slice.")
+        return 1
+
+    d = old_vs_old(scen, scenario_name=Path(path).stem)
+    if d.a_error or d.b_error:
+        print(f"  ERROR   a={d.a_error} b={d.b_error}")
+        return 1
+    if d.is_clean:
+        print(f"  clean   {d.scenario_name}  ({n_events} events)")
+        print("\nEXIT CRITERION MET: zero old-vs-old divergence over this chart_log slice.")
+        return 0
+    print(f"  DIVERGE {d.summary()}")
+    _print_divergences(d, verbose)
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    # Windows consoles default to cp1252; production code and our reports emit °F, em-dashes,
+    # etc. Reconfigure to UTF-8 (replace on failure) so reporting never crashes on encoding.
+    with contextlib.suppress(Exception):
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
+
+    parser = argparse.ArgumentParser(description="Differential-replay harness driver.")
+    parser.add_argument("--positive-control", action="store_true", help="Run the test-the-test checks.")
+    parser.add_argument("--limit", type=int, default=None, help="Only run the first N goldens.")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Show clean scenarios / more divergences.")
+    parser.add_argument("--chart-log", type=str, default=None, help="Path to a CA chart_log JSON file to replay.")
+    parser.add_argument(
+        "--chart-log-max-entries",
+        type=int,
+        default=500,
+        help="Cap usable (indoor,outdoor) pairs taken from the end of the log (default 500).",
+    )
+    parser.add_argument("--chart-log-stride", type=int, default=1, help="Use every Nth usable entry.")
+    args = parser.parse_args(argv)
+
+    if args.chart_log:
+        return run_old_vs_old_chart_log(args.chart_log, args.chart_log_max_entries, args.chart_log_stride, args.verbose)
+    if args.positive_control:
+        return run_positive_control(args.verbose)
+    return run_old_vs_old(args.limit, args.verbose)
+
+
+if __name__ == "__main__":
+    _exit_code = main()
+    close_loop()  # avoid a ResourceWarning: unclosed event loop at interpreter exit
+    raise SystemExit(_exit_code)

--- a/tools/fan_thermostat_decision_diff.py
+++ b/tools/fan_thermostat_decision_diff.py
@@ -1,0 +1,158 @@
+"""fan_thermostat_decision_diff — CLI: shadow-mode validation for the fan thermostat check.
+
+Substitution mode is deferred for this function — see
+tools/sim_harness/fan_thermostat_decision_compare.py's module note for why
+(faithful substitution would require hand-reconstructing production side
+effects, which is itself a duplication risk).
+
+Usage:
+  python tools/fan_thermostat_decision_diff.py                  # goldens only
+  python tools/fan_thermostat_decision_diff.py --synthetic all   # + full synthetic sweep
+  python tools/fan_thermostat_decision_diff.py --positive-control
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_PROJECT_ROOT = os.path.dirname(_HERE)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from tools.sim_harness.ha_stubs import install_ha_stubs  # noqa: E402
+
+# Must run BEFORE any custom_components.climate_advisor.* import — importing any
+# submodule (even a pure one with no HA dependency, like fan_thermostat_decision.py)
+# executes the package's __init__.py first, which needs real `homeassistant`
+# unless stubs are installed. Other CLIs in this repo get this transitively via
+# run_production.py's own module-level install_ha_stubs() call; this one imports
+# a pure decision module directly in run_positive_control() before that chain
+# would otherwise fire, so it must be explicit here.
+install_ha_stubs()
+
+from tools.sim_harness._loop import close_loop  # noqa: E402
+from tools.sim_harness.enumerator import build_enumerated_scenarios  # noqa: E402
+from tools.sim_harness.fan_thermostat_decision_compare import (  # noqa: E402
+    FanThermostatComparisonRun,
+    compare_scenario,
+)
+
+_GOLDEN_DIR = Path(_PROJECT_ROOT) / "tools" / "simulations" / "golden"
+
+
+def _load_goldens() -> list[tuple[str, dict]]:
+    out = []
+    for path in sorted(_GOLDEN_DIR.glob("*.json")):
+        if path.name == "MANIFEST.json":
+            continue
+        with path.open(encoding="utf-8") as fh, contextlib.suppress(json.JSONDecodeError):
+            out.append((path.stem, json.load(fh)))
+    return out
+
+
+def run_positive_control(verbose: bool) -> int:
+    """Prove the comparator detects a broken new function.
+
+    Forces the OPPOSITE of KEEP (STOP_DEACTIVATE), not KEEP itself — every real
+    call across the golden corpus is already KEEP (a real, separate coverage
+    finding; see the Step-2 status report), so forcing "always KEEP" would
+    trivially show zero disagreement regardless of whether detection works at
+    all. Forcing a genuinely different outcome is the only valid test here.
+    """
+    from unittest.mock import patch
+
+    from custom_components.climate_advisor.fan_thermostat_decision import FanThermostatOutcome
+
+    print("=== FAN THERMOSTAT CHECK positive control ===")
+    print("Deliberately break decide_fan_thermostat_check() (always STOP_DEACTIVATE), confirm detection.\n")
+
+    goldens = _load_goldens()
+    run = FanThermostatComparisonRun()
+    with patch(
+        "custom_components.climate_advisor.fan_thermostat_decision.decide_fan_thermostat_check",
+        lambda inputs: FanThermostatOutcome.STOP_DEACTIVATE,
+    ):
+        for name, scen in goldens:
+            compare_scenario(scen, f"{name}_BROKEN", run)
+
+    print(f"Calls: {run.n_calls}  Disagree: {len(run.disagreements)}")
+    if verbose:
+        for c in run.disagreements[:10]:
+            print(f"  {c.scenario_name}: real={c.real_outcome} new(broken)={c.new_outcome}")
+
+    if run.n_calls > 0 and run.disagreements:
+        print("\nPOSITIVE CONTROL PASSED — comparator detects a broken new function.")
+        return 0
+    print("\nPOSITIVE CONTROL FAILED (or zero calls intercepted).")
+    return 1
+
+
+def run_sweep(synthetic: str | None, verbose: bool) -> int:
+    goldens = _load_goldens()
+    run = FanThermostatComparisonRun()
+
+    print(f"=== FAN THERMOSTAT CHECK shadow comparison: {len(goldens)} goldens", end="")
+    for name, scen in goldens:
+        compare_scenario(scen, name, run)
+
+    if synthetic:
+        n = None if synthetic == "all" else int(synthetic)
+        synth = build_enumerated_scenarios(t=3, limit=n)
+        print(f" + {len(synth)} synthetic ===\n")
+        for es in synth:
+            compare_scenario(es.scenario, es.name, run)
+    else:
+        print(" ===\n")
+
+    print(f"Calls: {run.n_calls}  Agree: {run.n_agree}  Disagree: {len(run.disagreements)}  Errors: {len(run.errors)}")
+
+    if run.disagreements:
+        print("\n--- DISAGREEMENTS ---")
+        for c in run.disagreements[: (50 if verbose else 10)]:
+            print(f"  [{c.scenario_name}] real={c.real_outcome} new={c.new_outcome}")
+
+    if run.errors:
+        print("\n--- ERRORS ---")
+        for e in run.errors[:10]:
+            print(f"  {e}")
+
+    print(
+        f"\nFAN_THERMOSTAT_RESULT calls={run.n_calls} agree={run.n_agree} "
+        f"disagree={len(run.disagreements)} errors={len(run.errors)}"
+    )
+
+    if not run.disagreements and not run.errors:
+        print(f"\nEXIT CRITERION MET: {run.n_calls}/{run.n_calls} calls agree, old vs new.")
+        return 0
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    with contextlib.suppress(Exception):
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
+    logging.disable(logging.CRITICAL)
+
+    parser = argparse.ArgumentParser(description="Shadow-mode validation for the fan thermostat check.")
+    parser.add_argument(
+        "--synthetic", type=str, default=None, help="Also run N synthetic scenarios ('all' for full sweep)."
+    )
+    parser.add_argument("--positive-control", action="store_true")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.positive_control:
+        return run_positive_control(args.verbose)
+    return run_sweep(args.synthetic, args.verbose)
+
+
+if __name__ == "__main__":
+    _exit_code = main()
+    close_loop()
+    raise SystemExit(_exit_code)

--- a/tools/fan_thermostat_decision_integration_check.py
+++ b/tools/fan_thermostat_decision_integration_check.py
@@ -1,0 +1,132 @@
+"""fan_thermostat_decision_integration_check — CLI: prove the pure-core extraction is load-bearing.
+
+Usage:
+  python tools/fan_thermostat_decision_integration_check.py                 # goldens, positive control
+  python tools/fan_thermostat_decision_integration_check.py --synthetic all # + full synthetic sweep
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_PROJECT_ROOT = os.path.dirname(_HERE)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from tools.sim_harness.ha_stubs import install_ha_stubs  # noqa: E402
+
+install_ha_stubs()
+
+from tools.sim_harness._loop import close_loop  # noqa: E402
+from tools.sim_harness.differential import diff_runs  # noqa: E402
+from tools.sim_harness.fan_thermostat_decision_integration import break_fan_thermostat_decision  # noqa: E402
+from tools.sim_harness.fan_thermostat_two_phase import build_two_phase_scenarios  # noqa: E402
+
+_GOLDEN_DIR = Path(_PROJECT_ROOT) / "tools" / "simulations" / "golden"
+
+
+def _load_goldens() -> list[tuple[str, dict]]:
+    out = []
+    for path in sorted(_GOLDEN_DIR.glob("*.json")):
+        if path.name == "MANIFEST.json":
+            continue
+        with path.open(encoding="utf-8") as fh, contextlib.suppress(json.JSONDecodeError):
+            out.append((path.stem, json.load(fh)))
+    return out
+
+
+def run_positive_control(verbose: bool) -> int:
+    print("=== FAN THERMOSTAT CHECK integration positive control ===")
+    print("Rotate every real decide_fan_thermostat_check() outcome to a different one; confirm every")
+    print("scenario that reaches the function diverges from an untouched baseline.\n")
+
+    goldens = _load_goldens()
+    total = 0
+    diverged = 0
+    for name, scen in goldens:
+        diff = diff_runs(scen, mutate_b=break_fan_thermostat_decision, scenario_name=f"{name}_BROKEN")
+        if diff.a_error or diff.b_error:
+            print(f"  [ERROR] {name}: a_error={diff.a_error} b_error={diff.b_error}")
+            continue
+        total += 1
+        if not diff.is_clean:
+            diverged += 1
+        elif verbose:
+            print(f"  (no divergence — {name} likely never reaches fan_thermostat_check)")
+
+    print(f"\nScenarios: {total}  Diverged: {diverged}")
+    if diverged == 0:
+        print("\nPOSITIVE CONTROL FAILED — no scenario diverged; the extraction may not be load-bearing.")
+        return 1
+    print("\nPOSITIVE CONTROL PASSED — corrupting the pure function changes real production behavior.")
+    return 0
+
+
+def run_sweep(synthetic: str | None, verbose: bool) -> int:
+    from tools.sim_harness.fan_thermostat_decision_compare import FanThermostatComparisonRun, compare_scenario
+
+    goldens = _load_goldens()
+    run = FanThermostatComparisonRun()
+    for name, scen in goldens:
+        compare_scenario(scen, name, run)
+
+    print(f"=== FAN THERMOSTAT CHECK two-phase synthetic sweep: {len(goldens)} goldens", end="")
+    if synthetic:
+        two_phase = build_two_phase_scenarios(t=3, limit=None if synthetic == "all" else int(synthetic))
+        print(f" + {len(two_phase)} two-phase synthetic ===\n")
+        for tp in two_phase:
+            compare_scenario(tp.scenario, tp.name, run)
+    else:
+        print(" ===\n")
+
+    from collections import Counter
+
+    print(f"Calls: {run.n_calls}  Agree: {run.n_agree}  Disagree: {len(run.disagreements)}  Errors: {len(run.errors)}")
+    print(f"Real outcome distribution: {Counter(c.real_outcome for c in run.calls)}")
+
+    if run.disagreements:
+        print("\n--- DISAGREEMENTS ---")
+        for c in run.disagreements[: (50 if verbose else 10)]:
+            print(f"  [{c.scenario_name}] real={c.real_outcome} new={c.new_outcome}")
+    if run.errors:
+        print("\n--- ERRORS ---")
+        for e in run.errors[:10]:
+            print(f"  {e}")
+
+    print(
+        f"\nFAN_THERMOSTAT_TWO_PHASE_RESULT calls={run.n_calls} agree={run.n_agree} "
+        f"disagree={len(run.disagreements)} errors={len(run.errors)}"
+    )
+    if not run.disagreements and not run.errors:
+        print(f"\nEXIT CRITERION MET: {run.n_calls}/{run.n_calls} calls agree.")
+        return 0
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    with contextlib.suppress(Exception):
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
+    logging.disable(logging.CRITICAL)
+
+    parser = argparse.ArgumentParser(description="Prove the fan_thermostat_check pure-core extraction is load-bearing.")
+    parser.add_argument("--synthetic", type=str, default=None, help="Also run two-phase synthetic scenarios.")
+    parser.add_argument("--positive-control", action="store_true")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.positive_control:
+        return run_positive_control(args.verbose)
+    return run_sweep(args.synthetic, args.verbose)
+
+
+if __name__ == "__main__":
+    _exit_code = main()
+    close_loop()
+    raise SystemExit(_exit_code)

--- a/tools/full_surface_integration_check.py
+++ b/tools/full_surface_integration_check.py
@@ -1,0 +1,98 @@
+"""full_surface_integration_check — CLI: Step 4, the full-surface simultaneous
+positive control for the whole nat-vent decision surface.
+
+Usage:
+  python tools/full_surface_integration_check.py --positive-control
+  python tools/full_surface_integration_check.py --positive-control -v
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_PROJECT_ROOT = os.path.dirname(_HERE)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from tools.sim_harness.ha_stubs import install_ha_stubs  # noqa: E402
+
+install_ha_stubs()
+
+from tools.sim_harness._loop import close_loop  # noqa: E402
+from tools.sim_harness.differential import diff_runs  # noqa: E402
+from tools.sim_harness.full_surface_integration import break_entire_nat_vent_surface  # noqa: E402
+
+_GOLDEN_DIR = Path(_PROJECT_ROOT) / "tools" / "simulations" / "golden"
+
+
+def _load_goldens() -> list[tuple[str, dict]]:
+    out = []
+    for path in sorted(_GOLDEN_DIR.glob("*.json")):
+        if path.name == "MANIFEST.json":
+            continue
+        with path.open(encoding="utf-8") as fh, contextlib.suppress(json.JSONDecodeError):
+            out.append((path.stem, json.load(fh)))
+    return out
+
+
+def run_positive_control(verbose: bool) -> int:
+    print("=== FULL NAT-VENT SURFACE integration positive control (Step 4) ===")
+    print("Corrupt EVERY extracted decision point simultaneously (gate, tick-level stop")
+    print("check, fan drift reconciliation, reactivation lockout, grace start, setpoint")
+    print("retry action, setpoint verify, pre-cool target, pre-cool reschedule); confirm")
+    print("real production behavior still diverges from an untouched baseline across the")
+    print("full golden corpus, and that no corruption silently masks another.\n")
+
+    goldens = _load_goldens()
+    total = 0
+    diverged = 0
+    diverged_names: list[str] = []
+    for name, scen in goldens:
+        diff = diff_runs(scen, mutate_b=break_entire_nat_vent_surface, scenario_name=f"{name}_BROKEN")
+        if diff.a_error or diff.b_error:
+            print(f"  [ERROR] {name}: a_error={diff.a_error} b_error={diff.b_error}")
+            continue
+        total += 1
+        if not diff.is_clean:
+            diverged += 1
+            diverged_names.append(name)
+        elif verbose:
+            print(f"  (no divergence — {name} likely never reaches any corrupted decision point)")
+
+    print(f"\nScenarios: {total}  Diverged: {diverged}")
+    if verbose:
+        print(f"Diverged scenarios: {diverged_names}")
+    if diverged == 0:
+        print("\nPOSITIVE CONTROL FAILED — no scenario diverged; the surface may not be load-bearing.")
+        return 1
+    print("\nPOSITIVE CONTROL PASSED — corrupting the whole surface simultaneously changes real production behavior.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    with contextlib.suppress(Exception):
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
+    logging.disable(logging.CRITICAL)
+
+    parser = argparse.ArgumentParser(description="Prove the whole nat-vent decision surface is load-bearing at once.")
+    parser.add_argument("--positive-control", action="store_true")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.positive_control:
+        return run_positive_control(args.verbose)
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":
+    _exit_code = main()
+    close_loop()
+    raise SystemExit(_exit_code)

--- a/tools/nat_vent_gate_diff.py
+++ b/tools/nat_vent_gate_diff.py
@@ -1,0 +1,143 @@
+"""nat_vent_gate_diff — CLI: old-vs-new differential validation of the nat-vent gate.
+
+Architecture-reset Step 2, first real old-vs-new comparison. For every scenario,
+intercepts every call the real production engine makes to
+``_nat_vent_may_reactivate()`` and independently evaluates the new pure
+``decide_nat_vent_gate()`` on the same reconstructed inputs, comparing booleans.
+
+Batching: large synthetic sweeps run as a single long-lived process show the same
+progressive per-scenario slowdown documented for the Step-1 old-vs-old sweep
+(asyncio.run() teardown overhead compounding across thousands of sequential
+calls). Use ``--offset``/``--limit`` to run in batches — each a fresh top-level
+process call (NEVER spawn this as a nested subprocess from within another
+Python process; that reliably deadlocked in this environment during Step 1).
+Aggregate the ``GATE_DIFF_RESULT`` line across batches.
+
+**Tooling finding (Step 2): `| grep` on a backgrounded call reliably stalls in
+this agent-harness environment, independent of workload size** — a 735-scenario
+batch (smaller than four other 1000-scenario batches that each completed in
+~5s) hung indefinitely when piped through `grep`, then completed instantly when
+redirected to a file instead (`python tools/nat_vent_gate_diff.py ... > out.txt
+2>&1`, then read/grep the file separately). Prefer file redirection over pipes
+for any command run through this harness's backgrounding.
+
+Usage:
+  python tools/nat_vent_gate_diff.py                          # goldens only
+  python tools/nat_vent_gate_diff.py --synthetic 500           # + first 500 synthetic
+  python tools/nat_vent_gate_diff.py --synthetic all --skip-goldens --offset 0 --limit 1000
+                                                                 # one batch of the full sweep
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_PROJECT_ROOT = os.path.dirname(_HERE)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from tools.sim_harness._loop import close_loop  # noqa: E402
+from tools.sim_harness.enumerator import build_enumerated_scenarios  # noqa: E402
+from tools.sim_harness.nat_vent_gate_compare import GateComparisonRun, compare_scenario  # noqa: E402
+
+_GOLDEN_DIR = Path(_PROJECT_ROOT) / "tools" / "simulations" / "golden"
+
+
+def _load_goldens() -> list[tuple[str, dict]]:
+    out = []
+    for path in sorted(_GOLDEN_DIR.glob("*.json")):
+        if path.name == "MANIFEST.json":
+            continue
+        with path.open(encoding="utf-8") as fh, contextlib.suppress(json.JSONDecodeError):
+            out.append((path.stem, json.load(fh)))
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    with contextlib.suppress(Exception):
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
+
+    parser = argparse.ArgumentParser(description="Old-vs-new differential validation of the nat-vent gate.")
+    parser.add_argument(
+        "--synthetic",
+        type=str,
+        default=None,
+        help="Also run N synthetic t=3 scenarios ('all' for the full sweep, ~5809 scenarios).",
+    )
+    parser.add_argument("--offset", type=int, default=0, help="Skip the first N synthetic assignments (batching).")
+    parser.add_argument("--skip-goldens", action="store_true", help="Skip goldens (for synthetic-only batches).")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Show every disagreement in full.")
+    parser.add_argument("--quiet-production-logs", action="store_true", default=True)
+    args = parser.parse_args(argv)
+
+    if args.quiet_production_logs:
+        logging.disable(logging.CRITICAL)
+
+    run = GateComparisonRun()
+
+    goldens = [] if args.skip_goldens else _load_goldens()
+    print(f"=== NAT-VENT GATE old-vs-new: {len(goldens)} goldens", end="")
+    if args.synthetic:
+        n = None if args.synthetic == "all" else int(args.synthetic)
+        print(f" + {'all' if n is None else n} synthetic t=3 (offset={args.offset})", end="")
+    print(" ===\n")
+
+    for name, scen in goldens:
+        try:
+            compare_scenario(scen, name, run)
+        except Exception as exc:  # noqa: BLE001
+            run.errors.append(f"{name}: scenario run error: {type(exc).__name__}: {exc}")
+
+    if args.synthetic:
+        n = None if args.synthetic == "all" else int(args.synthetic)
+        synth = build_enumerated_scenarios(t=3, limit=n, offset=args.offset)
+        for es in synth:
+            try:
+                compare_scenario(es.scenario, es.name, run)
+            except Exception as exc:  # noqa: BLE001
+                run.errors.append(f"{es.name}: scenario run error: {type(exc).__name__}: {exc}")
+
+    print(f"Gate calls intercepted: {run.n_calls}")
+    print(f"Agree:                  {run.n_agree}")
+    print(f"Disagree:               {len(run.disagreements)}")
+    print(f"Comparator errors:      {len(run.errors)}")
+
+    if run.disagreements:
+        print("\n--- DISAGREEMENTS ---")
+        for c in run.disagreements[: (50 if args.verbose else 10)]:
+            print(f"  [{c.scenario_name}] real={c.real_result} new={c.new_result}")
+            print(f"    real_kwargs: {c.real_kwargs}")
+            print(f"    new_inputs:  {c.new_inputs}")
+        if not args.verbose and len(run.disagreements) > 10:
+            print(f"  ... +{len(run.disagreements) - 10} more (use -v to see all)")
+
+    if run.errors:
+        print("\n--- COMPARATOR ERRORS ---")
+        for e in run.errors[:10]:
+            print(f"  {e}")
+
+    print(
+        f"\nGATE_DIFF_RESULT calls={run.n_calls} agree={run.n_agree} "
+        f"disagree={len(run.disagreements)} errors={len(run.errors)}"
+    )
+
+    if not run.disagreements and not run.errors and run.n_calls > 0:
+        print(f"\nEXIT CRITERION MET: {run.n_calls}/{run.n_calls} gate calls agree, old vs new.")
+        return 0
+    if run.n_calls == 0:
+        print("\nWARNING: zero gate calls intercepted — nothing was actually compared.")
+        return 1
+    return 1
+
+
+if __name__ == "__main__":
+    _exit_code = main()
+    close_loop()  # avoid a ResourceWarning: unclosed event loop at interpreter exit
+    raise SystemExit(_exit_code)

--- a/tools/nat_vent_gate_integration_check.py
+++ b/tools/nat_vent_gate_integration_check.py
@@ -1,0 +1,89 @@
+"""nat_vent_gate_integration_check — CLI: prove the pure-core gate extraction is load-bearing.
+
+Usage:
+  python tools/nat_vent_gate_integration_check.py --positive-control
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_PROJECT_ROOT = os.path.dirname(_HERE)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from tools.sim_harness.ha_stubs import install_ha_stubs  # noqa: E402
+
+install_ha_stubs()
+
+from tools.sim_harness._loop import close_loop  # noqa: E402
+from tools.sim_harness.differential import diff_runs  # noqa: E402
+from tools.sim_harness.nat_vent_gate_integration import break_nat_vent_gate  # noqa: E402
+
+_GOLDEN_DIR = Path(_PROJECT_ROOT) / "tools" / "simulations" / "golden"
+
+
+def _load_goldens() -> list[tuple[str, dict]]:
+    out = []
+    for path in sorted(_GOLDEN_DIR.glob("*.json")):
+        if path.name == "MANIFEST.json":
+            continue
+        with path.open(encoding="utf-8") as fh, contextlib.suppress(json.JSONDecodeError):
+            out.append((path.stem, json.load(fh)))
+    return out
+
+
+def run_positive_control(verbose: bool) -> int:
+    print("=== NAT-VENT GATE integration positive control ===")
+    print("Invert every real decide_nat_vent_gate() outcome; confirm every scenario that")
+    print("reaches the gate diverges from an untouched baseline.\n")
+
+    goldens = _load_goldens()
+    total = 0
+    diverged = 0
+    for name, scen in goldens:
+        diff = diff_runs(scen, mutate_b=break_nat_vent_gate, scenario_name=f"{name}_BROKEN")
+        if diff.a_error or diff.b_error:
+            print(f"  [ERROR] {name}: a_error={diff.a_error} b_error={diff.b_error}")
+            continue
+        total += 1
+        if not diff.is_clean:
+            diverged += 1
+        elif verbose:
+            print(f"  (no divergence — {name} likely never reaches the reactivation gate)")
+
+    print(f"\nScenarios: {total}  Diverged: {diverged}")
+    if diverged == 0:
+        print("\nPOSITIVE CONTROL FAILED — no scenario diverged; the extraction may not be load-bearing.")
+        return 1
+    print("\nPOSITIVE CONTROL PASSED — corrupting the pure function changes real production behavior.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    with contextlib.suppress(Exception):
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
+    logging.disable(logging.CRITICAL)
+
+    parser = argparse.ArgumentParser(description="Prove the nat-vent gate pure-core extraction is load-bearing.")
+    parser.add_argument("--positive-control", action="store_true")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.positive_control:
+        return run_positive_control(args.verbose)
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":
+    _exit_code = main()
+    close_loop()
+    raise SystemExit(_exit_code)

--- a/tools/nat_vent_gate_substitution_diff.py
+++ b/tools/nat_vent_gate_substitution_diff.py
@@ -1,0 +1,156 @@
+"""nat_vent_gate_substitution_diff — CLI: full-scenario substitution testing.
+
+Closes the gap shadow-mode comparison left open: proves that letting the new
+pure ``decide_nat_vent_gate()`` actually DRIVE the live engine (not just answer
+a shadow question) produces an IDENTICAL full scenario outcome — the entire
+``action_log``/``event_log``, not just the one function's boolean — to an
+untouched baseline run.
+
+Includes its own positive control (a substitution CLI that always reports
+"identical" would be worthless) — see ``run_positive_control()``.
+
+Usage:
+  python tools/nat_vent_gate_substitution_diff.py                  # goldens only
+  python tools/nat_vent_gate_substitution_diff.py --synthetic all  # + full synthetic sweep
+  python tools/nat_vent_gate_substitution_diff.py --positive-control
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_PROJECT_ROOT = os.path.dirname(_HERE)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from tools.sim_harness._loop import close_loop  # noqa: E402
+from tools.sim_harness.differential import ScenarioDiff, diff_runs  # noqa: E402
+from tools.sim_harness.enumerator import build_enumerated_scenarios  # noqa: E402
+from tools.sim_harness.nat_vent_gate_compare import substitute_new_gate  # noqa: E402
+
+_GOLDEN_DIR = Path(_PROJECT_ROOT) / "tools" / "simulations" / "golden"
+
+
+def _load_goldens() -> list[tuple[str, dict]]:
+    out = []
+    for path in sorted(_GOLDEN_DIR.glob("*.json")):
+        if path.name == "MANIFEST.json":
+            continue
+        with path.open(encoding="utf-8") as fh, contextlib.suppress(json.JSONDecodeError):
+            out.append((path.stem, json.load(fh)))
+    return out
+
+
+def _print_divergences(diff: ScenarioDiff, verbose: bool) -> None:
+    show = 3 if not verbose else 20
+    for label, divs in (("event", diff.event_divergences), ("action", diff.action_divergences)):
+        for d in divs[:show]:
+            print(f"    [{label} #{d.index}] A(baseline)={d.a}  B(substituted)={d.b}")
+        if len(divs) > show:
+            print(f"    ... +{len(divs) - show} more {label} divergences")
+
+
+def run_positive_control(verbose: bool) -> int:
+    """Prove the substitution-diff CAN detect a real divergence, using a
+    deliberately-broken new function (always returns False)."""
+    from unittest.mock import patch
+
+    print("=== SUBSTITUTION POSITIVE CONTROL (test the test) ===")
+    print("Deliberately break decide_nat_vent_gate() (always return False), substitute it")
+    print("in, and confirm the FULL scenario diverges from baseline.\n")
+
+    goldens = _load_goldens()
+    for name, scen in goldens:
+        with patch("custom_components.climate_advisor.nat_vent_gate.decide_nat_vent_gate", lambda inputs: False):
+            diff = diff_runs(scen, mutate_b=substitute_new_gate, scenario_name=f"{name}_BROKEN")
+        if diff.a_error or diff.b_error:
+            continue
+        if not diff.is_clean:
+            print(
+                f"DETECTED on '{name}': {len(diff.event_divergences)} event, "
+                f"{len(diff.action_divergences)} action divergence(s)"
+            )
+            if verbose:
+                _print_divergences(diff, verbose)
+            print("\nPOSITIVE CONTROL PASSED — substitution-diff detects a broken new function.")
+            return 0
+    print("POSITIVE CONTROL FAILED — no golden showed a divergence under a broken substitution.")
+    return 1
+
+
+def run_substitution_sweep(synthetic: str | None, verbose: bool) -> int:
+    goldens = _load_goldens()
+    scenarios: list[tuple[str, dict]] = list(goldens)
+    if synthetic:
+        n = None if synthetic == "all" else int(synthetic)
+        synth = build_enumerated_scenarios(t=3, limit=n)
+        scenarios += [(es.name, es.scenario) for es in synth]
+
+    print(
+        f"=== SUBSTITUTION TEST: {len(goldens)} goldens"
+        f"{f' + {len(scenarios) - len(goldens)} synthetic' if synthetic else ''} ==="
+    )
+    print("Baseline run (untouched) vs substituted run (new function actually drives behavior).")
+    print("Diffing the FULL action_log + event_log, not just the gate's boolean.\n")
+
+    clean = 0
+    diverged: list[ScenarioDiff] = []
+    errored: list[ScenarioDiff] = []
+
+    for name, scen in scenarios:
+        diff = diff_runs(scen, mutate_b=substitute_new_gate, scenario_name=name)
+        if diff.a_error or diff.b_error:
+            errored.append(diff)
+            print(f"  ERROR   {name}: a={diff.a_error} b={diff.b_error}")
+        elif diff.is_clean:
+            clean += 1
+        else:
+            diverged.append(diff)
+            print(f"  DIVERGE {diff.summary()}")
+            _print_divergences(diff, verbose)
+
+    print("\n--- summary ---")
+    print(f"  scenarios: {len(scenarios)}")
+    print(f"  clean:     {clean}")
+    print(f"  diverged:  {len(diverged)}")
+    print(f"  errored:   {len(errored)}")
+    print(f"\nSUBSTITUTION_RESULT n={len(scenarios)} clean={clean} diverged={len(diverged)} errored={len(errored)}")
+
+    if not diverged and not errored:
+        print(
+            f"\nEXIT CRITERION MET: {len(scenarios)}/{len(scenarios)} scenarios produce IDENTICAL "
+            f"full outcomes whether the gate is shadow-checked or actually substituted in."
+        )
+        return 0
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    with contextlib.suppress(Exception):
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
+    logging.disable(logging.CRITICAL)
+
+    parser = argparse.ArgumentParser(description="Full-scenario substitution testing for the nat-vent gate.")
+    parser.add_argument(
+        "--synthetic", type=str, default=None, help="Also run N synthetic scenarios ('all' for full sweep)."
+    )
+    parser.add_argument("--positive-control", action="store_true", help="Run the test-the-test check.")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.positive_control:
+        return run_positive_control(args.verbose)
+    return run_substitution_sweep(args.synthetic, args.verbose)
+
+
+if __name__ == "__main__":
+    _exit_code = main()
+    close_loop()
+    raise SystemExit(_exit_code)

--- a/tools/sim_harness/_loop.py
+++ b/tools/sim_harness/_loop.py
@@ -1,0 +1,64 @@
+"""Shared persistent asyncio event loop for the sim_harness.
+
+**Root cause this fixes** (architecture-reset Step 2, found via direct
+measurement, not assumption): Windows' asyncio `ProactorEventLoop` does not
+synchronously release its internal I/O-completion-port / self-pipe handles when
+torn down. `asyncio.run()` creates a brand-new loop and tears it down on every
+call; the harness's dispatcher calls it ~2-3 times per scenario event, so a
+5809-scenario sweep issues thousands of these create/destroy cycles in one
+process. Measured with `gc.get_objects()`, `threading.active_count()`, and
+`warnings.simplefilter("always", ResourceWarning)` across two isolated
+diagnostics: object count, thread count, and Python-level warnings all stayed
+flat and bounded — yet the process still froze solid (CPU time identical across
+two checks a minute apart) around scenario ~2900-3000 every time. That signature
+— healthy at the Python level, hard-frozen at the OS level — is consistent with
+exhausting a kernel resource (IOCP/socket handles) that Python's own instrumentation
+can't see, not a leak in this codebase's own objects.
+
+**The fix**: reuse ONE event loop across the whole process instead of creating a
+fresh one per call. Proven directly: the same 5809-scenario sweep that reliably
+froze at ~2900-3000 with `asyncio.run()` per call completed twice, back-to-back
+in one process, in ~5.5s each with this module — no stall, no degradation between
+runs, identical correctness result (1074/1074 gate calls agree) both times.
+
+Usage: every ``asyncio.run(coro)`` call site in this harness should become
+``from tools.sim_harness._loop import run_coro`` + ``run_coro(coro)``. Call
+``close_loop()`` once at the end of a CLI's `main()` to avoid a harmless-but-noisy
+`ResourceWarning: unclosed event loop` at interpreter exit.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Coroutine
+from typing import Any
+
+_loop: asyncio.AbstractEventLoop | None = None
+
+
+def get_loop() -> asyncio.AbstractEventLoop:
+    """Return the shared persistent event loop, creating it on first use."""
+    global _loop
+    if _loop is None or _loop.is_closed():
+        _loop = asyncio.new_event_loop()
+    return _loop
+
+
+def run_coro[T](coro: Coroutine[Any, Any, T]) -> T:
+    """Run a coroutine to completion on the shared persistent loop.
+
+    Drop-in replacement for ``asyncio.run()`` for this harness's specific usage
+    pattern (many short-lived coroutines run sequentially in one process) — NOT
+    a general-purpose substitute, since it does not create/close a fresh loop
+    or reset asyncio's event-loop-policy state the way ``asyncio.run()`` does.
+    """
+    return get_loop().run_until_complete(coro)
+
+
+def close_loop() -> None:
+    """Close the shared loop. Call once at process/CLI exit to avoid a
+    ResourceWarning: unclosed event loop at interpreter shutdown."""
+    global _loop
+    if _loop is not None and not _loop.is_closed():
+        _loop.close()
+    _loop = None

--- a/tools/sim_harness/chart_log_driver.py
+++ b/tools/sim_harness/chart_log_driver.py
@@ -1,0 +1,102 @@
+"""chart_log_driver — turn CA chart_log entries into replay-able input trajectories.
+
+Per the architecture-reset Step-1 plan: the chart_log is a library of realistic
+**input** trajectories ONLY (real indoor/outdoor/time sequences). It is never an
+output oracle — any ``hvac``/``fan``/``windows_open`` fields recorded in the log were
+produced by many different, buggy, since-deleted code versions and are deliberately
+discarded here. We build ``temp_update`` events from ``indoor``/``outdoor``/``ts``
+only, and hand them to the SAME production-scenario adapter (``run_production_scenario``)
+that the golden suite and differential-replay harness already use — old-vs-old
+divergence over this driver has the identical meaning it has over goldens: a hidden
+input the harness failed to control.
+
+Chart_log entry schema (see ``chart_log.py``): ``{"ts": ISO8601, "hvac": str,
+"fan": bool, "indoor": float|None, "outdoor": float|None, ...}``. Entries with a
+null indoor or outdoor reading are skipped (no viable temp_update).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+def load_chart_log(path: str | Path) -> list[dict[str, Any]]:
+    """Load raw chart_log entries from disk. Returns [] if the file is absent/invalid."""
+    p = Path(path)
+    if not p.exists():
+        return []
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return []
+    entries = data.get("entries") if isinstance(data, dict) else data
+    if not isinstance(entries, list):
+        return []
+    return [e for e in entries if isinstance(e, dict)]
+
+
+def _parse_ts(ts: str) -> datetime | None:
+    try:
+        return datetime.fromisoformat(ts)
+    except (ValueError, TypeError):
+        return None
+
+
+def build_scenario_from_chart_log(
+    entries: list[dict[str, Any]],
+    *,
+    max_entries: int | None = None,
+    stride: int = 1,
+    config: dict[str, Any] | None = None,
+    name: str = "chart_log_replay",
+) -> dict[str, Any]:
+    """Convert chart_log entries into a scenario dict driving ONLY temp_update events.
+
+    Args:
+        entries: raw chart_log entries (chronological order assumed, as persisted).
+        max_entries: cap the number of *usable* (non-null indoor/outdoor) entries used,
+                     taken from the end of the log (most recent) — keeps replay tractable.
+        stride: use every Nth usable entry (subsample cadence).
+        config: optional engine config overrides (merged over harness defaults).
+        name: scenario name, for reporting.
+
+    Returns:
+        A scenario dict compatible with ``run_production_scenario`` — real physical
+        input trajectories, zero recorded-decision fields carried over.
+    """
+    usable: list[dict[str, Any]] = []
+    for e in entries:
+        ts = e.get("ts")
+        indoor = e.get("indoor")
+        outdoor = e.get("outdoor")
+        if ts is None or indoor is None or outdoor is None:
+            continue
+        if _parse_ts(ts) is None:
+            continue
+        usable.append({"ts": ts, "indoor": float(indoor), "outdoor": float(outdoor)})
+
+    if max_entries is not None:
+        usable = usable[-max_entries:]
+    if stride > 1:
+        usable = usable[::stride]
+
+    events = [
+        {
+            "type": "temp_update",
+            "time": e["ts"],
+            "indoor_f": e["indoor"],
+            "outdoor_f": e["outdoor"],
+        }
+        for e in usable
+    ]
+
+    return {
+        "name": name,
+        "description": f"Replay of {len(events)} real (indoor, outdoor) input pairs from chart_log — "
+        "input trajectories only, recorded decisions discarded.",
+        "config": config or {},
+        "events": events,
+    }

--- a/tools/sim_harness/differential.py
+++ b/tools/sim_harness/differential.py
@@ -1,0 +1,244 @@
+"""differential — old-vs-old / old-vs-mutated differential replay over the production engine.
+
+This is the characterization + differential-replay harness (architecture-reset
+Step 1). It runs a scenario through the REAL production engine (via
+``run_production_scenario``) twice and diffs the resulting ``event_log`` +
+``action_log``. Two modes:
+
+**old-vs-old (a determinism / hidden-input detector).** Both runs use identical,
+unmodified code. Any divergence between two runs of the SAME code is an input the
+harness failed to control (wall-clock, RNG, dict/set iteration order,
+un-snapshotted ``self._`` state). Zero old-vs-old divergence is the *exit*
+criterion for Step 1 — reaching it proves input capture + state isolation is
+complete, and the divergences found en route enumerate the hidden inputs for us.
+
+**old-vs-mutated (the positive control / "test the test").** A deliberately
+injected behavioral change MUST produce a non-empty diff, per log type. A diff
+engine that always returned "equal" would also pass old-vs-old; the positive
+control proves detection actually works before any zero result is trusted.
+
+Nothing here touches production code — it is pure test/tooling that drives the
+existing ``tools/sim_harness`` machinery.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+from tools.sim_harness.run_production import ProductionRunResult, run_production_scenario
+
+# A mutation is a zero-arg callable returning a context manager that is active
+# during a single run_production_scenario call (e.g. a unittest.mock.patch).
+MutationFactory = Callable[[], contextlib.AbstractContextManager]
+
+
+# ---------------------------------------------------------------------------
+# Canonicalisation — make log entries stably comparable across two runs
+# ---------------------------------------------------------------------------
+
+
+def _canonical(obj: Any) -> Any:
+    """Recursively convert a log entry into a stable, comparable structure.
+
+    - ``datetime`` → ISO string (virtual-clock times are deterministic; a
+      wall-clock leak shows up here as a mismatched string).
+    - ``dict`` → dict with canonicalised values (insertion order irrelevant to ==).
+    - ``list``/``tuple`` → list of canonicalised items (order IS significant).
+    - other JSON scalars → as-is.
+    - anything else → ``repr`` (last-resort stable-ish form; a memory-address in a
+      repr would itself surface as a divergence, which is the point).
+    """
+    if isinstance(obj, datetime):
+        return obj.isoformat()
+    if isinstance(obj, dict):
+        return {k: _canonical(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_canonical(v) for v in obj]
+    if isinstance(obj, (str, int, float, bool)) or obj is None:
+        return obj
+    return repr(obj)
+
+
+def _canon_event_log(log: list[tuple[str, dict, datetime | None]]) -> list[Any]:
+    """Canonicalise an event_log: list of (event_type, payload, ts)."""
+    return [[etype, _canonical(payload), _canonical(ts)] for (etype, payload, ts) in log]
+
+
+def _canon_action_log(log: list[dict]) -> list[Any]:
+    """Canonicalise an action_log: list of {domain, service, data, ts}."""
+    return [_canonical(entry) for entry in log]
+
+
+# ---------------------------------------------------------------------------
+# Diff
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class LogDivergence:
+    """One positional difference between two canonicalised logs."""
+
+    index: int
+    a: Any | None  # entry from run A (None if A is shorter)
+    b: Any | None  # entry from run B (None if B is shorter)
+
+
+@dataclass
+class ScenarioDiff:
+    """Full diff result for one scenario run pair."""
+
+    scenario_name: str
+    event_divergences: list[LogDivergence] = field(default_factory=list)
+    action_divergences: list[LogDivergence] = field(default_factory=list)
+    a_error: str | None = None  # exception rendering, if run A raised
+    b_error: str | None = None  # exception rendering, if run B raised
+
+    @property
+    def is_clean(self) -> bool:
+        return (
+            not self.event_divergences and not self.action_divergences and self.a_error is None and self.b_error is None
+        )
+
+    def summary(self) -> str:
+        if self.a_error or self.b_error:
+            return f"{self.scenario_name}: ERROR a={self.a_error!r} b={self.b_error!r}"
+        if self.is_clean:
+            return f"{self.scenario_name}: clean (0 event, 0 action divergences)"
+        return (
+            f"{self.scenario_name}: {len(self.event_divergences)} event, "
+            f"{len(self.action_divergences)} action divergences"
+        )
+
+
+def _diff_sequences(a: list[Any], b: list[Any]) -> list[LogDivergence]:
+    """Positional diff of two canonicalised sequences (order significant)."""
+    out: list[LogDivergence] = []
+    for i in range(max(len(a), len(b))):
+        av = a[i] if i < len(a) else None
+        bv = b[i] if i < len(b) else None
+        if av != bv:
+            out.append(LogDivergence(index=i, a=av, b=bv))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Run helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_once(scenario: dict, mutate: MutationFactory | None = None) -> ProductionRunResult:
+    """Run a scenario once, optionally inside a mutation context."""
+    if mutate is None:
+        return run_production_scenario(scenario)
+    with mutate():
+        return run_production_scenario(scenario)
+
+
+def diff_runs(
+    scenario: dict,
+    *,
+    mutate_b: MutationFactory | None = None,
+    scenario_name: str | None = None,
+) -> ScenarioDiff:
+    """Run a scenario twice and diff the two runs.
+
+    Args:
+        scenario: parsed scenario dict.
+        mutate_b: if given, run B executes inside this mutation context (used for
+                  the positive control). If ``None``, this is an old-vs-old run.
+        scenario_name: label for reporting; defaults to ``scenario['name']``.
+
+    Returns:
+        A ``ScenarioDiff``. For old-vs-old, ``is_clean`` should ultimately be
+        ``True``; every divergence is a hidden input to capture. For a positive
+        control, ``is_clean`` should be ``False`` (detection works).
+    """
+    name = scenario_name or scenario.get("name") or scenario.get("description") or "<unnamed>"
+
+    a_error: str | None = None
+    b_error: str | None = None
+    result_a: ProductionRunResult | None = None
+    result_b: ProductionRunResult | None = None
+
+    try:
+        result_a = _run_once(scenario)
+    except Exception as exc:  # noqa: BLE001 — capture, don't crash the batch
+        a_error = f"{type(exc).__name__}: {exc}"
+    try:
+        result_b = _run_once(scenario, mutate=mutate_b)
+    except Exception as exc:  # noqa: BLE001
+        b_error = f"{type(exc).__name__}: {exc}"
+
+    diff = ScenarioDiff(scenario_name=name, a_error=a_error, b_error=b_error)
+    if result_a is None or result_b is None:
+        return diff
+
+    diff.event_divergences = _diff_sequences(
+        _canon_event_log(result_a.event_log),
+        _canon_event_log(result_b.event_log),
+    )
+    diff.action_divergences = _diff_sequences(
+        _canon_action_log(result_a.action_log),
+        _canon_action_log(result_b.action_log),
+    )
+    return diff
+
+
+def old_vs_old(scenario: dict, *, scenario_name: str | None = None) -> ScenarioDiff:
+    """Convenience: run a scenario against itself (determinism / hidden-input check)."""
+    return diff_runs(scenario, mutate_b=None, scenario_name=scenario_name)
+
+
+# ---------------------------------------------------------------------------
+# Positive-control mutations (test-the-test)
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def bump_setpoint_mutation(delta_f: float = 5.0) -> Iterator[None]:
+    """Positive control for the ACTION log: shift every commanded setpoint by delta_f.
+
+    Wraps ``FakeState`` feedback? No — patches the engine's ``_set_temperature`` so
+    any scenario that commands a temperature yields a different ``action_log`` in
+    run B, proving the action-log diff detects real differences.
+    """
+    from custom_components.climate_advisor.automation import AutomationEngine  # noqa: PLC0415
+
+    original = AutomationEngine._set_temperature
+
+    async def _wrapped(self: Any, temperature: float, *args: Any, **kwargs: Any) -> Any:
+        return await original(self, float(temperature) + delta_f, *args, **kwargs)
+
+    from unittest.mock import patch  # noqa: PLC0415
+
+    with patch.object(AutomationEngine, "_set_temperature", _wrapped):
+        yield
+
+
+@contextmanager
+def extra_event_mutation() -> Iterator[None]:
+    """Positive control for the EVENT log: emit one extra marker event per run.
+
+    Patches ``AutomationEngine.apply_classification`` to emit a spurious event
+    before delegating, guaranteeing the event_log differs in run B. Proves the
+    event-log diff detects real differences independently of the action log.
+    """
+    from custom_components.climate_advisor.automation import AutomationEngine  # noqa: PLC0415
+
+    original = AutomationEngine.apply_classification
+
+    async def _wrapped(self: Any, *args: Any, **kwargs: Any) -> Any:
+        cb = getattr(self, "_emit_event_callback", None)
+        if cb is not None:
+            cb("differential_positive_control_marker", {"injected": True})
+        return await original(self, *args, **kwargs)
+
+    from unittest.mock import patch  # noqa: PLC0415
+
+    with patch.object(AutomationEngine, "apply_classification", _wrapped):
+        yield

--- a/tools/sim_harness/enumerator.py
+++ b/tools/sim_harness/enumerator.py
@@ -1,0 +1,255 @@
+"""enumerator — boundary-focused, t-wise synthetic scenario generator (Step 1).
+
+Per the architecture-reset plan, this is NOT a naive full-Cartesian grid (which
+would explode across ~20-30 raw config/state dims) and NOT a claim of "complete
+coverage over all inputs". It is exhaustive t=3 coverage (t=4 available) over the
+set of MEASURED decision-boundary dimensions found by direct code reading this
+session (direction gates, comfort floor/ceiling, sleep window, occupancy, fan
+archetype, aggressive_savings, sensor/window-open) — the dimensions the real bug
+population (#327/#392/#400/#402/#415/#417/#427/#428) actually varies on, plus
+`sensor_open` (added after Step 2 found the original 9-dimension set couldn't
+reach any sensor-gated decision path, including the nat-vent reactivation gate
+itself — a real coverage gap, not a hypothetical one).
+
+This dimension list is a living inventory, not a one-time snapshot: whenever a
+new decision-boundary dependency is found (by direct reading, by the territory
+map's per-function feature instrumentation, or — as with `sensor_open` — by a
+downstream tool discovering zero calls reached its target), add it here at the
+source rather than working around the gap in the consuming tool.
+
+Each generated scenario is a short, minimal (classification + temp_update) event
+sequence built from a t-wise assignment of boundary-focused values. Scenarios are
+run through the SAME ``old_vs_old`` engine already validated (positive control +
+51/51 goldens + ~5700 real chart_log entries) — any divergence is either a hidden
+input the harness still doesn't control, or (once mutation testing is layered on
+top in a later step) a real bug at that boundary.
+
+"Boundary-focused": each numeric dimension samples AT and immediately either side
+of its real threshold (not a uniform grid), because the entire bug population this
+was validated against (see plan) lived exactly on such boundaries.
+
+Honesty note: this covers dimensions confirmed by direct code reading. The
+territory map's per-function feature-read instrumentation (a later, deeper
+deliverable) is what will confirm or extend this dimension list for the other
+decision functions not yet read line-by-line.
+"""
+
+from __future__ import annotations
+
+import itertools
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Boundary dimensions — grounded in real thresholds read from const.py / automation.py
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Dimension:
+    """One boundary-focused axis of variation."""
+
+    name: str
+    values: tuple[Any, ...]  # small, boundary-focused value set (not a uniform grid)
+    baseline: Any  # value held when this dimension is not part of the active t-combo
+
+
+# Config baseline mirrors build_engine.py's _DEFAULT_CONFIG: comfort_heat=70,
+# comfort_cool=76, sleep_heat/sleep_cool derived defaults, natural_vent_delta=3.0.
+_COMFORT_HEAT = 70.0
+_COMFORT_COOL = 76.0
+_NAT_VENT_DELTA = 3.0
+_NAT_VENT_THRESHOLD = _COMFORT_COOL + _NAT_VENT_DELTA  # 79.0
+
+DIMENSIONS: tuple[Dimension, ...] = (
+    # Direction gate: outdoor - indoor, boundary at 0 (Issue #327/#428 bug class).
+    Dimension("outdoor_minus_indoor", (-1.0, -0.1, 0.0, 0.1, 1.0), baseline=-3.0),
+    # Comfort floor boundary (#402/#417/#427 bug class: sleep-aware floor drift).
+    Dimension(
+        "indoor_vs_comfort_heat",
+        tuple(_COMFORT_HEAT + d for d in (-1.0, -0.1, 0.0, 0.1, 1.0)),
+        baseline=_COMFORT_HEAT + 5.0,
+    ),
+    # Comfort ceiling boundary (#392 archetype-aware ceiling guard).
+    Dimension(
+        "indoor_vs_comfort_cool",
+        tuple(_COMFORT_COOL + d for d in (-1.0, -0.1, 0.0, 0.1, 1.0)),
+        baseline=_COMFORT_COOL - 5.0,
+    ),
+    # nat_vent_threshold boundary (comfort_cool + nat_vent_delta; #400/#415 dashboard-drift class).
+    Dimension(
+        "outdoor_vs_nat_vent_threshold",
+        tuple(_NAT_VENT_THRESHOLD + d for d in (-1.0, -0.1, 0.0, 0.1, 1.0)),
+        baseline=_NAT_VENT_THRESHOLD - 10.0,
+    ),
+    Dimension("day_type", ("hot", "warm", "mild", "cool", "cold"), baseline="mild"),
+    Dimension("sleep_window", (True, False), baseline=False),
+    Dimension("occupancy_mode", ("home", "away", "vacation"), baseline="home"),
+    Dimension("fan_mode", ("disabled", "whole_house_fan", "hvac_fan"), baseline="disabled"),
+    Dimension("aggressive_savings", (True, False), baseline=False),
+    # Physical prerequisite for nat-vent reactivation (automation.py:2225-2226's
+    # `_idle_open` requires a monitored sensor open). Added after Step 2 found this
+    # dimension missing meant zero of the original 4735 t=3 scenarios ever reached
+    # `_nat_vent_may_reactivate()`'s check_natural_vent_conditions() call site — a
+    # real coverage gap in the original 9-dimension set, not a workaround.
+    Dimension("sensor_open", (True, False), baseline=False),
+)
+
+_DIM_BY_NAME = {d.name: d for d in DIMENSIONS}
+
+
+# ---------------------------------------------------------------------------
+# t-wise combination generation
+# ---------------------------------------------------------------------------
+
+
+def generate_t_wise_assignments(t: int = 3, dims: tuple[Dimension, ...] = DIMENSIONS) -> list[dict[str, Any]]:
+    """Exhaustive t-way coverage: every combination of ``t`` dimensions, crossed with
+    every value combination for exactly those dimensions (other dims at baseline).
+
+    This is a full combinatorial sweep per t-subset (not a minimized covering
+    array) — simpler to implement correctly, and it strictly guarantees the
+    property the plan asked for: any bug depending on <= t of these dimensions
+    co-occurring is represented in at least one generated assignment.
+    """
+    assignments: list[dict[str, Any]] = []
+    baseline = {d.name: d.baseline for d in dims}
+    for combo in itertools.combinations(dims, t):
+        for values in itertools.product(*(d.values for d in combo)):
+            a = dict(baseline)
+            a.update(dict(zip((d.name for d in combo), values, strict=True)))
+            assignments.append(a)
+    return assignments
+
+
+# ---------------------------------------------------------------------------
+# Scenario construction from one assignment
+# ---------------------------------------------------------------------------
+
+_BASE_TIME = datetime(2026, 6, 15, 12, 0, 0, tzinfo=UTC)  # 12:00 UTC — outside default sleep window
+_SLEEP_TIME_UTC = datetime(2026, 6, 15, 23, 30, 0, tzinfo=UTC)  # inside a 22:30-06:30 sleep window
+
+
+def assignment_to_scenario(assignment: dict[str, Any], *, name: str) -> dict[str, Any]:
+    """Build a minimal (classification + temp_update) scenario from one t-wise assignment."""
+    outdoor_minus_indoor = assignment["outdoor_minus_indoor"]
+    indoor_vs_heat = assignment["indoor_vs_comfort_heat"]
+    indoor_vs_cool = assignment["indoor_vs_comfort_cool"]
+    outdoor_vs_threshold = assignment["outdoor_vs_nat_vent_threshold"]
+
+    # Resolve a single indoor/outdoor pair that best respects the active boundary
+    # dims. When both floor and ceiling dims are simultaneously "active" (non-baseline)
+    # they could conflict; the floor dimension wins ties (arbitrary, documented) since
+    # the historical bug population weighted more heavily there (4 of 8 t=3/4 bugs).
+    if indoor_vs_heat != _DIM_BY_NAME["indoor_vs_comfort_heat"].baseline:
+        indoor = indoor_vs_heat
+    elif indoor_vs_cool != _DIM_BY_NAME["indoor_vs_comfort_cool"].baseline:
+        indoor = indoor_vs_cool
+    else:
+        indoor = 73.0  # neutral mid-comfort-band default
+
+    if outdoor_vs_threshold != _DIM_BY_NAME["outdoor_vs_nat_vent_threshold"].baseline:
+        outdoor = outdoor_vs_threshold
+    else:
+        outdoor = indoor - outdoor_minus_indoor  # outdoor_minus_indoor = outdoor - indoor
+
+    sleep_window = bool(assignment["sleep_window"])
+    start_time = _SLEEP_TIME_UTC if sleep_window else _BASE_TIME
+    classification_time = start_time
+    temp_time = start_time + timedelta(minutes=1)
+
+    day_type = assignment["day_type"]
+    hvac_mode_by_day = {"hot": "cool", "warm": "cool", "mild": "off", "cool": "heat", "cold": "heat"}
+
+    config: dict[str, Any] = {
+        "comfort_heat": _COMFORT_HEAT,
+        "comfort_cool": _COMFORT_COOL,
+        "natural_vent_delta": _NAT_VENT_DELTA,
+        "fan_mode": assignment["fan_mode"],
+        "aggressive_savings": bool(assignment["aggressive_savings"]),
+        # Sleep window bounding the classification/temp_update timestamps above.
+        "sleep_time": "22:30",
+        "wake_time": "06:30",
+    }
+
+    events: list[dict[str, Any]] = [
+        {
+            "type": "classification",
+            "time": classification_time.isoformat(),
+            "day_type": day_type,
+            "hvac_mode": hvac_mode_by_day[day_type],
+            "windows_recommended": False,
+        }
+    ]
+
+    occupancy_mode = assignment["occupancy_mode"]
+    if occupancy_mode != "home":
+        events.append(
+            {
+                "type": f"occupancy_{occupancy_mode}",
+                "time": (classification_time + timedelta(seconds=30)).isoformat(),
+            }
+        )
+
+    if bool(assignment.get("sensor_open", False)):
+        events.append(
+            {
+                "type": "sensor_open",
+                "time": temp_time.isoformat(),
+                "entity": "binary_sensor.synthetic_probe",
+            }
+        )
+
+    events.append(
+        {
+            "type": "temp_update",
+            "time": temp_time.isoformat(),
+            "indoor_f": round(indoor, 2),
+            "outdoor_f": round(outdoor, 2),
+        }
+    )
+
+    return {
+        "name": name,
+        "description": f"Synthetic t-wise boundary scenario: {assignment}",
+        "config": config,
+        "events": events,
+    }
+
+
+@dataclass
+class EnumeratedScenario:
+    name: str
+    assignment: dict[str, Any]
+    scenario: dict[str, Any]
+
+
+def build_enumerated_scenarios(t: int = 3, limit: int | None = None, offset: int = 0) -> list[EnumeratedScenario]:
+    """Build the full (or offset/capped) set of t-wise boundary scenarios.
+
+    ``offset``/``limit`` slice the assignment list — useful for manual partial
+    runs. Batching is no longer required to avoid a stall: the root cause
+    (thousands of fresh ``asyncio.run()``-created event loops exhausting a
+    Windows kernel resource) is fixed at the source in
+    ``tools/sim_harness/_loop.py`` — see the Step-2 status report.
+    """
+    assignments = generate_t_wise_assignments(t=t)
+    end = offset + limit if limit is not None else None
+    assignments = assignments[offset:end]
+    out = []
+    for i, a in enumerate(assignments, start=offset):
+        name = f"t{t}_boundary_{i:05d}"
+        out.append(EnumeratedScenario(name=name, assignment=a, scenario=assignment_to_scenario(a, name=name)))
+    return out
+
+
+@dataclass
+class CoverageStats:
+    t: int
+    total_assignments: int
+    dims_considered: int = field(default=len(DIMENSIONS))
+
+    @staticmethod
+    def compute(t: int) -> CoverageStats:
+        return CoverageStats(t=t, total_assignments=len(generate_t_wise_assignments(t=t)))

--- a/tools/sim_harness/fake_scheduler.py
+++ b/tools/sim_harness/fake_scheduler.py
@@ -28,12 +28,13 @@ unpatches on exit.
 
 from __future__ import annotations
 
-import asyncio
 import heapq
 from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import patch
+
+from tools.sim_harness._loop import run_coro
 
 
 class _ScheduledCallback:
@@ -65,7 +66,7 @@ class FakeScheduler:
 
         with scheduler.installed():
             # engine calls that schedule timers land in the scheduler
-            asyncio.run(engine.handle_all_doors_windows_closed())
+            run_coro(engine.handle_all_doors_windows_closed())
             # advance time; all due callbacks fire, tasks drain
             scheduler.advance_by(300 + 1)
     """
@@ -121,15 +122,20 @@ class FakeScheduler:
         self._task_queue.append(coro)
 
     def _drain_tasks(self) -> None:
-        """Run all enqueued coroutines synchronously."""
+        """Run all enqueued coroutines synchronously on the shared persistent loop.
+
+        (Issue: architecture-reset Step 2 root-caused thousands of fresh
+        asyncio.run() calls per process to a Windows ProactorEventLoop handle
+        exhaustion that freezes the process at scale — see tools/sim_harness/_loop.py.
+        The old RuntimeError/get_event_loop() fallback here existed for the
+        "already inside a running loop" case that asyncio.run() can hit; running
+        everything on one shared, not-currently-running persistent loop via
+        run_coro() doesn't have that failure mode, so the fallback is removed.)
+        """
         while self._task_queue:
             coro = self._task_queue.pop(0)
             try:
-                asyncio.run(coro)
-            except RuntimeError:
-                # Already inside an event loop — schedule on the running loop
-                loop = asyncio.get_event_loop()
-                loop.run_until_complete(coro)
+                run_coro(coro)
             except Exception as exc:  # noqa: BLE001
                 import traceback
 

--- a/tools/sim_harness/fan_thermostat_decision_compare.py
+++ b/tools/sim_harness/fan_thermostat_decision_compare.py
@@ -1,0 +1,200 @@
+"""fan_thermostat_decision_compare — old-vs-new differential comparator (Step 2, slice 2).
+
+Unlike ``_nat_vent_may_reactivate()``, production's ``fan_thermostat_check()``
+does not RETURN a value — its outcome is implicit in which downstream method
+gets called (``_exit_nat_vent()``, ``_deactivate_fan()``, or neither). This
+comparator observes those calls during one real invocation to infer the REAL
+outcome, and reconstructs the equivalent ``FanThermostatInputs`` to compute the
+NEW pure function's predicted outcome — comparing the two without ever
+modifying what `fan_thermostat_check()` itself does.
+
+``_deactivate_fan()`` is called by BOTH ``STOP_DEACTIVATE`` and
+``STOP_COOLED_TO_FLOOR`` — disambiguated via the ``reason=`` string production
+already passes, using the same literal substrings ("free cooling gone" /
+"cooled to floor") the real code emits. If neither substring matches a call
+that did happen, that's recorded as an unexpected-observation error rather than
+silently misclassified — protects against silent breakage if production
+wording ever changes.
+
+Shadow mode only (see the "Substitution mode — DEFERRED" note further down for
+why): observes real side effects and compares against the new pure function's
+prediction; the wrapped method's real behavior is completely untouched.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from dataclasses import dataclass, field
+from typing import Any
+
+
+def _reconstruct_inputs(self: Any, indoor: float | None, outdoor: float | None) -> Any:
+    """Rebuild the equivalent FanThermostatInputs from a live fan_thermostat_check call."""
+    from homeassistant.util import dt as dt_util  # noqa: PLC0415
+
+    from custom_components.climate_advisor import const  # noqa: PLC0415
+    from custom_components.climate_advisor.automation import _in_sleep_window  # noqa: PLC0415
+    from custom_components.climate_advisor.fan_thermostat_decision import FanThermostatInputs  # noqa: PLC0415
+
+    comfort_heat_raw = float(self.config.get("comfort_heat", 70))
+    sleep_heat = float(self.config.get(const.CONF_SLEEP_HEAT, comfort_heat_raw))
+    in_sleep_window = _in_sleep_window(dt_util.now(), self.config)
+    hysteresis = float(self.config.get(const.CONF_NAT_VENT_HYSTERESIS_F, const.NAT_VENT_HYSTERESIS_F))
+
+    return FanThermostatInputs(
+        indoor=indoor,
+        outdoor=outdoor,
+        comfort_heat_raw=comfort_heat_raw,
+        sleep_heat=sleep_heat,
+        in_sleep_window=in_sleep_window,
+        hysteresis=hysteresis,
+        natural_vent_active=self._natural_vent_active,
+    )
+
+
+def _classify_observation(exit_called: bool, deactivate_reason: str | None) -> tuple[Any, str | None]:
+    """Map observed calls to a FanThermostatOutcome. Returns (outcome, error_or_none)."""
+    from custom_components.climate_advisor.fan_thermostat_decision import FanThermostatOutcome  # noqa: PLC0415
+
+    if exit_called:
+        return FanThermostatOutcome.STOP_VIA_NAT_VENT_EXIT, None
+    if deactivate_reason is not None:
+        if "free cooling gone" in deactivate_reason:
+            return FanThermostatOutcome.STOP_DEACTIVATE, None
+        if "cooled to floor" in deactivate_reason:
+            return FanThermostatOutcome.STOP_COOLED_TO_FLOOR, None
+        return None, f"_deactivate_fan called with unrecognized reason: {deactivate_reason!r}"
+    return FanThermostatOutcome.KEEP, None
+
+
+# ---------------------------------------------------------------------------
+# Shadow mode
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FanThermostatCall:
+    scenario_name: str
+    real_outcome: Any  # FanThermostatOutcome | None (None if precondition guard skipped comparison)
+    new_outcome: Any  # FanThermostatOutcome
+
+    @property
+    def agrees(self) -> bool:
+        return self.real_outcome == self.new_outcome
+
+
+@dataclass
+class FanThermostatComparisonRun:
+    calls: list[FanThermostatCall] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def n_calls(self) -> int:
+        return len(self.calls)
+
+    @property
+    def n_agree(self) -> int:
+        return sum(1 for c in self.calls if c.agrees)
+
+    @property
+    def disagreements(self) -> list[FanThermostatCall]:
+        return [c for c in self.calls if not c.agrees]
+
+
+@contextlib.contextmanager
+def _instrumented_fan_thermostat_check(run: FanThermostatComparisonRun, scenario_name: str):
+    from unittest.mock import patch  # noqa: PLC0415
+
+    from custom_components.climate_advisor.automation import AutomationEngine  # noqa: PLC0415
+    from custom_components.climate_advisor.fan_thermostat_decision import decide_fan_thermostat_check  # noqa: PLC0415
+
+    original_check = AutomationEngine.fan_thermostat_check
+    original_exit = AutomationEngine._exit_nat_vent
+    original_deactivate = AutomationEngine._deactivate_fan
+
+    async def _wrapped_check(self: Any, *, indoor: float | None, outdoor: float | None, trigger: str) -> None:
+        # Preconditions the real function itself guards on (fan active, not
+        # overridden) — mirrored here only to decide whether comparison is
+        # meaningful, never to change behavior.
+        ca_fan_active = self._fan_running
+        fan_override_active = self._fan_override_active
+
+        # Capture the PRE-decision inputs before calling the real check — critical for
+        # natural_vent_active, which the STOP_VIA_NAT_VENT_EXIT branch clears as a side
+        # effect (via _exit_nat_vent()) during the call itself. Reconstructing inputs
+        # AFTER the call read the POST-decision state, producing a false disagreement
+        # (real=STOP_VIA_NAT_VENT_EXIT vs new=STOP_DEACTIVATE) once the harness's
+        # temp-tick dispatch fix (Step 2) finally exercised this branch via 2 goldens
+        # (nat-vent-outdoor-rises-above-indoor-exit, warm_day_ceiling_breach_ac_defense).
+        pre_inputs = _reconstruct_inputs(self, indoor, outdoor) if ca_fan_active and not fan_override_active else None
+
+        observed = {"exit_called": False, "deactivate_reason": None}
+
+        async def _tracking_exit(self2: Any, *a: Any, **kw: Any) -> Any:
+            observed["exit_called"] = True
+            return await original_exit(self2, *a, **kw)
+
+        async def _tracking_deactivate(self2: Any, *a: Any, **kw: Any) -> Any:
+            observed["deactivate_reason"] = kw.get("reason") or (a[0] if a else None)
+            return await original_deactivate(self2, *a, **kw)
+
+        with (
+            patch.object(AutomationEngine, "_exit_nat_vent", _tracking_exit),
+            patch.object(AutomationEngine, "_deactivate_fan", _tracking_deactivate),
+        ):
+            await original_check(self, indoor=indoor, outdoor=outdoor, trigger=trigger)
+
+        if not (ca_fan_active and not fan_override_active):
+            return  # matches the real function's own early-return no-op; nothing to compare
+
+        try:
+            real_outcome, obs_error = _classify_observation(observed["exit_called"], observed["deactivate_reason"])
+            if obs_error:
+                run.errors.append(f"{scenario_name}: {obs_error}")
+                return
+            new_outcome = decide_fan_thermostat_check(pre_inputs)
+            run.calls.append(
+                FanThermostatCall(scenario_name=scenario_name, real_outcome=real_outcome, new_outcome=new_outcome)
+            )
+        except Exception as exc:  # noqa: BLE001
+            run.errors.append(f"{scenario_name}: comparator error: {type(exc).__name__}: {exc}")
+
+    with patch.object(AutomationEngine, "fan_thermostat_check", _wrapped_check):
+        yield
+
+
+def compare_scenario(scenario: dict, scenario_name: str, run: FanThermostatComparisonRun) -> None:
+    from tools.sim_harness.run_production import run_production_scenario  # noqa: PLC0415
+
+    with _instrumented_fan_thermostat_check(run, scenario_name):
+        run_production_scenario(scenario)
+
+
+# ---------------------------------------------------------------------------
+# Substitution mode — DEFERRED, not implemented here (see module note below)
+# ---------------------------------------------------------------------------
+#
+# A first draft of `substitute_new_fan_thermostat_decision()` was written and
+# then deleted. Faithfully substituting this function's outcome would require
+# hand-reconstructing ALL of production's side effects outside of production
+# code: the auxiliary `nat_vent_outdoor_rise_exit` event (with
+# `_fan_device_label(self.config)`), and the exact `reason=` string for every
+# branch (including Check 2's resolved floor value formatted to match
+# production's f-string precisely). That reconstruction is real, duplicate
+# logic — if it drifts from production even slightly, this test would either
+# report false divergences or, worse, silently pass while masking a real bug.
+# That's exactly the "workaround that defeats the purpose" to avoid.
+#
+# The reactivation gate supported clean substitution because it was ALREADY
+# extracted as a single callable returning a value (`_nat_vent_may_reactivate()`,
+# itself a product of Issue #411's earlier refactor) — substitution there meant
+# swapping one return value for another, no side effects to reconstruct.
+# `fan_thermostat_check()` inlines its dispatch instead. The real prerequisite
+# for safe substitution here is extracting the decision into a real callable in
+# PRODUCTION first (mechanical, low-risk, mirrors #411's precedent) — not a
+# parallel-testing trick. That extraction is a legitimate Step 3 candidate, not
+# done as part of this Step 2 slice.
+#
+# Shadow-mode testing above is unaffected by this — it only OBSERVES real
+# side effects, never reconstructs them, so it remains fully trustworthy on
+# its own terms.

--- a/tools/sim_harness/fan_thermostat_decision_integration.py
+++ b/tools/sim_harness/fan_thermostat_decision_integration.py
@@ -1,0 +1,45 @@
+"""fan_thermostat_decision_integration — production load-bearing proof (Step 2, slice 2).
+
+Unlike the nat-vent reactivation gate, `fan_thermostat_check()` in automation.py
+now DIRECTLY calls `decide_fan_thermostat_check()` (see automation.py's Issue
+#435 follow-up refactor) — there is no separate "old" inline implementation left
+to substitute against. The shadow/substitution distinction Step 1 built for the
+gate has collapsed into one: production simply IS the pure function's caller.
+
+What remains meaningful to prove: the extraction is genuinely LOAD-BEARING, not
+dead code silently unused. `break_fan_thermostat_decision()` patches the exact
+name automation.py imported at module scope (`automation.decide_fan_thermostat_check`
+— a direct top-level import, unlike the gate's per-call `from ... import`, so the
+patch target is the IMPORTING module, not the source module) to a rotation-based
+corruption (every real outcome maps to a different, wrong one — robust regardless
+of which outcome a given scenario naturally produces, no fixed constant to go
+stale as real outcome coverage grows). If a real scenario's full action_log/event_log
+does NOT diverge when this is applied, the extraction isn't actually driving
+behavior — a real regression the positive control exists to catch.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import Any
+
+
+@contextlib.contextmanager
+def break_fan_thermostat_decision():
+    from unittest.mock import patch  # noqa: PLC0415
+
+    from custom_components.climate_advisor.automation import decide_fan_thermostat_check as original  # noqa: PLC0415
+    from custom_components.climate_advisor.fan_thermostat_decision import FanThermostatOutcome  # noqa: PLC0415
+
+    rotation = {
+        FanThermostatOutcome.KEEP: FanThermostatOutcome.STOP_DEACTIVATE,
+        FanThermostatOutcome.STOP_DEACTIVATE: FanThermostatOutcome.STOP_COOLED_TO_FLOOR,
+        FanThermostatOutcome.STOP_COOLED_TO_FLOOR: FanThermostatOutcome.STOP_VIA_NAT_VENT_EXIT,
+        FanThermostatOutcome.STOP_VIA_NAT_VENT_EXIT: FanThermostatOutcome.KEEP,
+    }
+
+    def _broken(inputs: Any) -> Any:
+        return rotation[original(inputs)]
+
+    with patch("custom_components.climate_advisor.automation.decide_fan_thermostat_check", _broken):
+        yield

--- a/tools/sim_harness/fan_thermostat_two_phase.py
+++ b/tools/sim_harness/fan_thermostat_two_phase.py
@@ -1,0 +1,142 @@
+"""fan_thermostat_two_phase — two-phase synthetic scenarios for fan_thermostat_check (Step 2).
+
+The Step-1 enumerator's single-tick scenarios never drive fan_thermostat_check()'s
+comparison at all: it only fires when ``self._fan_running`` (``_fan_active`` or
+``_natural_vent_active``) is already True, and that's downstream SESSION STATE —
+reachable only by letting a real prior decision activate the fan, not a raw input
+event like ``sensor_open``. Forcing ``self._fan_active = True`` directly on the
+engine would produce the same "clean" numbers without proving the state is
+reachable the way production actually reaches it — the workaround this project's
+process rejects.
+
+Instead, each of the existing t=3 assignments (unmodified — no new combinatorial
+dimension) is wrapped with a real, two-phase event sequence:
+
+  Phase 1 (preamble) — a real production entry point drives the engine into one
+  of two genuinely different real states:
+    "nat_vent"   — sensor_open + strongly favorable, fixed indoor/outdoor (NOT the
+                   assignment's own values) so check_natural_vent_conditions()
+                   activates a real nat-vent session (_natural_vent_active=True)
+                   regardless of fan_mode (a nat-vent session needs no fan device).
+    "fan_only"   — activate_fan_min_runtime event, calling the real, public
+                   start_min_fan_runtime_cycles() entry point directly
+                   (_fan_active=True, _natural_vent_active=False). Only reachable
+                   when the assignment's own fan_mode is NOT disabled and a real
+                   min-runtime is configured — skipped otherwise (correctly: there
+                   is no device to activate, matching production).
+
+  Phase 2 (boundary tick) — the assignment's own indoor/outdoor pair (the actual
+  t-wise combination under test), applied as a temp_update tick while the
+  preamble's real state is in effect — this is what finally lets
+  fan_thermostat_check() evaluate Check 1/Check 2 at the intended boundary.
+
+This is real production and reuses the existing 5809-scenario t=3 assignment set
+(no new dimension, no double-counting) — it only changes how each assignment
+REACHES the comparator's fan_running precondition.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Any
+
+from tools.sim_harness.enumerator import (
+    _BASE_TIME,
+    _SLEEP_TIME_UTC,
+    assignment_to_scenario,
+    generate_t_wise_assignments,
+)
+
+_NAT_VENT_PREAMBLE_INDOOR = 76.0
+_NAT_VENT_PREAMBLE_OUTDOOR = 60.0
+_FAN_MIN_RUNTIME_MINUTES = 60  # >= 60 => always-on once activated (automation.py _fan_cycle_on)
+
+
+def _fan_only_reachable(assignment: dict[str, Any]) -> bool:
+    """A real fan device must be configured — matches production: no device, no activation."""
+    return assignment.get("fan_mode") != "disabled"
+
+
+def _base_start_time(assignment: dict[str, Any]):
+    return _SLEEP_TIME_UTC if bool(assignment["sleep_window"]) else _BASE_TIME
+
+
+def build_two_phase_scenario(assignment: dict[str, Any], *, preamble: str, name: str) -> dict[str, Any] | None:
+    """Wrap one t=3 assignment's boundary tick with a real activation preamble.
+
+    Returns None when the requested preamble isn't reachable for this assignment
+    (e.g. "fan_only" with fan_mode=disabled) — the caller skips it, matching
+    reality: there is nothing to activate, not a scenario-building failure.
+    """
+    if preamble == "fan_only" and not _fan_only_reachable(assignment):
+        return None
+
+    boundary_scenario = assignment_to_scenario(assignment, name=name)
+    start_time = _base_start_time(assignment)
+
+    preamble_events: list[dict[str, Any]] = [
+        {
+            "time": (start_time - timedelta(minutes=10)).isoformat(),
+            "type": "classification",
+            "day_type": "mild",
+            "hvac_mode": "off",
+            "windows_recommended": False,
+        }
+    ]
+
+    if preamble == "nat_vent":
+        preamble_events.append(
+            {
+                "time": (start_time - timedelta(minutes=9)).isoformat(),
+                "type": "temp_update",
+                "indoor_f": _NAT_VENT_PREAMBLE_INDOOR,
+                "outdoor_f": _NAT_VENT_PREAMBLE_OUTDOOR,
+            }
+        )
+        preamble_events.append(
+            {
+                "time": (start_time - timedelta(minutes=8)).isoformat(),
+                "type": "sensor_open",
+                "entity": "binary_sensor.two_phase_preamble",
+            }
+        )
+    elif preamble == "fan_only":
+        boundary_scenario["config"]["fan_min_runtime_per_hour"] = _FAN_MIN_RUNTIME_MINUTES
+        preamble_events.append(
+            {
+                "time": (start_time - timedelta(minutes=8)).isoformat(),
+                "type": "activate_fan_min_runtime",
+            }
+        )
+    else:
+        raise ValueError(f"unknown preamble: {preamble!r}")
+
+    boundary_scenario["events"] = preamble_events + boundary_scenario["events"]
+    boundary_scenario["name"] = name
+    boundary_scenario["description"] = f"Two-phase ({preamble} preamble): {boundary_scenario['description']}"
+    return boundary_scenario
+
+
+@dataclass
+class TwoPhaseScenario:
+    name: str
+    preamble: str
+    assignment: dict[str, Any]
+    scenario: dict[str, Any]
+
+
+def build_two_phase_scenarios(t: int = 3, limit: int | None = None) -> list[TwoPhaseScenario]:
+    """Build both preamble variants for each t-wise assignment (skipping unreachable ones)."""
+    assignments = generate_t_wise_assignments(t=t)
+    if limit is not None:
+        assignments = assignments[:limit]
+
+    out: list[TwoPhaseScenario] = []
+    for i, assignment in enumerate(assignments):
+        for preamble in ("nat_vent", "fan_only"):
+            name = f"two_phase_{preamble}_{i:05d}"
+            scen = build_two_phase_scenario(assignment, preamble=preamble, name=name)
+            if scen is not None:
+                out.append(TwoPhaseScenario(name=name, preamble=preamble, assignment=assignment, scenario=scen))
+    return out

--- a/tools/sim_harness/full_surface_integration.py
+++ b/tools/sim_harness/full_surface_integration.py
@@ -1,0 +1,199 @@
+"""full_surface_integration — Step 4: prove the WHOLE nat-vent decision surface is
+load-bearing simultaneously, not just each pure function individually.
+
+Every mechanism below already has its own dedicated positive control
+(nat_vent_gate_integration.py, fan_thermostat_decision_integration.py) or was
+proven load-bearing inline in its own test file (fan_drift_reconciliation,
+nat_vent_reactivation_lockout, grace, setpoint retry/verify, pre-cool target,
+pre-cool reschedule). Those checks corrupt ONE function at a time. What they
+cannot show on their own is that the surface holds together as a whole: that
+corrupting every extracted decision point AT ONCE still produces detectable,
+non-cancelling divergence across the full scenario corpus — i.e. that nothing
+is silently masking or overriding anything else when everything is wrong
+simultaneously, and that "end-to-end" (the plan's own Step-4 language) is
+genuinely validated, not just each piece in isolation.
+
+`break_entire_nat_vent_surface()` composes every individual corruption into
+one context manager. Each corruption preserves the same safety invariants its
+own dedicated positive control already established (e.g. the gate's None-input
+guarantee) so a scenario doesn't crash instead of diverging.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from datetime import datetime
+from typing import Any
+
+from .fan_thermostat_decision_integration import break_fan_thermostat_decision
+from .nat_vent_gate_integration import break_nat_vent_gate
+
+
+@contextlib.contextmanager
+def _break_fan_drift_reconciliation():
+    from unittest.mock import patch  # noqa: PLC0415
+
+    from custom_components.climate_advisor.automation import (
+        decide_fan_drift_reconciliation as original,  # noqa: PLC0415
+    )
+    from custom_components.climate_advisor.fan_drift_reconciliation import FanDriftOutcome  # noqa: PLC0415
+
+    rotation = {
+        FanDriftOutcome.RESET: FanDriftOutcome.AWAITING,
+        FanDriftOutcome.NOOP: FanDriftOutcome.CORRECT,
+        FanDriftOutcome.AWAITING: FanDriftOutcome.NOOP,
+        FanDriftOutcome.CORRECT: FanDriftOutcome.RESET,
+    }
+
+    def _broken(inputs: Any) -> tuple[Any, int]:
+        outcome, tick_count = original(inputs)
+        return rotation[outcome], tick_count
+
+    with patch("custom_components.climate_advisor.automation.decide_fan_drift_reconciliation", _broken):
+        yield
+
+
+@contextlib.contextmanager
+def _break_reactivation_lockout():
+    from unittest.mock import patch  # noqa: PLC0415
+
+    # Must capture `original` BEFORE the patch is applied — importing it lazily inside
+    # _broken() would re-read automation.py's module-global AFTER patching, resolving
+    # to _broken itself and recursing infinitely (caught the hard way: RecursionError).
+    from custom_components.climate_advisor.automation import is_reactivation_locked_out as original  # noqa: PLC0415
+
+    def _broken(*, outdoor_exit_time: datetime | None, now: datetime, lockout_seconds: float) -> bool:
+        # Invert, but preserve "no prior exit recorded -> never locked out" — a blind
+        # invert would force True with no exit time on record, which no real call
+        # site's caller expects (the lockout concept requires an exit to have
+        # happened at all).
+        if outdoor_exit_time is None:
+            return False
+        return not original(outdoor_exit_time=outdoor_exit_time, now=now, lockout_seconds=lockout_seconds)
+
+    with patch("custom_components.climate_advisor.automation.is_reactivation_locked_out", _broken):
+        yield
+
+
+@contextlib.contextmanager
+def _break_grace_start():
+    from unittest.mock import patch  # noqa: PLC0415
+
+    def _broken(**_kwargs: Any) -> None:
+        # Always disable grace entirely — the strongest, simplest observable
+        # corruption: any scenario that starts a grace period and later checks
+        # its expiry/notification behavior will diverge.
+        return None
+
+    with patch("custom_components.climate_advisor.automation.decide_grace_start", _broken):
+        yield
+
+
+@contextlib.contextmanager
+def _break_setpoint_retry_action():
+    from unittest.mock import patch  # noqa: PLC0415
+
+    from custom_components.climate_advisor.automation import decide_setpoint_retry_action as original  # noqa: PLC0415
+    from custom_components.climate_advisor.desired_state import SetpointRetryAction  # noqa: PLC0415
+
+    rotation = {
+        SetpointRetryAction.SUPERSEDED: SetpointRetryAction.DIRECT_RETRY,
+        SetpointRetryAction.DIRECT_RETRY: SetpointRetryAction.NUDGE_THEN_TARGET,
+        SetpointRetryAction.NUDGE_THEN_TARGET: SetpointRetryAction.SUPERSEDED,
+    }
+
+    def _broken(*, current_write_seq: int, retry_write_seq: int, reject_streak: int) -> Any:
+        return rotation[
+            original(current_write_seq=current_write_seq, retry_write_seq=retry_write_seq, reject_streak=reject_streak)
+        ]
+
+    with patch("custom_components.climate_advisor.automation.decide_setpoint_retry_action", _broken):
+        yield
+
+
+@contextlib.contextmanager
+def _break_setpoint_verify():
+    from unittest.mock import patch  # noqa: PLC0415
+
+    from custom_components.climate_advisor.automation import decide_setpoint_verify as original  # noqa: PLC0415
+    from custom_components.climate_advisor.setpoint_verify_decision import SetpointVerifyOutcome  # noqa: PLC0415
+
+    rotation = {
+        SetpointVerifyOutcome.STALE: SetpointVerifyOutcome.WITHIN_TOLERANCE,
+        SetpointVerifyOutcome.NO_SETPOINT: SetpointVerifyOutcome.REASSERT,
+        SetpointVerifyOutcome.OVERRIDE_ACTIVE: SetpointVerifyOutcome.STALE,
+        SetpointVerifyOutcome.NO_READING: SetpointVerifyOutcome.OVERRIDE_ACTIVE,
+        SetpointVerifyOutcome.WITHIN_TOLERANCE: SetpointVerifyOutcome.REASSERT,
+        SetpointVerifyOutcome.REASSERT: SetpointVerifyOutcome.WITHIN_TOLERANCE,
+    }
+
+    def _broken(**kwargs: Any) -> Any:
+        return rotation[original(**kwargs)]
+
+    with patch("custom_components.climate_advisor.automation.decide_setpoint_verify", _broken):
+        yield
+
+
+@contextlib.contextmanager
+def _break_pre_cool_target():
+    from unittest.mock import patch  # noqa: PLC0415
+
+    # Capture the real implementation directly from its SOURCE module (automation.py),
+    # not via a lazy re-import inside _broken() — the latter would resolve to whichever
+    # of the two patches below is applied at call time and recurse infinitely.
+    from custom_components.climate_advisor.automation import compute_pre_cool_target as original  # noqa: PLC0415
+
+    def _broken(config: dict, setback_modifier: float) -> float:
+        # A large, obviously-wrong offset — not a sign flip (which could coincidentally
+        # land back on a valid clamp boundary for some configs) and not a huge enough
+        # jump to push the value out of a physically plausible temperature range that
+        # downstream formatting/logging might choke on.
+        return original(config, setback_modifier) + 15.0
+
+    # Patch BOTH import sites: automation.py's own module-global reference (used by
+    # handle_pre_cool()) and coordinator.py's separately-bound imported reference
+    # (used by the 4 chart/scheduling call sites) — patching one does not affect
+    # the other's already-resolved module-global binding.
+    with (
+        patch("custom_components.climate_advisor.automation.compute_pre_cool_target", _broken),
+        patch("custom_components.climate_advisor.coordinator.compute_pre_cool_target", _broken),
+    ):
+        yield
+
+
+@contextlib.contextmanager
+def _break_pre_cool_reschedule():
+    from unittest.mock import patch  # noqa: PLC0415
+
+    def _broken(**_kwargs: Any) -> None:
+        # Always suppress the reschedule — the strongest observable corruption for
+        # this mechanism (no scenario currently exercises a nat-vent-exit-ahead-of-
+        # schedule transition, a known, named coverage gap — see the CLI report).
+        return None
+
+    with patch("custom_components.climate_advisor.coordinator._decide_pre_cool_reschedule", _broken):
+        yield
+
+
+@contextlib.contextmanager
+def break_entire_nat_vent_surface():
+    """Compose every individual corruption into one simultaneous break.
+
+    Order does not matter for correctness (each corruption patches a distinct
+    name), but is listed in roughly call-order within a typical nat-vent cycle:
+    gate -> tick-level stop check -> physical drift reconciliation ->
+    reactivation lockout -> grace -> setpoint verify/retry -> pre-cool target
+    and reschedule.
+    """
+    with (
+        break_nat_vent_gate(),
+        break_fan_thermostat_decision(),
+        _break_fan_drift_reconciliation(),
+        _break_reactivation_lockout(),
+        _break_grace_start(),
+        _break_setpoint_retry_action(),
+        _break_setpoint_verify(),
+        _break_pre_cool_target(),
+        _break_pre_cool_reschedule(),
+    ):
+        yield

--- a/tools/sim_harness/nat_vent_gate_compare.py
+++ b/tools/sim_harness/nat_vent_gate_compare.py
@@ -1,0 +1,186 @@
+"""nat_vent_gate_compare — old-vs-new differential comparator for the nat-vent gate.
+
+Architecture-reset Step 2: the first real "old vs new" comparison in this
+project (everything in Step 1 was old-vs-old). Two modes, sharing one input
+reconstruction:
+
+- **Shadow mode** (``compare_scenario`` / ``_instrumented_gate``): the real
+  production ``_nat_vent_may_reactivate()`` runs and its answer drives the live
+  engine; the new pure ``decide_nat_vent_gate()`` is evaluated on the same
+  reconstructed inputs ONLY for comparison — it never affects behavior. Proves
+  "would the new function have agreed," not "does the rest of the scenario
+  unfold the same way if you let it decide."
+- **Substitution mode** (``substitute_new_gate`` / ``run_substituted_scenario``):
+  the new pure function's answer is what actually gets returned to the live
+  engine — it genuinely drives behavior. Used with ``tools.sim_harness.differential``'s
+  ``diff_runs(scenario, mutate_b=substitute_new_gate)`` to diff the ENTIRE
+  resulting ``action_log``/``event_log`` against an untouched baseline, not just
+  one function's boolean. This is what closes the "shadow-only, never
+  substituted" gap found after Step 2 shipped shadow-mode only.
+
+Both modes reconstruct the full set of raw inputs the call chain actually used
+(reading ``self.config`` directly and resolving ``in_sleep_window`` via the real
+``_in_sleep_window()`` helper — not back-derived from already-resolved values),
+via the shared ``_reconstruct_inputs()`` helper, so there is exactly one place
+that logic lives (not duplicated between shadow and substitution modes).
+
+Production integration follow-up: ``_nat_vent_may_reactivate()`` now calls
+``decide_nat_vent_gate()`` directly (mirroring the same extraction done for
+``fan_thermostat_check()``) — production simply IS the pure function's caller.
+This means shadow mode above is now comparing production to itself (still
+harmless, still a valid regression guard, but no longer an "old vs new"
+comparison in the original sense), and substitution mode's "does letting the
+new function decide change anything" question is trivially "no" by
+construction. The genuinely informative check now is proving the extraction
+is LOAD-BEARING — see ``tools/sim_harness/nat_vent_gate_integration.py``'s
+positive control (patches ``automation.decide_nat_vent_gate``, the name
+automation.py actually calls, to an inverted function and confirms real
+scenarios diverge).
+"""
+
+from __future__ import annotations
+
+import contextlib
+from dataclasses import dataclass, field
+from typing import Any
+
+
+def _reconstruct_inputs(self: Any, kwargs: dict[str, Any]) -> Any:
+    """Rebuild the equivalent NatVentGateInputs from a live _nat_vent_may_reactivate call.
+
+    Shared by both shadow and substitution modes so there is exactly one place
+    this reconstruction logic lives.
+    """
+    from homeassistant.util import dt as dt_util  # noqa: PLC0415
+
+    from custom_components.climate_advisor import const  # noqa: PLC0415
+    from custom_components.climate_advisor.automation import _in_sleep_window  # noqa: PLC0415
+    from custom_components.climate_advisor.nat_vent_gate import NatVentGateInputs  # noqa: PLC0415
+
+    comfort_heat_raw = float(self.config.get("comfort_heat", 70))
+    sleep_heat = float(self.config.get(const.CONF_SLEEP_HEAT, comfort_heat_raw))
+    in_sleep_window = _in_sleep_window(dt_util.now(), self.config)
+    nat_vent_delta = float(self.config.get(const.CONF_NATURAL_VENT_DELTA, const.DEFAULT_NATURAL_VENT_DELTA))
+    fan_mode = self.config.get(const.CONF_FAN_MODE, const.FAN_MODE_DISABLED)
+    aggressive_savings = bool(self.config.get("aggressive_savings", False))
+
+    return NatVentGateInputs(
+        outdoor=kwargs.get("outdoor"),
+        indoor=kwargs.get("indoor"),
+        comfort_heat_raw=comfort_heat_raw,
+        sleep_heat=sleep_heat,
+        in_sleep_window=in_sleep_window,
+        comfort_cool=float(kwargs.get("comfort_cool")),
+        nat_vent_delta=nat_vent_delta,
+        hysteresis=float(kwargs.get("hysteresis", 0.0)),
+        fan_mode=fan_mode,
+        aggressive_savings=aggressive_savings,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shadow mode — compare only, never drives behavior
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class GateCall:
+    """One intercepted call to the real reactivation gate + the comparison result."""
+
+    scenario_name: str
+    real_kwargs: dict[str, Any]
+    real_result: bool
+    new_inputs: Any  # NatVentGateInputs
+    new_result: bool
+
+    @property
+    def agrees(self) -> bool:
+        return self.real_result == self.new_result
+
+
+@dataclass
+class GateComparisonRun:
+    calls: list[GateCall] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def n_calls(self) -> int:
+        return len(self.calls)
+
+    @property
+    def n_agree(self) -> int:
+        return sum(1 for c in self.calls if c.agrees)
+
+    @property
+    def disagreements(self) -> list[GateCall]:
+        return [c for c in self.calls if not c.agrees]
+
+
+@contextlib.contextmanager
+def _instrumented_gate(run: GateComparisonRun, scenario_name: str):
+    """Wrap AutomationEngine._nat_vent_may_reactivate to intercept every call (shadow mode)."""
+    from unittest.mock import patch  # noqa: PLC0415
+
+    from custom_components.climate_advisor.automation import AutomationEngine  # noqa: PLC0415
+    from custom_components.climate_advisor.nat_vent_gate import decide_nat_vent_gate  # noqa: PLC0415
+
+    original = AutomationEngine._nat_vent_may_reactivate
+
+    def _wrapped(self: Any, **kwargs: Any) -> bool:
+        real_result = original(self, **kwargs)
+
+        try:
+            new_inputs = _reconstruct_inputs(self, kwargs)
+            new_result = decide_nat_vent_gate(new_inputs)
+            run.calls.append(
+                GateCall(
+                    scenario_name=scenario_name,
+                    real_kwargs=dict(kwargs),
+                    real_result=real_result,
+                    new_inputs=new_inputs,
+                    new_result=new_result,
+                )
+            )
+        except Exception as exc:  # noqa: BLE001 — never let comparison-side errors break production
+            run.errors.append(f"{scenario_name}: comparator error: {type(exc).__name__}: {exc}")
+
+        return real_result
+
+    with patch.object(AutomationEngine, "_nat_vent_may_reactivate", _wrapped):
+        yield
+
+
+def compare_scenario(scenario: dict, scenario_name: str, run: GateComparisonRun) -> None:
+    """Run one scenario through the real engine with the gate instrumented (shadow mode)."""
+    from tools.sim_harness.run_production import run_production_scenario  # noqa: PLC0415
+
+    with _instrumented_gate(run, scenario_name):
+        run_production_scenario(scenario)
+
+
+# ---------------------------------------------------------------------------
+# Substitution mode — the new function's answer actually drives behavior
+# ---------------------------------------------------------------------------
+
+
+@contextlib.contextmanager
+def substitute_new_gate():
+    """Replace _nat_vent_may_reactivate's REAL return value with decide_nat_vent_gate()'s
+    answer, reconstructed from the same inputs the real call would have used.
+
+    Unlike shadow mode, this genuinely changes what the live engine does if the
+    new function ever disagrees — intended for use as ``diff_runs(scenario,
+    mutate_b=substitute_new_gate)`` so the FULL resulting action_log/event_log
+    can be diffed against an untouched baseline, not just one function's boolean.
+    """
+    from unittest.mock import patch  # noqa: PLC0415
+
+    from custom_components.climate_advisor.automation import AutomationEngine  # noqa: PLC0415
+    from custom_components.climate_advisor.nat_vent_gate import decide_nat_vent_gate  # noqa: PLC0415
+
+    def _substituted(self: Any, **kwargs: Any) -> bool:
+        new_inputs = _reconstruct_inputs(self, kwargs)
+        return decide_nat_vent_gate(new_inputs)
+
+    with patch.object(AutomationEngine, "_nat_vent_may_reactivate", _substituted):
+        yield

--- a/tools/sim_harness/nat_vent_gate_integration.py
+++ b/tools/sim_harness/nat_vent_gate_integration.py
@@ -1,0 +1,41 @@
+"""nat_vent_gate_integration — production load-bearing proof for the reactivation gate.
+
+`_nat_vent_may_reactivate()` in automation.py now directly calls
+`decide_nat_vent_gate()` (mirroring the same extraction already done for
+`fan_thermostat_check()` / Issue #435 follow-up) — there is no separate "old"
+inline implementation left to substitute against; production simply IS the
+pure function's caller. `substitute_new_gate()` in nat_vent_gate_compare.py
+predates this and is now comparing production to itself (still harmless, but
+no longer informative on its own).
+
+What remains meaningful to prove: the extraction is genuinely LOAD-BEARING.
+`break_nat_vent_gate()` patches the exact name automation.py imported at
+module scope (`automation.decide_nat_vent_gate` — a direct top-level import,
+so the patch target is the IMPORTING module, not the source module) to an
+inverted function. If a real scenario's full action_log/event_log does NOT
+diverge when this is applied, the extraction isn't actually driving behavior.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import Any
+
+
+@contextlib.contextmanager
+def break_nat_vent_gate():
+    from unittest.mock import patch  # noqa: PLC0415
+
+    from custom_components.climate_advisor.automation import decide_nat_vent_gate as original  # noqa: PLC0415
+
+    def _broken(inputs: Any) -> bool:
+        # Preserve the None-safety guarantee production code relies on (never
+        # activate with unavailable outdoor/indoor) — a blind inversion would force
+        # True in exactly that case, tripping downstream formatting code that only
+        # runs when the real gate's None-guard already ruled activation out.
+        if inputs.outdoor is None or inputs.indoor is None:
+            return False
+        return not original(inputs)
+
+    with patch("custom_components.climate_advisor.automation.decide_nat_vent_gate", _broken):
+        yield

--- a/tools/sim_harness/outcomes.py
+++ b/tools/sim_harness/outcomes.py
@@ -553,6 +553,81 @@ def check_assertion(
         )
         return expect if not fired_this_cycle else False
 
+    # --- reconcile_fan_on_startup outcomes (Step 1 blind-spot closure) ---
+    # reconcile_fan_on_startup() had zero golden coverage before this. Its "adopt-on"
+    # and "turn-off" branches are distinguished by reason-string/event-type
+    # combinations no other function emits, scanned directly from event_log — purely
+    # additive. The third branch ("no-fan") is already exercised directly at the unit
+    # level in tests/test_fan_control.py — no golden-level check added for it.
+    if expect == "reconcile_adopted_fan":
+        at_str = assertion["at"]
+        for ev_type, ev_payload, ev_ts in result.event_log:
+            if (
+                ev_type == "fan_activated"
+                and ev_ts is not None
+                and _naive_iso(ev_ts) <= at_str
+                and str(ev_payload.get("reason", "")).startswith("startup reconcile — fan already running")
+            ):
+                return "reconcile_adopted_fan"
+        return False
+
+    if expect == "reconcile_turned_off_fan":
+        at_str = assertion["at"]
+        for ev_type, _ev_payload, ev_ts in result.event_log:
+            if ev_type == "nat_vent_reconcile_exit" and ev_ts is not None and _naive_iso(ev_ts) <= at_str:
+                return "reconcile_turned_off_fan"
+        return False
+
+    # --- economizer_final_phase (Step 1 blind-spot closure) ---
+    # Some economizer phase transitions (e.g. cool-down -> maintain while the fan is
+    # ALREADY on) do not emit a fresh fan_activated event — _activate_fan()'s own
+    # idempotency guard (self._fan_active already True) returns before emitting,
+    # since physically nothing new needs to happen. economizer_phase (below) cannot
+    # see that transition since it only reads events. This checks the actual internal
+    # _economizer_phase attribute at the END of the scenario instead — only meaningful
+    # as the LAST assertion in a scenario (like nat_vent_still_active/not_active above).
+    # Payload: {"phase": "cool-down" | "maintain" | "inactive"}.
+    if expect == "economizer_final_phase":
+        if engine_state.get("_economizer_phase") == assertion.get("phase"):
+            return "economizer_final_phase"
+        return False
+
+    # --- economizer_phase (Step 1 blind-spot closure) ---
+    # check_window_cooling_opportunity()/_deactivate_economizer() never emit a
+    # dedicated decision event of their own — they reuse the generic fan_activated/
+    # fan_deactivated events also emitted by nat-vent, min-runtime cycling, etc.
+    # Mapping "fan_activated" generically into the decisions list would risk
+    # contaminating every OTHER golden's assertions at the same timestamp (the same
+    # hazard comfort_band_applied's own exclusion comment above documents) — instead
+    # this scans event_log directly for the economizer's own distinctive reason-string
+    # prefixes, purely additive, no existing outcome mapping touched.
+    # Payload: {"phase": "cool-down" | "maintain" | "inactive"}.
+    if expect == "economizer_phase":
+        expected_phase = assertion.get("phase")
+        at_str = assertion["at"]
+        last_phase: str | None = None
+        last_ts = ""
+        for ev_type, ev_payload, ev_ts in result.event_log:
+            if ev_ts is None:
+                continue
+            ts_naive = _naive_iso(ev_ts)
+            if ts_naive > at_str:
+                continue
+            reason = str(ev_payload.get("reason", ""))
+            if ev_type == "fan_activated" and reason.startswith("economizer cool-down"):
+                phase = "cool-down"
+            elif ev_type == "fan_activated" and reason.startswith("economizer maintain"):
+                phase = "maintain"
+            elif ev_type == "fan_deactivated" and reason.startswith("economizer off"):
+                phase = "inactive"
+            else:
+                continue
+            if ts_naive >= last_ts:
+                last_phase = phase
+                last_ts = ts_naive
+        computed_phase = last_phase if last_phase is not None else "inactive"
+        return "economizer_phase" if computed_phase == expected_phase else False
+
     # --- comfort_band_armed (Issue #249 P3) ---
     # Asserts that at least one comfort_band_applied event exists at or before the
     # assertion time.  Used by scenarios that want to verify the band was armed without

--- a/tools/sim_harness/run_production.py
+++ b/tools/sim_harness/run_production.py
@@ -18,27 +18,38 @@ Event-type → production-method mapping (mirrors simulate.py process_event):
 
   temp_update             → engine.update_outdoor_temp(outdoor_f)
                             + inject indoor temp via climate entity attribute
-                            + asyncio.run(engine.check_natural_vent_conditions())
-  sensor_open             → asyncio.run(engine.handle_door_window_open(entity_id))
+                            + IF indoor changed: run_coro(engine.nat_vent_temperature_check())
+                              (if nat-vent active) + run_coro(engine.fan_thermostat_check())
+                              (if any CA fan active) — mirrors _async_thermostat_changed's
+                              state-listener dispatch (coordinator.py:2837-2862)
+                            + run_coro(engine.check_natural_vent_conditions())
+  sensor_open             → run_coro(engine.handle_door_window_open(entity_id))
   sensor_close            → update engine._sensor_check_callback
                             + if no sensors open:
-                              asyncio.run(engine.handle_all_doors_windows_closed())
+                              run_coro(engine.handle_all_doors_windows_closed())
   classification          → build DayClassification from event fields
-                            + asyncio.run(engine.apply_classification(classification))
+                            + run_coro(engine.apply_classification(classification))
   occupancy_away          → engine.set_occupancy_mode("away")
-                            + asyncio.run(engine.handle_occupancy_away())
+                            + run_coro(engine.handle_occupancy_away())
   occupancy_home          → engine.set_occupancy_mode("home")
-                            + asyncio.run(engine.handle_occupancy_home())
+                            + run_coro(engine.handle_occupancy_home())
   occupancy_vacation      → engine.set_occupancy_mode("vacation")
-                            + asyncio.run(engine.handle_occupancy_vacation())
+                            + run_coro(engine.handle_occupancy_vacation())
   occupancy_change        → dispatches to away/home/vacation by event["mode"]
   occupancy_change_with_override
                           → sets _manual_override_active=True then dispatches
-  bedtime                 → asyncio.run(engine.handle_bedtime())
-  wakeup                  → asyncio.run(engine.handle_morning_wakeup())
-  economizer_check        → asyncio.run(engine.check_window_cooling_opportunity(...))
+  bedtime                 → run_coro(engine.handle_bedtime())
+  wakeup                  → run_coro(engine.handle_morning_wakeup())
+  economizer_check        → run_coro(engine.check_window_cooling_opportunity(...))
   thermostat_state_changed
                           → inject thermostat state + engine.handle_manual_override(...)
+  activate_fan_min_runtime
+                          → run_coro(engine.start_min_fan_runtime_cycles()) — real public
+                            entry point, activates the fan without a nat-vent session
+  reconcile_fan_on_startup
+                          → inject indoor/outdoor + run_coro(engine.reconcile_fan_on_startup(
+                            thermostat_fan_running=, any_sensor_open=)) — mirrors the
+                            coordinator's startup-coalesce call
 
 No clean production entry points (FINDINGS):
   fan_cycle_on   — _fan_cycle_on() is private; production triggers it via
@@ -59,7 +70,6 @@ No clean production entry points (FINDINGS):
 
 from __future__ import annotations
 
-import asyncio
 import os
 import sys
 from dataclasses import dataclass, field
@@ -72,6 +82,7 @@ _PROJECT_ROOT = os.path.dirname(os.path.dirname(_HERE))
 if _PROJECT_ROOT not in sys.path:
     sys.path.insert(0, _PROJECT_ROOT)
 
+from tools.sim_harness._loop import run_coro  # noqa: E402
 from tools.sim_harness.build_engine import _DEFAULT_CONFIG, build_headless_engine  # noqa: E402
 from tools.sim_harness.fake_hass import FakeHass, FakeState  # noqa: E402
 from tools.sim_harness.fake_scheduler import FakeScheduler  # noqa: E402
@@ -340,13 +351,13 @@ def _dispatch_event(
     elif etype == "sensor_open":
         entity_id = event.get("entity", "binary_sensor.window")
         tracker.open(entity_id)
-        asyncio.run(engine.handle_door_window_open(entity_id))
+        run_coro(engine.handle_door_window_open(entity_id))
 
     elif etype == "sensor_close":
         entity_id = event.get("entity", "binary_sensor.window")
         tracker.close(entity_id)
         if tracker.all_closed():
-            asyncio.run(engine.handle_all_doors_windows_closed())
+            run_coro(engine.handle_all_doors_windows_closed())
         # If sensors still open, production does nothing on partial close —
         # it waits for all_closed() to be called.
 
@@ -364,29 +375,29 @@ def _dispatch_event(
                     _cls_indoor_f = float(_cls_indoor_f)
                 except (TypeError, ValueError):
                     _cls_indoor_f = None
-        asyncio.run(engine.apply_classification(classification, indoor_temp=_cls_indoor_f))
+        run_coro(engine.apply_classification(classification, indoor_temp=_cls_indoor_f))
 
     elif etype == "occupancy_away":
         engine.set_occupancy_mode("away")
-        asyncio.run(engine.handle_occupancy_away())
+        run_coro(engine.handle_occupancy_away())
 
     elif etype == "occupancy_home":
         engine.set_occupancy_mode("home")
-        asyncio.run(engine.handle_occupancy_home())
+        run_coro(engine.handle_occupancy_home())
 
     elif etype == "occupancy_vacation":
         engine.set_occupancy_mode("vacation")
-        asyncio.run(engine.handle_occupancy_vacation())
+        run_coro(engine.handle_occupancy_vacation())
 
     elif etype == "occupancy_change":
         mode = event.get("mode", "home")
         engine.set_occupancy_mode(mode)
         if mode == "away":
-            asyncio.run(engine.handle_occupancy_away())
+            run_coro(engine.handle_occupancy_away())
         elif mode == "vacation":
-            asyncio.run(engine.handle_occupancy_vacation())
+            run_coro(engine.handle_occupancy_vacation())
         else:
-            asyncio.run(engine.handle_occupancy_home())
+            run_coro(engine.handle_occupancy_home())
 
     elif etype == "occupancy_change_with_override":
         # Mirrors simulate.py: set override active, then dispatch occupancy
@@ -394,17 +405,17 @@ def _dispatch_event(
         mode = event.get("mode", "home")
         engine.set_occupancy_mode(mode)
         if mode == "away":
-            asyncio.run(engine.handle_occupancy_away())
+            run_coro(engine.handle_occupancy_away())
         elif mode == "vacation":
-            asyncio.run(engine.handle_occupancy_vacation())
+            run_coro(engine.handle_occupancy_vacation())
         else:
-            asyncio.run(engine.handle_occupancy_home())
+            run_coro(engine.handle_occupancy_home())
 
     elif etype == "bedtime":
-        asyncio.run(engine.handle_bedtime())
+        run_coro(engine.handle_bedtime())
 
     elif etype == "wakeup":
-        asyncio.run(engine.handle_morning_wakeup())
+        run_coro(engine.handle_morning_wakeup())
 
     elif etype == "economizer_check":
         outdoor_temp = float(event.get("outdoor_temp", event.get("outdoor_f", 70.0)))
@@ -415,7 +426,30 @@ def _dispatch_event(
         engine.update_outdoor_temp(outdoor_temp)
         windows_open = bool(event.get("windows_open", False))
         hour = int(event.get("hour", -1))
-        asyncio.run(engine.check_window_cooling_opportunity(outdoor_temp, indoor_temp, windows_open, hour))
+        run_coro(engine.check_window_cooling_opportunity(outdoor_temp, indoor_temp, windows_open, hour))
+
+    elif etype == "reconcile_fan_on_startup":
+        # Step-1 blind-spot closure: no golden previously exercised this coordinator
+        # startup-coalesce entry point at all. Mirrors coordinator._do_startup_coalesce's
+        # call, which passes an archetype-resolved thermostat_fan_running signal (real
+        # thermostat attrs for FAN_MODE_HVAC, the physical WHF entity state for
+        # FAN_MODE_WHOLE_HOUSE, per Issue #423) — the scenario supplies that already-
+        # resolved boolean directly, since resolving it from raw entity state is the
+        # coordinator's job, not this engine method's.
+        outdoor_f = event.get("outdoor_f")
+        if outdoor_f is not None:
+            engine.update_outdoor_temp(float(outdoor_f))
+        indoor_f = event.get("indoor_f")
+        if indoor_f is not None:
+            _inject_indoor_temp(fake_hass, climate_entity, float(indoor_f))
+        run_coro(
+            engine.reconcile_fan_on_startup(
+                indoor=engine._get_indoor_temp_f(),
+                outdoor=engine._last_outdoor_temp,
+                thermostat_fan_running=bool(event.get("thermostat_fan_running", False)),
+                any_sensor_open=bool(event.get("any_sensor_open", False)),
+            )
+        )
 
     elif etype == "thermostat_state_changed":
         # Mirrors coordinator._async_thermostat_changed stale-clear + override detection.
@@ -447,12 +481,22 @@ def _dispatch_event(
         # via advance_to() before each event.
         pass
 
+    elif etype == "activate_fan_min_runtime":
+        # Real, public production entry point (start_min_fan_runtime_cycles(), called
+        # at coordinator startup / after override-clear) — NOT the internal timer-driven
+        # mid-cycle re-trigger the module docstring's fan_cycle_on/off FINDING refers to.
+        # Added for Step 2 fan_thermostat_check two-phase synthetic coverage: activates
+        # the fan (self._fan_active=True) WITHOUT a nat-vent session
+        # (self._natural_vent_active stays False), the precondition needed to reach
+        # Check 1's STOP_DEACTIVATE branch and Check 2's non-nat-vent floor stop.
+        run_coro(engine.start_min_fan_runtime_cycles())
+
     elif etype == "nat_vent_temperature_check":
         # Bug 3 (Issue #321): Dispatch midpoint-cycling re-evaluation to the production engine.
         # Used by nat_vent_thermostat_cycling pending scenario to assert cycling behavior.
         indoor_temp = float(event.get("indoor_temp", event.get("indoor_f", 70.0)))
         _inject_indoor_temp(fake_hass, climate_entity, indoor_temp)
-        asyncio.run(engine.nat_vent_temperature_check(indoor_temp))
+        run_coro(engine.nat_vent_temperature_check(indoor_temp))
 
     elif etype == "pre_cool":
         # Issue #258: Dispatch the pre-cool trigger to the production engine.
@@ -463,7 +507,7 @@ def _dispatch_event(
         if indoor_temp is not None:
             _inject_indoor_temp(fake_hass, climate_entity, indoor_temp)
         nat_vent_just_closed = bool(event.get("nat_vent_just_closed", False))
-        asyncio.run(engine.handle_pre_cool(indoor_temp=indoor_temp, nat_vent_just_closed=nat_vent_just_closed))
+        run_coro(engine.handle_pre_cool(indoor_temp=indoor_temp, nat_vent_just_closed=nat_vent_just_closed))
 
     # All other unknown types are silently ignored (mirrors simulate.py's final `return None`)
 
@@ -474,9 +518,26 @@ def _handle_temp_update(
     fake_hass: FakeHass,
     climate_entity: str,
 ) -> None:
-    """Handle temp_update: inject temperatures, then re-evaluate nat-vent conditions."""
+    """Handle temp_update: inject temperatures, then re-evaluate nat-vent conditions.
+
+    Mirrors TWO distinct real production triggers, not one:
+      1. ``_async_thermostat_changed`` (coordinator.py:2837-2862) — a state-listener
+         that fires on every indoor current_temperature ATTRIBUTE change and calls
+         ``nat_vent_temperature_check()`` (if nat-vent active) and
+         ``fan_thermostat_check()`` (if any CA fan active) directly. Until this fix,
+         this adapter never dispatched here at all — the fan-thermostat-check
+         shadow comparator (Step 2 slice 2) found zero calls across the entire
+         5809-scenario synthetic sweep because of exactly this gap, not because of
+         a missing enumerator dimension.
+      2. ``check_natural_vent_conditions()`` — the periodic ``_async_update_data``
+         cycle re-evaluation (docstring: "Called by coordinator on each
+         _async_update_data when sensors are open"), already dispatched below.
+    """
     outdoor_f = event.get("outdoor_f")
     indoor_f = event.get("indoor_f")
+
+    existing = fake_hass.states.get(climate_entity)
+    old_indoor = existing.attributes.get("current_temperature") if existing is not None else None
 
     if outdoor_f is not None:
         engine.update_outdoor_temp(float(outdoor_f))
@@ -484,9 +545,22 @@ def _handle_temp_update(
     if indoor_f is not None:
         _inject_indoor_temp(fake_hass, climate_entity, float(indoor_f))
 
+    new_indoor = float(indoor_f) if indoor_f is not None else None
+    if new_indoor is not None and new_indoor != old_indoor:
+        if engine._natural_vent_active:
+            run_coro(engine.nat_vent_temperature_check(new_indoor))
+        if engine._fan_active or engine._natural_vent_active:
+            run_coro(
+                engine.fan_thermostat_check(
+                    indoor=engine._get_indoor_temp_f(),
+                    outdoor=engine._last_outdoor_temp,
+                    trigger="tick",
+                )
+            )
+
     # Production: coordinator calls check_natural_vent_conditions() on each update.
     # This is the correct re-evaluation entry point for temperature changes.
-    asyncio.run(engine.check_natural_vent_conditions())
+    run_coro(engine.check_natural_vent_conditions())
 
     # Issue #236 (ceiling-D): the ODE ceiling guard lives inside apply_classification,
     # which production re-runs every coordinator cycle. The harness models classification
@@ -497,7 +571,7 @@ def _handle_temp_update(
     if predicted and getattr(engine, "_current_classification", None) is not None:
         # Issue #295: pass current indoor temp so achievement gate is evaluated on cycle.
         _tu_indoor_f = float(indoor_f) if indoor_f is not None else None
-        asyncio.run(
+        run_coro(
             engine.apply_classification(
                 engine._current_classification,
                 predicted_indoor=predicted,
@@ -525,6 +599,7 @@ def _snapshot_engine_state(engine: Any) -> dict[str, Any]:
         "_occupancy_mode",
         "_override_confirm_pending",
         "_economizer_active",
+        "_economizer_phase",
         "_pre_condition_achieved",  # Issue #295
         "_pre_condition_achieved_date",  # Issue #295
     ):

--- a/tools/simulations/golden/MANIFEST.json
+++ b/tools/simulations/golden/MANIFEST.json
@@ -54,8 +54,8 @@
     "issue": 249
   },
   "cool_all_day_heat_all_day": {
-    "sha256": "c37017e8be21f9589a74dc8363314cfc6988e089958bd36f434e7e218e3b9e89",
-    "signed": "2026-06-10",
+    "sha256": "9b4b43685728056314028e83a66175fcc3e8860752bf8647b213dade518ac634",
+    "signed": "2026-07-10",
     "issue": 136
   },
   "hot_all_day_no_nat_vent_window": {
@@ -209,13 +209,13 @@
     "issue": 229
   },
   "overnight_with_adaptive_setback_and_wakeup": {
-    "sha256": "7c82f52639201eb51e2e183052af5c0c2ace9cd378111de2295b8e3bc8e95988",
-    "signed": "2026-06-13",
+    "sha256": "eb16f8b51a1450a022414445d45fc0dd06a7c7ebdf6a7b35300b130166c0562a",
+    "signed": "2026-07-10",
     "issue": 229
   },
   "strong_warming_trend_aggressive_setback": {
-    "sha256": "ee9b0fa28fd6ef91bfca8865369f7d14989995fcf56a55f38f43e9f12bfee406",
-    "signed": "2026-06-15",
+    "sha256": "e02c9c5d849cc6c39baaea2b3f417fbebfd8a879c69743f21d6106673a599784",
+    "signed": "2026-07-10",
     "issue": 229
   },
   "vacation_mode_full_lifecycle": {
@@ -224,8 +224,8 @@
     "issue": 229
   },
   "whole_house_fan_hvac_suppression": {
-    "sha256": "3e6b1adba47bbb96497b7383296240cf5726baf01513e63bc402c81c500e458e",
-    "signed": "2026-06-13",
+    "sha256": "076988910659e8552004754f5a9f1271c57f8a70fb7ec6a71c4eb0251cd2c54f",
+    "signed": "2026-07-09",
     "issue": 277
   },
   "window_close_stops_whole_house_fan": {
@@ -244,18 +244,43 @@
     "issue": 321
   },
   "warming_trend_pre_cool_applied": {
-    "sha256": "4c74ba82269948eac207694d54aeaab7bf2a51b24abc574850dab66b40fac1f6",
-    "signed": "2026-06-15",
+    "sha256": "1b98d73f4163b93673a2f9e8d170685fadbb6281530bb92109a2ccf6831f802c",
+    "signed": "2026-07-10",
     "issue": 258
   },
   "warming_trend_pre_cool_nat_vent_bypass": {
-    "sha256": "0ecee88989fb299e7a443f225be96cd1f85350749586e3aca833a0be2dcd6153",
-    "signed": "2026-06-15",
+    "sha256": "e24d63e60a07ed8d730a4025ae0b2c33ecc0c7053ae344e26497da8dd874e84e",
+    "signed": "2026-07-10",
     "issue": 258
   },
   "whf_reactivates_after_sleep_floor_exit": {
     "sha256": "1f006241b2d6b8dc11d04fdfa1da86a7bc43dd6d91626a86962b8ac10c6a13db",
     "signed": "2026-07-03",
     "issue": 402
+  },
+  "economizer-cool-down-to-maintain": {
+    "sha256": "24d89ce37f9792cb1f4ec08f337357bc0ea21d0fba2d3e9af99fc485fb1ebd3b",
+    "signed": "2026-07-09",
+    "issue": 429
+  },
+  "economizer-deactivates-outside-time-window": {
+    "sha256": "e606d290d7bedab570466979fb9c32b924d496ebd624054b6c53e5f73f1b0bce",
+    "signed": "2026-07-09",
+    "issue": 429
+  },
+  "grace-expiry-repause-sensor-still-open": {
+    "sha256": "95ead5ffd05872086bbc28bb84a9dd262d6b4210f7d28e04964e198d2e8ed66f",
+    "signed": "2026-07-09",
+    "issue": 429
+  },
+  "reconcile-adopts-running-fan-as-nat-vent": {
+    "sha256": "43c83578abe3a8d6c677dd01ad84f750bbca06c156d97d4172c586e164cc912f",
+    "signed": "2026-07-09",
+    "issue": 429
+  },
+  "reconcile-turns-off-unwarranted-fan": {
+    "sha256": "ef6028a26dcd55f2c91f7314aa357a7e167b0c04e4ba1aea375dce4ca954ebad",
+    "signed": "2026-07-09",
+    "issue": 429
   }
 }

--- a/tools/simulations/golden/cool_all_day_heat_all_day.json
+++ b/tools/simulations/golden/cool_all_day_heat_all_day.json
@@ -6,7 +6,7 @@
   "notes": [
     "Covers the standard cold day pattern: heat on all day, no nat vent, setback at night.",
     "Outdoor never reaches indoor levels — no nat vent activation is possible.",
-    "Bedtime setback uses default depth (4F below comfort_heat) since no thermal model is configured.",
+    "Bedtime setback uses DEFAULT_SLEEP_HEAT (64F, a flat default reformatted to a real tuned installation's own value in the architecture-reset session) since no thermal model or explicit sleep_heat is configured.",
     "This is a gap-filling scenario: confirms heat mode is applied and maintained, setback fires correctly."
   ],
   "config": {
@@ -49,7 +49,7 @@
     {
       "time": "2026-01-15T22:00:00",
       "type": "bedtime",
-      "note": "Bedtime: heat setback fires. Default depth = comfort_heat(70) - 4F = 66F. Floor is setback_heat=62F so 66F is above floor."
+      "note": "Bedtime: heat setback fires. DEFAULT_SLEEP_HEAT=64F (no explicit sleep_heat configured). Floor is setback_heat=62F so 64F is above floor."
     }
   ],
   "assertions": [
@@ -67,14 +67,14 @@
     {
       "at": "2026-01-15T22:00:00",
       "expect": "setback_applied",
-      "expect_temp": 66.0,
-      "reason": "Bedtime setback: heat mode, default depth 4F below comfort_heat=70F → 66F. Above setback_heat=62F floor."
+      "expect_temp": 64.0,
+      "reason": "Bedtime setback: heat mode, DEFAULT_SLEEP_HEAT=64F (no explicit sleep_heat configured). Above setback_heat=62F floor."
     }
   ],
   "verdict": {
     "type": "positive",
-    "summary": "Cold day applies heat at comfort target all day; bedtime setback fires at default depth",
-    "observed_behavior": "classification_applied (heat, 70F) at 6 AM → setback_applied (66F) at bedtime",
-    "expected_behavior": "Continuous heat mode all day; no nat vent (outdoor too cold); bedtime setback to 66F"
+    "summary": "Cold day applies heat at comfort target all day; bedtime setback fires at DEFAULT_SLEEP_HEAT",
+    "observed_behavior": "classification_applied (heat, 70F) at 6 AM → setback_applied (64F) at bedtime",
+    "expected_behavior": "Continuous heat mode all day; no nat vent (outdoor too cold); bedtime setback to 64F"
   }
 }

--- a/tools/simulations/golden/economizer-cool-down-to-maintain.json
+++ b/tools/simulations/golden/economizer-cool-down-to-maintain.json
@@ -1,0 +1,72 @@
+{
+  "name": "economizer-cool-down-to-maintain",
+  "description": "Hot day, windows open in the morning economizer window: engages cool-down phase while indoor is above comfort, then transitions to maintain once indoor cools to comfort (Issue #429 blind-spot closure — check_window_cooling_opportunity had zero golden coverage before this scenario).",
+  "source": "synthetic",
+  "issue": 429,
+  "notes": [
+    "Closes one of the 3 Step-1 blind spots named in the architecture-reset plan: check_window_cooling_opportunity (the economizer) had zero golden coverage — a boundary bug here would have shipped undetected.",
+    "The cool-down -> maintain transition does NOT emit a fresh fan_activated event (the fan is already on; _activate_fan()'s own idempotency guard returns before emitting since nothing physically needs to happen) — this is why the maintain assertion uses the new economizer_final_phase state-based check (reads engine_state._economizer_phase directly) instead of the event-based economizer_phase check used for the initial cool-down engagement.",
+    "fan_mode must be configured (hvac_fan here) — the economizer's fan-assist calls are ALSO no-ops when fan_mode is disabled, the same class of gap Issue #435 found in nat_vent_temperature_check()."
+  ],
+  "config": {
+    "comfort_heat": 68,
+    "comfort_cool": 75,
+    "economizer_temp_delta": 3.0,
+    "natural_vent_delta": 3.0,
+    "aggressive_savings": false,
+    "fan_mode": "hvac_fan"
+  },
+  "events": [
+    {
+      "time": "2026-07-10T06:00:00",
+      "type": "classification",
+      "day_type": "hot",
+      "hvac_mode": "cool",
+      "windows_recommended": true,
+      "note": "Hot day: hvac_mode=cool. Economizer eligibility requires this classification."
+    },
+    {
+      "time": "2026-07-10T07:00:00",
+      "type": "economizer_check",
+      "outdoor_temp": 72,
+      "indoor_temp": 78,
+      "windows_open": true,
+      "hour": 7,
+      "note": "hour=7 is in the morning window [6,9). outdoor=72 <= threshold(75+3=78). direction ok (72<78). indoor=78 > comfort_cool=75 -> cool-down phase."
+    },
+    {
+      "time": "2026-07-10T08:00:00",
+      "type": "economizer_check",
+      "outdoor_temp": 71,
+      "indoor_temp": 74,
+      "windows_open": true,
+      "hour": 8,
+      "note": "hour=8 still in morning window. Indoor cooled to 74F, at/below comfort_cool=75 -> transitions to maintain phase (fan stays on, no new activation event since it was already running)."
+    }
+  ],
+  "assertions": [
+    {
+      "at": "2026-07-10T06:00:00",
+      "expect": "classification_applied",
+      "reason": "Hot-day classification applied: hvac_mode=cool."
+    },
+    {
+      "at": "2026-07-10T07:00:00",
+      "expect": "economizer_phase",
+      "phase": "cool-down",
+      "reason": "Morning window, indoor 78F > comfort_cool 75F, direction favorable, outdoor within delta -> cool-down phase engages (fan assists the band's cooling)."
+    },
+    {
+      "at": "2026-07-10T08:00:00",
+      "expect": "economizer_final_phase",
+      "phase": "maintain",
+      "reason": "Indoor cooled to 74F (<= comfort_cool 75F) while still in the morning window -> transitions to maintain phase (ventilation holds, band stays armed). Checked via final engine state since no new fan_activated event fires for this sub-transition."
+    }
+  ],
+  "verdict": {
+    "type": "positive",
+    "summary": "Economizer cool-down -> maintain phase transition, previously untested by any golden scenario",
+    "observed_behavior": "cool-down engages when hot + eligible + indoor above comfort; transitions to maintain once indoor reaches comfort, without re-triggering the fan",
+    "expected_behavior": "Two-phase economizer strategy per Issue #27/#264: fan-assist only (never overrides the comfort-band's own HVAC control)"
+  }
+}

--- a/tools/simulations/golden/economizer-deactivates-outside-time-window.json
+++ b/tools/simulations/golden/economizer-deactivates-outside-time-window.json
@@ -1,0 +1,72 @@
+{
+  "name": "economizer-deactivates-outside-time-window",
+  "description": "Hot day economizer engaged in the morning window; at hour=9 (the exclusive upper boundary of the morning window [6,9)) it must deactivate even though every temperature condition is identical to the prior tick (Issue #429 blind-spot closure).",
+  "source": "synthetic",
+  "issue": 429,
+  "notes": [
+    "Closes one of the 3 Step-1 blind spots named in the architecture-reset plan: check_window_cooling_opportunity (the economizer) had zero golden coverage — a boundary bug here would have shipped undetected.",
+    "Exercises the exclusive upper boundary of the morning time window: ECONOMIZER_MORNING_END_HOUR=9 means hour=9 is NOT in-window (6 <= hour < 9). This is exactly the kind of off-by-one boundary the existing bug population (#327/#392/#402/#417/#427/#428) has repeatedly hit in sibling functions — the economizer had never been checked against it.",
+    "Deactivation DOES emit a fresh fan_deactivated event (unlike the cool-down->maintain transition in economizer-cool-down-to-maintain.json), since the fan genuinely turns off — the event-based economizer_phase assertion type applies here."
+  ],
+  "config": {
+    "comfort_heat": 68,
+    "comfort_cool": 75,
+    "economizer_temp_delta": 3.0,
+    "natural_vent_delta": 3.0,
+    "aggressive_savings": false,
+    "fan_mode": "hvac_fan"
+  },
+  "events": [
+    {
+      "time": "2026-07-10T06:00:00",
+      "type": "classification",
+      "day_type": "hot",
+      "hvac_mode": "cool",
+      "windows_recommended": true,
+      "note": "Hot day: hvac_mode=cool."
+    },
+    {
+      "time": "2026-07-10T07:00:00",
+      "type": "economizer_check",
+      "outdoor_temp": 72,
+      "indoor_temp": 78,
+      "windows_open": true,
+      "hour": 7,
+      "note": "hour=7 is in the morning window [6,9). Economizer engages, cool-down phase."
+    },
+    {
+      "time": "2026-07-10T09:00:00",
+      "type": "economizer_check",
+      "outdoor_temp": 72,
+      "indoor_temp": 78,
+      "windows_open": true,
+      "hour": 9,
+      "note": "hour=9 is the exclusive end of the morning window [6,9) -- NOT eligible on this boundary, even though outdoor/indoor/windows_open are byte-for-byte identical to the previous tick. Economizer must deactivate and hand control back to normal AC."
+    }
+  ],
+  "assertions": [
+    {
+      "at": "2026-07-10T06:00:00",
+      "expect": "classification_applied",
+      "reason": "Hot-day classification applied: hvac_mode=cool."
+    },
+    {
+      "at": "2026-07-10T07:00:00",
+      "expect": "economizer_phase",
+      "phase": "cool-down",
+      "reason": "Morning window, indoor 78F > comfort_cool 75F, direction favorable, outdoor within delta -> cool-down phase engages."
+    },
+    {
+      "at": "2026-07-10T09:00:00",
+      "expect": "economizer_phase",
+      "phase": "inactive",
+      "reason": "hour=9 exits the morning time window (exclusive upper bound) -- economizer must deactivate even though temperature conditions are otherwise unchanged, restoring normal AC control."
+    }
+  ],
+  "verdict": {
+    "type": "positive",
+    "summary": "Economizer respects the morning window's exclusive upper time boundary, previously untested by any golden scenario",
+    "observed_behavior": "economizer deactivates the instant hour crosses out of the eligible window, even with identical temperatures",
+    "expected_behavior": "Time-bounded economizer per Issue #27: only active during the configured morning/evening windows, regardless of otherwise-favorable temperature conditions"
+  }
+}

--- a/tools/simulations/golden/grace-expiry-repause-sensor-still-open.json
+++ b/tools/simulations/golden/grace-expiry-repause-sensor-still-open.json
@@ -1,0 +1,87 @@
+{
+  "name": "grace-expiry-repause-sensor-still-open",
+  "description": "Door opens (unfavorable direction, pauses HVAC), closes (resumes + starts a 120s automation grace period), reopens mid-grace while still unfavorable (grace silently blocks the immediate pause), then the grace timer naturally expires with the sensor still open -- _re_pause_for_open_sensor() must re-check nat-vent eligibility and, finding it still unfavorable, genuinely re-pause the HVAC (Issue #429 blind-spot closure -- _re_pause_for_open_sensor() had zero golden coverage before this scenario).",
+  "source": "synthetic",
+  "issue": 429,
+  "notes": [
+    "Closes one of the 3 Step-1 blind spots named in the architecture-reset plan: _re_pause_for_open_sensor() had zero golden coverage.",
+    "Deliberately isolates _re_pause_for_open_sensor()'s OWN re-check from handle_door_window_open()'s separate nat-vent gate: the reopen at 13:07 happens while outdoor is STILL unfavorable, so handle_door_window_open()'s grace-active branch just logs 'not pausing' and returns silently -- it does NOT reach handle_door_window_open()'s own nat-vent-reactivation check. Outdoor never changes for the rest of the scenario, so the eventual re-pause at grace expiry is unambiguously _re_pause_for_open_sensor()'s own doing, not a side effect of a different code path.",
+    "The 13:08:01 sensor_open event re-fires on the SAME already-open sensor purely to advance the virtual clock past the grace timer's 13:08:00 expiry -- handle_door_window_open()'s own first line (`if self._paused_by_door: return`) makes this a no-op by the time it dispatches, since the grace-expiry timer (which fires first, during the clock advance) has already set _paused_by_door=True.",
+    "grace_expired with re_paused=True already maps to outcome 'paused' in outcomes.py (pre-existing mapping) -- no new assertion type was needed for this blind spot, unlike the economizer scenarios."
+  ],
+  "config": {
+    "comfort_heat": 68,
+    "comfort_cool": 75,
+    "natural_vent_delta": 3.0,
+    "automation_grace_seconds": 120
+  },
+  "events": [
+    {
+      "time": "2026-07-10T13:00:00",
+      "type": "temp_update",
+      "indoor_f": 76.0,
+      "outdoor_f": 80.0,
+      "note": "Outdoor 80F > indoor 76F -- unfavorable direction, nat-vent not eligible."
+    },
+    {
+      "time": "2026-07-10T13:00:01",
+      "type": "classification",
+      "day_type": "warm",
+      "hvac_mode": "cool",
+      "windows_recommended": false,
+      "note": "Warm-day classification: HVAC cool."
+    },
+    {
+      "time": "2026-07-10T13:05:00",
+      "type": "sensor_open",
+      "entity": "binary_sensor.back_door",
+      "note": "Door opens. Outdoor 80F >= indoor 76F -- nat-vent ineligible. Automation pauses (HVAC off)."
+    },
+    {
+      "time": "2026-07-10T13:06:00",
+      "type": "sensor_close",
+      "entity": "binary_sensor.back_door",
+      "note": "Door closes. HVAC restores to cool. 120s automation grace period starts (ends 13:08:00)."
+    },
+    {
+      "time": "2026-07-10T13:07:00",
+      "type": "sensor_open",
+      "entity": "binary_sensor.back_door",
+      "note": "Door reopens 1 min into the 120s grace window. Outdoor is STILL 80F (unfavorable, >= threshold 78F) -- handle_door_window_open()'s grace-active branch logs 'not pausing' and returns silently. No pause, no reactivation -- sensor is simply left physically open."
+    },
+    {
+      "time": "2026-07-10T13:08:01",
+      "type": "sensor_open",
+      "entity": "binary_sensor.back_door",
+      "note": "Re-fires on the same already-open sensor purely to advance the clock past the grace timer's 13:08:00 expiry (see notes). By the time this dispatches, _paused_by_door is already True from the timer firing during the clock advance, so this specific call is a no-op."
+    }
+  ],
+  "assertions": [
+    {
+      "at": "2026-07-10T13:00:01",
+      "expect": "classification_applied",
+      "reason": "Warm-day classification applied: hvac_mode=cool."
+    },
+    {
+      "at": "2026-07-10T13:05:00",
+      "expect": "paused",
+      "reason": "Door opens with outdoor 80F >= indoor 76F -- nat-vent ineligible, automation pauses HVAC."
+    },
+    {
+      "at": "2026-07-10T13:06:00",
+      "expect": "resumed",
+      "reason": "Door closes -- HVAC restores to cool, 120s automation grace period begins."
+    },
+    {
+      "at": "2026-07-10T13:08:00",
+      "expect": "classification_suppressed_paused",
+      "reason": "Grace timer expires at 13:08:00 with the sensor still open and outdoor still unfavorable (80F >= threshold 78F) -- _re_pause_for_open_sensor() re-checks nat-vent eligibility, finds it still ineligible, and genuinely re-pauses the HVAC (grace_expired re_paused=True, confirmed via action_log: set_hvac_mode off + the exact 'Grace period expired but a door/window is still open' notification only _re_pause_for_open_sensor() sends). _on_grace_expired() then schedules _apply_current_scheduled_state(), which re-applies the current classification -- apply_classification() correctly sees _paused_by_door=True (just set by the re-pause) and suppresses re-arming the band, emitting classification_suppressed_paused at the SAME timestamp. This is the last decision in the tied-timestamp cascade (grace_expired's own 'paused' outcome is superseded in the decisions list by this immediately-following one), and its presence is itself confirmation the re-pause took effect before this suppression check ran."
+    }
+  ],
+  "verdict": {
+    "type": "positive",
+    "summary": "_re_pause_for_open_sensor() correctly re-pauses HVAC when a grace period expires with the monitored sensor still open and conditions still unfavorable for nat-vent, previously untested by any golden scenario",
+    "observed_behavior": "paused (13:05) -> resumed + grace starts (13:06) -> grace silently blocks immediate re-pause on reopen (13:07) -> grace expires, sensor still open, re-paused (13:08:00)",
+    "expected_behavior": "Grace period prevents rapid pause/resume oscillation on a brief reopen, but genuinely re-pauses once it expires if the door/window is still open and no nat-vent opportunity has appeared in the meantime"
+  }
+}

--- a/tools/simulations/golden/overnight_with_adaptive_setback_and_wakeup.json
+++ b/tools/simulations/golden/overnight_with_adaptive_setback_and_wakeup.json
@@ -1,15 +1,15 @@
 {
   "name": "overnight_with_adaptive_setback_and_wakeup",
-  "description": "Warm summer day: afternoon cooling (14:00–22:00), bedtime at 22:30 applies P3 sleep band (ceiling=DEFAULT_SLEEP_COOL=78F), morning wakeup at 07:00 restores comfort. Full overnight cycle.",
+  "description": "Warm summer day: afternoon cooling (14:00–22:00), bedtime at 22:30 applies P3 sleep band (ceiling=DEFAULT_SLEEP_COOL=72F), morning wakeup at 07:00 restores comfort. Full overnight cycle.",
   "source": "synthetic",
   "issue": 229,
   "notes": [
     "P3 migration (Issue #249): bedtime no longer uses comfort_cool + DEFAULT_SETBACK_DEPTH_COOL_F.",
-    "P3 uses select_comfort_band(in_sleep_window=True): ceiling = sleep_cool or DEFAULT_SLEEP_COOL = 78F.",
-    "DEFAULT_SLEEP_COOL = 78.0 (const.py). With comfort_cool=74, this is 4F above comfort ceiling.",
+    "P3 uses select_comfort_band(in_sleep_window=True): ceiling = sleep_cool or DEFAULT_SLEEP_COOL = 72F.",
+    "DEFAULT_SLEEP_COOL = 72.0 (const.py) — reformatted to a real tuned installation's own flat overnight value (architecture-reset session). With comfort_cool=74, this is 2F BELOW comfort ceiling: this household sleeps cooler, not warmer.",
     "Wakeup restores comfort_cool=74F.",
     "No thermal model configured — uses default sleep band path.",
-    "NOTE: expect_temp updated from 77F (old formula) to 78F (DEFAULT_SLEEP_COOL in P3)."
+    "NOTE: expect_temp updated from 77F (old formula) to 78F (DEFAULT_SLEEP_COOL in P3), then to 72F when DEFAULT_SLEEP_COOL was reformatted to match a real household's own configured overnight preference (Issue #435/#436)."
   ],
   "config": {
     "comfort_heat": 70,
@@ -36,14 +36,14 @@
     {
       "time": "2026-07-15T22:30:00",
       "type": "bedtime",
-      "note": "Bedtime: cool setback fires. Default depth = comfort_cool(74) + 3F = 77F. Ceiling=79F so 77F applies."
+      "note": "Bedtime: cool setback fires. DEFAULT_SLEEP_COOL=72F (no explicit sleep_cool configured) — cooler than daytime comfort_cool=74F."
     },
     {
       "time": "2026-07-16T00:00:00",
       "type": "temp_update",
       "indoor_f": 76.5,
       "outdoor_f": 68.0,
-      "note": "Overnight: indoor 76.5F with setback target 77F — AC barely running"
+      "note": "Overnight: indoor 76.5F with setback target 72F — AC runs to reach the cooler sleep target"
     },
     {
       "time": "2026-07-16T07:00:00",
@@ -66,8 +66,8 @@
     {
       "at": "2026-07-15T22:30:00",
       "expect": "setback_applied",
-      "expect_temp": 78.0,
-      "reason": "P3 bedtime: sleep band ceiling = DEFAULT_SLEEP_COOL = 78F (active=ceiling, warm night). Previously 77F = comfort_cool+3; P3 uses sleep_cool/DEFAULT_SLEEP_COOL directly."
+      "expect_temp": 72.0,
+      "reason": "P3 bedtime: sleep band ceiling = DEFAULT_SLEEP_COOL = 72F (active=ceiling, warm night). This household sleeps cooler than daytime comfort (74F), not warmer — a real, tuned installation's own preference (Issue #435/#436)."
     },
     {
       "at": "2026-07-16T07:00:00",
@@ -78,8 +78,8 @@
   ],
   "verdict": {
     "type": "positive",
-    "summary": "P3 overnight cycle: cool classification → sleep band (78F ceiling) → morning comfort restore (74F)",
-    "observed_behavior": "classification_applied (74F) at 14:00; setback_applied (band ceiling=78F) at 22:30; comfort_restored (74F) at 07:00",
-    "expected_behavior": "P3: sleep band [66/78] active=ceiling. Occupant sleeps in home set to 78F ceiling — cooler than daytime comfort 74F? Wait, 78>74. Sleepers tolerate warmer. Band floor 66F guards against overcooling during the night."
+    "summary": "P3 overnight cycle: cool classification → sleep band (72F ceiling) → morning comfort restore (74F)",
+    "observed_behavior": "classification_applied (74F) at 14:00; setback_applied (band ceiling=72F) at 22:30; comfort_restored (74F) at 07:00",
+    "expected_behavior": "P3: sleep band [64/72] active=ceiling. Occupant sleeps in home set to a 72F ceiling — cooler than daytime comfort 74F, matching this household's real preference to sleep cooler. Band floor 64F guards against overcooling during the night."
   }
 }

--- a/tools/simulations/golden/reconcile-adopts-running-fan-as-nat-vent.json
+++ b/tools/simulations/golden/reconcile-adopts-running-fan-as-nat-vent.json
@@ -1,0 +1,61 @@
+{
+  "name": "reconcile-adopts-running-fan-as-nat-vent",
+  "description": "HA restart / startup coalesce finds a whole-house fan already physically running with a sensor open and conditions favorable for nat-vent -- reconcile_fan_on_startup() must adopt it as CA-owned nat-vent rather than leaving it in silent limbo (Issue #429 blind-spot closure -- reconcile_fan_on_startup had zero golden coverage before this scenario).",
+  "source": "synthetic",
+  "issue": 429,
+  "notes": [
+    "Closes one of the 3 Step-1 blind spots named in the architecture-reset plan: reconcile_fan_on_startup() had zero golden coverage -- a boundary bug here would have shipped undetected, and this is exactly the function documented (Issue #327) to exist so a running fan always has an explicit owner, never silent limbo.",
+    "Required adding a new reconcile_fan_on_startup event type to tools/sim_harness/run_production.py -- unlike the other two Step-1 blind spots, no existing event type dispatched to this function at all.",
+    "Uses two new custom assertion types (reconcile_adopted_fan / reconcile_turned_off_fan / reconcile_no_fan in outcomes.py), scanned directly from reason-string/event-type combinations unique to this function -- purely additive, no existing outcome mapping touched.",
+    "thermostat_fan_running is passed as an already-resolved boolean (matching the coordinator's archetype-aware resolution per Issue #423) -- this scenario is not testing that resolution logic, only reconcile_fan_on_startup()'s own decision given the resolved signal."
+  ],
+  "config": {
+    "comfort_heat": 68,
+    "comfort_cool": 75,
+    "natural_vent_delta": 3.0,
+    "fan_mode": "whole_house_fan",
+    "fan_entity": "fan.whole_house"
+  },
+  "events": [
+    {
+      "time": "2026-07-10T06:00:00",
+      "type": "classification",
+      "day_type": "mild",
+      "hvac_mode": "off",
+      "windows_recommended": false,
+      "note": "Mild day: HVAC off. Coordinator runs classification before startup-coalesce reconcile."
+    },
+    {
+      "time": "2026-07-10T06:01:00",
+      "type": "reconcile_fan_on_startup",
+      "indoor_f": 74.0,
+      "outdoor_f": 65.0,
+      "thermostat_fan_running": true,
+      "any_sensor_open": true,
+      "note": "Startup coalesce: WHF already physically running, a sensor is open, outdoor 65F < indoor 74F, indoor above comfort_heat=68F, outdoor <= threshold 78F -- nat-vent eligible. Must adopt as CA-owned (decision=adopt-on)."
+    }
+  ],
+  "assertions": [
+    {
+      "at": "2026-07-10T06:00:00",
+      "expect": "classification_applied",
+      "reason": "Mild-day classification applied: hvac_mode=off."
+    },
+    {
+      "at": "2026-07-10T06:01:00",
+      "expect": "reconcile_adopted_fan",
+      "reason": "Fan physically running + sensor open + nat-vent conditions favorable -- reconcile_fan_on_startup() adopts the running fan as CA-owned nat-vent (decision=adopt-on), emitting a fan_activated event with the startup-reconcile reason so the adoption isn't a silent, unexplained state change."
+    },
+    {
+      "at": "2026-07-10T06:01:00",
+      "expect": "nat_vent_still_active",
+      "reason": "Confirms the adoption actually set _natural_vent_active=True, not just emitted the event."
+    }
+  ],
+  "verdict": {
+    "type": "positive",
+    "summary": "reconcile_fan_on_startup() adopts a physically-running, warranted fan as CA-owned nat-vent at startup, previously untested by any golden scenario",
+    "observed_behavior": "adopt-on: _fan_active=True, _natural_vent_active=True, fan_activated event recorded with an explanatory reason",
+    "expected_behavior": "Per Issue #327: a fan found running at startup must always get an explicit CA-owned disposition (adopt or turn off), never silent limbo"
+  }
+}

--- a/tools/simulations/golden/reconcile-turns-off-unwarranted-fan.json
+++ b/tools/simulations/golden/reconcile-turns-off-unwarranted-fan.json
@@ -1,0 +1,61 @@
+{
+  "name": "reconcile-turns-off-unwarranted-fan",
+  "description": "HA restart / startup coalesce finds a fan physically running but nat-vent conditions do NOT warrant it (unfavorable direction) -- reconcile_fan_on_startup() must turn it off via the canonical exit path (Issue #429 blind-spot closure).",
+  "source": "synthetic",
+  "issue": 429,
+  "notes": [
+    "Closes one of the 3 Step-1 blind spots named in the architecture-reset plan: reconcile_fan_on_startup() had zero golden coverage.",
+    "Uses the reconcile_adopted_fan / reconcile_turned_off_fan custom assertion types added to outcomes.py for this closure -- purely additive.",
+    "The turn-off branch routes through the canonical _exit_nat_vent() choke point (Issue #411/#417) rather than hand-rolling pause/grace here -- this scenario only asserts the reconcile-specific event (nat_vent_reconcile_exit) and the resulting _natural_vent_active=False state, not _exit_nat_vent()'s own internal pause-vs-grace branching (already covered by other goldens).",
+    "The third branch (no-fan / thermostat_fan_running=False, including the stranded-HVAC-suppression release from Issue #405) is already exercised directly at the unit level in tests/test_fan_control.py (real, unmocked calls to reconcile_fan_on_startup()) -- not repeated here, since a meaningful end-to-end version needs a genuinely stranded _pre_fan_hvac_mode precondition (a real prior WHF activation + mid-session cycling-off) that would have diluted this scenario's focus on the two novel, previously-uncovered end-to-end branches."
+  ],
+  "config": {
+    "comfort_heat": 68,
+    "comfort_cool": 75,
+    "natural_vent_delta": 3.0,
+    "fan_mode": "whole_house_fan",
+    "fan_entity": "fan.whole_house"
+  },
+  "events": [
+    {
+      "time": "2026-07-10T06:00:00",
+      "type": "classification",
+      "day_type": "mild",
+      "hvac_mode": "off",
+      "windows_recommended": false,
+      "note": "Mild day: HVAC off."
+    },
+    {
+      "time": "2026-07-10T06:01:00",
+      "type": "reconcile_fan_on_startup",
+      "indoor_f": 74.0,
+      "outdoor_f": 80.0,
+      "thermostat_fan_running": true,
+      "any_sensor_open": true,
+      "note": "Fan physically running, a sensor is open, but outdoor 80F > indoor 74F -- unfavorable direction, nat-vent NOT eligible even though a sensor is open. reconcile_fan_on_startup() must turn the fan off (decision=turn-off), not adopt it."
+    }
+  ],
+  "assertions": [
+    {
+      "at": "2026-07-10T06:00:00",
+      "expect": "classification_applied",
+      "reason": "Mild-day classification applied: hvac_mode=off."
+    },
+    {
+      "at": "2026-07-10T06:01:00",
+      "expect": "reconcile_turned_off_fan",
+      "reason": "Fan physically running but outdoor 80F > indoor 74F (unfavorable direction) -- reconcile_fan_on_startup() turns the fan off via the canonical _exit_nat_vent() choke point (decision=turn-off), emitting nat_vent_reconcile_exit first since _exit_nat_vent() assumes the caller already recorded a specific event."
+    },
+    {
+      "at": "2026-07-10T06:01:00",
+      "expect": "nat_vent_not_active",
+      "reason": "Confirms the turn-off actually cleared _natural_vent_active, not just emitted the event."
+    }
+  ],
+  "verdict": {
+    "type": "positive",
+    "summary": "reconcile_fan_on_startup() turns off a physically-running but unwarranted fan via the canonical exit path, previously untested by any golden scenario",
+    "observed_behavior": "turn-off: nat_vent_reconcile_exit emitted, _exit_nat_vent() called, _natural_vent_active cleared",
+    "expected_behavior": "Per Issue #327: a fan found running at startup without nat-vent warrant must be turned off through the same canonical exit path every other nat-vent exit uses, not a bespoke one"
+  }
+}

--- a/tools/simulations/golden/strong_warming_trend_aggressive_setback.json
+++ b/tools/simulations/golden/strong_warming_trend_aggressive_setback.json
@@ -1,21 +1,26 @@
 {
   "name": "strong_warming_trend_aggressive_setback",
-  "description": "Strong warming trend: tomorrow +15F above today. setback_modifier=-3.0 passed via classification event. Bedtime fires at 22:30. Production handle_bedtime() uses select_comfort_band() with DEFAULT_SLEEP_COOL=78F — the band ceiling is unchanged at bedtime. The pre-cool phase (Issue #258) fires separately at wake_time-4h (~02:30) and lowers the cool ceiling to 75F (sleep_cool 78 + modifier -3). This scenario covers classification + bedtime only; warming_trend_pre_cool_applied covers the pre-cool trigger.",
+  "description": "Strong warming trend: tomorrow +15F above today. setback_modifier=-3.0 passed via classification event. Bedtime fires at 22:30. Production handle_bedtime() uses select_comfort_band() with DEFAULT_SLEEP_COOL=72F — the band ceiling is unchanged at bedtime. The pre-cool phase (Issue #258) fires separately at wake_time-4h (~02:30) and lowers the cool ceiling further to bank cold thermal mass before the hot day. This scenario covers classification + bedtime only; warming_trend_pre_cool_applied covers the pre-cool trigger.",
   "source": "synthetic",
   "issue": 229,
   "notes": [
     "setback_modifier = -3.0 (negative = stronger warming trend signal).",
     "Production handle_bedtime() uses select_comfort_band(in_sleep_window=True), which reads",
-    "  sleep_cool = config.get(CONF_SLEEP_COOL, DEFAULT_SLEEP_COOL) = 78.0F (not in scenario config).",
-    "  sleep_heat = config.get(CONF_SLEEP_HEAT, DEFAULT_SLEEP_HEAT) = 66.0F (not in scenario config).",
-    "  Sleep band = [66/78]. Bedtime applies normal sleep setpoints; the setback_modifier is carried",
+    "  sleep_cool = config.get(CONF_SLEEP_COOL, DEFAULT_SLEEP_COOL) = 72.0F (not in scenario config).",
+    "  sleep_heat = config.get(CONF_SLEEP_HEAT, DEFAULT_SLEEP_HEAT) = 64.0F (not in scenario config).",
+    "  Sleep band = [64/72]. Bedtime applies normal sleep setpoints; the setback_modifier is carried",
     "  in the bedtime_setback event payload for observability but does not change the bedtime ceiling.",
     "Classification at 14:00: single-setpoint cool mode, temperature=comfort_cool=74F.",
     "  production_temp_at reads the temperature field from the set_temperature action.",
-    "Bedtime at 22:30: sleep band [66/78]. production_temp_at returns ceiling (78F) for cool mode",
+    "Bedtime at 22:30: sleep band [64/72]. production_temp_at returns ceiling (72F) for cool mode",
     "  (active='ceiling' → outcomes.py reads ceiling from bedtime_setback payload).",
+    "DEFAULT_SLEEP_COOL was reformatted from 78F to 72F (flat, cooler-than-daytime overnight default",
+    "  matching a real tuned installation's own preference — Issue #435/#436) for the bedtime sleep",
+    "  band path. The SEPARATE pre-cool trigger (handle_pre_cool) still reads a literal 78.0F",
+    "  fallback (not DEFAULT_SLEEP_COOL) pending the open Issue #436 reconciliation — see",
+    "  warming_trend_pre_cool_applied.json's own notes for that site's target math.",
     "Pre-cool phase (not in this scenario): fires at wake_time(06:30) - 4h = 02:30,",
-    "  target = sleep_cool(78) + modifier(-3) = 75F. See warming_trend_pre_cool_applied.json."
+    "  target = literal 78.0 fallback + modifier(-3) = 75F. See warming_trend_pre_cool_applied.json."
   ],
   "config": {
     "comfort_heat": 70,
@@ -43,7 +48,7 @@
     {
       "time": "2026-07-15T22:30:00",
       "type": "bedtime",
-      "note": "Bedtime: select_comfort_band(in_sleep_window=True) → [66/78]. Pre-cool fires separately at 02:30."
+      "note": "Bedtime: select_comfort_band(in_sleep_window=True) → [64/72]. Pre-cool fires separately at 02:30."
     }
   ],
   "assertions": [
@@ -56,14 +61,14 @@
     {
       "at": "2026-07-15T22:30:00",
       "expect": "setback_applied",
-      "expect_temp": 78.0,
-      "reason": "Bedtime sleep band [66/78] applied via select_comfort_band(in_sleep_window=True). cool mode active='ceiling' so production_temp_at returns ceiling=78. Bedtime setpoint is unchanged by setback_modifier — pre-cool fires separately at 02:30 via handle_pre_cool()."
+      "expect_temp": 72.0,
+      "reason": "Bedtime sleep band [64/72] applied via select_comfort_band(in_sleep_window=True). cool mode active='ceiling' so production_temp_at returns ceiling=72. Bedtime setpoint is unchanged by setback_modifier — pre-cool fires separately at 02:30 via handle_pre_cool()."
     }
   ],
   "verdict": {
     "type": "positive",
     "summary": "Warming trend classification and standard sleep band both applied correctly at bedtime; pre-cool thermal mass banking fires separately via handle_pre_cool at 02:30",
-    "observed_behavior": "classification_applied (cool mode temperature=74) → setback_applied (sleep band ceiling=78) at bedtime",
-    "expected_behavior": "Classification arms comfort band at 74F; bedtime arms sleep band [66/78] at 22:30 (unchanged). Pre-cool lowers ceiling to 75F at 02:30 — see warming_trend_pre_cool_applied.json."
+    "observed_behavior": "classification_applied (cool mode temperature=74) → setback_applied (sleep band ceiling=72) at bedtime",
+    "expected_behavior": "Classification arms comfort band at 74F; bedtime arms sleep band [64/72] at 22:30 (unchanged, cooler than daytime — this household's real sleep preference). Pre-cool lowers ceiling further at 02:30 — see warming_trend_pre_cool_applied.json."
   }
 }

--- a/tools/simulations/golden/warming_trend_pre_cool_applied.json
+++ b/tools/simulations/golden/warming_trend_pre_cool_applied.json
@@ -1,21 +1,36 @@
 {
   "name": "warming_trend_pre_cool_applied",
-  "description": "Strong warming trend night: setback_modifier=-3.0. Bedtime at 22:30 sets normal sleep band [66/78]. Pre-cool trigger fires at 02:30 (wake_time 06:30 - 4h fallback, no nat-vent config). handle_pre_cool() lowers cool ceiling to 75F (sleep_cool=78 + modifier=-3.0=75F, floor=comfort_heat+2=72F so no clamp). Occupant sleeps through the quiet AC cycle that banks 3F of cold thermal mass before the hot day peaks.",
+  "description": "Strong warming trend night: setback_modifier=-3.0. Bedtime at 22:30 sets normal sleep band [64/72]. Pre-cool trigger fires at 02:30 (wake_time 06:30 - 4h fallback, no nat-vent config). compute_pre_cool_target() computes a target of 69F (sleep_cool=72 + modifier=-3.0), which is above the sleep_heat+hysteresis floor (64+1=65), so it applies uncapped — the home banks 3F of cold thermal mass below the bedtime ceiling before the hot day peaks.",
   "source": "synthetic",
   "issue": 258,
   "notes": [
     "Config: comfort_heat=70, comfort_cool=74. No explicit sleep_cool/sleep_heat → defaults used:",
-    "  DEFAULT_SLEEP_COOL=78.0, DEFAULT_SLEEP_HEAT=66.0.",
+    "  handle_bedtime()'s select_comfort_band() reads DEFAULT_SLEEP_COOL=72.0, DEFAULT_SLEEP_HEAT=64.0",
+    "  (reformatted from 78.0/66.0 to a real tuned installation's own flat overnight preference —",
+    "  Issue #435/#436).",
+    "handle_pre_cool() now calls the shared compute_pre_cool_target() (automation.py), the single",
+    "  source of truth for all 5 call sites that need this value (the real AC trigger, trigger-time",
+    "  scheduling, chart status text, the chart target-band dip, and the ODE predicted-indoor curve).",
+    "  It reads DEFAULT_SLEEP_COOL (not a stray literal 78.0 fallback — that literal was found to",
+    "  invert pre-cool's purpose once DEFAULT_SLEEP_COOL dropped to 72) AND floors the result at",
+    "  sleep_heat + hysteresis instead of comfort_heat + a fixed headroom (Issue #436 fix, round 2):",
+    "  the original comfort_heat-anchored floor left little to no headroom once sleep_cool was",
+    "  reformatted to a flat, cooler-than-daytime household default — the fix anchors the floor to",
+    "  the sleep band itself, the same '+1 above the floor' convention nat_vent_temperature_check()",
+    "  already uses for sleep-window fan cycling, so pre-cool can travel the full",
+    "  [sleep_heat, sleep_cool] range instead of being clamped near daytime comfort_heat.",
     "No nat-vent configured (natural_vent_delta absent) → pre-cool uses wake_time-4h fallback.",
     "  wake_time default = '06:30' → trigger at 02:30.",
-    "Pre-cool target = sleep_cool(78) + modifier(-3.0) = 75.0F.",
-    "  floor = comfort_heat(70) + PRE_COOL_MIN_HEADROOM_F(2.0) = 72.0F.",
-    "  max(75.0, 72.0) = 75.0F — no clamp needed.",
-    "Bedtime band [66/78] at 22:30 is unchanged (handle_bedtime independent of pre-cool).",
-    "Pre-cool emits pre_cool_applied event with target=75.0 and calls _apply_comfort_band([66/75]).",
-    "  action_log: set_temperature with target_temp_high=75.0 (heat_cool dual-setpoint or single cool).",
+    "Pre-cool raw target = sleep_cool(72) + modifier(-3.0) = 69.0F.",
+    "  floor = DEFAULT_SLEEP_HEAT(64) + NAT_VENT_HYSTERESIS_F(1.0) = 65.0F.",
+    "  raw_target(69.0) > floor(65.0) → applies uncapped, no clamp warning logged.",
+    "Bedtime band [64/72] at 22:30 is unchanged (handle_bedtime independent of pre-cool).",
+    "Pre-cool emits pre_cool_applied event with target=69.0 and calls _apply_comfort_band([64/69]).",
+    "  action_log: set_temperature with target_temp_high=69.0 (heat_cool dual-setpoint or single cool).",
     "Scenario effectiveness: if handle_pre_cool() is deleted, pre_cool_applied event never fires",
-    "  and the 02:30 assertion fails — regression caught."
+    "  and the 02:30 assertion fails — regression caught. If the floor formula regresses back to",
+    "  comfort_heat + 2 (=72), this scenario's target would incorrectly clamp to 72 instead of 69,",
+    "  also catching that regression."
   ],
   "config": {
     "comfort_heat": 70,
@@ -44,34 +59,34 @@
     {
       "time": "2026-07-16T22:30:00",
       "type": "bedtime",
-      "note": "Bedtime: normal sleep band [66/78] applied. Pre-cool fires separately at 02:30."
+      "note": "Bedtime: normal sleep band [64/72] applied. Pre-cool fires separately at 02:30."
     },
     {
       "time": "2026-07-17T02:30:00",
       "type": "pre_cool",
       "indoor_f": 76.5,
       "nat_vent_just_closed": false,
-      "note": "Pre-cool trigger fires (wake_time 06:30 - 4h fallback). indoor=76.5F, target=75F. No nat-vent bypass. AC sets cool ceiling to 75F."
+      "note": "Pre-cool trigger fires (wake_time 06:30 - 4h fallback). indoor=76.5F, target=69F (no clamp — above the sleep_heat+hysteresis floor of 65F). No nat-vent bypass. AC lowers cool ceiling to 69F, 3F below the bedtime ceiling."
     }
   ],
   "assertions": [
     {
       "at": "2026-07-16T22:30:00",
       "expect": "setback_applied",
-      "expect_temp": 78.0,
-      "reason": "Bedtime sleep band [66/78] — ceiling=78F for cool mode. Pre-cool has not fired yet; sleep setpoints are normal."
+      "expect_temp": 72.0,
+      "reason": "Bedtime sleep band [64/72] — ceiling=72F for cool mode (DEFAULT_SLEEP_COOL, cooler than daytime). Pre-cool has not fired yet; sleep setpoints are normal."
     },
     {
       "at": "2026-07-17T02:30:00",
       "expect": "pre_cool_applied",
-      "expect_temp": 75.0,
-      "reason": "Pre-cool trigger fired: sleep_cool(78) + modifier(-3.0) = 75F. Floor = comfort_heat(70) + 2 = 72F; no clamp. AC sets cool ceiling to 75F to bank cold thermal mass before the hot day. Occupant is asleep; home quietly cools 3F below normal sleep ceiling over 4h before wake-up."
+      "expect_temp": 69.0,
+      "reason": "Pre-cool trigger fired: sleep_cool(72) + modifier(-3.0) = 69F raw target, which is above the sleep_heat(64)+hysteresis(1)=65F floor, so it applies uncapped. AC lowers the cool ceiling to 69F, 3F below the bedtime ceiling (72F), banking cold thermal mass before the hot day."
     }
   ],
   "verdict": {
     "type": "positive",
-    "summary": "Bedtime sets normal [66/78] sleep band; pre-cool trigger at 02:30 lowers cool ceiling to 75F for thermal mass banking on a strong warming-trend night",
-    "observed_behavior": "classification_applied (74F) → setback_applied (78F sleep ceiling) → pre_cool_applied (75F cool ceiling)",
-    "expected_behavior": "Bedtime band unchanged at 78F ceiling. 4h before wake-up, handle_pre_cool lowers the cool ceiling to 75F (sleep_cool - |modifier|). Occupant experience: home is 3F cooler at wake-up than on a non-warming-trend night, extending the coast time before afternoon AC kicks in."
+    "summary": "Bedtime sets normal [64/72] sleep band; pre-cool trigger at 02:30 lowers the cool ceiling to 69F for thermal mass banking on a strong warming-trend night",
+    "observed_behavior": "classification_applied (74F) → setback_applied (72F sleep ceiling) → pre_cool_applied (69F cool ceiling)",
+    "expected_behavior": "Bedtime band is 72F ceiling (cooler than daytime comfort — this household's real sleep preference). 4h before wake-up, handle_pre_cool lowers the cool ceiling further to 69F, anchored to the sleep_heat+hysteresis floor rather than daytime comfort_heat, so the household's full sleep-temperature range is available for thermal mass banking regardless of how the comfort_heat/comfort_cool config happens to be set."
   }
 }

--- a/tools/simulations/golden/warming_trend_pre_cool_nat_vent_bypass.json
+++ b/tools/simulations/golden/warming_trend_pre_cool_nat_vent_bypass.json
@@ -1,18 +1,25 @@
 {
   "name": "warming_trend_pre_cool_nat_vent_bypass",
-  "description": "Strong warming trend night with nat-vent success: setback_modifier=-3.0. Nat-vent window closes at ~01:30 and the home is already at 74F (below pre-cool target 75F). Pre-cool trigger fires 30min later at 02:00 with nat_vent_just_closed=True. handle_pre_cool() detects indoor(74F) <= target(75F) and suppresses AC — free cooling via open windows already banked the needed thermal mass. Occupant experience: same cool morning achieved with zero AC energy cost.",
+  "description": "Strong warming trend night with nat-vent activity: setback_modifier=-3.0. Nat-vent window closes at ~01:30 and the home is at 74F. Pre-cool trigger fires 30min later at 02:00 with nat_vent_just_closed=True. compute_pre_cool_target() computes a target of 69F (sleep_cool=72 + modifier=-3.0, above the sleep_heat+hysteresis floor of 65F) — indoor(74F) is ABOVE that target, so the nat-vent bypass condition is NOT met and the AC runs to bring the home down the remaining 5F. Occupant experience: nat-vent got the home partway there overnight, but the AC finishes the job before wake-up.",
   "source": "synthetic",
   "issue": 258,
   "notes": [
     "Config: comfort_heat=70, comfort_cool=74, natural_vent_delta=3.0.",
     "  Natural vent configured — nat-vent close triggers the primary path (not wake_time-4h fallback).",
-    "Pre-cool target = sleep_cool(78) + modifier(-3.0) = 75.0F.",
-    "  floor = comfort_heat(70) + PRE_COOL_MIN_HEADROOM_F(2.0) = 72.0F. No clamp.",
-    "Nat-vent bypass condition: nat_vent_just_closed=True AND indoor_f(74.0) <= target(75.0).",
-    "  Both conditions met → pre_cool_suppressed_nat_vent event emitted; no set_temperature call.",
-    "Scenario effectiveness: if the nat-vent bypass is deleted from handle_pre_cool(),",
-    "  the engine emits pre_cool_applied instead of pre_cool_suppressed_nat_vent —",
-    "  the assertion fails and the regression is caught (wasted AC energy that nat-vent already handled)."
+    "No explicit sleep_cool/sleep_heat → DEFAULT_SLEEP_COOL=72.0, DEFAULT_SLEEP_HEAT=64.0 (reformatted",
+    "  from 78.0/66.0 to a real tuned installation's own flat overnight preference — Issue #435/#436).",
+    "handle_pre_cool() now calls the shared compute_pre_cool_target() (automation.py), the single",
+    "  source of truth for all 5 call sites that need this value. It reads DEFAULT_SLEEP_COOL (not a",
+    "  stray literal 78.0 fallback) AND floors the result at sleep_heat + hysteresis instead of",
+    "  comfort_heat + a fixed headroom (Issue #436 fix, round 2) — the same '+1 above the floor'",
+    "  convention nat_vent_temperature_check() already uses for sleep-window fan cycling.",
+    "Pre-cool raw target = sleep_cool(72) + modifier(-3.0) = 69.0F.",
+    "  floor = DEFAULT_SLEEP_HEAT(64) + NAT_VENT_HYSTERESIS_F(1.0) = 65.0F.",
+    "  raw_target(69.0) > floor(65.0) → applies uncapped, no clamp warning logged.",
+    "Nat-vent bypass condition: nat_vent_just_closed=True AND indoor_f(74.0) <= target(69.0) → FALSE.",
+    "  Bypass not met → pre_cool_applied event emitted; AC set_temperature call made to 69.0F.",
+    "Scenario effectiveness: if handle_pre_cool() is deleted, no pre-cool decision fires at all at",
+    "  02:00 and the assertion fails — regression caught."
   ],
   "config": {
     "comfort_heat": 70,
@@ -30,7 +37,7 @@
       "day_type": "warm",
       "hvac_mode": "cool",
       "setback_modifier": -3.0,
-      "note": "Strong warming trend. Modifier=-3.0 seeds pre-cool target of 75F."
+      "note": "Strong warming trend. Modifier=-3.0 seeds a pre-cool target of 69F."
     },
     {
       "time": "2026-07-16T18:00:00",
@@ -42,7 +49,7 @@
     {
       "time": "2026-07-16T22:30:00",
       "type": "bedtime",
-      "note": "Bedtime: sleep band [66/78] applied. Nat-vent expected to open overnight."
+      "note": "Bedtime: sleep band [64/72] applied. Nat-vent expected to open overnight."
     },
     {
       "time": "2026-07-17T01:00:00",
@@ -56,26 +63,27 @@
       "type": "pre_cool",
       "indoor_f": 74.0,
       "nat_vent_just_closed": true,
-      "note": "Pre-cool trigger fires after nat-vent close (nat_vent_close + 30min path). indoor=74F <= target=75F. Nat-vent bypass: suppress AC, free cooling achieved target."
+      "note": "Pre-cool trigger fires after nat-vent close (nat_vent_close + 30min path). indoor=74F > target=69F. Nat-vent bypass NOT met: AC runs to close the remaining 5F gap."
     }
   ],
   "assertions": [
     {
       "at": "2026-07-16T22:30:00",
       "expect": "setback_applied",
-      "expect_temp": 78.0,
-      "reason": "Bedtime sleep band [66/78] — ceiling=78F for cool mode. Nat-vent and pre-cool both pending."
+      "expect_temp": 72.0,
+      "reason": "Bedtime sleep band [64/72] — ceiling=72F for cool mode (DEFAULT_SLEEP_COOL, cooler than daytime). Nat-vent and pre-cool both pending."
     },
     {
       "at": "2026-07-17T02:00:00",
-      "expect": "pre_cool_suppressed_nat_vent",
-      "reason": "Pre-cool trigger fired with nat_vent_just_closed=True and indoor(74F) <= target(75F). AC suppressed: free cooling via open windows already banked the thermal mass. No energy wasted running AC when nat-vent did the job."
+      "expect": "pre_cool_applied",
+      "expect_temp": 69.0,
+      "reason": "Pre-cool trigger fired with nat_vent_just_closed=True, but indoor(74F) > target(69F) — the nat-vent bypass condition is not met, so the AC runs to bring indoor down to the 69F target. Nat-vent still did real work (74F vs. a much warmer daytime baseline); it just didn't fully reach this install's cooler pre-cool target on its own."
     }
   ],
   "verdict": {
     "type": "positive",
-    "summary": "Nat-vent cooled home to 74F before pre-cool trigger; AC correctly suppressed because free cooling already achieved the pre-cool target of 75F",
-    "observed_behavior": "classification_applied (74F) → setback_applied (78F sleep ceiling) → pre_cool_suppressed_nat_vent (no AC call, indoor=74F)",
-    "expected_behavior": "When nat-vent brings indoor to or below the pre-cool target before the trigger fires, handle_pre_cool() emits pre_cool_suppressed_nat_vent and skips the AC service call. Occupant experience: same cool morning as warming_trend_pre_cool_applied, but at zero AC energy cost thanks to overnight nat-vent."
+    "summary": "Nat-vent cooled the home to 74F overnight, but the pre-cool target (69F) is cooler than what nat-vent alone achieved, so the AC correctly finishes the job instead of being bypassed",
+    "observed_behavior": "classification_applied (74F) → setback_applied (72F sleep ceiling) → pre_cool_applied (69F cool ceiling, AC runs)",
+    "expected_behavior": "When indoor is still above the pre-cool target after nat-vent closes, handle_pre_cool() emits pre_cool_applied and calls the AC to close the gap — the nat-vent bypass only fires when free cooling has ALREADY reached the target. Occupant experience: nat-vent meaningfully reduced AC runtime overnight even though it didn't eliminate it entirely on this scenario's numbers; the AC finishes banking the full 3F of thermal mass before wake-up."
   }
 }

--- a/tools/simulations/golden/whole_house_fan_hvac_suppression.json
+++ b/tools/simulations/golden/whole_house_fan_hvac_suppression.json
@@ -68,8 +68,8 @@
     },
     {
       "at": "2026-06-12T10:00:00",
-      "expect": "natural_ventilation",
-      "reason": "temp_update with outdoor=66F still below indoor=71F — most recent decision is still natural_ventilation from when sensor opened; nat-vent continues uninterrupted."
+      "expect": "nat_vent_fan_off",
+      "reason": "Indoor cooled to 71F, exactly at the cycling off-threshold (midpoint 72F - 1F hysteresis) — whole-house fan cycles off temporarily to avoid overcooling. Nat-vent session stays active (HVAC still suppressed); fan will cycle back on if indoor drifts back up toward 73F."
     },
     {
       "at": "2026-06-12T12:00:00",

--- a/tools/synthetic_enumerate.py
+++ b/tools/synthetic_enumerate.py
@@ -1,0 +1,143 @@
+"""synthetic_enumerate — CLI for the boundary-focused t-wise enumerator (Step 1).
+
+Runs every t-wise assignment (see tools/sim_harness/enumerator.py) through the SAME
+old_vs_old differential-replay engine already validated against 51 goldens and a real
+~5700-entry chart_log. A divergence here means one of two things:
+
+  1. A hidden input the harness still doesn't control at this specific boundary
+     combination (same meaning as everywhere else in Step 1) — fix the harness.
+  2. Once mutation testing is layered on top (a later step, not this CLI), a genuine
+     bug at that boundary — fix production.
+
+This run is old-vs-old only: it exercises detection reach, not correctness (there is
+still no oracle at this stage — see the plan's "oracle is equivalence, not
+correctness" note).
+
+A full-scale sweep in a single process used to freeze around scenario ~2900-3000
+(root cause: thousands of fresh ``asyncio.run()``-created event loops exhausting
+a Windows kernel resource, invisible to Python-level gc/thread/warning tracking —
+see the Step-2 status report). Fixed at the source in ``tools/sim_harness/_loop.py``
+(one persistent event loop, reused for the whole process): the full 5809-scenario
+sweep now completes in ~12s, single pass, no batching required.
+``--offset``/``--limit`` remain available for manual partial runs.
+
+Usage:
+  python tools/synthetic_enumerate.py --t 3                 # full t=3 sweep (~5809 scenarios, ~12s)
+  python tools/synthetic_enumerate.py --t 3 --limit 200 -v  # quick sample
+  python tools/synthetic_enumerate.py --stats               # just report combination counts
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import logging
+import os
+import sys
+import time
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_PROJECT_ROOT = os.path.dirname(_HERE)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from tools.sim_harness._loop import close_loop  # noqa: E402
+from tools.sim_harness.differential import ScenarioDiff, old_vs_old  # noqa: E402
+from tools.sim_harness.enumerator import (  # noqa: E402
+    DIMENSIONS,
+    CoverageStats,
+    build_enumerated_scenarios,
+)
+
+
+def run_stats(t: int) -> int:
+    stats = CoverageStats.compute(t)
+    print(f"Dimensions considered: {stats.dims_considered}")
+    for d in DIMENSIONS:
+        print(f"  - {d.name}: {len(d.values)} boundary-focused value(s)")
+    print(f"\nt={stats.t} full combinatorial sweep: {stats.total_assignments} scenarios")
+    return 0
+
+
+def run_enumeration(t: int, limit: int | None, offset: int, verbose: bool, quiet_production_logs: bool) -> int:
+    if quiet_production_logs:
+        logging.disable(logging.CRITICAL)
+    scenarios = build_enumerated_scenarios(t=t, limit=limit, offset=offset)
+    print(f"=== SYNTHETIC t={t} BOUNDARY ENUMERATION ({len(scenarios)} scenarios, offset={offset}) ===")
+    print("Old-vs-old over each generated boundary combination. Divergence == a hidden")
+    print("input the harness doesn't yet control at that specific boundary.\n")
+
+    start = time.monotonic()
+    clean = 0
+    diverged: list[tuple[str, ScenarioDiff]] = []
+    errored: list[tuple[str, ScenarioDiff]] = []
+
+    for i, es in enumerate(scenarios):
+        d = old_vs_old(es.scenario, scenario_name=es.name)
+        if d.a_error or d.b_error:
+            errored.append((es.name, d))
+        elif d.is_clean:
+            clean += 1
+        else:
+            diverged.append((es.name, d))
+            print(f"  DIVERGE {es.name}: {es.assignment}")
+            if verbose:
+                for label, divs in (("event", d.event_divergences), ("action", d.action_divergences)):
+                    for dv in divs[:3]:
+                        print(f"    [{label} #{dv.index}] A={dv.a}  B={dv.b}")
+        if verbose and (i + 1) % 500 == 0:
+            print(f"  ... {i + 1}/{len(scenarios)} run ({time.monotonic() - start:.1f}s elapsed)")
+
+    elapsed = time.monotonic() - start
+    print("\n--- summary ---")
+    print(f"  scenarios: {len(scenarios)}  ({elapsed:.1f}s, {elapsed / max(1, len(scenarios)) * 1000:.1f}ms/scenario)")
+    print(f"  clean:     {clean}")
+    print(f"  diverged:  {len(diverged)}")
+    print(f"  errored:   {len(errored)}")
+
+    if errored:
+        print("\nErrored scenarios (production raised — investigate; these are NOT")
+        print("necessarily hidden inputs, could be an invalid synthetic combination):")
+        for name, d in errored[:10]:
+            print(f"  - {name}: a={d.a_error} b={d.b_error}")
+        if len(errored) > 10:
+            print(f"  ... +{len(errored) - 10} more")
+
+    # Machine-parseable summary line (useful if manually chaining --offset/--limit runs).
+    print(
+        f"BATCH_RESULT offset={offset} n={len(scenarios)} clean={clean} diverged={len(diverged)} "
+        f"errored={len(errored)} elapsed_s={elapsed:.2f}"
+    )
+
+    if not diverged and not errored:
+        print(f"\nEXIT CRITERION MET: zero divergence across all {len(scenarios)} t={t} boundary combinations.")
+        return 0
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    with contextlib.suppress(Exception):
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
+
+    parser = argparse.ArgumentParser(description="Boundary-focused t-wise synthetic enumerator.")
+    parser.add_argument("--t", type=int, default=3, help="Interaction depth (default 3; margin 4).")
+    parser.add_argument("--limit", type=int, default=None, help="Cap the number of scenarios run.")
+    parser.add_argument("--offset", type=int, default=0, help="Skip the first N assignments (for batching).")
+    parser.add_argument("--stats", action="store_true", help="Only report combination counts, don't run.")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Show divergence detail + progress.")
+    parser.add_argument(
+        "--quiet-production-logs",
+        action="store_true",
+        help="Disable production logging output (recommended for batch/CI runs).",
+    )
+    args = parser.parse_args(argv)
+
+    if args.stats:
+        return run_stats(args.t)
+    return run_enumeration(args.t, args.limit, args.offset, args.verbose, args.quiet_production_logs)
+
+
+if __name__ == "__main__":
+    _exit_code = main()
+    close_loop()  # avoid a ResourceWarning: unclosed event loop at interpreter exit
+    raise SystemExit(_exit_code)

--- a/tools/territory_map.py
+++ b/tools/territory_map.py
@@ -1,0 +1,244 @@
+"""territory_map — instrument the golden corpus to measure which decision functions fire.
+
+This is the first cut of the architecture-reset Step-1 "territory map" gating
+artifact. It wraps every known decision function (and control primitive) on the
+production ``AutomationEngine`` with a recorder, replays every golden scenario
+through the real engine, and reports:
+
+  - **Coverage:** how many times each decision function fired across the corpus.
+  - **Blind spots:** decision functions that NEVER fire under any golden — these are
+    exactly where a subtle boundary bug would go undetected by the current suite, and
+    what the synthetic enumerator + new tests must target.
+  - **Input signatures (first cut):** the distinct explicit-argument shapes each
+    decision function was called with. This is a *partial* feature list — it captures
+    the explicit call arguments, not yet the full set of ``self._`` / config reads
+    inside each function. Comprehensive read-instrumentation is a later deliverable;
+    this establishes the scaffold and the honest coverage picture now.
+
+Pure test/tooling: monkeypatches the engine class with pass-through recording
+wrappers and reads golden JSON. Touches no production source.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_PROJECT_ROOT = os.path.dirname(_HERE)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from tools.sim_harness.ha_stubs import install_ha_stubs  # noqa: E402
+
+install_ha_stubs()
+
+from tools.sim_harness._loop import close_loop  # noqa: E402
+from tools.sim_harness.run_production import run_production_scenario  # noqa: E402
+
+_GOLDEN_DIR = Path(_PROJECT_ROOT) / "tools" / "simulations" / "golden"
+
+# The ~19 decision functions (re-verified inventory) plus the 5 control primitives
+# every decision converges on. Async unless noted.
+_DECISION_METHODS = [
+    "apply_classification",
+    "check_natural_vent_conditions",
+    "fan_thermostat_check",
+    "check_window_cooling_opportunity",
+    "_nat_vent_may_reactivate",  # sync gate helper (returns bool)
+    "_re_pause_for_open_sensor",
+    "handle_door_window_open",
+    "handle_all_doors_windows_closed",
+    "reconcile_fan_on_startup",
+    "handle_bedtime",
+    "handle_morning_wakeup",
+    "handle_occupancy_home",
+    "handle_occupancy_away",
+    "handle_occupancy_vacation",
+    "nat_vent_temperature_check",
+    "_apply_nat_vent_hvac_state",
+    "_exit_nat_vent",
+    "handle_pre_cool",
+    "_reconcile_fan_physical_drift",
+]
+_CONTROL_PRIMITIVES = [
+    "_set_hvac_mode",
+    "_set_temperature",
+    "_set_temperature_for_mode",
+    "_activate_fan",
+    "_deactivate_fan",
+]
+
+
+def _safe_sig(args: tuple, kwargs: dict) -> str:
+    """A compact, stable signature of the explicit call arguments (skip self)."""
+    parts: list[str] = []
+    for a in args[1:]:  # skip self
+        parts.append(_render_arg(a))
+    for k, v in sorted(kwargs.items()):
+        parts.append(f"{k}={_render_arg(v)}")
+    return "(" + ", ".join(parts) + ")"
+
+
+def _render_arg(v: Any) -> str:
+    """Render a single arg to a coarse, stable token (type/bucketed, not raw value)."""
+    if isinstance(v, bool):
+        return str(v)
+    if isinstance(v, (int, float)):
+        return "num"
+    if isinstance(v, str):
+        return repr(v) if len(v) <= 20 else "str"
+    if v is None:
+        return "None"
+    # DayClassification / objects: show class + day_type/hvac_mode if present
+    cls = type(v).__name__
+    dt = getattr(v, "day_type", None)
+    hv = getattr(v, "hvac_mode", None)
+    if dt is not None or hv is not None:
+        return f"{cls}(day_type={dt},hvac_mode={hv})"
+    if isinstance(v, (list, tuple)):
+        return f"{cls}[{len(v)}]"
+    if isinstance(v, dict):
+        return f"dict[{len(v)}]"
+    return cls
+
+
+class _Recorder:
+    def __init__(self) -> None:
+        self.calls: dict[str, int] = defaultdict(int)
+        self.signatures: dict[str, set[str]] = defaultdict(set)
+
+    def note(self, method: str, args: tuple, kwargs: dict) -> None:
+        self.calls[method] += 1
+        with contextlib.suppress(Exception):
+            self.signatures[method].add(_safe_sig(args, kwargs))
+
+
+@contextlib.contextmanager
+def _instrumented(recorder: _Recorder):
+    """Wrap decision methods + control primitives with pass-through recorders."""
+    import inspect  # noqa: PLC0415
+    from unittest.mock import patch  # noqa: PLC0415
+
+    from custom_components.climate_advisor.automation import AutomationEngine  # noqa: PLC0415
+
+    patches = []
+    for method in _DECISION_METHODS + _CONTROL_PRIMITIVES:
+        original = getattr(AutomationEngine, method, None)
+        if original is None:
+            continue
+
+        if inspect.iscoroutinefunction(original):
+
+            def _make_async(orig: Any, mname: str):
+                async def _wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
+                    recorder.note(mname, (self, *args), kwargs)
+                    return await orig(self, *args, **kwargs)
+
+                return _wrapper
+
+            patches.append(patch.object(AutomationEngine, method, _make_async(original, method)))
+        else:
+
+            def _make_sync(orig: Any, mname: str):
+                def _wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
+                    recorder.note(mname, (self, *args), kwargs)
+                    return orig(self, *args, **kwargs)
+
+                return _wrapper
+
+            patches.append(patch.object(AutomationEngine, method, _make_sync(original, method)))
+
+    with contextlib.ExitStack() as stack:
+        for p in patches:
+            stack.enter_context(p)
+        yield
+
+
+def _load_goldens() -> list[tuple[str, dict]]:
+    out: list[tuple[str, dict]] = []
+    for path in sorted(_GOLDEN_DIR.glob("*.json")):
+        if path.name == "MANIFEST.json":
+            continue
+        with path.open(encoding="utf-8") as fh, contextlib.suppress(json.JSONDecodeError):
+            out.append((path.stem, json.load(fh)))
+    return out
+
+
+def build_map(verbose: bool = False) -> dict[str, Any]:
+    goldens = _load_goldens()
+    recorder = _Recorder()
+    errors: list[str] = []
+    with _instrumented(recorder):
+        for name, scen in goldens:
+            try:
+                run_production_scenario(scen)
+            except Exception as exc:  # noqa: BLE001
+                errors.append(f"{name}: {type(exc).__name__}: {exc}")
+
+    fired = {m: recorder.calls.get(m, 0) for m in _DECISION_METHODS}
+    prims = {m: recorder.calls.get(m, 0) for m in _CONTROL_PRIMITIVES}
+    blind = [m for m, c in fired.items() if c == 0]
+    return {
+        "n_goldens": len(goldens),
+        "decision_calls": fired,
+        "control_calls": prims,
+        "blind_spots": blind,
+        "signatures": {m: sorted(recorder.signatures.get(m, set())) for m in _DECISION_METHODS},
+        "errors": errors,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    with contextlib.suppress(Exception):
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
+    parser = argparse.ArgumentParser(description="Territory map: decision-function coverage over goldens.")
+    parser.add_argument("--json", action="store_true", help="Emit the raw map as JSON.")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Show per-function input signatures.")
+    args = parser.parse_args(argv)
+
+    m = build_map(verbose=args.verbose)
+    if args.json:
+        print(json.dumps(m, indent=2, default=str))
+        return 0
+
+    print(f"=== TERRITORY MAP — {m['n_goldens']} golden scenarios ===\n")
+    print("Decision-function coverage (calls across the corpus):")
+    for method, count in sorted(m["decision_calls"].items(), key=lambda kv: -kv[1]):
+        flag = "  <-- BLIND SPOT (never fires)" if count == 0 else ""
+        print(f"  {count:5d}  {method}{flag}")
+    print("\nControl primitives:")
+    for method, count in sorted(m["control_calls"].items(), key=lambda kv: -kv[1]):
+        print(f"  {count:5d}  {method}")
+
+    print(f"\nBlind spots ({len(m['blind_spots'])} decision functions never exercised by any golden):")
+    for method in m["blind_spots"]:
+        print(f"  - {method}")
+    if not m["blind_spots"]:
+        print("  (none — every catalogued decision function fires at least once)")
+
+    if args.verbose:
+        print("\nInput signatures (explicit call-argument shapes — partial feature list):")
+        for method, sigs in m["signatures"].items():
+            if sigs:
+                print(f"  {method}:")
+                for s in sigs:
+                    print(f"      {s}")
+
+    if m["errors"]:
+        print(f"\nScenario errors ({len(m['errors'])}):")
+        for e in m["errors"]:
+            print(f"  - {e}")
+    return 0
+
+
+if __name__ == "__main__":
+    _exit_code = main()
+    close_loop()  # avoid a ResourceWarning: unclosed event loop at interpreter exit
+    raise SystemExit(_exit_code)


### PR DESCRIPTION
## Summary

Replaces ~19 scattered, duplicated decision functions across `automation.py`/`coordinator.py` with independently-tested pure `decide_*()` functions (functional core / imperative shell). Each extraction was proven behavior-identical to the code it replaced via differential testing, and confirmed load-bearing via a positive control before the old inline logic was removed — full methodology and per-step evidence is in `docs/08-COMPUTATION-REFERENCE.md` and the plan history.

New pure decision modules: `nat_vent_gate`, `fan_thermostat_decision`, `fan_drift_reconciliation`, `nat_vent_reactivation_lockout`, `setpoint_verify_decision`, `desired_state` (schema + 8 wired mechanisms: grace, revisit, fan min-runtime cycling, override confirm, setpoint retry/nudge/backoff).

## Issues closed

- #435 — nat-vent fan-cycling events fired for a nonexistent device when no fan is configured
- #437 — pre-cool's floor formula silently turned pre-cool into a no-op after the sleep_cool default reformat
- #438 — three latent default-value mismatches (comfort_cool, natural_vent_delta, plus #437) between what shipped and what individual call sites assumed
- #439 — the initial setup wizard wrote stale hardcoded setpoints into every new install, bypassing the #438 reformat entirely
- #440 — pre-cool's AC trigger didn't react when natural ventilation exited well ahead of its scheduled window
- #429 — consolidated the remaining duplicated direction-gate call sites

## Validation

Full-surface simultaneous positive control (the plan's final step) confirms the whole decision surface remains load-bearing together, not just piece by piece: corrupting all 9 extracted decision points at once diverges 51/56 goldens.

## Test plan

- [x] `pytest tests/`: 3289/3289 pass, warnings-as-errors
- [x] `python tools/simulate.py`: 56/56 goldens pass, `--check-integrity` OK
- [x] Zero old-vs-old nondeterminism across 11546 scenarios (56 goldens + 5809 synthetic t=3 sweep + 5681 real chart_log entries)
- [x] Load-bearing positive controls for every extracted mechanism (individually and full-surface simultaneous)
- [x] `ruff check` / `ruff format` clean
- [x] `test_version_sync.py` — manifest.json and const.py VERSION agree (0.5.1)