### PR TITLE
Fix #444: dedupe redundant 'Comfort band applied' notifications

### DIFF
--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -24,6 +24,7 @@ from .const import (
     CEILING_ESCALATION_SAVINGS_MARGIN_F,
     CEILING_PRECOOL_FALLBACK_MIN,
     CLIMATE_FEATURE_TARGET_TEMP_RANGE,
+    COMFORT_BAND_EVENT_DEDUP_SECONDS,
     CONF_ADAPTIVE_PREHEAT,
     CONF_ADAPTIVE_SETBACK,
     CONF_AUTOMATION_GRACE_NOTIFY,
@@ -474,6 +475,12 @@ class AutomationEngine:
         self._last_resume_source: str | None = None
         self._grace_end_time: str | None = None
         self._grace_duration_seconds: int = 0
+
+        # Comfort-band event dedup (Issue #444): tracks the last-announced band so
+        # overlapping triggers (startup coalesce + its own refresh, grace-expiry
+        # re-application) don't each re-announce an identical band as a fresh event.
+        self._last_comfort_band_signature: tuple[str, str, float] | None = None
+        self._last_comfort_band_event_at: datetime | None = None
 
         # Economizer state (two-phase window cooling per Issue #27)
         # Phase "cool-down": AC runs to cool to set temp (outdoor air assists)
@@ -1601,9 +1608,11 @@ class AutomationEngine:
         if band.active == "ceiling" and caps.supports_cool:
             await self._set_temperature(band.ceiling, reason=reason, mode="cool")
             _cmd_shape = "cool"
+            _target = band.ceiling
         elif band.active == "floor" and caps.supports_heat:
             await self._set_temperature(band.floor, reason=reason, mode="heat")
             _cmd_shape = "heat"
+            _target = band.floor
         else:
             # The thermostat advertises no mode that can defend the active edge (e.g. a heat-only
             # unit on a warm day, or an unavailable entity). Surface this at INFO in real operation
@@ -1613,6 +1622,42 @@ class AutomationEngine:
                 "_apply_comfort_band: no capable mode for active=%r (modes=%s) — band not armed this cycle",
                 band.active,
                 list(caps.modes),
+            )
+            return
+
+        # Issue #444: _set_temperature() above is always called (unconditional thermostat
+        # re-assertion) — only the human-facing ANNOUNCEMENT is deduped here. Overlapping
+        # triggers (startup coalesce + its own follow-on refresh; grace-expiry re-application
+        # colliding with the regular cycle) otherwise each re-announce an identical band as a
+        # fresh comfort_band_applied event within the same minute. Time-windowed, not
+        # permanent: a real re-announcement after COMFORT_BAND_EVENT_DEDUP_SECONDS (well under
+        # the 30-min regular cycle) still fires normally.
+        _signature = (band.active, _cmd_shape, round(_target, 2))
+        _now = dt_util.now()
+        # getattr: some tests construct AutomationEngine via object.__new__() and populate
+        # only the attributes they need, bypassing __init__ — mirrors the existing
+        # _nat_vent_was_active defensive-read pattern in coordinator.py._emit_event().
+        _last_signature = getattr(self, "_last_comfort_band_signature", None)
+        _last_at = getattr(self, "_last_comfort_band_event_at", None)
+        # isinstance guard: some tests mock dt_util as a bare MagicMock (never calling
+        # datetime.now() for real), which would otherwise make the elapsed-time comparison
+        # below operate on MagicMock objects instead of real timedeltas. Treat anything that
+        # isn't a real datetime as "no prior timestamp" — the safe default (never suppress).
+        _is_redundant = (
+            _last_signature == _signature
+            and isinstance(_last_at, datetime)
+            and isinstance(_now, datetime)
+            and (_now - _last_at).total_seconds() < COMFORT_BAND_EVENT_DEDUP_SECONDS
+        )
+        self._last_comfort_band_signature = _signature
+        self._last_comfort_band_event_at = _now
+
+        if _is_redundant:
+            _LOGGER.debug(
+                "comfort_band_applied event suppressed — identical band (%s %.1f°F) already announced %.1fs ago",
+                _cmd_shape,
+                _target,
+                (_now - _last_at).total_seconds(),
             )
             return
 

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,18 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.1"
+VERSION = "0.5.2"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.2": [
+        "Fix #444: the Activity Report could show the same 'Comfort band applied' line"
+        " 2-3 times in a row for the exact same setpoint — most visibly right after an"
+        " HA restart, when the startup sequence and the regular classification cycle"
+        " both independently re-announced the identical band within the same minute."
+        " The underlying thermostat command was always correct; only the notification"
+        " was duplicated. A short-window dedup now suppresses a redundant announcement"
+        " of an unchanged band, without ever skipping the actual setpoint command.",
+    ],
     "0.5.1": [
         "Fix #439: the initial setup wizard could write stale sleep-temperature"
         " defaults into a brand-new install — Fahrenheit sleep fields, and all six"
@@ -851,6 +860,33 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    444: {
+        "version_fixed": "0.5.2",
+        "title": "Duplicate 'Comfort band applied' Activity Report entries for the same setpoint",
+        "scope_covered": (
+            "automation.py: _apply_comfort_band() had no idempotency guard — it unconditionally"
+            " emitted a comfort_band_applied event on every call, even when the band (active edge,"
+            " mode, target temperature) was identical to the one just announced. At least 2"
+            " overlapping call paths independently invoke apply_classification() -> _apply_comfort_band()"
+            " back-to-back around a restart: _do_startup_coalesce() (coordinator.py) calls it directly,"
+            " then at the end of that same sequence schedules async_request_refresh(), which triggers a"
+            " second, independent _async_update_data() cycle whose regular-cycle path calls it again"
+            " within seconds. A grace-expiry re-application colliding with the regular cycle produces the"
+            " same duplicate pattern outside of a restart. Real telemetry (Issue #444) confirmed this on"
+            " both 0.4.74 and 0.5.1 — a pre-existing defect, not a regression from the architecture-reset"
+            " work. Fixed with a short (10 minute) time-windowed dedup on the ANNOUNCEMENT only:"
+            " COMFORT_BAND_EVENT_DEDUP_SECONDS in const.py; new _last_comfort_band_signature /"
+            " _last_comfort_band_event_at instance state on AutomationEngine. The underlying"
+            " _set_temperature() thermostat command is never suppressed — only the redundant event."
+        ),
+        "scope_not_covered": (
+            "Does not touch the overlapping-trigger structure itself (coalesce's own"
+            " async_request_refresh() call, or the grace-expiry/regular-cycle overlap) — the dedup is a"
+            " choke-point fix at the single emission site, not a change to when apply_classification()"
+            " is invoked. A genuine re-announcement of an unchanged band after the dedup window (e.g. the"
+            " next real 30-min cycle) still fires normally by design."
+        ),
+    },
     440: {
         "version_fixed": "0.5.1",
         "title": "Pre-cool AC trigger stuck on stale schedule when nat-vent exits ahead of its scheduled close",
@@ -3369,6 +3405,18 @@ DEFAULT_WELCOME_HOME_DEBOUNCE_SECONDS = 3600  # 60 minutes
 DEFAULT_OVERRIDE_CONFIRM_SECONDS = 600  # 10 minutes
 OCCUPANCY_SETBACK_MINUTES = 15
 MAX_CONTINUOUS_RUNTIME_HOURS = 3
+
+# Issue #444: _apply_comfort_band() has no source-of-truth "did the band actually
+# change" check, so overlapping triggers (startup coalesce + its own follow-on
+# refresh; grace-expiry re-application colliding with the regular cycle) each
+# unconditionally re-announce the identical band as a fresh comfort_band_applied
+# event. This window suppresses a redundant *announcement* of an unchanged band
+# within N seconds of the last one — the underlying _set_temperature() call is
+# NEVER suppressed (thermostat control must stay unconditional). Sized to
+# comfortably span the widest observed redundant-call gap in real telemetry
+# (~5-6 minutes) while staying well under the 30-minute regular classification
+# cycle, so a genuine re-announcement after a real cycle is never swallowed.
+COMFORT_BAND_EVENT_DEDUP_SECONDS = 600  # 10 minutes
 
 # Economizer (window cooling) threshold
 ECONOMIZER_TEMP_DELTA = 3  # °F — activate when outdoor temp within this delta of comfort_cool

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.1"
+  "version": "0.5.2"
 }

--- a/tests/test_grace_refresh_and_band_call.py
+++ b/tests/test_grace_refresh_and_band_call.py
@@ -16,7 +16,8 @@ from __future__ import annotations
 
 import asyncio
 import sys
-from unittest.mock import AsyncMock, MagicMock
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
 
 # ── HA module stubs — must run before any climate_advisor import ──
 if "homeassistant" not in sys.modules:
@@ -278,3 +279,90 @@ class TestApplyComfortBandSingleServiceCall:
         call_data = climate_calls[0].args[2]
         assert call_data.get("hvac_mode") == "heat", f"Floor band must send hvac_mode='heat', got {call_data}"
         assert call_data.get("temperature") == 68.0, f"Floor band must send temperature=floor (68.0), got {call_data}"
+
+
+# ---------------------------------------------------------------------------
+# Issue #444: comfort_band_applied event dedup — overlapping triggers (startup
+# coalesce + its own follow-on refresh; grace-expiry re-application colliding with
+# the regular cycle) must not each re-announce an identical band as a fresh event.
+# ---------------------------------------------------------------------------
+
+
+def _band_engine() -> AutomationEngine:
+    """Like _minimal_engine() but with a heat_cool-capable thermostat and an
+    _emit_event_callback that records every emitted (event_type, payload)."""
+    engine = _minimal_engine()
+    state_mock = MagicMock()
+    state_mock.state = "cool"
+    state_mock.attributes = {
+        "hvac_modes": ["off", "heat", "cool", "heat_cool"],
+        "supported_features": CLIMATE_FEATURE_TARGET_TEMP_RANGE | 1,
+    }
+    engine.hass.states.get.return_value = state_mock
+    engine._emitted_events = []
+    engine._emit_event_callback = lambda etype, payload: engine._emitted_events.append((etype, payload))
+    return engine
+
+
+class TestApplyComfortBandEventDedup:
+    """Issue #444 — the comfort_band_applied EVENT is deduped within a short window
+    when the band is unchanged; the underlying set_temperature call is never deduped."""
+
+    def test_identical_band_within_window_emits_event_once(self):
+        """Revert-test: without the guard this emits 2 events, not 1."""
+        engine = _band_engine()
+        band = ComfortBand(floor=68.0, ceiling=76.0, active="ceiling", reason="test")
+
+        with patch(
+            "custom_components.climate_advisor.automation.dt_util.now",
+            return_value=datetime(2026, 7, 10, 10, 53, 0, tzinfo=UTC),
+        ):
+            asyncio.run(engine._apply_comfort_band(band, reason="coalesce path"))
+            asyncio.run(engine._apply_comfort_band(band, reason="regular cycle path"))
+
+        band_events = [e for e in engine._emitted_events if e[0] == "comfort_band_applied"]
+        assert len(band_events) == 1, f"Expected exactly 1 comfort_band_applied event, got {len(band_events)}"
+
+        # The underlying thermostat command is NEVER deduped — both calls must have fired.
+        climate_calls = [c for c in engine.hass.services.async_call.call_args_list if c.args[0] == "climate"]
+        assert len(climate_calls) == 2, (
+            f"Expected 2 set_temperature calls (thermostat re-assertion is unconditional), got {len(climate_calls)}"
+        )
+
+    def test_different_band_always_emits_regardless_of_timing(self):
+        """A genuinely different band must never be suppressed, even seconds apart."""
+        engine = _band_engine()
+        band_a = ComfortBand(floor=68.0, ceiling=76.0, active="ceiling", reason="test")
+        band_b = ComfortBand(floor=68.0, ceiling=74.0, active="ceiling", reason="test")  # different ceiling
+
+        with patch(
+            "custom_components.climate_advisor.automation.dt_util.now",
+            return_value=datetime(2026, 7, 10, 10, 53, 0, tzinfo=UTC),
+        ):
+            asyncio.run(engine._apply_comfort_band(band_a, reason="first"))
+            asyncio.run(engine._apply_comfort_band(band_b, reason="second"))
+
+        band_events = [e for e in engine._emitted_events if e[0] == "comfort_band_applied"]
+        assert len(band_events) == 2, f"Different bands must both emit, got {len(band_events)}"
+
+    def test_identical_band_after_dedup_window_emits_again(self):
+        """Not a permanent suppression — a real re-announcement after the window fires normally."""
+        engine = _band_engine()
+        band = ComfortBand(floor=68.0, ceiling=76.0, active="ceiling", reason="test")
+
+        with patch(
+            "custom_components.climate_advisor.automation.dt_util.now",
+            return_value=datetime(2026, 7, 10, 10, 53, 0, tzinfo=UTC),
+        ):
+            asyncio.run(engine._apply_comfort_band(band, reason="first"))
+
+        with patch(
+            "custom_components.climate_advisor.automation.dt_util.now",
+            return_value=datetime(2026, 7, 10, 11, 5, 0, tzinfo=UTC),  # 12 min later — past the 10-min window
+        ):
+            asyncio.run(engine._apply_comfort_band(band, reason="30-min cycle, unchanged"))
+
+        band_events = [e for e in engine._emitted_events if e[0] == "comfort_band_applied"]
+        assert len(band_events) == 2, (
+            f"A re-announcement after COMFORT_BAND_EVENT_DEDUP_SECONDS must not be suppressed, got {len(band_events)}"
+        )


### PR DESCRIPTION
## Summary

`_apply_comfort_band()` had no idempotency guard — every call unconditionally
re-announced `comfort_band_applied`, even when the band was identical to the
one just applied. At least two overlapping call paths independently invoke
`apply_classification()` → `_apply_comfort_band()` back-to-back:

- `_do_startup_coalesce()` calls it directly, then at the end of that same
  sequence schedules `async_request_refresh()`, which kicks off a second,
  independent `_async_update_data()` cycle whose regular-cycle path calls it
  again within seconds.
- A grace-expiry re-application colliding with the regular cycle produces the
  same duplicate pattern outside of a restart.

Confirmed via real telemetry on both 0.4.74 and 0.5.1 (Issue #444) — this is
a pre-existing defect, not a regression from the nat-vent architecture-reset
work.

## Fix

A short (10-minute) time-windowed dedup on the **announcement only**.
`COMFORT_BAND_EVENT_DEDUP_SECONDS` in `const.py`; new
`_last_comfort_band_signature` / `_last_comfort_band_event_at` instance state
on `AutomationEngine`. The underlying `_set_temperature()` thermostat command
is never suppressed — only the redundant event. A real re-announcement after
the window (e.g. the next 30-min cycle, even with an unchanged band) still
fires normally by design.

## Test plan

- [x] 3 new regression tests in `test_grace_refresh_and_band_call.py`,
      verified via revert-test discipline (fail without the guard, pass with it)
- [x] `pytest tests/`: 3292/3292 pass, warnings-as-errors
- [x] `python tools/simulate.py`: 56/56 goldens unchanged, `--check-integrity` OK
- [x] Both existing production integration positive controls re-verified
      unaffected (nat-vent gate 31/56 diverge, fan-thermostat-check 7/56 diverge)
- [x] `ruff check` / `ruff format` clean
- [x] `test_version_sync.py` — manifest.json and const.py VERSION agree (0.5.2)