### PR TITLE
Fix #460: consolidate the occupancy-defer predicate duplicated 3 ways (v0.5.9)

### DIFF
--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -305,6 +305,22 @@ def _in_sleep_window(now: datetime, config: dict) -> bool:
     return now_time >= sleep_t or now_time < wake_t
 
 
+def should_defer_to_occupancy_setback(occupancy_mode: str) -> bool:
+    """Return True if `occupancy_mode` means comfort/setback logic should defer to
+    the away/vacation setback handlers instead of running normally (Issue #460).
+
+    Single source of truth for a gate previously phrased 3 different (but
+    logically equivalent) ways across this module's setpoint paths — the same
+    "sibling formulation drift" risk as #400/#402/#417/#456/#458. Equivalence
+    relies on occupancy_mode always being one of exactly the 4 values in
+    const.py (OCCUPANCY_HOME, OCCUPANCY_AWAY, OCCUPANCY_VACATION, OCCUPANCY_GUEST):
+    `occupancy_mode in (OCCUPANCY_AWAY, OCCUPANCY_VACATION)` is equivalent to
+    `occupancy_mode not in (OCCUPANCY_HOME, OCCUPANCY_GUEST)`, the inverted form
+    handle_morning_wakeup() used.
+    """
+    return occupancy_mode in (OCCUPANCY_AWAY, OCCUPANCY_VACATION)
+
+
 def _fan_device_label(config: dict) -> str:
     """Return a human-readable device label for the active fan type."""
     mode = config.get(CONF_FAN_MODE, FAN_MODE_DISABLED)
