### PR TITLE
Fix #446: correct grace-period mislabeling + rate-limit reconcile spam

### DIFF
--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -571,6 +571,8 @@ class AutomationEngine:
         self._last_classification_applied: tuple[str, str] | None = None
         # Issue #96: override event dedup — track last emission time
         self._last_override_detected_time: datetime | None = None
+        # Issue #446: unwarranted-fan reconcile-correction dedup — track last correction time
+        self._last_unwarranted_fan_correction_at: datetime | None = None
 
         # Resume-from-pause tracking (Issue #47)
         self._resumed_from_pause: bool = False
@@ -847,6 +849,7 @@ class AutomationEngine:
         reason: str,
         trigger_label: str = "fan_off",
         preserve_nat_vent_session: bool = False,
+        source: str = "manual",
     ) -> None:
         """Shared "fan confirmed off" flag-clearing + grace-period logic.
 
@@ -869,6 +872,10 @@ class AutomationEngine:
                 the session survives the correction (Issue #423 drift-correction case). When
                 False (the default, matching the original `on_fan_turned_off()` behavior), the
                 session ends — a genuine fan-off is a real end-of-session signal.
+            source: `source` field on the grace period — "manual" for a genuine user action,
+                "automation" for a CA-internal correction (Issue #446: the drift-correction
+                caller was previously hardcoded to "manual" here, making the Activity Report
+                claim the user turned the fan off when CA corrected itself).
         """
         self._fan_active = False
         self._fan_on_since = None
@@ -888,7 +895,7 @@ class AutomationEngine:
 
         # Start grace period to gate nat-vent re-activation — same duration as manual grace
         # but with a distinct trigger string so logs/events are distinguishable.
