### PR TITLE
Fix #449: force real state transitions on dual-entity WHF control commands

### DIFF
--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -4200,6 +4200,69 @@ class AutomationEngine:
                 comfort_heat, reason="nat-vent savings mode — protecting comfort floor", mode="heat"
             )
 
+    async def _command_whf_control_entity(self, desired_on: bool, *, reason: str) -> bool:
+        """Command the WHF control/transmitter entity, guarding against HA's belief-based
+        command dedup in dual-entity (split control/detect) setups (Issue #449).
+
+        Scope: WHOLE_HOUSE_FAN/BOTH archetypes only, and only when dual-entity feedback
+        ground truth is available (``_get_fan_physical_state_callback`` returns non-None).
+        Single-entity/command-only WHF setups and FAN_MODE_HVAC are entirely untouched —
+        a single-entity control can be trusted, and the separate HVAC fan-mode command
+        path is unaffected.
+
+        A one-way transmitter entity has no feedback of its own; its HA-reported state
+        can silently drift from physical reality. Confirmed via real HA history (Issue
+        #449): ~14 repeated ``turn_on`` calls produced zero state transitions once the
+        entity's HA-reported state already read "on", because the physical fan had been
+        turned off by something outside HA's command path. When the control entity's
+        belief already matches the desired state AND ground truth disagrees, force a
+        real transition by commanding the OPPOSITE state first, waiting 5 seconds, then
+        the desired state. When both signals already agree, do nothing — no redundant
+        command.
+
+        Returns:
+            True if an HA service call was issued, False if the desired state was
+            already confirmed correct and nothing needed to change.
+        """
+        fan_mode = self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED)
+        if fan_mode not in (FAN_MODE_WHOLE_HOUSE, FAN_MODE_BOTH):
+            return False
+        fan_entity = self.config.get(CONF_FAN_ENTITY)
+        if not fan_entity:
+            return False
+        domain = fan_entity.split(".")[0]  # "fan" or "switch"
+        desired_service = "turn_on" if desired_on else "turn_off"
+
+        ground_truth = self._get_fan_physical_state_callback() if self._get_fan_physical_state_callback else None
+
+        if ground_truth is not None:
+            control_state = self.hass.states.get(fan_entity)
+            control_matches_desired = bool(control_state and (control_state.state == "on") == desired_on)
+            if control_matches_desired and ground_truth == desired_on:
+                _LOGGER.debug(
+                    "WHF control entity and detected physical state already agree (%s) — no command needed (%s)",
+                    "on" if desired_on else "off",
+                    reason,
+                )
+                return False
+            if control_matches_desired and ground_truth != desired_on:
+                _LOGGER.warning(
+                    "WHF control entity already reads %s but detected physical state"
+                    " disagrees — forcing a real transition before reasserting (%s)",
+                    "on" if desired_on else "off",
+                    reason,
+                )
+                opposite_service = "turn_off" if desired_on else "turn_on"
+                await self.hass.services.async_call(domain, opposite_service, {"entity_id": fan_entity})
+                await asyncio.sleep(5)
+                await self.hass.services.async_call(domain, desired_service, {"entity_id": fan_entity})
+                return True
+
+        # Not dual-entity mode, ground truth unavailable this tick, or control entity
+        # doesn't yet match the desired state — a plain command is a genuine transition.
+        await self.hass.services.async_call(domain, desired_service, {"entity_id": fan_entity})
+        return True
+
     async def _activate_fan(self, *, reason: str, emit_event: bool = True) -> None:
         """Activate fan based on configured fan_mode.
 
@@ -4245,8 +4308,9 @@ class AutomationEngine:
                 fan_entity = self.config.get(CONF_FAN_ENTITY)
                 if fan_entity:
                     domain = fan_entity.split(".")[0]  # "fan" or "switch"
-                    await self.hass.services.async_call(domain, "turn_on", {"entity_id": fan_entity})
-                    _LOGGER.warning("Activated %s fan (%s) — %s", domain, fan_entity, reason)
+                    _commanded = await self._command_whf_control_entity(True, reason=reason)
+                    if _commanded:
+                        _LOGGER.warning("Activated %s fan (%s) — %s", domain, fan_entity, reason)
 
             if fan_mode in (FAN_MODE_HVAC, FAN_MODE_BOTH):
                 hvac_state = self.hass.states.get(self.climate_entity)
@@ -4484,6 +4548,15 @@ class AutomationEngine:
             preserve_nat_vent_session=True,
             source="automation",
         )
+        # Issue #449: the control entity's own HA-reported state can silently stay
+        # stuck "on" (a one-way transmitter has no feedback of its own) even though
+        # ground truth has just confirmed the fan is physically off — reconcile it now
+        # so the very next reactivation attempt (nat_vent_temperature_check()'s
+        # immediate same-tick re-fire, since preserve_nat_vent_session=True above)
+        # starts from a control entity that genuinely reads "off".
+        self.hass.async_create_task(
+            self._command_whf_control_entity(False, reason="physical-state drift confirmed over 2 backstop ticks")
+        )
 
     async def _deactivate_fan(self, *, reason: str, restore_hvac: bool = True, emit_event: bool = True) -> None:
         """Deactivate fan based on configured fan_mode.