@@ -1991,14 +2007,16 @@ class AutomationEngine:
         Safety net: redirects to setback handlers when occupancy is away/vacation
         so that any code path calling this function respects occupancy mode (Issue #85).
         """
-        # Issue #85: redirect to setback when not home/guest
-        if self._occupancy_mode == OCCUPANCY_AWAY:
-            _LOGGER.info("Away mode — redirecting to setback instead of comfort (%s)", reason)
-            await self.handle_occupancy_away()
-            return
-        if self._occupancy_mode == OCCUPANCY_VACATION:
-            _LOGGER.info("Vacation mode — redirecting to deep setback instead of comfort (%s)", reason)
-            await self.handle_occupancy_vacation()
+        # Issue #85: redirect to setback when not home/guest. Gate unified via
+        # should_defer_to_occupancy_setback() (Issue #460); which handler to redirect
+        # to still depends on which of the two deferring modes this is.
+        if should_defer_to_occupancy_setback(self._occupancy_mode):
+            if self._occupancy_mode == OCCUPANCY_AWAY:
+                _LOGGER.info("Away mode — redirecting to setback instead of comfort (%s)", reason)
+                await self.handle_occupancy_away()
+            else:
+                _LOGGER.info("Vacation mode — redirecting to deep setback instead of comfort (%s)", reason)
+                await self.handle_occupancy_vacation()
             return
 
         unit = self.config.get("temp_unit", "fahrenheit")
@@ -3664,8 +3682,9 @@ class AutomationEngine:
             _LOGGER.debug("handle_bedtime: skipping — setpoint write within last 30s (startup dedup guard)")
             return
 
-        # Issue #85: vacation/away already has a setback — don't override it with sleep temps
-        if self._occupancy_mode in (OCCUPANCY_VACATION, OCCUPANCY_AWAY):
+        # Issue #85: vacation/away already has a setback — don't override it with sleep temps.
+        # Gate unified via should_defer_to_occupancy_setback() (Issue #460).
+        if should_defer_to_occupancy_setback(self._occupancy_mode):
             _LOGGER.info("Bedtime skipped — %s mode (setback already active)", self._occupancy_mode)
             if self._emit_event_callback:
                 self._emit_event_callback(
@@ -3793,7 +3812,8 @@ class AutomationEngine:
             )
             return "skipped: no warming trend"
 
-        if self._occupancy_mode in (OCCUPANCY_VACATION, OCCUPANCY_AWAY):
+        # Gate unified via should_defer_to_occupancy_setback() (Issue #460).
+        if should_defer_to_occupancy_setback(self._occupancy_mode):
             _LOGGER.info("Pre-cool skipped — %s mode (setback already active)", self._occupancy_mode)
             return f"skipped: {self._occupancy_mode}"
 
@@ -3886,8 +3906,12 @@ class AutomationEngine:
 
     async def handle_morning_wakeup(self, indoor_temp: float | None = None) -> None:
         """Restore comfort for morning wake-up."""
-        # Issue #85: skip comfort restore when nobody is home
-        if self._occupancy_mode not in (OCCUPANCY_HOME, OCCUPANCY_GUEST):
+        # Issue #85: skip comfort restore when nobody is home. Gate unified via
+        # should_defer_to_occupancy_setback() (Issue #460) — this call site's original
+        # inverted form (`not in (HOME, GUEST)`) is logically equivalent to the
+        # predicate's `in (AWAY, VACATION)`, since occupancy_mode is always one of
+        # exactly those 4 values.
+        if should_defer_to_occupancy_setback(self._occupancy_mode):
             _LOGGER.info(
                 "Morning wakeup skipped — occupancy mode is '%s'",
                 self._occupancy_mode,

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,20 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.8"
+VERSION = "0.5.9"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.9": [
+        "Fix #460: no user-visible change (confirmed via unit tests and a positive"
+        " control). Consolidated the 'should this comfort/setback code path defer"
+        " because occupancy is away/vacation' gate — previously phrased 3 different"
+        " (but logically equivalent) ways across automation.py's setpoint paths"
+        " (_set_temperature_for_mode, handle_bedtime, handle_pre_cool,"
+        " handle_morning_wakeup) — into a single should_defer_to_occupancy_setback()"
+        " function. No drift had occurred yet, but the risk was live: a future change"
+        " to which occupancy modes should defer could easily be applied to 3 of the 4"
+        " sites and miss the 4th, the same class of bug already found once in #458.",
+    ],
     "0.5.8": [
         "Fix #458: the AI Activity Report could misreport the whole-house fan as a"
         " contradiction ('hvac_mode=off but hvac_action=fan') during the brief window"
@@ -934,6 +945,30 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    460: {
+        "version_fixed": "0.5.9",
+        "title": "Consolidate the occupancy-defer predicate (3 formulations across automation.py)",
+        "scope_covered": (
+            "automation.py: new pure module-level function should_defer_to_occupancy_setback"
+            "(occupancy_mode) — True for OCCUPANCY_AWAY/OCCUPANCY_VACATION. Routed handle_bedtime(),"
+            " handle_pre_cool(), and handle_morning_wakeup() (previously the inverted"
+            " 'not in (HOME, GUEST)' form) through it directly, and routed"
+            " _set_temperature_for_mode() through it as an outer guard while preserving its"
+            " distinct per-mode redirect (AWAY -> handle_occupancy_away(),"
+            " VACATION -> handle_occupancy_vacation()) — only the boolean gate is unified, not"
+            " the dispatch logic. Verified via a unit test proving the predicate agrees with"
+            " the original inverted formulation across all 4 occupancy modes, plus a positive"
+            " control: corrupting the predicate to always return False was independently caught"
+            " by 9 unit test failures across all 4 call sites AND 2 golden scenario divergences"
+            " (54/56), proving the extraction is load-bearing in production."
+        ),
+        "scope_not_covered": (
+            "Does not change which occupancy modes defer (still exactly AWAY/VACATION) or add a"
+            " 5th occupancy mode. Does not touch the display/status-label occupancy checks in"
+            " coordinator.py (next_human_action, status-string builders) — those are a different,"
+            " lower-risk kind of duplication (labeling, not control-flow gating), out of scope here."
+        ),
+    },
     458: {
         "version_fixed": "0.5.8",
         "title": "Consolidate CA-fan-running suppression predicate; fix missing 'active (unconfirmed)'",

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.8"
+  "version": "0.5.9"
 }

--- a/tests/test_occupancy_automation.py
+++ b/tests/test_occupancy_automation.py
@@ -12,8 +12,17 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from custom_components.climate_advisor.automation import AutomationEngine
+from custom_components.climate_advisor.automation import (
+    AutomationEngine,
+    should_defer_to_occupancy_setback,
+)
 from custom_components.climate_advisor.classifier import DayClassification
+from custom_components.climate_advisor.const import (
+    OCCUPANCY_AWAY,
+    OCCUPANCY_GUEST,
+    OCCUPANCY_HOME,
+    OCCUPANCY_VACATION,
+)
 
 AUTOMATION_LOGGER = "custom_components.climate_advisor.automation"
 
@@ -467,3 +476,29 @@ class TestSetOccupancyMode:
         with caplog.at_level(logging.INFO, logger=AUTOMATION_LOGGER):
             engine.set_occupancy_mode("away")
         assert "home → away" in caplog.text
+
+
+class TestShouldDeferToOccupancySetback:
+    """Issue #460: should_defer_to_occupancy_setback() is the single source of
+    truth for the occupancy-defer gate, consolidating 3 formulations previously
+    scattered across _set_temperature_for_mode(), handle_bedtime(),
+    handle_pre_cool(), and handle_morning_wakeup() (the last phrased inverted)."""
+
+    def test_away_defers(self):
+        assert should_defer_to_occupancy_setback(OCCUPANCY_AWAY) is True
+
+    def test_vacation_defers(self):
+        assert should_defer_to_occupancy_setback(OCCUPANCY_VACATION) is True
+
+    def test_home_does_not_defer(self):
+        assert should_defer_to_occupancy_setback(OCCUPANCY_HOME) is False
+
+    def test_guest_does_not_defer(self):
+        assert should_defer_to_occupancy_setback(OCCUPANCY_GUEST) is False
+
+    def test_matches_inverted_formulation(self):
+        """The predicate must agree with handle_morning_wakeup()'s original
+        inverted form (`occupancy_mode not in (HOME, GUEST)`) for all 4 modes."""
+        for mode in (OCCUPANCY_HOME, OCCUPANCY_AWAY, OCCUPANCY_VACATION, OCCUPANCY_GUEST):
+            inverted_form = mode not in (OCCUPANCY_HOME, OCCUPANCY_GUEST)
+            assert should_defer_to_occupancy_setback(mode) == inverted_form


### PR DESCRIPTION
## Summary
Continues the architecture-consolidation direction (#441, #452, #454, #456, #458). The "should this comfort/setback code path defer because occupancy is away/vacation" gate was phrased three different (but logically equivalent) ways across `automation.py`'s setpoint paths — the same "sibling formulation drift" bug class as #400/#402/#417/#456/#458:

1. `_set_temperature_for_mode()` — two separate `== OCCUPANCY_AWAY` / `== OCCUPANCY_VACATION` checks, each redirecting to a different handler
2. `handle_bedtime()` — `occupancy_mode in (OCCUPANCY_VACATION, OCCUPANCY_AWAY)`, sets `setback_skipped_reason`
3. `handle_pre_cool()` — same tuple form, no side-effect field
4. `handle_morning_wakeup()` — inverted: `occupancy_mode not in (OCCUPANCY_HOME, OCCUPANCY_GUEST)`

- Add a pure module-level `should_defer_to_occupancy_setback()` in `automation.py` (all 4 use sites already live in this module — no new module needed, unlike #458's `fan_status.py`).
- Route `handle_bedtime()`/`handle_pre_cool()`/`handle_morning_wakeup()` through it directly.
- Route `_set_temperature_for_mode()` through it as an outer guard while preserving its distinct per-mode redirect — only the boolean gate is unified, not the dispatch logic.

## Test plan
- [x] Unit test proving the predicate agrees with the original inverted formulation across all 4 occupancy modes
- [x] Positive control: corrupted the predicate to always return `False` and confirmed it was independently caught by 9 unit test failures across all 4 call sites **and** 2 golden scenario divergences (54/56) — proving the extraction is load-bearing in production. Restored and reverified clean before this PR.
- [x] `python -m ruff check`/`format` clean
- [x] 3322/3322 unit tests pass, including with `-W error::pytest.PytestUnraisableExceptionWarning -W error::RuntimeWarning`
- [x] 56/56 golden simulation scenarios pass
- [x] `test_version_sync.py` passes (0.5.9 in both `const.py` and `manifest.json`)