-        self._start_grace_period("manual", trigger=trigger_label)
+        self._start_grace_period(source, trigger=trigger_label)
 
     def clear_fan_override(self) -> None:
         """Clear the fan override flag (called at transition points, Issue #327).
@@ -3137,6 +3144,27 @@ class AutomationEngine:
                 archetype,
             )
             _turn_off_reason = "startup reconcile — fan running without CA warrant"
+
+            # Issue #446: reconcile_fan_on_startup() is called from 4 different sites
+            # (startup coalesce, 30-min backstop, thermostat state-change, post-grace-expiry)
+            # with no rate limit — a fan that keeps re-appearing as "unwarranted" (e.g. a
+            # thermostat's own circulation schedule CA cannot durably override with one
+            # command) previously triggered a full correction every single call, producing
+            # repeated near-identical Activity Report spam every few minutes. Cooldown
+            # mirrors the existing _last_override_detected_time dedup pattern above.
+            _cooldown_window = timedelta(minutes=5)
+            _now = dt_util.now()
+            _last_correction = self._last_unwarranted_fan_correction_at
+            if _last_correction is not None and (_now - _last_correction) < _cooldown_window:
+                _LOGGER.info(
+                    "Unwarranted-fan correction suppressed — already corrected at %s,"
+                    " within the 5-minute cooldown (likely a recurring condition CA cannot"
+                    " durably override with one command, e.g. a thermostat circulation schedule)",
+                    _last_correction.isoformat(),
+                )
+                return
+            self._last_unwarranted_fan_correction_at = _now
+
             # Ensure flags are correct before deactivating — _exit_nat_vent()'s internal
             # _deactivate_fan() call is a no-op unless _fan_active reads True.
             self._fan_active = True  # let _deactivate_fan see an owned fan
@@ -4396,6 +4424,24 @@ class AutomationEngine:
         ):
             physical_on = self._get_fan_physical_state_callback()
 
+        # Issue #446 instrumentation: log the raw inputs on EVERY tick, not just on confirmed
+        # drift, so a future recurrence has real evidence instead of inference. `physical_on`
+        # already reflects whatever entity the coordinator treats as ground truth (fan_state_entity
+        # when configured, else the command entity) — logged alongside the command entity's own
+        # reported state for direct comparison.
+        _command_state = self.hass.states.get(self.config.get(CONF_FAN_ENTITY, ""))
+        _LOGGER.debug(
+            "Fan drift tick: fan_active=%s fan_mode=%s recent_command=%s physical_available=%s"
+            " physical_on=%s command_entity_state=%s tick_count=%d",
+            self._fan_active,
+            fan_mode,
+            recent_fan_command,
+            physical_state_available,
+            physical_on,
+            _command_state.state if _command_state else "unavailable",
+            self._fan_drift_tick_count,
+        )
+
         inputs = FanDriftInputs(
             fan_active=self._fan_active,
             fan_mode=fan_mode,
@@ -4436,6 +4482,7 @@ class AutomationEngine:
             reason="physical-state drift confirmed over 2 backstop ticks",
             trigger_label="physical_drift_correction",
             preserve_nat_vent_session=True,
+            source="automation",
         )
 
     async def _deactivate_fan(self, *, reason: str, restore_hvac: bool = True, emit_event: bool = True) -> None:

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,22 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.2"
+VERSION = "0.5.3"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.3": [
+        "Fix #446: an automated self-correction (Issue #423's fan physical-drift check"
+        " fixing its own stale belief about whether the fan was on) was reported in the"
+        " Activity Report as 'Grace period started (manual)' — telling you that you"
+        " turned the fan off when nobody did. It's now correctly labeled as an"
+        " automation-triggered grace period.",
+        "Fix #446: after a restart, if a fan kept appearing as 'running without CA"
+        " warrant' (e.g. a thermostat's own circulation schedule CA can't durably"
+        " override with a single command), CA re-issued the same correction attempt"
+        " every few minutes for up to 45 minutes. It now waits 5 minutes between"
+        " correction attempts for the same condition, while still keeping a"
+        " persistently-stray fan visible in the logs.",
+    ],
     "0.5.2": [
         "Fix #444: the Activity Report could show the same 'Comfort band applied' line"
         " 2-3 times in a row for the exact same setpoint — most visibly right after an"
@@ -860,6 +873,40 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    446: {
+        "version_fixed": "0.5.3",
+        "title": "Automated fan drift-correction mislabeled as manual grace + repeated unwarranted-fan reconcile spam",
+        "scope_covered": (
+            "automation.py: _clear_fan_flags_and_start_grace() had exactly 2 callers"
+            " (on_fan_turned_off(), a genuine user action, and _reconcile_fan_physical_drift(),"
+            " Issue #423's automated self-healing correction) but both hit the same hardcoded"
+            " self._start_grace_period('manual', ...) — reporting an automated correction to"
+            " the user as if they had turned the fan off themselves. Added a source parameter"
+            " (default 'manual', preserving on_fan_turned_off()'s call unchanged) and pass"
+            " source='automation' from the drift-correction path; the codebase already had 3"
+            " precedent call sites using 'automation' for this field. Also added DEBUG-level"
+            " instrumentation logging the raw fan_entity/fan_state_entity read on every"
+            " backstop tick (not just confirmed drift) — the true root cause of why the"
+            " physical-state read repeatedly disagrees on an exact 10-minute cadence overnight"
+            " was investigated (ruled out: a tick-counter bug, command-only mode, a toggle-type"
+            " RF fan entity — all verified against the real code/config) but not conclusively"
+            " identified, since real incident logs were unavailable (rotated on restart)."
+            " Separately, reconcile_fan_on_startup()'s 'turn off unwarranted fan' branch had no"
+            " rate limit across its 4 call sites, so a recurring condition (e.g. a thermostat's"
+            " own fan circulation schedule) triggered a full correction attempt every few"
+            " minutes for up to 45 minutes. Added a 5-minute cooldown (reusing the existing"
+            " _last_override_detected_time dedup pattern) inside the function itself so it"
+            " applies regardless of which caller triggered it; a suppressed correction still"
+            " logs at INFO so a persistently-stray fan stays visible."
+        ),
+        "scope_not_covered": (
+            "The true root cause of the repeating 10-minute physical-state disagreement"
+            " (Finding 2b) is NOT fixed — only instrumented. The retry behavior itself (CA"
+            " keeps trying to reactivate the fan every cycle when conditions favor free"
+            " cooling) was deliberately left unchanged per explicit user direction — a"
+            " genuine free-cooling opportunity should keep being retried, not abandoned."
+        ),
+    },
     444: {
         "version_fixed": "0.5.2",
         "title": "Duplicate 'Comfort band applied' Activity Report entries for the same setpoint",

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.2"
+  "version": "0.5.3"
 }

--- a/tests/test_fan_control.py
+++ b/tests/test_fan_control.py
@@ -2033,6 +2033,7 @@ class TestReconcileFanPhysicalDrift:
             reason="physical-state drift confirmed over 2 backstop ticks",
             trigger_label="physical_drift_correction",
             preserve_nat_vent_session=True,
+            source="automation",
         )
         assert engine._fan_drift_tick_count == 0
 
@@ -2064,6 +2065,31 @@ class TestReconcileFanPhysicalDrift:
 
         assert engine._fan_drift_tick_count == 0
         engine._clear_fan_flags_and_start_grace.assert_not_called()
+
+    def test_correction_grace_period_is_labeled_automation_not_manual(self):
+        """Issue #446: the drift correction is CA fixing its own stale belief, not a user
+        action — the grace period it starts must be labeled "automation", not "manual",
+        or the Activity Report falsely tells the user they turned the fan off.
+
+        Uses the REAL (unmocked) _clear_fan_flags_and_start_grace()/_start_grace_period()
+        so the actual emitted grace_started event's source field is asserted directly —
+        a mock-call-args assertion alone wouldn't catch a label bug this specific."""
+        engine = _make_automation_engine({CONF_FAN_MODE: FAN_MODE_WHOLE_HOUSE})
+        engine._get_fan_physical_state_callback = MagicMock(return_value=False)
+        engine._is_recent_fan_command_callback = MagicMock(return_value=False)
+        engine._fan_active = True
+        events: list[tuple] = []
+        engine._emit_event_callback = lambda name, payload: events.append((name, payload))
+
+        engine._reconcile_fan_physical_drift()
+        engine._reconcile_fan_physical_drift()
+
+        grace_events = [e for e in events if e[0] == "grace_started"]
+        assert len(grace_events) == 1, f"Expected one grace_started event; got: {events}"
+        assert grace_events[0][1]["source"] == "automation", (
+            f"Drift-correction grace period must be source='automation', not "
+            f"{grace_events[0][1]['source']!r} — nobody touched the fan"
+        )
 
 
 class TestReconcileFanDriftIntegration:
