### PR TITLE
Fix #456: consolidate the nat-vent hard-exit floor formula duplicated 3 times (v0.5.7)

### DIFF
--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -96,6 +96,7 @@ from .fan_thermostat_decision import (
     FanThermostatOutcome,
     _resolve_vent_floor,
     decide_fan_thermostat_check,
+    resolve_hard_exit_floor,
 )
 from .nat_vent_gate import NatVentGateInputs, decide_nat_vent_gate
 from .nat_vent_reactivation_lockout import is_reactivation_locked_out
@@ -2477,14 +2478,15 @@ class AutomationEngine:
                         indoor,
                         comfort_cool,
                     )
-                # During sleep window, lower the hard exit floor to sleep_heat - hysteresis so the
-                # cycling logic can gracefully pause the fan at sleep_heat before the session terminates.
+                # Hard exit floor — single source of truth in resolve_hard_exit_floor()
+                # (Issue #456), also used by fan_thermostat_check()/nat_vent_temperature_check().
                 _hysteresis_cv = float(self.config.get(CONF_NAT_VENT_HYSTERESIS_F, NAT_VENT_HYSTERESIS_F))
-                if _in_sleep_window(dt_util.now(), self.config):
-                    _sleep_heat_cv = float(self.config.get(CONF_SLEEP_HEAT, comfort_heat))
-                    _vent_floor = _sleep_heat_cv - _hysteresis_cv
-                else:
-                    _vent_floor = comfort_heat
+                _vent_floor = resolve_hard_exit_floor(
+                    comfort_heat_raw=comfort_heat,
+                    sleep_heat=float(self.config.get(CONF_SLEEP_HEAT, comfort_heat)),
+                    in_sleep_window=_in_sleep_window(dt_util.now(), self.config),
+                    hysteresis=_hysteresis_cv,
+                )
                 if indoor is not None and indoor <= _vent_floor:
                     self._natural_vent_active = False
                     await self._deactivate_fan(
@@ -2740,17 +2742,24 @@ class AutomationEngine:
             comfort_heat = float(self.config.get("comfort_heat", DEFAULT_COMFORT_HEAT))
             comfort_cool = float(self.config.get("comfort_cool", DEFAULT_COMFORT_COOL))
             hysteresis = float(self.config.get(CONF_NAT_VENT_HYSTERESIS_F, NAT_VENT_HYSTERESIS_F))
-            if _in_sleep_window(dt_util.now(), self.config):
-                sleep_heat = float(self.config.get(CONF_SLEEP_HEAT, comfort_heat))
+            sleep_heat = float(self.config.get(CONF_SLEEP_HEAT, comfort_heat))
+            in_sleep_window = _in_sleep_window(dt_util.now(), self.config)
+            if in_sleep_window:
                 nat_vent_target = sleep_heat + hysteresis  # e.g. 65+1=66; off at 65, on at 67
-                # Hard exit floor is one hysteresis step below the cycling-off threshold so the
-                # fan can cycle off gracefully at sleep_heat before the session ends.
-                _hard_floor = sleep_heat - hysteresis  # e.g. 64°F
                 _context = "sleep"
             else:
                 nat_vent_target = (comfort_heat + comfort_cool) / 2.0
-                _hard_floor = comfort_heat
                 _context = "daytime"
+            # Hard exit floor — single source of truth in resolve_hard_exit_floor() (Issue #456),
+            # also used by fan_thermostat_check()/check_natural_vent_conditions(). In the sleep
+            # branch this is one hysteresis step below the cycling-off threshold above, so the
+            # fan can cycle off gracefully at sleep_heat before the session ends.
+            _hard_floor = resolve_hard_exit_floor(
+                comfort_heat_raw=comfort_heat,
+                sleep_heat=sleep_heat,
+                in_sleep_window=in_sleep_window,
+                hysteresis=hysteresis,
+            )
             off_threshold = nat_vent_target - hysteresis
             on_threshold = nat_vent_target + hysteresis
 

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,20 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.6"
+VERSION = "0.5.7"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.7": [
+        "Fix #456: no user-visible change (confirmed via differential testing and a"
+        " positive control). Consolidated the nat-vent 'hard exit floor' formula — the"
+        " sleep-aware threshold below which an active free-cooling session ends outright"
+        " — from 3 independent implementations down to 1. Two automation.py call sites"
+        " (check_natural_vent_conditions, nat_vent_temperature_check) previously"
+        " recomputed this formula inline instead of using the already-pure, already-tested"
+        " fan_thermostat_decision.py version — the same 'sibling function silently drifts'"
+        " bug class behind issues #400/#402/#417. No drift had occurred yet here, but the"
+        " risk was live: a future fix to one copy could easily miss the other two.",
+    ],
     "0.5.6": [
         "Fix #454: no user-visible change. Extracted the shared shape behind the"
         " nat-vent gate's old-vs-new differential comparator (shadow-mode instrumentation,"
@@ -911,6 +922,32 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    456: {
+        "version_fixed": "0.5.7",
+        "title": "Consolidate the nat-vent hard-exit floor formula duplicated 3 times",
+        "scope_covered": (
+            "fan_thermostat_decision.py: promoted the private _resolve_vent_floor()'s body into"
+            " a new public, standalone pure function resolve_hard_exit_floor(comfort_heat_raw,"
+            " sleep_heat, in_sleep_window, hysteresis); _resolve_vent_floor() now delegates to it."
+            " automation.py: routed check_natural_vent_conditions()'s inline _vent_floor and"
+            " nat_vent_temperature_check()'s inline _hard_floor through the new function instead"
+            " of recomputing the sleep/day branch inline. Explicitly out of scope:"
+            " _nat_vent_reactivation_floor() (the reactivation GATE's floor) is a deliberately"
+            " different formula (no hysteresis subtraction) answering a different question — not"
+            " a 4th copy of this same formula, left untouched. Verified via a unit test"
+            " reproducing both old inline formulas exactly across 5 sleep/day/hysteresis"
+            " combinations, plus a positive control: corrupting resolve_hard_exit_floor() was"
+            " independently caught by 3 unit test failures AND a golden scenario divergence"
+            " (55/56), proving the extraction is load-bearing in production, not just in tests."
+        ),
+        "scope_not_covered": (
+            "Does not touch the cycling-midpoint logic (nat_vent_target/on_threshold/off_threshold)"
+            " in nat_vent_temperature_check() — that's a distinct concept (how far past the target"
+            " the fan is allowed to cycle), not the hard-exit floor this issue consolidates. Does"
+            " not change any threshold value or boundary — confirmed behavior-identical, not a"
+            " behavior fix."
+        ),
+    },
     454: {
         "version_fixed": "0.5.6",
         "title": "Extract shared differential-comparator base for pure decide_*() modules",

--- a/custom_components/climate_advisor/fan_thermostat_decision.py
+++ b/custom_components/climate_advisor/fan_thermostat_decision.py
@@ -69,18 +69,44 @@ class FanThermostatInputs:
     natural_vent_active: bool
 
 
-def _resolve_vent_floor(inputs: FanThermostatInputs) -> float:
-    """Pure reimplementation of Check 2's floor resolution.
+def resolve_hard_exit_floor(
+    *,
+    comfort_heat_raw: float,
+    sleep_heat: float,
+    in_sleep_window: bool,
+    hysteresis: float,
+) -> float:
+    """The nat-vent hard-exit floor: the sleep-aware threshold below which an
+    active nat-vent session ends outright (Issue #456 — single source of truth,
+    consolidating three prior copies: this function, automation.py's
+    check_natural_vent_conditions()'s ``_vent_floor``, and
+    nat_vent_temperature_check()'s ``_hard_floor``).
 
     Deliberately asymmetric, matching production exactly: the sleep-window
     branch subtracts hysteresis from sleep_heat; the awake branch does NOT
     subtract hysteresis from comfort_heat_raw. This is not a simplification
     opportunity — it's what the real code does, and the two floors are allowed
     to have different boundary shapes.
+
+    Not to be confused with ``_nat_vent_reactivation_floor()`` in automation.py
+    (the reactivation GATE's floor) — that is a deliberately different formula
+    (no hysteresis subtraction) answering a different question ("is it still
+    eligible to reactivate") than this one ("should the live session end now").
     """
-    if inputs.in_sleep_window:
-        return inputs.sleep_heat - inputs.hysteresis
-    return inputs.comfort_heat_raw
+    if in_sleep_window:
+        return sleep_heat - hysteresis
+    return comfort_heat_raw
+
+
+def _resolve_vent_floor(inputs: FanThermostatInputs) -> float:
+    """Pure reimplementation of Check 2's floor resolution — delegates to
+    resolve_hard_exit_floor(), the single source of truth (Issue #456)."""
+    return resolve_hard_exit_floor(
+        comfort_heat_raw=inputs.comfort_heat_raw,
+        sleep_heat=inputs.sleep_heat,
+        in_sleep_window=inputs.in_sleep_window,
+        hysteresis=inputs.hysteresis,
+    )
 
 
 def decide_fan_thermostat_check(inputs: FanThermostatInputs) -> FanThermostatOutcome:

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.6"
+  "version": "0.5.7"
 }

--- a/tests/test_fan_thermostat_decision.py
+++ b/tests/test_fan_thermostat_decision.py
@@ -12,6 +12,7 @@ from custom_components.climate_advisor.fan_thermostat_decision import (
     FanThermostatOutcome,
     _resolve_vent_floor,
     decide_fan_thermostat_check,
+    resolve_hard_exit_floor,
 )
 
 _BASE = {
@@ -118,6 +119,81 @@ class TestCheck2CooledToFloor:
 
     def test_none_indoor_never_triggers_check2(self):
         assert decide_fan_thermostat_check(_inputs(indoor=None, outdoor=65.0)) == FanThermostatOutcome.KEEP
+
+
+class TestResolveHardExitFloorConsolidation:
+    """Issue #456: resolve_hard_exit_floor() is the single source of truth for the
+    nat-vent hard-exit floor, consolidating this module's own _resolve_vent_floor(),
+    automation.py's check_natural_vent_conditions() (formerly inline _vent_floor),
+    and automation.py's nat_vent_temperature_check() (formerly inline _hard_floor).
+    These tests reproduce the exact old inline formulas from both automation.py
+    sites to prove the shared function is behavior-identical to what it replaced.
+    """
+
+    def _old_check_natural_vent_conditions_formula(
+        self, comfort_heat: float, sleep_heat: float, hysteresis: float, in_sleep_window: bool
+    ) -> float:
+        """The exact pre-#456 inline formula from check_natural_vent_conditions()."""
+        if in_sleep_window:
+            return sleep_heat - hysteresis
+        return comfort_heat
+
+    def _old_nat_vent_temperature_check_formula(
+        self, comfort_heat: float, sleep_heat: float, hysteresis: float, in_sleep_window: bool
+    ) -> float:
+        """The exact pre-#456 inline formula from nat_vent_temperature_check()."""
+        if in_sleep_window:
+            return sleep_heat - hysteresis
+        return comfort_heat
+
+    def test_matches_old_check_natural_vent_conditions_formula(self):
+        for comfort_heat, sleep_heat, hysteresis, in_sleep_window in [
+            (70.0, 64.0, 1.0, True),
+            (70.0, 64.0, 1.0, False),
+            (68.0, 60.0, 2.0, True),
+            (68.0, 60.0, 2.0, False),
+            (72.0, 72.0, 0.0, True),
+        ]:
+            expected = self._old_check_natural_vent_conditions_formula(
+                comfort_heat, sleep_heat, hysteresis, in_sleep_window
+            )
+            actual = resolve_hard_exit_floor(
+                comfort_heat_raw=comfort_heat,
+                sleep_heat=sleep_heat,
+                in_sleep_window=in_sleep_window,
+                hysteresis=hysteresis,
+            )
+            assert actual == expected
+
+    def test_matches_old_nat_vent_temperature_check_formula(self):
+        for comfort_heat, sleep_heat, hysteresis, in_sleep_window in [
+            (70.0, 64.0, 1.0, True),
+            (70.0, 64.0, 1.0, False),
+            (68.0, 60.0, 2.0, True),
+            (68.0, 60.0, 2.0, False),
+            (72.0, 72.0, 0.0, True),
+        ]:
+            expected = self._old_nat_vent_temperature_check_formula(
+                comfort_heat, sleep_heat, hysteresis, in_sleep_window
+            )
+            actual = resolve_hard_exit_floor(
+                comfort_heat_raw=comfort_heat,
+                sleep_heat=sleep_heat,
+                in_sleep_window=in_sleep_window,
+                hysteresis=hysteresis,
+            )
+            assert actual == expected
+
+    def test_resolve_vent_floor_delegates_to_resolve_hard_exit_floor(self):
+        """_resolve_vent_floor() (this module's own consumer) must produce the
+        identical value as calling resolve_hard_exit_floor() directly."""
+        inputs = _inputs(comfort_heat_raw=70.0, sleep_heat=64.0, hysteresis=1.0, in_sleep_window=True)
+        assert _resolve_vent_floor(inputs) == resolve_hard_exit_floor(
+            comfort_heat_raw=inputs.comfort_heat_raw,
+            sleep_heat=inputs.sleep_heat,
+            in_sleep_window=inputs.in_sleep_window,
+            hysteresis=inputs.hysteresis,
+        )
 
 
 class TestCheckOrdering:


### PR DESCRIPTION
## Summary
Continues the architecture-consolidation direction (#441, #452, #454). The nat-vent "hard exit floor" — the sleep-aware threshold below which an active free-cooling session ends outright — was computed identically in three places, only one of which was pure/tested:

1. `automation.py`'s `check_natural_vent_conditions()` — inline `_vent_floor`
2. `automation.py`'s `nat_vent_temperature_check()` — inline `_hard_floor`
3. `fan_thermostat_decision.py`'s already-pure, already-tested `_resolve_vent_floor()`

This is the same "sibling function recomputes the same threshold" bug class behind issues #400/#402/#417 — one level below the reactivation gate that #411/#417/#441 already consolidated.

- `fan_thermostat_decision.py`: promote `_resolve_vent_floor()`'s body into a new public, standalone pure function `resolve_hard_exit_floor()`; `_resolve_vent_floor()` now delegates to it.
- `automation.py`: route both inline call sites through the new function instead of recomputing.
- **Explicitly out of scope:** `_nat_vent_reactivation_floor()` (the reactivation gate's floor) is a deliberately different formula (no hysteresis subtraction) answering a different question ("is it still eligible to reactivate" vs. "should the live session end now") — not a 4th copy of this formula.

## Test plan
- [x] Unit test reproducing both old inline formulas exactly across 5 sleep/day/hysteresis combinations
- [x] Positive control: corrupted `resolve_hard_exit_floor()` and confirmed it was independently caught by 3 unit test failures **and** a golden scenario divergence (55/56) — proving the extraction is load-bearing in production, not just in tests. Restored and reverified clean before this PR.
- [x] `python -m ruff check`/`format` clean
- [x] 3310/3310 unit tests pass, including with `-W error::pytest.PytestUnraisableExceptionWarning -W error::RuntimeWarning`
- [x] 56/56 golden simulation scenarios pass
- [x] `test_version_sync.py` passes (0.5.7 in both `const.py` and `manifest.json`)