### PR TITLE
Sync README with v0.5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,6 +495,7 @@ See [Issue #11](https://github.com/gunkl/ClimateAdvisor/issues/11) for full trac
 - [x] Nat-vent decision surface (reactivation gate, fan-thermostat stop check, drift reconciliation, reactivation lockout, grace, retry/verify, pre-cool) extracted into independently unit-tested pure functions with differential and positive-control validation, closing the repeated-drift bug class behind #400/#402/#417/#427/#429 (#429)
 - [x] Duplicate "Comfort band applied" Activity Report entries at restart and grace-expiry eliminated with a short-window announcement dedup — the thermostat command itself was always correct, only the notification repeated (#444)
 - [x] Automated fan physical-drift self-corrections no longer mislabeled as a manual grace period in the Activity Report; repeated "fan running without CA warrant" reconcile attempts rate-limited to once per 5 minutes (#446)
+- [x] Dual-entity whole-house-fan setups (separate control + power-detection sensor) no longer silently drop reactivation commands — a plain command can be absorbed once the control entity's HA state already agrees with what's being commanded, so CA now forces a real transition when a real incident's device history proved the control entity was stuck "on" for hours (#449)
 
 ### Phase 4: Seasonal & Cost Intelligence (v0.5+) — Future
 - [ ] Seasonal performance baselines (after 1 year of data)


### PR DESCRIPTION
## Summary
README's Phase 3 roadmap stopped at #446. Adds an entry for #449 (WHF control-entity command dedup fix, v0.5.4).

Docs-only, no production code touched.