@@ -2299,6 +2325,97 @@ class TestReconcileFanOnStartup:
         )
 
         engine._deactivate_fan.assert_awaited()
+
+    def test_unwarranted_fan_correction_suppressed_within_cooldown(self):
+        """Issue #446: reconcile_fan_on_startup() is called from 4 different sites with no
+        rate limit — a fan that keeps re-appearing as unwarranted (e.g. a thermostat's own
+        circulation schedule) previously triggered a full correction on every single call.
+        Two calls within the 5-minute cooldown must only correct once."""
+        engine = self._engine(fan_mode=FAN_MODE_HVAC)
+
+        with patch(
+            "custom_components.climate_advisor.automation.dt_util.now",
+            return_value=datetime(2026, 7, 10, 8, 24, 0),
+        ):
+            asyncio.run(
+                engine.reconcile_fan_on_startup(
+                    indoor=75.0, outdoor=65.0, thermostat_fan_running=True, any_sensor_open=False
+                )
+            )
+        with patch(
+            "custom_components.climate_advisor.automation.dt_util.now",
+            return_value=datetime(2026, 7, 10, 8, 28, 59),  # just under 5 min later — within cooldown
+        ):
+            asyncio.run(
+                engine.reconcile_fan_on_startup(
+                    indoor=75.0, outdoor=65.0, thermostat_fan_running=True, any_sensor_open=False
+                )
+            )
+
+        assert engine._deactivate_fan.await_count == 1, (
+            f"Expected exactly 1 correction within the cooldown window, got {engine._deactivate_fan.await_count}"
+        )
+
+    def test_unwarranted_fan_correction_fires_again_after_cooldown(self):
+        """Not a permanent suppression — a genuinely persistent stray fan must still get
+        corrected again once the cooldown window elapses."""
+        engine = self._engine(fan_mode=FAN_MODE_HVAC)
+
+        with patch(
+            "custom_components.climate_advisor.automation.dt_util.now",
+            return_value=datetime(2026, 7, 10, 8, 24, 0),
+        ):
+            asyncio.run(
+                engine.reconcile_fan_on_startup(
+                    indoor=75.0, outdoor=65.0, thermostat_fan_running=True, any_sensor_open=False
+                )
+            )
+        with patch(
+            "custom_components.climate_advisor.automation.dt_util.now",
+            return_value=datetime(2026, 7, 10, 8, 30, 1),  # just past the 5-minute cooldown
+        ):
+            asyncio.run(
+                engine.reconcile_fan_on_startup(
+                    indoor=75.0, outdoor=65.0, thermostat_fan_running=True, any_sensor_open=False
+                )
+            )
+
+        assert engine._deactivate_fan.await_count == 2, (
+            f"Expected a fresh correction after the cooldown elapsed, got {engine._deactivate_fan.await_count}"
+        )
+
+    def test_suppressed_correction_is_logged_not_silent(self, caplog):
+        """A persistently-stray fan must stay visible in logs even while suppressed —
+        never silently dropped."""
+        import logging
+
+        engine = self._engine(fan_mode=FAN_MODE_HVAC)
+
+        with patch(
+            "custom_components.climate_advisor.automation.dt_util.now",
+            return_value=datetime(2026, 7, 10, 8, 24, 0),
+        ):
+            asyncio.run(
+                engine.reconcile_fan_on_startup(
+                    indoor=75.0, outdoor=65.0, thermostat_fan_running=True, any_sensor_open=False
+                )
+            )
+        with (
+            caplog.at_level(logging.INFO, logger="custom_components.climate_advisor.automation"),
+            patch(
+                "custom_components.climate_advisor.automation.dt_util.now",
+                return_value=datetime(2026, 7, 10, 8, 27, 0),
+            ),
+        ):
+            asyncio.run(
+                engine.reconcile_fan_on_startup(
+                    indoor=75.0, outdoor=65.0, thermostat_fan_running=True, any_sensor_open=False
+                )
+            )
+
+        assert any("suppressed" in r.message.lower() for r in caplog.records), (
+            "Expected an INFO log line reporting the suppressed correction"
+        )
 
 
 class TestFanEventEmission:


### PR DESCRIPTION
## Summary

Two follow-up findings from #444's real Activity Report, deferred there.

### 1. Grace period mislabeling

`_clear_fan_flags_and_start_grace()` hardcoded the grace period's source as `"manual"` for both callers: `on_fan_turned_off()` (a genuine user action) and `_reconcile_fan_physical_drift()` (Issue #423's automated self-correction). The Activity Report told the user they turned the fan off when CA was correcting its own stale belief. Added a `source` parameter, now passing `"automation"` from the drift-correction path (3 existing precedent call sites already use this value elsewhere).

### 2. Drift instrumentation (root cause not yet confirmed)

Added DEBUG-level instrumentation in `_reconcile_fan_physical_drift()` logging the raw fan entity states on every backstop tick. The exact 10-minute recurrence period is confirmed to be CA's own 5-min backstop × 2-tick confirmation cadence (software, not a hardware timer, verified directly against `decide_fan_drift_reconciliation()`) — but why the physical-state read repeatedly disagrees every cycle isn't yet conclusively identified (real incident logs were unavailable, rotated on restart). Instrumenting rather than shipping a guessed fix.

### 3. Reconcile spam rate limit

`reconcile_fan_on_startup()`'s "turn off unwarranted fan" branch had no rate limit across its 4 call sites — a recurring condition (e.g. a thermostat's own circulation schedule CA can't durably override with one command) triggered a full correction attempt every few minutes for up to 45 minutes. Added a 5-minute cooldown reusing the existing `_last_override_detected_time` dedup pattern, scoped inside the function itself so it applies regardless of caller. A suppressed correction still logs at INFO so a persistently-stray fan stays visible.

## Test plan

- [x] 4 new regression tests, verified via revert-test discipline (fail without the fix, pass with it)
- [x] `pytest tests/`: 3296/3296 pass, warnings-as-errors
- [x] `python tools/simulate.py`: 56/56 goldens unchanged, `--check-integrity` OK
- [x] Both existing production integration positive controls re-verified unaffected (nat-vent gate 31/56 diverge, fan-thermostat-check 7/56 diverge)
- [x] `ruff check` / `ruff format` clean
- [x] `test_version_sync.py` — manifest.json and const.py VERSION agree (0.5.3)