### PR TITLE
Fix #452: HomeAssistantView test stub gap forced 14 replicated-logic test helpers (v0.5.5)

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -302,14 +302,13 @@ Reference: `TestPredIndoorIntegration::test_ode_cache_diverges_after_model_refre
 
 #### Testing Sensor Attributes and API Views
 
-**Sensor entity classes (`ClimateAdvisorBaseSensor` subclasses) CANNOT be directly instantiated in test files that use the lightweight HA module stubs** (e.g., `test_fan_control.py`, `test_contact_status.py`). Importing `sensor.py` in that environment causes a metaclass conflict:
-```
-TypeError: metaclass conflict: the metaclass of a derived class must be a (non-strict) subclass of the metaclasses of all its bases
-```
+**As of Issue #452, sensor entity classes and `HomeAssistantView` subclasses CAN both be directly instantiated in the lightweight HA stub environment.** `tools/sim_harness/ha_stubs.py` realifies the base classes each needs (`_MockSensorEntity`/`_MockCoordinatorEntity` for sensors, `_MockHomeAssistantView` + `_MockJsonResponse` for API views), so there is no more metaclass conflict for either. **Do not replicate `extra_state_attributes` or a view's `get()`/`post()` logic as a plain helper function** — instantiate the real class and exercise it directly.
 
-**Pattern to follow**: Replicate the `extra_state_attributes` logic as a plain helper function in the test file and test that directly. Reference implementations: `test_fan_control.py` (`_fan_sensor_extra_state_attributes` / `TestFanSensorAttributes`), `test_contact_status.py` (`_compute_contact_status`).
+**Sensor pattern**: build a `MagicMock()` (or partially-instantiated real) coordinator, set `.data`, then `SomeSensor(coordinator, entry).extra_state_attributes`. Reference: `test_fan_control.py` (`_fan_sensor_extra_state_attributes`), `test_status_sensors.py` (`_compliance_sensor_extra_state_attributes_with_thermal`).
 
-**`HomeAssistantView` subclasses (API views) have the same metaclass constraint.** Do NOT try to instantiate `ClimateAdvisorRespondSuggestionView` or similar view classes in tests. Instead, replicate the validation and dispatch logic as a plain `_simulate_post()` helper function in the test file and test that directly. Reference implementation: `test_api_respond_suggestion.py`.
+**API view pattern**: instantiate the view (`SomeView()`), build a `MagicMock()` request with `.app = {"hass": hass}` and (for POST) `.json = AsyncMock(return_value=body)`, then `await view.get(request)`/`await view.post(request)`. The response is a `_MockJsonResponse` exposing `.status` and `.json_data`. Reference: `test_api_respond_suggestion.py` (`_post`), `test_api.py` (`_simulate_status_get`), `test_ai_investigator.py` (`_post_investigate`).
+
+**Coordinator methods** (not sensor/view classes) still use the pre-existing `object.__new__(ClimateAdvisorCoordinator)` + `types.MethodType(RealMethod, instance)` partial-instantiation pattern (never metaclass-blocked — see below) — bind only the method(s) under test and set the specific `self.*` attributes that method reads. Reference: `test_contact_status.py` (`_make_real_coordinator`), `test_status_sensors.py` (`_compute_automation_status`/`_compute_next_automation_action`).
 
 #### Coordinator Class After test_occupancy.py Module Deletion
 

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,20 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.4"
+VERSION = "0.5.5"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.5": [
+        "Fix #452: no user-visible change. Continues the nat-vent architecture-reset"
+        " direction (v0.5.1) into the test suite — 14 test helpers that hand-copied"
+        " production logic (API view dispatch, sensor attributes, coordinator status"
+        " strings) because HomeAssistantView couldn't be instantiated in tests now"
+        " exercise the real classes directly. Along the way this caught and fixed a"
+        " stale test assertion that had silently drifted from production: the bedtime"
+        " status line's expected setpoint used an old comfort-temp-plus-delta formula"
+        " that stopped matching the real sleep_heat/sleep_cool config keys, so the old"
+        " test was passing against logic that no longer runs.",
+    ],
     "0.5.4": [
         "Fix #449: found the real reason a whole-house fan could stay off for hours"
         " overnight after being turned off outside of Climate Advisor (e.g. a wall"
@@ -889,6 +900,37 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    452: {
+        "version_fixed": "0.5.5",
+        "title": "HomeAssistantView test stub gap forced 14 test helpers to hand-replicate production logic",
+        "scope_covered": (
+            "tools/sim_harness/ha_stubs.py: added _MockHomeAssistantView + _MockJsonResponse, wired"
+            " into install_ha_stubs() the same way _MockSensorEntity/_MockCoordinatorEntity already"
+            " were — HomeAssistantView subclasses (the 23 api.py view classes) previously silently"
+            " became MagicMock instances on instantiation (not a hard error, so it went unnoticed) since"
+            " the base was an unconfigured MagicMock attribute. Deleted and rewrote the 14 test helpers"
+            " that hand-replicated production logic as a workaround: 3 API-view helpers now drive the"
+            " real ClimateAdvisorStatusView/LearningView/RespondSuggestionView/InvestigateView/"
+            " InvestigationReportsView; 3 sensor helpers now instantiate the real"
+            " ClimateAdvisorFanStatusSensor/ClimateAdvisorComplianceSensor (confirmed already"
+            " instantiable — the SensorEntity/CoordinatorEntity metaclass conflict this was blamed on"
+            " had already been resolved by an earlier pass and the docs were stale); 3 coordinator-method"
+            " helpers (_compute_contact_status/_details, _compute_automation_status,"
+            " _compute_next_automation_action) now use the established object.__new__() +"
+            " types.MethodType() partial-instantiation pattern instead of replicated bodies. Along the"
+            " way, rewriting _compute_next_automation_action's tests against the real method surfaced"
+            " and fixed a stale assertion: the old replicated helper's bedtime-setback formula"
+            " (comfort_heat - 4 + setback_modifier) predates the sleep_heat/sleep_cool config keys the"
+            " real method has read for some time, so two tests were passing against logic production no"
+            " longer runs."
+        ),
+        "scope_not_covered": (
+            "Does not touch any production behavior — this is test-infrastructure only. Does not convert"
+            " the remaining source-text-inspection tests (e.g. TestContactStatusSensorSource) or extend"
+            " coverage to the ~18 API view classes that still have no logic-level test at all; both are"
+            " separate follow-ups, not blocked by this fix."
+        ),
+    },
     449: {
         "version_fixed": "0.5.4",
         "title": "WHF control-entity command dedup silently drops reactivation in dual-entity setups",

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.4"
+  "version": "0.5.5"
 }

--- a/tests/test_ai_investigator.py
+++ b/tests/test_ai_investigator.py
@@ -728,79 +728,45 @@ class TestInvestigatorRateLimit:
 
 
 # ---------------------------------------------------------------------------
-# Group 6: API endpoint logic (replicated as plain helpers)
+# Group 6: API endpoint logic — exercises the real views (Issue #452)
 # ---------------------------------------------------------------------------
 
 
-async def _simulate_investigate_post(
-    coordinator: MagicMock,
-    focus: str | None = None,
-    hours: int = 48,
-    run_skill: bool = False,
-) -> tuple[int, str]:
-    """Replicate the logic of ClimateAdvisorInvestigateView.post() as a plain function.
+def _make_investigate_request(coordinator: MagicMock, body: dict | None = None) -> MagicMock:
+    from custom_components.climate_advisor.const import DOMAIN
 
-    Returns (status_code, body_text) for assertions.
-    This avoids instantiating HomeAssistantView which has metaclass constraints.
+    hass = coordinator.hass if isinstance(coordinator.hass, MagicMock) else MagicMock()
+    hass.data = {DOMAIN: {"entry1": coordinator}}
 
-    When *run_skill* is True, also replicates the non-streaming execution branch
-    (calls coordinator.ai_skills.async_execute(), logs a WARNING and stores the
-    report on success — mirroring api.py's truncation handling, Issue #420).
-    """
-    import logging
-
-    from custom_components.climate_advisor.const import (
-        CONF_AI_ENABLED,
-        CONF_AI_INVESTIGATOR_ENABLED,
-        DEFAULT_AI_ENABLED,
-        DEFAULT_AI_INVESTIGATOR_ENABLED,
-    )
-
-    if not coordinator.config.get(CONF_AI_ENABLED, DEFAULT_AI_ENABLED):
-        return 403, "AI features are not enabled"
-
-    if not coordinator.config.get(CONF_AI_INVESTIGATOR_ENABLED, DEFAULT_AI_INVESTIGATOR_ENABLED):
-        return 403, "Investigative agent is not enabled"
-
-    if coordinator.claude_client is None:
-        return 503, "AI client not available"
-
-    allowed, reason = coordinator.claude_client.check_investigator_rate_limit()
-    if not allowed:
-        return 429, reason
-
-    if not run_skill:
-        return 200, "ok"
-
-    result = await coordinator.ai_skills.async_execute(
-        "investigator",
-        coordinator.hass,
-        coordinator,
-        coordinator.claude_client,
-        focus=focus or "",
-        hours=hours,
-    )
-
-    if result.get("success") or result.get("source") == "fallback":
-        if result.get("truncated"):
-            logging.getLogger("custom_components.climate_advisor.api").warning(
-                "Investigation report truncated: hit max_tokens limit; "
-                "consider raising Investigator Max Response Length"
-            )
-        coordinator.claude_client.increment_investigator_counter()
-        await coordinator.async_store_investigation_report(result)
-        return 200, "ok"
-
-    return 500, result.get("error", "Investigation failed")
+    req = MagicMock()
+    req.app = {"hass": hass}
+    req.json = AsyncMock(return_value=body or {})
+    req.headers = {}
+    return req
 
 
-def _simulate_investigation_reports_get(coordinator: MagicMock) -> list[dict]:
-    """Replicate the logic of ClimateAdvisorInvestigationReportsView.get()."""
-    return coordinator.get_investigation_report_history()
+async def _post_investigate(coordinator: MagicMock, body: dict | None = None):
+    from custom_components.climate_advisor.api import ClimateAdvisorInvestigateView
+
+    view = ClimateAdvisorInvestigateView()
+    request = _make_investigate_request(coordinator, body)
+    return await view.post(request)
+
+
+async def _get_investigation_reports(coordinator: MagicMock):
+    from custom_components.climate_advisor.api import ClimateAdvisorInvestigationReportsView
+    from custom_components.climate_advisor.const import DOMAIN
+
+    view = ClimateAdvisorInvestigationReportsView()
+    hass = MagicMock()
+    hass.data = {DOMAIN: {"entry1": coordinator}}
+    req = MagicMock()
+    req.app = {"hass": hass}
+    return await view.get(req)
 
 
 class TestAPIEndpointLogic:
-    """Tests for the investigate POST / investigation_reports GET endpoint logic."""
+    """Tests for the real ClimateAdvisorInvestigateView.post() / InvestigationReportsView.get()."""
 
     def _make_api_coordinator(self, **config_overrides) -> MagicMock:
         config = {
@@ -814,58 +780,70 @@ class TestAPIEndpointLogic:
         claude.check_investigator_rate_limit.return_value = (True, "")
         coord.claude_client = claude
         coord.get_investigation_report_history.return_value = []
+        coord.hass = MagicMock()
+        coord.ai_skills = MagicMock()
+        coord.ai_skills.async_execute = AsyncMock(
+            return_value={
+                "success": True,
+                "source": "ai",
+                "data": {},
+                "error": None,
+                "input_context": "ctx",
+                "raw_response": "ok",
+                "truncated": False,
+            }
+        )
+        coord.async_store_investigation_report = AsyncMock()
         return coord
 
     def test_post_ai_disabled_returns_403(self):
         """POST returns 403 when ai_enabled is False."""
         coord = self._make_api_coordinator(ai_enabled=False)
 
-        status, body = asyncio.run(_simulate_investigate_post(coord))
+        resp = asyncio.run(_post_investigate(coord))
 
-        assert status == 403
-        assert "AI features are not enabled" in body
+        assert resp.status == 403
+        assert "AI features are not enabled" in resp.json_data["message"]
 
     def test_post_investigator_disabled_returns_403(self):
         """POST returns 403 when ai_investigator_enabled is False."""
         coord = self._make_api_coordinator(ai_investigator_enabled=False)
 
-        status, body = asyncio.run(_simulate_investigate_post(coord))
+        resp = asyncio.run(_post_investigate(coord))
 
-        assert status == 403
-        assert "Investigative agent is not enabled" in body
+        assert resp.status == 403
+        assert "Investigative agent is not enabled" in resp.json_data["message"]
 
     def test_post_no_client_returns_503(self):
         """POST returns 503 when claude_client is None."""
         coord = self._make_api_coordinator()
         coord.claude_client = None
 
-        status, body = asyncio.run(_simulate_investigate_post(coord))
+        resp = asyncio.run(_post_investigate(coord))
 
-        assert status == 503
+        assert resp.status == 503
 
     def test_post_rate_limit_reached_returns_429(self):
         """POST returns 429 when the investigator daily limit is reached."""
         coord = self._make_api_coordinator()
         coord.claude_client.check_investigator_rate_limit.return_value = (False, "limit reached")
 
-        status, body = asyncio.run(_simulate_investigate_post(coord))
+        resp = asyncio.run(_post_investigate(coord))
 
-        assert status == 429
-        assert "limit reached" in body
+        assert resp.status == 429
+        assert "limit reached" in resp.json_data["message"]
 
     def test_post_all_checks_pass_returns_200(self):
         """POST returns 200 when all pre-conditions are satisfied."""
         coord = self._make_api_coordinator()
 
-        status, _ = asyncio.run(_simulate_investigate_post(coord))
+        resp = asyncio.run(_post_investigate(coord))
 
-        assert status == 200
+        assert resp.status == 200
 
     def test_post_truncated_result_logs_warning_and_stores_flag(self, caplog):
         """A truncated skill result logs a WARNING and stores truncated=True (Issue #420)."""
         coord = self._make_api_coordinator()
-        coord.hass = MagicMock()
-        coord.ai_skills = MagicMock()
         coord.ai_skills.async_execute = AsyncMock(
             return_value={
                 "success": True,
@@ -877,12 +855,11 @@ class TestAPIEndpointLogic:
                 "truncated": True,
             }
         )
-        coord.async_store_investigation_report = AsyncMock()
 
         with caplog.at_level("WARNING"):
-            status, _ = asyncio.run(_simulate_investigate_post(coord, run_skill=True))
+            resp = asyncio.run(_post_investigate(coord))
 
-        assert status == 200
+        assert resp.status == 200
         assert any("truncated" in rec.message.lower() for rec in caplog.records)
         stored = coord.async_store_investigation_report.call_args[0][0]
         assert stored["truncated"] is True
@@ -890,8 +867,6 @@ class TestAPIEndpointLogic:
     def test_post_normal_result_does_not_warn(self, caplog):
         """A normal (non-truncated) result stores truncated=False and logs no warning."""
         coord = self._make_api_coordinator()
-        coord.hass = MagicMock()
-        coord.ai_skills = MagicMock()
         coord.ai_skills.async_execute = AsyncMock(
             return_value={
                 "success": True,
@@ -903,12 +878,11 @@ class TestAPIEndpointLogic:
                 "truncated": False,
             }
         )
-        coord.async_store_investigation_report = AsyncMock()
 
         with caplog.at_level("WARNING"):
-            status, _ = asyncio.run(_simulate_investigate_post(coord, run_skill=True))
+            resp = asyncio.run(_post_investigate(coord))
 
-        assert status == 200
+        assert resp.status == 200
         assert not any("truncated" in rec.message.lower() for rec in caplog.records)
         stored = coord.async_store_investigation_report.call_args[0][0]
         assert stored["truncated"] is False
@@ -919,18 +893,18 @@ class TestAPIEndpointLogic:
         expected = [{"timestamp": "2026-04-06T10:00:00", "result": {"summary": "test"}}]
         coord.get_investigation_report_history.return_value = expected
 
-        result = _simulate_investigation_reports_get(coord)
+        resp = asyncio.run(_get_investigation_reports(coord))
 
-        assert result == expected
+        assert resp.json_data == expected
 
     def test_get_reports_returns_empty_list_initially(self):
         """GET returns [] when there are no stored reports."""
         coord = self._make_api_coordinator()
         coord.get_investigation_report_history.return_value = []
 
-        result = _simulate_investigation_reports_get(coord)
+        resp = asyncio.run(_get_investigation_reports(coord))
 
-        assert result == []
+        assert resp.json_data == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -20,12 +20,8 @@ from custom_components.climate_advisor.const import (
     API_SEND_BRIEFING,
     API_STATUS,
     API_TOGGLE_AUTOMATION,
-    ATTR_CONTACT_STATUS,
+    ATTR_CURRENT_SETPOINT,
     ATTR_DAY_TYPE,
-    ATTR_FAN_STATUS,
-    ATTR_NEXT_ACTION,
-    ATTR_NEXT_AUTOMATION_ACTION,
-    ATTR_NEXT_AUTOMATION_TIME,
     ATTR_TREND,
     ATTR_TREND_MAGNITUDE,
     CONF_AUTOMATION_GRACE_PERIOD,
@@ -262,91 +258,63 @@ class TestToggleAutomationView:
 # ---------------------------------------------------------------------------
 
 
-def _simulate_status_get(coordinator):
-    """Replicate ClimateAdvisorStatusView.get() response dict."""
-    from custom_components.climate_advisor.temperature import convert_delta, from_fahrenheit
+# ---------------------------------------------------------------------------
+# View-driving helpers — exercise the real HomeAssistantView subclasses
+# (HomeAssistantView is a real minimal base class as of Issue #452, so these
+# no longer need to hand-replicate the view's response dict).
+# ---------------------------------------------------------------------------
 
-    data = coordinator.data or {}
-    unit = coordinator.config.get("temp_unit", "fahrenheit")
-    indoor_temp = coordinator._get_indoor_temp()
-    outdoor_temp = coordinator._last_outdoor_temp
-    indoor_temp_display = round(from_fahrenheit(indoor_temp, unit), 1) if indoor_temp is not None else None
-    outdoor_temp_display = round(from_fahrenheit(outdoor_temp, unit), 1) if outdoor_temp is not None else None
-    trend_magnitude_display = round(convert_delta(data.get(ATTR_TREND_MAGNITUDE, 0), unit), 1)
-    return {
-        "day_type": data.get(ATTR_DAY_TYPE, "unknown"),
-        "trend_direction": data.get(ATTR_TREND, "unknown"),
-        "trend_magnitude": trend_magnitude_display,
-        "hvac_mode": "off",
-        "indoor_temp": indoor_temp_display,
-        "outdoor_temp": outdoor_temp_display,
-        "current_setpoint": None,
-        "target_temp_low": None,
-        "target_temp_high": None,
-        "automation_status": data.get("automation_status", "unknown"),
-        "compliance_score": data.get("compliance_score", 1.0),
-        "next_action": data.get(ATTR_NEXT_ACTION, ""),
-        "next_automation_action": data.get(ATTR_NEXT_AUTOMATION_ACTION, ""),
-        "next_automation_time": data.get(ATTR_NEXT_AUTOMATION_TIME, ""),
-        "automation_enabled": coordinator.automation_enabled,
-        "occupancy_mode": coordinator._occupancy_mode,
-        "fan_status": data.get(ATTR_FAN_STATUS, "disabled"),
-        "contact_status": data.get(ATTR_CONTACT_STATUS, "no sensors"),
-        "contact_sensors": [],
-        "manual_override_active": False,
-        "fan_override_active": False,
-        "paused_by_door": False,
-        "unit": unit,
-    }
+
+def _make_view_request(coordinator, climate_state=None):
+    hass = MagicMock()
+    hass.data = {DOMAIN: {"entry1": coordinator}}
+    hass.states.get.return_value = climate_state
+    req = MagicMock()
+    req.app = {"hass": hass}
+    return req
+
+
+def _simulate_status_get(coordinator, climate_state=None):
+    """Call the real ClimateAdvisorStatusView.get() and return its json body."""
+    import asyncio
+
+    from custom_components.climate_advisor.api import ClimateAdvisorStatusView
+
+    view = ClimateAdvisorStatusView()
+    request = _make_view_request(coordinator, climate_state)
+    resp = asyncio.run(view.get(request))
+    return resp.json_data
 
 
 def _simulate_learning_get(coordinator):
-    """Replicate ClimateAdvisorLearningView.get() response dict."""
-    from custom_components.climate_advisor.temperature import from_fahrenheit
+    """Call the real ClimateAdvisorLearningView.get() and return its json body."""
+    import asyncio
 
-    unit = coordinator.config.get("temp_unit", "fahrenheit")
-    return {
-        "today_record": None,
-        "yesterday_record": coordinator.yesterday_record,
-        "tomorrow_plan": coordinator.tomorrow_plan,
-        "suggestions": [],
-        "compliance": {},
-        "comfort_range_low": round(from_fahrenheit(coordinator.config.get("comfort_heat", 70), unit), 1),
-        "comfort_range_high": round(from_fahrenheit(coordinator.config.get("comfort_cool", 75), unit), 1),
-        "unit": unit,
-    }
+    from custom_components.climate_advisor.api import ClimateAdvisorLearningView
+
+    view = ClimateAdvisorLearningView()
+    request = _make_view_request(coordinator)
+    resp = asyncio.run(view.get(request))
+    return resp.json_data
 
 
-def _extract_setpoints(climate_state, hvac_mode):
-    """Replicate the api.py status setpoint extraction (Issue #266).
-
-    Single-setpoint modes (cool/heat) expose `temperature`; the heat_cool band exposes
-    `target_temp_low`/`target_temp_high`. Nothing is exposed when HVAC is off.
-    """
-    setpoint = target_temp_low = target_temp_high = None
-    if climate_state and hvac_mode != "off":
-        setpoint = climate_state.attributes.get("temperature")
-        target_temp_low = climate_state.attributes.get("target_temp_low")
-        target_temp_high = climate_state.attributes.get("target_temp_high")
-    return setpoint, target_temp_low, target_temp_high
-
-
-def _compute_ca_targets(config: dict, now) -> tuple[float | None, float | None]:
-    """Replicate the Issue #402 ca_target_heat/cool sleep-aware logic in api.py.
-
-    Before the fix, these were always the flat comfort_heat/comfort_cool values,
-    so the divergence check (both the pre-existing heat_cool one and the new
-    single-setpoint one, Issue #402) compared the real thermostat setpoint against
-    the wrong intended value throughout the sleep window.
-    """
-    from custom_components.climate_advisor.automation import _in_sleep_window
-
-    if _in_sleep_window(now, config):
-        return (
-            config.get("sleep_heat", config.get("comfort_heat")),
-            config.get("sleep_cool", config.get("comfort_cool")),
-        )
-    return config.get("comfort_heat"), config.get("comfort_cool")
+def _status_get_with_climate_state(config: dict, climate_state, indoor_temp=70.0, outdoor_temp=None):
+    """Build a minimal coordinator and drive the real status view, for setpoint/ca-target tests."""
+    coord = MagicMock()
+    coord.config = config
+    coord.data = {}
+    coord._get_indoor_temp.return_value = indoor_temp
+    coord._last_outdoor_temp = outdoor_temp
+    coord.automation_enabled = True
+    coord._occupancy_mode = "home"
+    ae = MagicMock()
+    ae._manual_override_active = False
+    ae._override_confirm_pending = False
+    ae._fan_override_active = False
+    ae.is_paused_by_door = False
+    coord.automation_engine = ae
+    coord._compute_contact_details.return_value = []
+    return _simulate_status_get(coord, climate_state)
 
 
 class TestCATargetSleepAware:
@@ -367,11 +335,24 @@ class TestCATargetSleepAware:
         "wake_time": "07:00",
     }
 
+    def _get_ca_targets(self, config: dict, now):
+        """Drive the real ClimateAdvisorStatusView.get(), patching dt_util.now()."""
+        from unittest.mock import patch
+
+        from homeassistant.util import dt as dt_util
+
+        state = MagicMock()
+        state.state = "heat"
+        state.attributes = {"temperature": 70, "target_temp_low": None, "target_temp_high": None}
+        with patch.object(dt_util, "now", return_value=now):
+            response = _status_get_with_climate_state(config, state)
+        return response["ca_target_heat"], response["ca_target_cool"]
+
     def test_daytime_uses_comfort_band(self):
         from datetime import datetime
 
         now = datetime(2026, 7, 21, 14, 0, 0)  # 14:00 — outside sleep window
-        heat, cool = _compute_ca_targets(self._CONFIG, now)
+        heat, cool = self._get_ca_targets(self._CONFIG, now)
         assert heat == 68.0
         assert cool == 74.0
 
@@ -379,7 +360,7 @@ class TestCATargetSleepAware:
         from datetime import datetime
 
         now = datetime(2026, 7, 21, 2, 0, 0)  # 02:00 — inside 22:30-07:00 sleep window
-        heat, cool = _compute_ca_targets(self._CONFIG, now)
+        heat, cool = self._get_ca_targets(self._CONFIG, now)
         assert heat == 64.0
         assert cool == 72.0
         assert heat != 68.0, "must not fall back to the flat daytime comfort_heat overnight"
@@ -390,7 +371,7 @@ class TestCATargetSleepAware:
 
         config = {"comfort_heat": 68.0, "comfort_cool": 74.0, "sleep_time": "22:30", "wake_time": "07:00"}
         now = datetime(2026, 7, 21, 2, 0, 0)
-        heat, cool = _compute_ca_targets(config, now)
+        heat, cool = self._get_ca_targets(config, now)
         assert heat == 68.0
         assert cool == 74.0
 
@@ -398,26 +379,32 @@ class TestCATargetSleepAware:
 class TestStatusSetpointExtraction:
     """Issue #266: the status endpoint must expose the dual band setpoints in heat_cool mode."""
 
+    _CONFIG = {"comfort_heat": 68.0, "comfort_cool": 74.0}
+
     def test_heat_cool_band_exposes_dual_setpoints(self):
         state = MagicMock()
+        state.state = "heat_cool"
         state.attributes = {"temperature": None, "target_temp_low": 64, "target_temp_high": 72}
-        setpoint, low, high = _extract_setpoints(state, "heat_cool")
-        assert setpoint is None  # single setpoint is absent in the heat_cool band
-        assert low == 64
-        assert high == 72
+        response = _status_get_with_climate_state(self._CONFIG, state)
+        assert response[ATTR_CURRENT_SETPOINT] is None  # single setpoint is absent in the heat_cool band
+        assert response["target_temp_low"] == 64
+        assert response["target_temp_high"] == 72
 
     def test_cool_mode_exposes_single_setpoint(self):
         state = MagicMock()
+        state.state = "cool"
         state.attributes = {"temperature": 74, "target_temp_low": None, "target_temp_high": None}
-        setpoint, low, high = _extract_setpoints(state, "cool")
-        assert setpoint == 74
-        assert low is None and high is None
+        response = _status_get_with_climate_state(self._CONFIG, state)
+        assert response[ATTR_CURRENT_SETPOINT] == 74
+        assert response["target_temp_low"] is None and response["target_temp_high"] is None
 
     def test_off_mode_exposes_no_setpoints(self):
         state = MagicMock()
+        state.state = "off"
         state.attributes = {"temperature": 74, "target_temp_low": 64, "target_temp_high": 72}
-        setpoint, low, high = _extract_setpoints(state, "off")
-        assert setpoint is None and low is None and high is None
+        response = _status_get_with_climate_state(self._CONFIG, state)
+        assert response[ATTR_CURRENT_SETPOINT] is None
+        assert response["target_temp_low"] is None and response["target_temp_high"] is None
 
 
 class TestStatusViewCelsiusUnit:

--- a/tests/test_api_respond_suggestion.py
+++ b/tests/test_api_respond_suggestion.py
@@ -1,53 +1,44 @@
 """Tests for respond_suggestion endpoint feedback handling (Issue #84).
 
-The view class cannot be directly instantiated in the lightweight test
-environment (same metaclass constraint as sensor entities). Tests verify:
-- The endpoint path constant is correct
-- The underlying record_feedback / dismiss_suggestion integration logic
-- Validation conditions that the post() handler checks
+Exercises the real ClimateAdvisorRespondSuggestionView.post() handler —
+HomeAssistantView is now a real minimal base class (Issue #452), so the
+view no longer needs to be hand-replicated in this test file.
 """
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
 
-from custom_components.climate_advisor.const import API_RESPOND_SUGGESTION
-
-# ---------------------------------------------------------------------------
-# Helpers — replicate the logic the post() handler executes
-# ---------------------------------------------------------------------------
+from custom_components.climate_advisor.api import ClimateAdvisorRespondSuggestionView
+from custom_components.climate_advisor.const import API_RESPOND_SUGGESTION, DOMAIN
 
 
-def _simulate_post(body: dict, coordinator: MagicMock) -> str:
-    """Simulate the validation + dispatch logic of ClimateAdvisorRespondSuggestionView.post().
+def _make_request(body: dict, coordinator) -> MagicMock:
+    hass = MagicMock()
+    hass.data = {DOMAIN: {"entry1": coordinator}}
+    hass.async_add_executor_job = AsyncMock()
 
-    Returns the logical outcome: 'ok', '400_feedback', '400_key', '400_none',
-    '400_action', or 'feedback_only_ok'.
-    """
-    action = body.get("action")
-    suggestion_key = body.get("suggestion_key")
-    feedback = body.get("feedback")
+    req = MagicMock()
+    req.app = {"hass": hass}
+    req.json = AsyncMock(return_value=body)
+    return req
 
-    if feedback is not None and feedback not in ("correct", "incorrect"):
-        return "400_feedback"
-    if not suggestion_key:
-        return "400_key"
-    if action is None and feedback is None:
-        return "400_none"
-    if action is not None and action not in ("accept", "dismiss"):
-        return "400_action"
 
-    if feedback is not None:
-        coordinator.learning.record_feedback(suggestion_key, feedback)
+def _post(body: dict, coordinator):
+    view = ClimateAdvisorRespondSuggestionView()
+    request = _make_request(body, coordinator)
+    return asyncio.run(view.post(request))
 
-    if action == "accept":
-        coordinator.learning.accept_suggestion(suggestion_key)
-        return "ok"
-    elif action == "dismiss":
-        coordinator.learning.dismiss_suggestion(suggestion_key)
-        return "ok"
-    else:
-        return "ok"
+
+def _coord() -> MagicMock:
+    coord = MagicMock()
+    coord.config = {}
+    coord.learning.record_feedback = MagicMock()
+    coord.learning.dismiss_suggestion = MagicMock()
+    coord.learning.accept_suggestion = MagicMock(return_value={})
+    coord.learning.save_state = MagicMock()
+    return coord
 
 
 # ---------------------------------------------------------------------------
@@ -66,47 +57,41 @@ class TestRespondSuggestionEndpoint:
 
 
 # ---------------------------------------------------------------------------
-# TestRespondSuggestionFeedback — logic-level tests
+# TestRespondSuggestionFeedback — real view.post() tests
 # ---------------------------------------------------------------------------
 
 
 class TestRespondSuggestionFeedback:
-    """Logic-level tests for the feedback dispatch in post()."""
-
-    def _coord(self) -> MagicMock:
-        coord = MagicMock()
-        coord.learning.record_feedback = MagicMock()
-        coord.learning.dismiss_suggestion = MagicMock()
-        coord.learning.accept_suggestion = MagicMock(return_value={})
-        return coord
+    """Tests against the real ClimateAdvisorRespondSuggestionView.post() handler."""
 
     def test_feedback_correct_recorded(self):
-        coord = self._coord()
-        result = _simulate_post({"suggestion_key": "low_window_compliance", "feedback": "correct"}, coord)
-        assert result == "ok"
+        coord = _coord()
+        resp = _post({"suggestion_key": "low_window_compliance", "feedback": "correct"}, coord)
+        assert resp.status == 200
+        assert resp.json_data["status"] == "ok"
         coord.learning.record_feedback.assert_called_once_with("low_window_compliance", "correct")
 
     def test_feedback_incorrect_recorded(self):
-        coord = self._coord()
-        result = _simulate_post({"suggestion_key": "low_window_compliance", "feedback": "incorrect"}, coord)
-        assert result == "ok"
+        coord = _coord()
+        resp = _post({"suggestion_key": "low_window_compliance", "feedback": "incorrect"}, coord)
+        assert resp.status == 200
         coord.learning.record_feedback.assert_called_once_with("low_window_compliance", "incorrect")
 
     def test_feedback_invalid_value_rejected(self):
-        coord = self._coord()
-        result = _simulate_post({"suggestion_key": "low_window_compliance", "feedback": "maybe"}, coord)
-        assert result == "400_feedback"
+        coord = _coord()
+        resp = _post({"suggestion_key": "low_window_compliance", "feedback": "maybe"}, coord)
+        assert resp.status == 400
         coord.learning.record_feedback.assert_not_called()
 
     def test_feedback_requires_suggestion_key(self):
-        coord = self._coord()
-        result = _simulate_post({"feedback": "correct"}, coord)
-        assert result == "400_key"
+        coord = _coord()
+        resp = _post({"feedback": "correct"}, coord)
+        assert resp.status == 400
         coord.learning.record_feedback.assert_not_called()
 
     def test_action_and_feedback_together(self):
-        coord = self._coord()
-        result = _simulate_post(
+        coord = _coord()
+        resp = _post(
             {
                 "suggestion_key": "low_window_compliance",
                 "action": "dismiss",
@@ -114,27 +99,36 @@ class TestRespondSuggestionFeedback:
             },
             coord,
         )
-        assert result == "ok"
+        assert resp.status == 200
+        assert resp.json_data["dismissed"] == "low_window_compliance"
         coord.learning.record_feedback.assert_called_once_with("low_window_compliance", "incorrect")
         coord.learning.dismiss_suggestion.assert_called_once_with("low_window_compliance")
 
     def test_feedback_only_no_action_returns_ok(self):
-        coord = self._coord()
-        result = _simulate_post({"suggestion_key": "low_window_compliance", "feedback": "correct"}, coord)
-        assert result == "ok"
+        coord = _coord()
+        resp = _post({"suggestion_key": "low_window_compliance", "feedback": "correct"}, coord)
+        assert resp.status == 200
         coord.learning.dismiss_suggestion.assert_not_called()
         coord.learning.accept_suggestion.assert_not_called()
 
     def test_no_action_no_feedback_returns_400(self):
-        coord = self._coord()
-        result = _simulate_post({"suggestion_key": "low_window_compliance"}, coord)
-        assert result == "400_none"
+        coord = _coord()
+        resp = _post({"suggestion_key": "low_window_compliance"}, coord)
+        assert resp.status == 400
         coord.learning.record_feedback.assert_not_called()
 
     def test_invalid_action_returns_400(self):
-        coord = self._coord()
-        result = _simulate_post({"suggestion_key": "low_window_compliance", "action": "snooze"}, coord)
-        assert result == "400_action"
+        coord = _coord()
+        resp = _post({"suggestion_key": "low_window_compliance", "action": "snooze"}, coord)
+        assert resp.status == 400
         coord.learning.record_feedback.assert_not_called()
         coord.learning.dismiss_suggestion.assert_not_called()
         coord.learning.accept_suggestion.assert_not_called()
+
+    def test_accept_action_applies_changes_to_config(self):
+        coord = _coord()
+        coord.learning.accept_suggestion = MagicMock(return_value={"comfort_heat": 68})
+        resp = _post({"suggestion_key": "low_window_compliance", "action": "accept"}, coord)
+        assert resp.status == 200
+        assert resp.json_data["changes"] == {"comfort_heat": 68}
+        assert coord.config["comfort_heat"] == 68

--- a/tests/test_contact_status.py
+++ b/tests/test_contact_status.py
@@ -40,48 +40,39 @@ def _states_getter(state_map: dict[str, MagicMock]):
     return lambda eid: state_map.get(eid)
 
 
-def _is_sensor_open(hass_states_get, entity_id: str, polarity_inverted: bool = False) -> bool:
-    """Check if a sensor is open, respecting polarity.
+def _make_real_coordinator(resolved_sensors: list[str], hass_states_get, polarity_inverted: bool = False):
+    """Build a bare ClimateAdvisorCoordinator bound to the real contact-status methods.
 
-    This mirrors ClimateAdvisorCoordinator._is_sensor_open().
+    Uses object.__new__() + types.MethodType() (the established pattern for
+    partially instantiating the coordinator in tests — see test_daily_record_accuracy.py)
+    rather than replicating the method bodies, so these tests exercise the real
+    ClimateAdvisorCoordinator._is_sensor_open/_compute_contact_status/_compute_contact_details.
     """
-    state = hass_states_get(entity_id)
-    if not state:
-        return False
-    if polarity_inverted:
-        return state.state == "off"
-    return state.state == "on"
+    import types
+
+    from custom_components.climate_advisor.coordinator import ClimateAdvisorCoordinator
+
+    coord = object.__new__(ClimateAdvisorCoordinator)
+    coord.config = {"sensor_polarity_inverted": polarity_inverted}
+    coord._resolved_sensors = resolved_sensors
+    coord.hass = MagicMock()
+    coord.hass.states.get = hass_states_get
+    coord._is_sensor_open = types.MethodType(ClimateAdvisorCoordinator._is_sensor_open, coord)
+    coord._compute_contact_status = types.MethodType(ClimateAdvisorCoordinator._compute_contact_status, coord)
+    coord._compute_contact_details = types.MethodType(ClimateAdvisorCoordinator._compute_contact_details, coord)
+    return coord
 
 
 def _compute_contact_status(resolved_sensors: list[str], hass_states_get) -> str:
-    """Compute the contact sensor summary string.
-
-    This mirrors ClimateAdvisorCoordinator._compute_contact_status().
-    """
-    if not resolved_sensors:
-        return "no sensors"
-    open_count = sum(1 for s in resolved_sensors if _is_sensor_open(hass_states_get, s))
-    if open_count == 0:
-        return "all closed"
-    return f"{open_count} open"
+    """Call the real ClimateAdvisorCoordinator._compute_contact_status()."""
+    coord = _make_real_coordinator(resolved_sensors, hass_states_get)
+    return coord._compute_contact_status()
 
 
 def _compute_contact_details(resolved_sensors: list[str], hass_states_get) -> list[dict]:
-    """Return per-sensor details for contact status attributes.
-
-    This mirrors ClimateAdvisorCoordinator._compute_contact_details().
-    """
-    details = []
-    for sensor_id in resolved_sensors:
-        friendly = sensor_id.split(".")[-1].replace("_", " ").title()
-        details.append(
-            {
-                "entity_id": sensor_id,
-                "friendly_name": friendly,
-                "open": _is_sensor_open(hass_states_get, sensor_id),
-            }
-        )
-    return details
+    """Call the real ClimateAdvisorCoordinator._compute_contact_details()."""
+    coord = _make_real_coordinator(resolved_sensors, hass_states_get)
+    return coord._compute_contact_details()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_fan_control.py
+++ b/tests/test_fan_control.py
@@ -875,26 +875,21 @@ class TestFanStatusComputation:
 
 
 def _fan_sensor_extra_state_attributes(data: dict) -> dict:
-    """Mirror of ClimateAdvisorFanStatusSensor.extra_state_attributes for unit testing.
+    """Build a real ClimateAdvisorFanStatusSensor over `data` and return its attributes."""
+    from custom_components.climate_advisor.sensor import ClimateAdvisorFanStatusSensor
 
-    Replicates the attribute computation without importing sensor.py
-    (which triggers a metaclass conflict in the HA stub environment).
-    """
-    if not data:
-        return {}
-    return {
-        "fan_runtime_minutes": round(data.get(ATTR_FAN_RUNTIME, 0.0), 1),
-        "fan_override_since": data.get(ATTR_FAN_OVERRIDE_SINCE),
-        "fan_running": data.get(ATTR_FAN_RUNNING, False),
-    }
+    coord = MagicMock()
+    coord.data = data
+    entry = MagicMock()
+    entry.entry_id = "test_entry"
+    sensor = ClimateAdvisorFanStatusSensor(coord, entry)
+    return sensor.extra_state_attributes
 
 
 class TestFanSensorAttributes:
-    """Unit tests for ClimateAdvisorFanStatusSensor.extra_state_attributes (Issue #55).
+    """Unit tests for the real ClimateAdvisorFanStatusSensor.extra_state_attributes (Issue #55).
 
     Verifies fan_override_since and fan_running are exposed correctly.
-    Uses a replicated helper instead of importing sensor.py directly
-    (HA entity metaclass conflicts in test stubs prevent direct instantiation).
     """
 
     def test_attributes_include_runtime(self):

--- a/tests/test_status_sensors.py
+++ b/tests/test_status_sensors.py
@@ -64,30 +64,63 @@ def _make_automation_engine(
     grace_active: bool = False,
     last_resume_source: str | None = None,
 ) -> MagicMock:
-    """Create a mock AutomationEngine with given state flags."""
+    """Create a mock AutomationEngine with given state flags.
+
+    Also defaults the newer gates _compute_automation_status() checks
+    (override-confirm pending, stuck-grace detection, resumed-from-pause) to
+    inactive so callers exercising the original 4-flag surface see the same
+    "active"/"disabled"/"paused"/"grace period" outcomes as before.
+    """
     ae = MagicMock()
     ae.is_paused_by_door = is_paused_by_door
     ae.natural_vent_active = natural_vent_active
     ae._grace_active = grace_active
     ae._last_resume_source = last_resume_source
+    ae._manual_override_active = False
+    ae._override_confirm_pending = False
+    ae._grace_end_time = None
+    ae._resumed_from_pause = False
+    ae._is_within_planned_window_period = MagicMock(return_value=False)
     return ae
 
 
-def _compute_automation_status(
-    automation_enabled: bool,
-    automation_engine,
-) -> str:
-    """Replicate _compute_automation_status from coordinator.py."""
-    if not automation_enabled:
-        return "disabled"
-    if automation_engine.natural_vent_active:
-        return "natural ventilation"
-    if automation_engine.is_paused_by_door:
-        return "paused — door/window open"
-    if automation_engine._grace_active:
-        source = automation_engine._last_resume_source or "automation"
-        return f"grace period ({source})"
-    return "active"
+def _make_real_coordinator(automation_enabled: bool, automation_engine, occupancy_mode: str = "home"):
+    """Build a bare ClimateAdvisorCoordinator bound to the real status-computation methods.
+
+    Uses object.__new__() + types.MethodType() (the established coordinator
+    partial-instantiation pattern — see test_daily_record_accuracy.py) rather than
+    replicating the method bodies, so these tests exercise the real
+    ClimateAdvisorCoordinator._compute_automation_status/_compute_next_automation_action.
+    """
+    import types
+
+    from custom_components.climate_advisor.coordinator import ClimateAdvisorCoordinator
+
+    coord = object.__new__(ClimateAdvisorCoordinator)
+    coord._automation_enabled = automation_enabled
+    coord._startup_coalesce_active = False
+    coord._startup_coalesce_expiry = None
+    coord._startup_timer_fired = False
+    coord._current_classification = None
+    coord._occupancy_mode = occupancy_mode
+    coord.automation_engine = automation_engine
+    coord._any_sensor_open = MagicMock(return_value=False)
+    coord._door_open_timers = {}
+    coord._door_open_timer_expiry = {}
+    coord._pre_cool_trigger_dt = None
+    coord._pre_cool_target = None
+    coord.config = {}
+    coord._compute_automation_status = types.MethodType(ClimateAdvisorCoordinator._compute_automation_status, coord)
+    coord._compute_next_automation_action = types.MethodType(
+        ClimateAdvisorCoordinator._compute_next_automation_action, coord
+    )
+    return coord
+
+
+def _compute_automation_status(automation_enabled: bool, automation_engine) -> str:
+    """Call the real ClimateAdvisorCoordinator._compute_automation_status()."""
+    coord = _make_real_coordinator(automation_enabled, automation_engine)
+    return coord._compute_automation_status()
 
 
 def _compute_next_automation_action(
@@ -96,55 +129,26 @@ def _compute_next_automation_action(
     config: dict,
     now_time: time,
 ) -> tuple[str, str]:
-    """Replicate _compute_next_automation_action from coordinator.py."""
-    if c is None:
-        return ("Waiting for classification...", "")
+    """Call the real ClimateAdvisorCoordinator._compute_next_automation_action().
 
-    if automation_engine.is_paused_by_door:
-        return ("Waiting — HVAC paused (door/window open)", "")
+    now_time (a plain time-of-day) is combined with a fixed date and patched in
+    as dt_util.now()/as_local() — the real method now works in full datetimes
+    (to correctly order cross-midnight events like pre-cool), not bare times.
+    """
+    from datetime import date, datetime
+    from unittest.mock import patch
 
-    if automation_engine._grace_active:
-        source = automation_engine._last_resume_source or "automation"
-        return (f"Grace period active ({source})", "")
+    from custom_components.climate_advisor import coordinator as _coord_mod
 
-    wake_time = config.get("wake_time", "06:30:00")
-    sleep_time = config.get("sleep_time", "22:30:00")
-    briefing_time = config.get("briefing_time", "06:00:00")
+    coord = _make_real_coordinator(True, automation_engine)
+    coord.config = config
 
-    def _parse_time(t: str) -> time:
-        parts = t.split(":")
-        return time(int(parts[0]), int(parts[1]), int(parts[2]) if len(parts) > 2 else 0)
-
-    events: list[tuple[time, str]] = []
-
-    bt = _parse_time(briefing_time)
-    wt = _parse_time(wake_time)
-    st = _parse_time(sleep_time)
-
-    if now_time < bt:
-        events.append((bt, "Send daily briefing"))
-    if now_time < wt:
-        if c.hvac_mode in ("heat", "cool"):
-            events.append((wt, f"Morning wake-up — restore {c.hvac_mode} comfort"))
-        else:
-            events.append((wt, "Morning wake-up check"))
-    if now_time < st:
-        if c.hvac_mode == "heat":
-            bedtime_target = config.get("comfort_heat", 70) - 4 + c.setback_modifier
-            events.append((st, f"Bedtime — heat setback to {bedtime_target:.0f}°F"))
-        elif c.hvac_mode == "cool":
-            bedtime_target = config.get("comfort_cool", 75) + 3
-            events.append((st, f"Bedtime — cool setback to {bedtime_target:.0f}°F"))
-        else:
-            events.append((st, "Bedtime check"))
-
-    if not events:
-        return ("No more actions today", "")
-
-    events.sort(key=lambda e: e[0])
-    next_time, next_desc = events[0]
-    time_str = next_time.strftime("%I:%M %p").lstrip("0")
-    return (next_desc, time_str)
+    now_dt = datetime.combine(date(2026, 7, 10), now_time)
+    with (
+        patch.object(_coord_mod.dt_util, "now", return_value=now_dt),
+        patch.object(_coord_mod.dt_util, "as_local", side_effect=lambda x: x),
+    ):
+        return coord._compute_next_automation_action(c)
 
 
 # ---------------------------------------------------------------------------
@@ -244,12 +248,16 @@ class TestComputeNextAutomationAction:
             "wake_time": "06:30:00",
             "sleep_time": "22:30:00",
             "comfort_cool": 75,
+            "sleep_cool": 72,
         }
         # Current time is 14:00 — after briefing and wakeup, before sleep
         action, t = _compute_next_automation_action(c, ae, config, time(14, 0))
         assert "Bedtime" in action
         assert "cool setback" in action
-        assert "78°F" in action  # 75 + 3
+        # The real method reads CONF_SLEEP_COOL directly (not a comfort_cool+delta
+        # formula) — matches select_comfort_band(in_sleep_window=True), see
+        # coordinator.py's _compute_next_automation_action() comment.
+        assert "72°F" in action
 
     def test_before_bedtime_heat_day_returns_heat_setback(self):
         """Time before bedtime on heat day → bedtime heat setback with correct temp."""
@@ -260,13 +268,15 @@ class TestComputeNextAutomationAction:
             "wake_time": "06:30:00",
             "sleep_time": "22:30:00",
             "comfort_heat": 70,
+            "sleep_heat": 64,
         }
         # Current time is 20:00 — before sleep at 22:30
         action, t = _compute_next_automation_action(c, ae, config, time(20, 0))
         assert "Bedtime" in action
         assert "heat setback" in action
-        # 70 - 4 + 2 = 68°F
-        assert "68°F" in action
+        # The real method reads CONF_SLEEP_HEAT directly, not a comfort_heat-4+modifier
+        # formula (that formula predates the sleep_heat/sleep_cool config keys).
+        assert "64°F" in action
 
     def test_after_all_events_returns_no_more_actions(self):
         """After all scheduled events have passed → 'No more actions today'."""
@@ -381,33 +391,20 @@ class TestNewConstants:
 
 
 def _compliance_sensor_extra_state_attributes_with_thermal(coordinator):
-    """Replicate ClimateAdvisorComplianceSensor.extra_state_attributes logic including thermal attrs."""
-    from custom_components.climate_advisor.const import (
-        ATTR_FORECAST_BIAS_CONFIDENCE,
-        ATTR_FORECAST_HIGH_BIAS,
-        ATTR_FORECAST_LOW_BIAS,
-        ATTR_THERMAL_CONFIDENCE,
-        ATTR_THERMAL_COOLING_RATE,
-        ATTR_THERMAL_HEATING_RATE,
-    )
-    from custom_components.climate_advisor.temperature import FAHRENHEIT, convert_delta
+    """Return the real ClimateAdvisorComplianceSensor.extra_state_attributes for `coordinator`.
 
-    unit = coordinator.config.get("temp_unit", FAHRENHEIT)
-    thermal = coordinator.learning.get_thermal_model()
-    heat_rate_f = thermal.get("heating_rate_f_per_hour")
-    cool_rate_f = thermal.get("cooling_rate_f_per_hour")
-    attrs = {}
-    attrs[ATTR_THERMAL_HEATING_RATE] = convert_delta(heat_rate_f, unit) if heat_rate_f is not None else None
-    attrs[ATTR_THERMAL_COOLING_RATE] = convert_delta(cool_rate_f, unit) if cool_rate_f is not None else None
-    attrs[ATTR_THERMAL_CONFIDENCE] = thermal.get("confidence", "none")
-    attrs["thermal_observation_count"] = thermal.get("observation_count_heat", 0) + thermal.get(
-        "observation_count_cool", 0
-    )
-    weather_bias = coordinator.learning.get_weather_bias()
-    attrs[ATTR_FORECAST_HIGH_BIAS] = convert_delta(weather_bias.get("high_bias", 0.0), unit)
-    attrs[ATTR_FORECAST_LOW_BIAS] = convert_delta(weather_bias.get("low_bias", 0.0), unit)
-    attrs[ATTR_FORECAST_BIAS_CONFIDENCE] = weather_bias.get("confidence", "none")
-    return attrs
+    coordinator is already a real ClimateAdvisorCoordinator instance (constructed
+    via _make_coordinator_with_learning), so the sensor can be instantiated directly —
+    no replication needed.
+    """
+    from unittest.mock import MagicMock
+
+    from custom_components.climate_advisor.sensor import ClimateAdvisorComplianceSensor
+
+    entry = MagicMock()
+    entry.entry_id = "test_entry"
+    sensor = ClimateAdvisorComplianceSensor(coordinator, entry)
+    return sensor.extra_state_attributes
 
 
 def _make_coordinator_with_learning(tmp_path):
@@ -436,6 +433,7 @@ def _make_coordinator_with_learning(tmp_path):
     }
 
     coordinator = ClimateAdvisorCoordinator(hass, config)
+    coordinator.data = {}
     coordinator.learning = LearningEngine(Path(tmp_path))
     coordinator.learning.load_state()
     coordinator.automation_engine = MagicMock()

--- a/tests/test_thermal_rejection.py
+++ b/tests/test_thermal_rejection.py
@@ -6,7 +6,6 @@ Coverage:
 - coordinator _rejection_log accumulation, capping, and per-type isolation
 - _build_learning_health() reason-code counting
 - ClimateAdvisorComplianceSensor.extra_state_attributes thermal_learning_health key
-  (tested via plain helper — never instantiate the sensor class directly)
 """
 
 from __future__ import annotations
@@ -39,6 +38,7 @@ from custom_components.climate_advisor.learning import (  # noqa: E402
     LearningEngine,
     compute_k_passive,
 )
+from custom_components.climate_advisor.sensor import ClimateAdvisorComplianceSensor  # noqa: E402
 
 _TODAY = "2026-03-27"
 
@@ -351,61 +351,17 @@ class TestLearningHealth:
 
 
 def _compliance_extra_state_attributes(coordinator) -> dict:
-    """Replicate ClimateAdvisorComplianceSensor.extra_state_attributes logic.
+    """Return the real ClimateAdvisorComplianceSensor.extra_state_attributes for `coordinator`.
 
-    Pattern: plain helper function, never instantiate the sensor class directly
-    (metaclass conflict in the lightweight HA stub environment).
-    Reference: test_fan_control.py / test_contact_status.py.
+    HomeAssistantView/sensor bases are real minimal classes now (Issue #452), so
+    the sensor can be instantiated directly instead of replicated — this was
+    already independently duplicated in test_status_sensors.py, a live drift risk
+    this consolidation removes.
     """
-    from custom_components.climate_advisor.const import (
-        ATTR_FORECAST_BIAS_CONFIDENCE,
-        ATTR_FORECAST_HIGH_BIAS,
-        ATTR_FORECAST_LOW_BIAS,
-        ATTR_LEARNING_SUGGESTIONS,
-        ATTR_THERMAL_CONFIDENCE,
-        ATTR_THERMAL_COOLING_RATE,
-        ATTR_THERMAL_HEATING_RATE,
-    )
-    from custom_components.climate_advisor.temperature import FAHRENHEIT, convert_delta
-
-    data = coordinator.data or {}
-    suggestions = data.get(ATTR_LEARNING_SUGGESTIONS, [])
-    today = coordinator.today_record
-    attrs: dict = {
-        "pending_suggestions": len(suggestions),
-        "comfort_violations_minutes_today": today.comfort_violations_minutes if today else 0.0,
-        "comfort_range_low": coordinator.config.get("comfort_heat", 70),
-        "comfort_range_high": coordinator.config.get("comfort_cool", 75),
-    }
-    unit = coordinator.config.get("temp_unit", FAHRENHEIT)
-    thermal = coordinator.learning.get_thermal_model()
-    heat_rate_f = thermal.get("heating_rate_f_per_hour")
-    cool_rate_f = thermal.get("cooling_rate_f_per_hour")
-    attrs[ATTR_THERMAL_HEATING_RATE] = convert_delta(heat_rate_f, unit) if heat_rate_f is not None else None
-    attrs[ATTR_THERMAL_COOLING_RATE] = convert_delta(cool_rate_f, unit) if cool_rate_f is not None else None
-    attrs[ATTR_THERMAL_CONFIDENCE] = thermal.get("confidence", "none")
-    attrs["thermal_observation_count"] = thermal.get("observation_count_heat", 0) + thermal.get(
-        "observation_count_cool", 0
-    )
-    health = thermal.get("learning_health", {})
-    attrs["thermal_learning_health"] = (
-        {
-            obs_type: {
-                "attempts": h.get("attempts", 0),
-                "committed": h.get("committed", 0),
-                "rejections": h.get("rejections", {}),
-                "last_rejection_reason": (h["last_rejection"]["reason_code"] if h.get("last_rejection") else None),
-            }
-            for obs_type, h in health.items()
-        }
-        if health
-        else {}
-    )
-    weather_bias = coordinator.learning.get_weather_bias()
-    attrs[ATTR_FORECAST_HIGH_BIAS] = convert_delta(weather_bias.get("high_bias", 0.0), unit)
-    attrs[ATTR_FORECAST_LOW_BIAS] = convert_delta(weather_bias.get("low_bias", 0.0), unit)
-    attrs[ATTR_FORECAST_BIAS_CONFIDENCE] = weather_bias.get("confidence", "none")
-    return attrs
+    entry = MagicMock()
+    entry.entry_id = "test_entry"
+    sensor = ClimateAdvisorComplianceSensor(coordinator, entry)
+    return sensor.extra_state_attributes
 
 
 def _make_compliance_coordinator_stub(learning_health: dict) -> MagicMock:

--- a/tools/sim_harness/ha_stubs.py
+++ b/tools/sim_harness/ha_stubs.py
@@ -101,6 +101,36 @@ class _MockSensorEntity:
     """Minimal stand-in for homeassistant.components.sensor.SensorEntity."""
 
 
+class _MockJsonResponse:
+    """Minimal stand-in for the aiohttp.web.Response a real HomeAssistantView.json() returns.
+
+    Exposes ``status`` and ``json_data`` so tests can assert on both without
+    round-tripping through a real aiohttp response body.
+    """
+
+    def __init__(self, data, status_code: int = 200) -> None:
+        self.status = status_code
+        self.json_data = data
+
+
+class _MockHomeAssistantView:
+    """Minimal stand-in for homeassistant.components.http.HomeAssistantView.
+
+    Real subclasses in api.py set ``url``/``name``/``requires_auth`` as class
+    attributes and call ``self.json(data, status_code=...)`` from their
+    ``get``/``post`` handlers — this provides both without pulling in aiohttp.
+    """
+
+    requires_auth = True
+    cors_allowed = False
+
+    def json(self, result, status_code: int = 200, headers=None):
+        return _MockJsonResponse(result, status_code)
+
+    def json_message(self, message, status_code: int = 200, message_code=None, headers=None):
+        return _MockJsonResponse({"message": message}, status_code)
+
+
 class _SensorStateClass(_enum.StrEnum):
     MEASUREMENT = "measurement"
     TOTAL = "total"
@@ -154,6 +184,9 @@ def install_ha_stubs() -> None:
     sensor.SensorEntity = _MockSensorEntity
     sensor.SensorStateClass = _SensorStateClass
     sensor.SensorDeviceClass = _SensorDeviceClass
+
+    http = sys.modules["homeassistant.components.http"]
+    http.HomeAssistantView = _MockHomeAssistantView
 
     const = sys.modules["homeassistant.const"]
     const.UnitOfTemperature = _UnitOfTemperature


### PR DESCRIPTION
## Summary
Continues the nat-vent architecture-reset direction (v0.5.1) into the test suite. `HomeAssistantView` was left as an unconfigured `MagicMock` in `tools/sim_harness/ha_stubs.py`, so `api.py` view subclasses silently became `MagicMock` instances on instantiation instead of raising — not a hard failure, so it went unnoticed and forced 14 test helpers across 6 files to hand-replicate production logic instead of exercising the real code. One helper (`ComplianceSensor.extra_state_attributes`) was already independently duplicated twice with no shared source — a live drift risk.

- Add `_MockHomeAssistantView` + `_MockJsonResponse` to `ha_stubs.py`, wired into `install_ha_stubs()` the same way `_MockSensorEntity` already was.
- Delete the 14 replicated helpers; rewrite the affected tests to instantiate and exercise the real API view / sensor / coordinator classes. Sensor classes turned out to already be safely instantiable (an earlier pass had already realified `SensorEntity`/`CoordinatorEntity`) — only the API views had a genuine metaclass gap; the coordinator-method helpers just hadn't adopted the existing `object.__new__` + `types.MethodType` partial-instantiation pattern used elsewhere.
- Rewriting `_compute_next_automation_action`'s tests against the real method surfaced a stale assertion: the old replicated helper's bedtime-setback formula (`comfort_heat - 4 + setback_modifier`) predates the `sleep_heat`/`sleep_cool` config keys the real method has read for some time — two tests were passing against logic production no longer runs. Fixed.
- Updated `CLAUDE.md`'s testing section to reflect current (non-stale) constraints.

## Test plan
- [x] `python -m ruff check`/`format` clean
- [x] 3307/3307 unit tests pass, including with `-W error::pytest.PytestUnraisableExceptionWarning -W error::RuntimeWarning`
- [x] 56/56 golden simulation scenarios pass (confirms no production behavior changed — this is test-infrastructure only)
- [x] `test_version_sync.py` passes (0.5.5 in both `const.py` and `manifest.json`)