@@ -4544,8 +4617,9 @@ class AutomationEngine:
                 fan_entity = self.config.get(CONF_FAN_ENTITY)
                 if fan_entity:
                     domain = fan_entity.split(".")[0]
-                    await self.hass.services.async_call(domain, "turn_off", {"entity_id": fan_entity})
-                    _LOGGER.warning("Deactivated %s fan (%s) — %s", domain, fan_entity, reason)
+                    _commanded = await self._command_whf_control_entity(False, reason=reason)
+                    if _commanded:
+                        _LOGGER.warning("Deactivated %s fan (%s) — %s", domain, fan_entity, reason)
 
                 # Restore prior HVAC mode that was suppressed when the fan activated
                 # (Issue #277 Fix C). Only restore if we have a stored mode to go back to.

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,25 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.3"
+VERSION = "0.5.4"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.4": [
+        "Fix #449: found the real reason a whole-house fan could stay off for hours"
+        " overnight after being turned off outside of Climate Advisor (e.g. a wall"
+        " switch or the device's own remote) — in dual-entity setups (a control switch"
+        " plus a separate power-detection sensor), the control entity's Home Assistant"
+        " state can silently keep saying 'on' even though the fan is truly off, since"
+        " it's a one-way command with no feedback of its own. A plain 'turn on' command"
+        " sent to an entity Home Assistant already believes is on can be silently"
+        " dropped before it ever reaches the device. Climate Advisor now checks the"
+        " power-detection sensor before every command: if the control entity and the"
+        " sensor already agree, nothing is touched; if they disagree, it forces a real"
+        " transition (off, briefly, then on — or the reverse) so the command actually"
+        " reaches the fan. Confirmed against real device history from an actual"
+        " overnight incident. Only affects dual-entity whole-house-fan setups —"
+        " single-entity setups and HVAC-fan-mode ventilation are unchanged.",
+    ],
     "0.5.3": [
         "Fix #446: an automated self-correction (Issue #423's fan physical-drift check"
         " fixing its own stale belief about whether the fan was on) was reported in the"
@@ -873,6 +889,32 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    449: {
+        "version_fixed": "0.5.4",
+        "title": "WHF control-entity command dedup silently drops reactivation in dual-entity setups",
+        "scope_covered": (
+            "automation.py: confirmed the real root cause behind #446's symptoms via real HA entity"
+            " history (not theory) — a whole-house-fan control/transmitter entity's HA-reported state"
+            " showed only 2 transitions across a ~14-hour incident window (on at adoption, off at"
+            " morning wake-up), while ~14 repeated turn_on calls during a drift-correction loop"
+            " produced zero state changes, because the physical fan had been turned off outside HA's"
+            " command path and the one-way transmitter entity had no feedback to reflect that. New"
+            " _command_whf_control_entity(desired_on, reason) helper, used by _activate_fan(),"
+            " _deactivate_fan(), and the drift-reconciliation correction path: when dual-entity ground"
+            " truth (fan_state_entity) is available and the control entity already claims the desired"
+            " state but ground truth disagrees, forces a real transition by commanding the OPPOSITE"
+            " state first, waiting 5 seconds, then the desired state — symmetric in both directions"
+            " (want-on-but-stuck-on and want-off-but-stuck-off). When both signals already agree, no"
+            " command is sent at all. Scoped narrowly: single-entity/command-only WHF setups and all"
+            " FAN_MODE_HVAC fan-mode control are completely untouched — the helper only activates when"
+            " a live dual-entity ground-truth reading is available to justify it."
+        ),
+        "scope_not_covered": (
+            "Does not change the drift-detection cadence or thresholds (already confirmed correct) —"
+            " only the correction's command reliability. Does not add any new configuration; relies"
+            " entirely on the existing fan_state_entity/fan_state_feedback dual-entity setup."
+        ),
+    },
     446: {
         "version_fixed": "0.5.3",
         "title": "Automated fan drift-correction mislabeled as manual grace + repeated unwarranted-fan reconcile spam",

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.3"
+  "version": "0.5.4"
 }

--- a/tests/test_fan_control.py
+++ b/tests/test_fan_control.py
@@ -2856,3 +2856,178 @@ class TestDualFanStatus:
             climate_fan_mode="auto",
         )
         assert coord._compute_hvac_fan_status() == "inactive"
