### PR TITLE
Fix #458: consolidate CA-fan-running suppression predicate (v0.5.8)

### DIFF
--- a/custom_components/climate_advisor/ai_skills_activity.py
+++ b/custom_components/climate_advisor/ai_skills_activity.py
@@ -34,6 +34,7 @@ from .const import (
     FAN_MODE_WHOLE_HOUSE,
     THERMAL_SWING_DEFAULT_F,
 )
+from .fan_status import is_ca_fan_running
 from .temperature import format_temp
 
 _LOGGER = logging.getLogger(__name__)
@@ -1252,12 +1253,11 @@ async def async_build_activity_context(
         # Suppress if CA intentionally has the fan running (e.g., natural ventilation).
         # hvac_mode=off + hvac_action=fan is expected when CA activated fan_mode=on.
         # Only warn when the thermostat reports activity CA cannot account for.
-        ca_fan_running = fan_status in (
-            "active",
-            "running (manual override)",
-            "running (untracked)",
-            "nat-vent (session active, fan idle)",
-        )
+        # is_ca_fan_running() is the single source of truth for this check (Issue #458) —
+        # this call site previously omitted "active (unconfirmed)" (the WHF ground-truth-
+        # disagreement state added by #423), so a fan legitimately in that state was
+        # misreported as a contradiction.
+        ca_fan_running = is_ca_fan_running(fan_status)
         if str(hvac_action).lower() == "fan" and ca_fan_running:
             pass  # Expected: CA activated HVAC fan-only mode for natural ventilation
         else:

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,21 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.7"
+VERSION = "0.5.8"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.8": [
+        "Fix #458: the AI Activity Report could misreport the whole-house fan as a"
+        " contradiction ('hvac_mode=off but hvac_action=fan') during the brief window"
+        " where CA detects and self-corrects a stale WHF on/off flag (Issue #423's"
+        " 'active (unconfirmed)' state) — that specific fan state was missing from this"
+        " report's allow-list of expected fan activity, even though the dashboard status"
+        " card already handled it correctly. Consolidated the two independently-written"
+        " checks (coordinator.py, ai_skills_activity.py) onto one shared predicate so this"
+        " class of drift can't recur; also fixed a second latent gap the consolidation"
+        " surfaced: a confirmed-running manual fan override wasn't suppressing the"
+        " coordinator's own internal contradiction-warning event either.",
+    ],
     "0.5.7": [
         "Fix #456: no user-visible change (confirmed via differential testing and a"
         " positive control). Consolidated the nat-vent 'hard exit floor' formula — the"
@@ -922,6 +934,34 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    458: {
+        "version_fixed": "0.5.8",
+        "title": "Consolidate CA-fan-running suppression predicate; fix missing 'active (unconfirmed)'",
+        "scope_covered": (
+            "New fan_status.py module (mirrors the temperature.py precedent): FAN_STATUS_ACTIVE_VALUES"
+            " + is_ca_fan_running(fan_status) — the single source of truth for 'does this fan_status"
+            " represent activity CA can account for.' ai_skills_activity.py's async_build_activity_context()"
+            " now calls it directly, fixing the real bug: its allow-list was missing"
+            " 'active (unconfirmed)' (the WHF ground-truth-disagreement state added by #423), so the AI"
+            " Activity Report misreported that specific fan state as a contradiction. coordinator.py's"
+            " _async_update_data() state-contradiction check also routed through the same predicate"
+            " (previously a separate ae._fan_active/_natural_vent_active flag check plus an ad hoc"
+            " running-untracked check) — this ALSO fixed a second latent gap: a manual fan override"
+            " confirmed running via physical state (ae._fan_override_active=True, ae._fan_active=False)"
+            " was not suppressing the coordinator's own contradiction-warning event, even though"
+            " ai_skills_activity.py's independent check already treated that case as expected."
+            " ae._natural_vent_active is kept as an explicit extra OR condition in coordinator.py,"
+            " covering the nat-vent-armed-but-idle moment between cycles"
+            " ('nat-vent (session active, fan idle)') — deliberately not one of the four canonical"
+            " active values, since the physical fan genuinely isn't running then."
+        ),
+        "scope_not_covered": (
+            "Does not add a fan_status.py constant for every _compute_fan_status() literal — only the"
+            " suppression-check subset needed here. Does not change dashboard/status-card fan display"
+            " logic, which already handled 'active (unconfirmed)' correctly before this fix; only the"
+            " AI Activity Report and the coordinator's internal contradiction-warning event were wrong."
+        ),
+    },
     456: {
         "version_fixed": "0.5.7",
         "title": "Consolidate the nat-vent hard-exit floor formula duplicated 3 times",

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -211,6 +211,7 @@ from .const import (
     VACATION_SETBACK_EXTRA,
     VERSION,
 )
+from .fan_status import is_ca_fan_running
 from .learning import DailyRecord, LearningEngine, compute_k_passive_blocks
 from .nat_vent_gate import NatVentGateInputs, decide_nat_vent_gate
 from .state import StatePersistence
@@ -1808,11 +1809,24 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         # Suppress when Climate Advisor itself activated fan-only mode (natural ventilation).
         _active_hvac_actions = {"heating", "cooling", "fan"}
         if hvac_mode == "off" and str(hvac_action).lower() in _active_hvac_actions:
-            # Suppress when CA activated the fan OR when thermostat ground-truth shows
-            # fan running (untracked) — either way the fan action is not a contradiction.
-            _ca_fan_running = self.automation_engine._fan_active or self.automation_engine._natural_vent_active
-            _fan_untracked = str(hvac_action).lower() == "fan" and self._compute_fan_status() == "running (untracked)"
-            _is_expected_fan = str(hvac_action).lower() == "fan" and (_ca_fan_running or _fan_untracked)
+            # Suppress when CA's own fan activity explains the reading (Issue #458 —
+            # is_ca_fan_running() is the single source of truth for this, consolidating
+            # what was a separate ad hoc flag check here). _natural_vent_active is kept
+            # as an explicit extra condition — it covers the nat-vent-armed-but-idle
+            # moment between cycles, a distinct state _compute_fan_status() reports as
+            # "nat-vent (session active, fan idle)" (not one of the four active values,
+            # since the physical fan genuinely isn't running then).
+            #
+            # Consolidating onto is_ca_fan_running() also fixes a second latent gap this
+            # issue found: previously a manual fan override confirmed running via physical
+            # state (ae._fan_override_active=True, ae._fan_active=False) was NOT suppressed
+            # here, even though ai_skills_activity.py's independent check already treated
+            # "running (manual override)" as expected — the two sites had silently
+            # disagreed on this case.
+            _ca_fan_running = self.automation_engine._natural_vent_active or is_ca_fan_running(
+                self._compute_fan_status()
+            )
+            _is_expected_fan = str(hvac_action).lower() == "fan" and _ca_fan_running
             if not _is_expected_fan:
                 _now = dt_util.now()
                 _dedup_window = timedelta(minutes=30)

--- a/custom_components/climate_advisor/fan_status.py
+++ b/custom_components/climate_advisor/fan_status.py
@@ -1,0 +1,41 @@
+"""Fan-status suppression predicate for Climate Advisor.
+
+``ClimateAdvisorCoordinator._compute_fan_status()`` returns one of seven string
+values (see CLAUDE.md's "Fan Status Values" table). Multiple call sites need to
+answer the same question — "is the thermostat reporting fan activity that CA's
+own fan control already explains, or is this a genuine contradiction worth a
+warning?" — and each has historically hand-rolled its own allow-list of "active"
+values (Issue #458, following the same "sibling threshold drift" pattern as
+#400/#402/#417/#456). This module is the single source of truth for that
+predicate, mirroring the existing ``temperature.py`` precedent: a tiny,
+dependency-free utility module imported by both ``coordinator.py`` and
+``ai_skills_activity.py``.
+"""
+
+from __future__ import annotations
+
+FAN_STATUS_ACTIVE_VALUES: frozenset[str] = frozenset(
+    {
+        "active",
+        "active (unconfirmed)",
+        "running (manual override)",
+        "running (untracked)",
+    }
+)
+
+
+def is_ca_fan_running(fan_status: str) -> bool:
+    """True if `fan_status` represents fan activity CA can account for.
+
+    `fan_status` is the return value of ``_compute_fan_status()``. Used to
+    suppress a false "state contradiction" warning when the thermostat reports
+    `hvac_action="fan"` while `hvac_mode="off"` — expected whenever CA itself
+    activated fan-only mode (natural ventilation, manual override, or an
+    untracked-but-real fan run), not a genuine data inconsistency.
+
+    Must include all four non-inactive, non-disabled active values from the
+    "Fan Status Values" table — omitting any one (as `ai_skills_activity.py`
+    omitted `"active (unconfirmed)"` before Issue #458) causes a fan legitimately
+    in that state to be misreported as a contradiction.
+    """
+    return fan_status in FAN_STATUS_ACTIVE_VALUES

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.7"
+  "version": "0.5.8"
 }

--- a/tests/test_ai_activity.py
+++ b/tests/test_ai_activity.py
@@ -171,6 +171,29 @@ class TestActivityCrossValidationSection:
         )
         assert "[WARNING]" not in ctx
 
