### PR TITLE
Fix #454: extract shared differential-comparator base for pure decide_*() modules (v0.5.6)

### DIFF
--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,20 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.5"
+VERSION = "0.5.6"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.6": [
+        "Fix #454: no user-visible change. Extracted the shared shape behind the"
+        " nat-vent gate's old-vs-new differential comparator (shadow-mode instrumentation,"
+        " the Call/ComparisonRun result shape, substitution mode) into a reusable base so"
+        " each upcoming pure decide_*() extraction gets a comparator by supplying only"
+        " which production method and pure function to wire together, instead of a new"
+        " copy-pasted comparator file. A first cut of the refactor introduced an import-order"
+        " bug that broke the CLI comparator tool (resolving the production class before the"
+        " module that installs test HA stubs) — caught by running the tool directly, not"
+        " just the test suite, and fixed before merge.",
+    ],
     "0.5.5": [
         "Fix #452: no user-visible change. Continues the nat-vent architecture-reset"
         " direction (v0.5.1) into the test suite — 14 test helpers that hand-copied"
@@ -900,6 +911,33 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    454: {
+        "version_fixed": "0.5.6",
+        "title": "Extract shared differential-comparator base for pure decide_*() modules",
+        "scope_covered": (
+            "tools/sim_harness/decision_compare_base.py: new module providing the shape shared"
+            " by every differential comparator for a production method that RETURNS a value"
+            " (shadow-mode instrumentation, DecisionCall/DecisionComparisonRun result shape,"
+            " substitution mode). nat_vent_gate_compare.py refactored onto it, keeping its exact"
+            " public API (GateCall/GateComparisonRun/compare_scenario/substitute_new_gate)"
+            " unchanged for existing callers (tools/nat_vent_gate_diff.py,"
+            " tools/nat_vent_gate_substitution_diff.py, tests/test_nat_vent_gate_compare.py,"
+            " tests/test_nat_vent_gate_substitution.py). Verified behavior-preserving: 39/39 gate"
+            " calls agree (nat_vent_gate_diff.py) and 56/56 scenarios produce identical full"
+            " outcomes under substitution (nat_vent_gate_substitution_diff.py), matching pre-refactor"
+            " results exactly. fan_thermostat_decision_compare.py deliberately NOT refactored onto"
+            " the base — its production method returns nothing (outcome inferred from side-effect"
+            " calls) and requires pre-call input capture, a genuinely different instrumentation"
+            " shape; verified unaffected (228/228 calls still agree)."
+        ),
+        "scope_not_covered": (
+            "Does not add comparators for any of the four upcoming Phase A extractions (sleep-aware"
+            " floor resolver, fan-suppression predicate, occupancy-defer predicate, comfort-band"
+            " branch) — this issue only builds the reusable base those will consume. Does not touch"
+            " fan_thermostat_decision_compare.py's instrumentation (only its module docstring, to"
+            " cross-reference the new base and explain why it's excluded)."
+        ),
+    },
     452: {
         "version_fixed": "0.5.5",
         "title": "HomeAssistantView test stub gap forced 14 test helpers to hand-replicate production logic",

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.5"
+  "version": "0.5.6"
 }

--- a/tools/sim_harness/decision_compare_base.py
+++ b/tools/sim_harness/decision_compare_base.py
@@ -1,0 +1,158 @@
+"""decision_compare_base — shared scaffolding for value-returning decision comparators.
+
+Factors out the shape shared by differential comparators that prove a pure
+``decide_*()`` module is behavior-identical to the production method it
+replaces, for the common case where that production method RETURNS a value
+(a bool, float, or small dataclass) rather than expressing its outcome only
+through side effects. ``nat_vent_gate_compare.py`` is the first instance of
+this shape; the architecture-consolidation Phase A extractions (sleep-aware
+floor resolver, fan-suppression predicate, occupancy-defer predicate,
+comfort-band branch) all return a value too, so each gets a comparator by
+supplying ``(engine_cls, method_name, reconstruct_inputs, pure_fn)`` here
+instead of hand-rolling a new ``Call``/``ComparisonRun`` pair and
+instrumentation contextmanager.
+
+Two modes, mirroring ``nat_vent_gate_compare.py``'s original split:
+
+- **Shadow mode** (``instrumented_value_decision`` / ``compare_scenario``):
+  the real production method runs and its answer drives the live engine; the
+  new pure function is evaluated on the same reconstructed inputs ONLY for
+  comparison — it never affects behavior.
+- **Substitution mode** (``substitute_new_decision``): the new pure
+  function's answer is what actually gets returned to the live engine. Use
+  with ``tools.sim_harness.differential.diff_runs(scenario,
+  mutate_b=substitute_new_decision(...))`` to diff the entire resulting
+  ``action_log``/``event_log`` against an untouched baseline.
+
+Out of scope: ``fan_thermostat_decision_compare.py`` does NOT fit this base.
+Its production method (``fan_thermostat_check()``) returns nothing — the
+outcome must be inferred by observing side-effect calls
+(``_exit_nat_vent()``/``_deactivate_fan()``), and inputs must be captured
+BEFORE the call because production mutates state as part of the decision.
+Forcing that shape onto a value-returning base would either lose the
+side-effect-observation correctness or bloat this module with a second,
+unrelated instrumentation strategy for a single consumer. It stays a bespoke
+comparator; see its own module docstring for the full reasoning.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import patch
+
+
+@dataclass
+class DecisionCall:
+    """One intercepted call to a production decision method + the comparison result."""
+
+    scenario_name: str
+    real_kwargs: dict[str, Any]
+    real_result: Any
+    new_inputs: Any
+    new_result: Any
+
+    @property
+    def agrees(self) -> bool:
+        return self.real_result == self.new_result
+
+
+@dataclass
+class DecisionComparisonRun:
+    calls: list[DecisionCall] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def n_calls(self) -> int:
+        return len(self.calls)
+
+    @property
+    def n_agree(self) -> int:
+        return sum(1 for c in self.calls if c.agrees)
+
+    @property
+    def disagreements(self) -> list[DecisionCall]:
+        return [c for c in self.calls if not c.agrees]
+
+
+@contextlib.contextmanager
+def instrumented_value_decision(
+    engine_cls: type,
+    method_name: str,
+    reconstruct_inputs: Callable[[Any, dict[str, Any]], Any],
+    pure_fn: Callable[[Any], Any],
+    run: DecisionComparisonRun,
+    scenario_name: str,
+):
+    """Shadow-mode instrumentation for a production method that RETURNS a value.
+
+    Wraps ``engine_cls.method_name`` so every call: runs the real method
+    unchanged, reconstructs the equivalent pure-function inputs via
+    ``reconstruct_inputs(self, kwargs)``, computes ``pure_fn(inputs)``, and
+    records agreement on `run` — without ever changing what the real method
+    returns to its caller.
+    """
+    original = getattr(engine_cls, method_name)
+
+    def _wrapped(self: Any, **kwargs: Any) -> Any:
+        real_result = original(self, **kwargs)
+        try:
+            new_inputs = reconstruct_inputs(self, kwargs)
+            new_result = pure_fn(new_inputs)
+            run.calls.append(
+                DecisionCall(
+                    scenario_name=scenario_name,
+                    real_kwargs=dict(kwargs),
+                    real_result=real_result,
+                    new_inputs=new_inputs,
+                    new_result=new_result,
+                )
+            )
+        except Exception as exc:  # noqa: BLE001 — never let comparison-side errors break production
+            run.errors.append(f"{scenario_name}: comparator error: {type(exc).__name__}: {exc}")
+        return real_result
+
+    with patch.object(engine_cls, method_name, _wrapped):
+        yield
+
+
+def compare_scenario(
+    scenario: dict,
+    scenario_name: str,
+    run: DecisionComparisonRun,
+    *,
+    engine_cls: type,
+    method_name: str,
+    reconstruct_inputs: Callable[[Any, dict[str, Any]], Any],
+    pure_fn: Callable[[Any], Any],
+) -> None:
+    """Run one scenario through the real engine with `method_name` instrumented (shadow mode)."""
+    from tools.sim_harness.run_production import run_production_scenario  # noqa: PLC0415
+
+    with instrumented_value_decision(engine_cls, method_name, reconstruct_inputs, pure_fn, run, scenario_name):
+        run_production_scenario(scenario)
+
+
+@contextlib.contextmanager
+def substitute_new_decision(
+    engine_cls: type,
+    method_name: str,
+    reconstruct_inputs: Callable[[Any, dict[str, Any]], Any],
+    pure_fn: Callable[[Any], Any],
+):
+    """Substitution mode: the pure function's answer replaces the real return value.
+
+    Intended for ``tools.sim_harness.differential.diff_runs(scenario,
+    mutate_b=lambda: substitute_new_decision(...))`` so the FULL resulting
+    action_log/event_log can be diffed against an untouched baseline, not
+    just one function's return value.
+    """
+
+    def _substituted(self: Any, **kwargs: Any) -> Any:
+        new_inputs = reconstruct_inputs(self, kwargs)
+        return pure_fn(new_inputs)
+
+    with patch.object(engine_cls, method_name, _substituted):
+        yield

--- a/tools/sim_harness/fan_thermostat_decision_compare.py
+++ b/tools/sim_harness/fan_thermostat_decision_compare.py
@@ -19,6 +19,14 @@ wording ever changes.
 Shadow mode only (see the "Substitution mode — DEFERRED" note further down for
 why): observes real side effects and compares against the new pure function's
 prediction; the wrapped method's real behavior is completely untouched.
+
+Does NOT use ``tools.sim_harness.decision_compare_base`` (Issue #454): that
+base covers comparators for production methods that RETURN a value (see
+``nat_vent_gate_compare.py``). This comparator's production method returns
+nothing and requires capturing inputs BEFORE the call (production mutates
+state as part of the decision) plus side-effect observation to infer the
+outcome — a genuinely different instrumentation shape, not a variation the
+base should be stretched to cover.
 """
 
 from __future__ import annotations

--- a/tools/sim_harness/nat_vent_gate_compare.py
+++ b/tools/sim_harness/nat_vent_gate_compare.py
@@ -4,15 +4,15 @@ Architecture-reset Step 2: the first real "old vs new" comparison in this
 project (everything in Step 1 was old-vs-old). Two modes, sharing one input
 reconstruction:
 
-- **Shadow mode** (``compare_scenario`` / ``_instrumented_gate``): the real
-  production ``_nat_vent_may_reactivate()`` runs and its answer drives the live
-  engine; the new pure ``decide_nat_vent_gate()`` is evaluated on the same
+- **Shadow mode** (``compare_scenario``): the real production
+  ``_nat_vent_may_reactivate()`` runs and its answer drives the live engine;
+  the new pure ``decide_nat_vent_gate()`` is evaluated on the same
   reconstructed inputs ONLY for comparison — it never affects behavior. Proves
   "would the new function have agreed," not "does the rest of the scenario
   unfold the same way if you let it decide."
-- **Substitution mode** (``substitute_new_gate`` / ``run_substituted_scenario``):
-  the new pure function's answer is what actually gets returned to the live
-  engine — it genuinely drives behavior. Used with ``tools.sim_harness.differential``'s
+- **Substitution mode** (``substitute_new_gate``): the new pure function's
+  answer is what actually gets returned to the live engine — it genuinely
+  drives behavior. Used with ``tools.sim_harness.differential``'s
   ``diff_runs(scenario, mutate_b=substitute_new_gate)`` to diff the ENTIRE
   resulting ``action_log``/``event_log`` against an untouched baseline, not just
   one function's boolean. This is what closes the "shadow-only, never
@@ -23,6 +23,15 @@ Both modes reconstruct the full set of raw inputs the call chain actually used
 ``_in_sleep_window()`` helper — not back-derived from already-resolved values),
 via the shared ``_reconstruct_inputs()`` helper, so there is exactly one place
 that logic lives (not duplicated between shadow and substitution modes).