+
+
+class TestCommandWhfControlEntity:
+    """Issue #449 — dedup-safe WHF control-entity commands in dual-entity setups.
+
+    Root cause (confirmed via real HA entity history, not theory): once a one-way
+    transmitter entity's HA-reported state already says "on", a plain turn_on call is
+    silently absorbed and never reaches the physical device — the real fan stayed off
+    for hours while CA repeated the same no-op command every 10 minutes.
+    """
+
+    def _engine(self, *, control_state, ground_truth):
+        engine = _make_automation_engine({CONF_FAN_MODE: FAN_MODE_WHOLE_HOUSE, CONF_FAN_ENTITY: "fan.whf"})
+        if control_state is None:
+            engine.hass.states.get = MagicMock(return_value=None)
+        else:
+            state_mock = MagicMock()
+            state_mock.state = control_state
+            engine.hass.states.get = MagicMock(return_value=state_mock)
+        engine._get_fan_physical_state_callback = MagicMock(return_value=ground_truth)
+        return engine
+
+    def test_no_ground_truth_sends_plain_command_regardless_of_control_state(self):
+        """Command-only mode (or the callback currently returns None) — always the
+        plain, direct command, matching pre-#449 behavior exactly. A control entity
+        already reading "on" must NOT trigger a toggle here — this is the blast-radius
+        boundary for single-entity setups."""
+        engine = self._engine(control_state="on", ground_truth=None)
+
+        commanded = asyncio.run(engine._command_whf_control_entity(True, reason="test"))
+
+        assert commanded is True
+        calls = engine.hass.services.async_call.call_args_list
+        assert len(calls) == 1
+        assert calls[0].args == ("fan", "turn_on", {"entity_id": "fan.whf"})
+
+    def test_want_on_control_on_ground_truth_on_leaves_alone(self):
+        """Both signals agree the fan is really on — no command, nothing to fix."""
+        engine = self._engine(control_state="on", ground_truth=True)
+
+        commanded = asyncio.run(engine._command_whf_control_entity(True, reason="test"))
+
+        assert commanded is False
+        engine.hass.services.async_call.assert_not_called()
+
+    def test_want_on_control_on_ground_truth_off_forces_toggle(self):
+        """The confirmed real-world bug: control claims on but the fan is really off —
+        must force off->wait->on, not a single (silently-dropped) turn_on."""
+        engine = self._engine(control_state="on", ground_truth=False)
+
+        with patch("custom_components.climate_advisor.automation.asyncio.sleep", new=AsyncMock()) as mock_sleep:
+            commanded = asyncio.run(engine._command_whf_control_entity(True, reason="test"))
+
+        assert commanded is True
+        calls = engine.hass.services.async_call.call_args_list
+        assert len(calls) == 2
+        assert calls[0].args == ("fan", "turn_off", {"entity_id": "fan.whf"})
+        assert calls[1].args == ("fan", "turn_on", {"entity_id": "fan.whf"})
+        mock_sleep.assert_awaited_once_with(5)
+
+    def test_want_off_control_off_ground_truth_off_leaves_alone(self):
+        """Both signals agree the fan is really off — no command needed."""
+        engine = self._engine(control_state="off", ground_truth=False)
+
+        commanded = asyncio.run(engine._command_whf_control_entity(False, reason="test"))
+
+        assert commanded is False
+        engine.hass.services.async_call.assert_not_called()
+
+    def test_want_off_control_off_ground_truth_on_forces_toggle(self):
+        """Mirror-image stuck-off case: control claims off but the fan is really still
+        running — must force on->wait->off."""
+        engine = self._engine(control_state="off", ground_truth=True)
+
+        with patch("custom_components.climate_advisor.automation.asyncio.sleep", new=AsyncMock()) as mock_sleep:
+            commanded = asyncio.run(engine._command_whf_control_entity(False, reason="test"))
+
+        assert commanded is True
+        calls = engine.hass.services.async_call.call_args_list
+        assert len(calls) == 2
+        assert calls[0].args == ("fan", "turn_on", {"entity_id": "fan.whf"})
+        assert calls[1].args == ("fan", "turn_off", {"entity_id": "fan.whf"})
+        mock_sleep.assert_awaited_once_with(5)
+
+    def test_control_does_not_match_desired_sends_single_direct_command(self):
+        """Control genuinely needs to transition — no toggle needed, one command."""
+        engine = self._engine(control_state="off", ground_truth=False)
+
+        commanded = asyncio.run(engine._command_whf_control_entity(True, reason="test"))
+
+        assert commanded is True
+        calls = engine.hass.services.async_call.call_args_list
+        assert len(calls) == 1
+        assert calls[0].args == ("fan", "turn_on", {"entity_id": "fan.whf"})
+
+    def test_hvac_mode_is_a_no_op(self):
+        """FAN_MODE_HVAC must be entirely unaffected — the helper no-ops for this
+        archetype regardless of inputs, confirming the blast-radius boundary."""
+        engine = self._engine(control_state="on", ground_truth=False)
+        engine.config[CONF_FAN_MODE] = FAN_MODE_HVAC
+
+        commanded = asyncio.run(engine._command_whf_control_entity(True, reason="test"))
+
+        assert commanded is False
+        engine.hass.services.async_call.assert_not_called()
+
+
+class TestCommandWhfControlEntityWiring:
+    """Issue #449 — confirms the new helper is genuinely load-bearing through
+    _activate_fan()/_deactivate_fan()/drift-reconciliation, not dead code."""
+
+    def test_activate_fan_uses_the_new_helper(self):
+        """_activate_fan()'s WHF branch must route through _command_whf_control_entity,
+        not a direct service call — proven by forcing the toggle path and confirming
+        the resulting 2-call sequence."""
+        engine = _make_automation_engine({CONF_FAN_MODE: FAN_MODE_WHOLE_HOUSE, CONF_FAN_ENTITY: "fan.whf"})
+        state_mock = MagicMock()
+        state_mock.state = "on"
+        engine.hass.states.get = MagicMock(return_value=state_mock)
+        engine._get_fan_physical_state_callback = MagicMock(return_value=False)
+
+        with patch("custom_components.climate_advisor.automation.asyncio.sleep", new=AsyncMock()):
+            asyncio.run(engine._activate_fan(reason="test"))
+
+        calls = [c for c in engine.hass.services.async_call.call_args_list if c.args[0] == "fan"]
+        assert len(calls) == 2, f"Expected the forced toggle (2 calls), got {calls}"
+        assert engine._fan_active is True
+
+    def test_deactivate_fan_uses_the_new_helper(self):
+        """_deactivate_fan()'s WHF branch must route through _command_whf_control_entity."""
+        engine = _make_automation_engine({CONF_FAN_MODE: FAN_MODE_WHOLE_HOUSE, CONF_FAN_ENTITY: "fan.whf"})
+        engine._fan_active = True
+        state_mock = MagicMock()
+        state_mock.state = "off"
+        engine.hass.states.get = MagicMock(return_value=state_mock)
+        engine._get_fan_physical_state_callback = MagicMock(return_value=True)
+
+        with patch("custom_components.climate_advisor.automation.asyncio.sleep", new=AsyncMock()):
+            asyncio.run(engine._deactivate_fan(reason="test"))
+
+        calls = [c for c in engine.hass.services.async_call.call_args_list if c.args[0] == "fan"]
+        assert len(calls) == 2, f"Expected the forced toggle (2 calls), got {calls}"
+        assert engine._fan_active is False
+
+    def test_drift_correction_schedules_control_entity_reconcile(self):
+        """The real overnight incident, reproduced and fixed end-to-end: control entity
+        stuck "on", ground truth confirms off over 2 backstop ticks — the drift
+        correction must schedule a reconcile that turns the control entity off (a
+        single direct command, since control no longer matches "off" once we ask for
+        it), so the next reactivation starts from a truthful state."""
+        engine = _make_automation_engine({CONF_FAN_MODE: FAN_MODE_WHOLE_HOUSE, CONF_FAN_ENTITY: "fan.whf"})
+        state_mock = MagicMock()
+        state_mock.state = "on"
+        engine.hass.states.get = MagicMock(return_value=state_mock)
+        engine._get_fan_physical_state_callback = MagicMock(return_value=False)
+        engine._is_recent_fan_command_callback = MagicMock(return_value=False)
+        engine._fan_active = True
+
+        scheduled: list = []
+        engine.hass.async_create_task = MagicMock(side_effect=lambda coro: scheduled.append(coro))
+
+        engine._reconcile_fan_physical_drift()
+        engine._reconcile_fan_physical_drift()  # 2nd tick confirms drift -> CORRECT
+
+        # Find the reconcile coroutine (not the min-runtime-cycle one _clear_fan_flags
+        # also schedules) and run it for real to prove it issues the off command.
+        assert scheduled, "Expected _reconcile_fan_physical_drift to schedule at least one task"
+        engine.hass.services.async_call.reset_mock()
+        for coro in scheduled:
+            asyncio.run(coro)
+        calls = [c for c in engine.hass.services.async_call.call_args_list if c.args[:2] == ("fan", "turn_off")]
+        assert len(calls) == 1, (
+            f"Expected exactly one turn_off reconcile command among scheduled tasks, got: "
+            f"{engine.hass.services.async_call.call_args_list}"
+        )