+    def test_no_warning_when_hvac_mode_off_action_fan_active_unconfirmed(self):
+        """Issue #458 regression: fan_status='active (unconfirmed)' (the WHF ground-truth-
+        disagreement state added by #423) must suppress the contradiction warning, same as
+        'active'/'running (manual override)'/'running (untracked)' — this allow-list
+        previously omitted this value, misreporting a fan CA itself was running."""
+        ctx = _build_context(
+            hvac_mode="off",
+            hvac_action="fan",
+            current_temp=72.0,
+            fan_status="active (unconfirmed)",
+        )
+        assert "[WARNING]" not in ctx
+
+    def test_no_warning_when_hvac_mode_off_action_fan_untracked(self):
+        """No [WARNING] when hvac_mode=off + hvac_action=fan + fan_status=running (untracked)."""
+        ctx = _build_context(
+            hvac_mode="off",
+            hvac_action="fan",
+            current_temp=72.0,
+            fan_status="running (untracked)",
+        )
+        assert "[WARNING]" not in ctx
+
     def test_warning_when_hvac_mode_off_action_heating(self):
         """[WARNING] emitted when hvac_mode=off but hvac_action=heating."""
         ctx = _build_context(hvac_mode="off", hvac_action="heating")

--- a/tests/test_fan_status.py
+++ b/tests/test_fan_status.py
@@ -1,0 +1,57 @@
+"""Tests for the CA-fan-running suppression predicate (Issue #458).
+
+Consolidates two independently-drifted implementations (coordinator.py's
+flag-based check, ai_skills_activity.py's status-string allow-list — the
+latter was missing "active (unconfirmed)", added by #423) into a single
+source of truth: fan_status.is_ca_fan_running().
+"""
+
+from __future__ import annotations
+
+from custom_components.climate_advisor.fan_status import (
+    FAN_STATUS_ACTIVE_VALUES,
+    is_ca_fan_running,
+)
+
+# All seven documented fan-status values (CLAUDE.md "Fan Status Values" table).
+_ALL_FAN_STATUS_VALUES = {
+    "active",
+    "active (unconfirmed)",
+    "running (manual override)",
+    "running (untracked)",
+    "inactive",
+    "off (manual override)",
+    "disabled",
+}
+
+_EXPECTED_ACTIVE = {
+    "active",
+    "active (unconfirmed)",
+    "running (manual override)",
+    "running (untracked)",
+}
+
+
+class TestIsCaFanRunning:
+    def test_active_values_return_true(self):
+        for status in _EXPECTED_ACTIVE:
+            assert is_ca_fan_running(status) is True, f"{status!r} must be treated as CA fan running"
+
+    def test_non_active_values_return_false(self):
+        for status in _ALL_FAN_STATUS_VALUES - _EXPECTED_ACTIVE:
+            assert is_ca_fan_running(status) is False, f"{status!r} must NOT be treated as CA fan running"
+
+    def test_active_unconfirmed_regression(self):
+        """Issue #458: this specific value was missing from ai_skills_activity.py's
+        allow-list — the concrete bug this consolidation fixes."""
+        assert is_ca_fan_running("active (unconfirmed)") is True
+
+    def test_unknown_status_returns_false(self):
+        assert is_ca_fan_running("some-unexpected-string") is False
+
+    def test_constant_matches_function(self):
+        """FAN_STATUS_ACTIVE_VALUES and is_ca_fan_running() must agree — the
+        constant is exposed for callers that need the set itself, not just
+        membership testing."""
+        for status in _ALL_FAN_STATUS_VALUES:
+            assert (status in FAN_STATUS_ACTIVE_VALUES) == is_ca_fan_running(status)