+
+Instrumentation itself (the shadow-mode patch/compare loop, the
+``GateCall``/``GateComparisonRun`` shape, substitution-mode's patch) is now
+provided by ``tools.sim_harness.decision_compare_base`` (Issue #454) — this
+module supplies only what's specific to the reactivation gate: input
+reconstruction and which production method/pure function to wire together.
+``GateCall``/``GateComparisonRun`` are thin aliases of the base's
+``DecisionCall``/``DecisionComparisonRun`` kept for backward compatibility with
+existing callers (``tools/nat_vent_gate_diff.py``).
 
 Production integration follow-up: ``_nat_vent_may_reactivate()`` now calls
 ``decide_nat_vent_gate()`` directly (mirroring the same extraction done for
@@ -40,9 +49,22 @@ scenarios diverge).
 
 from __future__ import annotations
 
-import contextlib
-from dataclasses import dataclass, field
 from typing import Any
+
+from tools.sim_harness.decision_compare_base import (
+    DecisionCall as GateCall,
+)
+from tools.sim_harness.decision_compare_base import (
+    DecisionComparisonRun as GateComparisonRun,
+)
+from tools.sim_harness.decision_compare_base import (
+    compare_scenario as _base_compare_scenario,
+)
+from tools.sim_harness.decision_compare_base import (
+    substitute_new_decision,
+)
+
+__all__ = ["GateCall", "GateComparisonRun", "compare_scenario", "substitute_new_gate"]
 
 
 def _reconstruct_inputs(self: Any, kwargs: dict[str, Any]) -> Any:
@@ -78,92 +100,41 @@ def _reconstruct_inputs(self: Any, kwargs: dict[str, Any]) -> Any:
     )
 
 
-# ---------------------------------------------------------------------------
-# Shadow mode — compare only, never drives behavior
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class GateCall:
-    """One intercepted call to the real reactivation gate + the comparison result."""
-
-    scenario_name: str
-    real_kwargs: dict[str, Any]
-    real_result: bool
-    new_inputs: Any  # NatVentGateInputs
-    new_result: bool
-
-    @property
-    def agrees(self) -> bool:
-        return self.real_result == self.new_result
-
-
-@dataclass
-class GateComparisonRun:
-    calls: list[GateCall] = field(default_factory=list)
-    errors: list[str] = field(default_factory=list)
-
-    @property
-    def n_calls(self) -> int:
-        return len(self.calls)
-
-    @property
-    def n_agree(self) -> int:
-        return sum(1 for c in self.calls if c.agrees)
-
-    @property
-    def disagreements(self) -> list[GateCall]:
-        return [c for c in self.calls if not c.agrees]
-
-
-@contextlib.contextmanager
-def _instrumented_gate(run: GateComparisonRun, scenario_name: str):
-    """Wrap AutomationEngine._nat_vent_may_reactivate to intercept every call (shadow mode)."""
-    from unittest.mock import patch  # noqa: PLC0415
-
+def _engine_and_pure_fn():
     from custom_components.climate_advisor.automation import AutomationEngine  # noqa: PLC0415
     from custom_components.climate_advisor.nat_vent_gate import decide_nat_vent_gate  # noqa: PLC0415
 
-    original = AutomationEngine._nat_vent_may_reactivate
-
-    def _wrapped(self: Any, **kwargs: Any) -> bool:
-        real_result = original(self, **kwargs)
-
-        try:
-            new_inputs = _reconstruct_inputs(self, kwargs)
-            new_result = decide_nat_vent_gate(new_inputs)
-            run.calls.append(
-                GateCall(
-                    scenario_name=scenario_name,
-                    real_kwargs=dict(kwargs),
-                    real_result=real_result,
-                    new_inputs=new_inputs,
-                    new_result=new_result,
-                )
-            )
-        except Exception as exc:  # noqa: BLE001 — never let comparison-side errors break production
-            run.errors.append(f"{scenario_name}: comparator error: {type(exc).__name__}: {exc}")
-
-        return real_result
-
-    with patch.object(AutomationEngine, "_nat_vent_may_reactivate", _wrapped):
-        yield
+    return AutomationEngine, decide_nat_vent_gate
 
 
 def compare_scenario(scenario: dict, scenario_name: str, run: GateComparisonRun) -> None:
-    """Run one scenario through the real engine with the gate instrumented (shadow mode)."""
-    from tools.sim_harness.run_production import run_production_scenario  # noqa: PLC0415
+    """Run one scenario through the real engine with the gate instrumented (shadow mode).
 
-    with _instrumented_gate(run, scenario_name):
-        run_production_scenario(scenario)
+    Import order matters here: ``run_production`` must be imported (installing
+    the HA stubs as its own module-level side effect) BEFORE anything imports
+    ``custom_components.climate_advisor.automation`` — that module needs
+    ``homeassistant.core`` already present in ``sys.modules``. The original
+    (pre-#454) ``compare_scenario`` got this ordering right by accident (its
+    ``run_production`` import came first, textually, in the function body); a
+    first cut of this refactor broke it by resolving the engine class before
+    handing off to the shared base. Kept as an explicit, load-bearing import
+    here rather than relying on import order elsewhere staying accidentally
+    correct.
+    """
+    from tools.sim_harness.run_production import run_production_scenario  # noqa: F401,PLC0415
+
+    engine_cls, pure_fn = _engine_and_pure_fn()
+    _base_compare_scenario(
+        scenario,
+        scenario_name,
+        run,
+        engine_cls=engine_cls,
+        method_name="_nat_vent_may_reactivate",
+        reconstruct_inputs=_reconstruct_inputs,
+        pure_fn=pure_fn,
+    )
 
 
-# ---------------------------------------------------------------------------
-# Substitution mode — the new function's answer actually drives behavior
-# ---------------------------------------------------------------------------
-
-
-@contextlib.contextmanager
 def substitute_new_gate():
     """Replace _nat_vent_may_reactivate's REAL return value with decide_nat_vent_gate()'s
     answer, reconstructed from the same inputs the real call would have used.
@@ -173,14 +144,10 @@ def substitute_new_gate():
     mutate_b=substitute_new_gate)`` so the FULL resulting action_log/event_log
     can be diffed against an untouched baseline, not just one function's boolean.
     """
-    from unittest.mock import patch  # noqa: PLC0415
-
-    from custom_components.climate_advisor.automation import AutomationEngine  # noqa: PLC0415
-    from custom_components.climate_advisor.nat_vent_gate import decide_nat_vent_gate  # noqa: PLC0415
-
-    def _substituted(self: Any, **kwargs: Any) -> bool:
-        new_inputs = _reconstruct_inputs(self, kwargs)
-        return decide_nat_vent_gate(new_inputs)
-
-    with patch.object(AutomationEngine, "_nat_vent_may_reactivate", _substituted):
-        yield
+    engine_cls, pure_fn = _engine_and_pure_fn()
+    return substitute_new_decision(
+        engine_cls,
+        "_nat_vent_may_reactivate",
+        _reconstruct_inputs,
+        pure_fn,
+    )


### PR DESCRIPTION
## Summary
Continues the nat-vent architecture-reset direction (v0.5.1) / #452's test consolidation. The two existing old-vs-new differential comparators (`nat_vent_gate_compare.py`, `fan_thermostat_decision_compare.py`) were structurally parallel — each hand-rolled its own `Call`/`ComparisonRun` dataclass pair, input-reconstruction wiring, and instrumentation contextmanager. The four upcoming architecture-consolidation Phase A extractions (sleep-aware floor resolver, fan-suppression predicate, occupancy-defer predicate, comfort-band branch) all return a value — matching `nat_vent_gate_compare`'s shape — so extracting that shape into a reusable base now means each gets a comparator by supplying only `(production_method, reconstruct_inputs, pure_fn)` instead of a fifth copy-pasted comparator file.

- Add `tools/sim_harness/decision_compare_base.py`: `DecisionCall`/`DecisionComparisonRun`, `instrumented_value_decision()` (shadow mode), `compare_scenario()`, `substitute_new_decision()` (substitution mode).
- Refactor `nat_vent_gate_compare.py` onto the base, keeping its exact public API (`GateCall`/`GateComparisonRun`/`compare_scenario`/`substitute_new_gate`) unchanged for existing callers.
- `fan_thermostat_decision_compare.py` deliberately **not** refactored — its production method returns nothing (outcome inferred from side-effect calls) and requires pre-call input capture, a genuinely different instrumentation shape. Added a docstring cross-reference explaining why.

**Caught during verification, not by the test suite alone:** a first cut of the refactor introduced a real import-order bug — resolving the production `AutomationEngine` class before anything imported `run_production.py` (which installs the test HA stub modules as a side effect) broke the CLI comparator tool with `ModuleNotFoundError`, even though pytest stayed green throughout. Running `tools/nat_vent_gate_diff.py` directly (not just the test suite) surfaced it; fixed before this PR.

## Test plan
- [x] `python -m ruff check`/`format` clean
- [x] 3307/3307 unit tests pass, including with `-W error::pytest.PytestUnraisableExceptionWarning -W error::RuntimeWarning`
- [x] 56/56 golden simulation scenarios pass
- [x] `tools/nat_vent_gate_diff.py`: 39/39 gate calls agree (matches pre-refactor exactly)
- [x] `tools/nat_vent_gate_substitution_diff.py`: 56/56 scenarios identical under substitution
- [x] `tools/fan_thermostat_decision_diff.py` (untouched module, run as a control): 228/228 calls agree
- [x] `test_version_sync.py` passes (0.5.6 in both `const.py` and `manifest.json`)