### PR DESCRIPTION
## Summary

Real root cause behind #446's symptoms, confirmed via actual HA entity history rather than theory: a whole-house-fan control/transmitter entity's HA-reported state showed only 2 transitions across a ~14-hour incident window (on at adoption, off at morning wake-up). Between them, a real manual fan-off event and ~14 repeated `turn_on` retries during a drift-correction loop produced **zero** state changes on the control entity.

The drift detection was correct the entire time — the separate power-detection entity genuinely read "off" and CA genuinely reacted to it. The bug is in the correction: a plain `turn_on` service call is silently absorbed once the control entity's own HA-reported state already says "on" — a one-way transmitter has no feedback of its own and can drift from physical reality once the fan is toggled by something outside HA's command path.

## Fix

New `_command_whf_control_entity(desired_on, reason)` helper, used by `_activate_fan()`, `_deactivate_fan()`, and the drift-reconciliation correction path:

- Control already matches desired state AND ground truth agrees → no command, leave alone.
- Control already matches desired state BUT ground truth disagrees → force a real transition: command the opposite state first, wait 5s, then the desired state. Symmetric in both directions (stuck-on and stuck-off).
- Control doesn't yet match desired state → a genuine transition is already expected, single direct command.
- No dual-entity ground truth available (command-only mode, or transiently unavailable) → plain command, today's exact unmodified behavior.

Scoped narrowly: single-entity/command-only WHF setups and all FAN_MODE_HVAC fan-mode control are completely untouched.

## Test plan

- [x] 10 new regression tests, verified via revert-test discipline (fail without the fix, pass with it)
- [x] `pytest tests/`: 3306/3306 pass, warnings-as-errors
- [x] `python tools/simulate.py`: 56/56 goldens unchanged, `--check-integrity` OK
- [x] Both existing production integration positive controls re-verified unaffected (nat-vent gate 31/56 diverge, fan-thermostat-check 7/56 diverge)
- [x] `ruff check` / `ruff format` clean
- [x] `test_version_sync.py` — manifest.json and const.py VERSION agree (0.5.4)