--- a/tests/test_hvac_session_detection.py
+++ b/tests/test_hvac_session_detection.py
@@ -253,7 +253,11 @@ def _make_update_data_coord(*, hvac_mode: str, hvac_action: str, ca_fan_active: 
     coord._compute_next_automation_action = MagicMock(return_value=("No action", ""))
     coord._compute_next_action = MagicMock(return_value="No action")
     coord._compute_automation_status = MagicMock(return_value="active")
-    coord._compute_fan_status = MagicMock(return_value="inactive")
+    # Must track ca_fan_active (Issue #458): the state-contradiction suppression
+    # check now derives "is CA's fan explaining this reading" from
+    # is_ca_fan_running(self._compute_fan_status()) rather than the ae._fan_active
+    # flag directly, so this stub has to agree with the flag set on `ae` below.
+    coord._compute_fan_status = MagicMock(return_value="active" if ca_fan_active else "inactive")
     coord._compute_contact_status = MagicMock(return_value="closed")
     coord._any_sensor_open = MagicMock(return_value=False)
     coord._last_briefing = ""


### PR DESCRIPTION
## Summary
Continues the architecture-consolidation direction (#441, #452, #454, #456). The "is this hvac_action=fan reading CA's own doing" suppression check — used to decide whether `hvac_mode=off` + `hvac_action=fan` is a real contradiction worth a warning, or just CA's own fan activity — was implemented two different ways:

1. `coordinator.py` (flag-based: `_fan_active or _natural_vent_active`, plus a separate untracked-fan check)
2. `ai_skills_activity.py` (status-string-based allow-list)

Per CLAUDE.md's documented "Fan Status Values" invariant, any such check must include all four active values. **`ai_skills_activity.py`'s allow-list was missing `"active (unconfirmed)"`** (the WHF ground-truth-disagreement state added by #423), so the AI Activity Report misreported a fan legitimately in that state as a contradiction — the real bug this PR fixes. Same "sibling threshold drift" bug class as #400/#402/#417/#456.

- Add `fan_status.py` (mirrors the `temperature.py` precedent): a small, dependency-free module with `FAN_STATUS_ACTIVE_VALUES` and `is_ca_fan_running(fan_status)`.
- Route `ai_skills_activity.py` through it directly, fixing the missing-value bug.
- Route `coordinator.py` through it too — **this surfaced a second latent gap**: a manual fan override confirmed running via physical state wasn't suppressing the coordinator's own internal warning either, even though `ai_skills_activity.py`'s independent check already handled that case correctly. `_natural_vent_active` is kept as an explicit extra condition (the nat-vent-armed-but-idle state is deliberately not one of the four canonical active values, since the physical fan genuinely isn't running then).

## Test plan
- [x] Unit tests enumerating all 7 documented fan-status values against `is_ca_fan_running()`
- [x] Regression test proving the exact bug (`fan_status="active (unconfirmed)"` + `hvac_action="fan"` must not warn) — confirmed this test **fails** against the pre-fix allow-list, then restored the fix and reverified clean
- [x] Fixed one test-fixture staleness found along the way: a hardcoded `_compute_fan_status()="inactive"` stub in `test_hvac_session_detection.py` never mattered under the old flag-only check but needed to track `ca_fan_active` once the real predicate was wired in
- [x] `python -m ruff check`/`format` clean
- [x] 3317/3317 unit tests pass, including with `-W error::pytest.PytestUnraisableExceptionWarning -W error::RuntimeWarning`
- [x] 56/56 golden simulation scenarios pass
- [x] `test_version_sync.py` passes (0.5.8 in both `const.py` and `manifest.json`)