### PR TITLE
Fix #462: route api.py's ca_target_heat/cool through select_comfort_band() (v0.5.10)

### DIFF
--- a/custom_components/climate_advisor/api.py
+++ b/custom_components/climate_advisor/api.py
@@ -120,16 +120,44 @@ class ClimateAdvisorStatusView(HomeAssistantView):
         # single-setpoint divergence check below (and any heat_cool-mode consumer of these
         # fields) compares the real thermostat setpoint against the wrong intended value
         # all night, masking exactly the kind of stuck/frozen-target bug this issue covers.
+        #
+        # Issue #462: route through select_comfort_band() — the canonical resolver every
+        # real setpoint-writing code path (apply_classification, handle_bedtime,
+        # handle_pre_cool, handle_morning_wakeup, occupancy handlers) already uses — instead
+        # of a third independent inline implementation of this branch. Deliberately NOT
+        # compute_bedtime_setback() (the chart/briefing's adaptive resolver, a different,
+        # documented split — see const.py's #333 changelog): this field exists to detect
+        # divergence from what the thermostat is ACTUALLY being driven to, which is
+        # select_comfort_band()'s job. Routing through it also fixes a real gap the old
+        # inline branch had: it ignored occupancy mode entirely, so away/vacation setback
+        # was never reflected here even though the thermostat was really being held at the
+        # setback band — exactly the kind of divergence this field exists to catch.
         from homeassistant.util import dt as dt_util  # noqa: PLC0415
 
-        from .automation import _in_sleep_window  # noqa: PLC0415
+        from .automation import _in_sleep_window, select_comfort_band  # noqa: PLC0415
 
-        if _in_sleep_window(dt_util.now(), coordinator.config):
-            _ca_target_heat = coordinator.config.get("sleep_heat", coordinator.config.get("comfort_heat"))
-            _ca_target_cool = coordinator.config.get("sleep_cool", coordinator.config.get("comfort_cool"))
+        classification = coordinator.current_classification
+        if classification is not None:
+            _band = select_comfort_band(
+                classification,
+                coordinator.config,
+                occupancy_mode=coordinator._occupancy_mode,
+                in_sleep_window=_in_sleep_window(dt_util.now(), coordinator.config),
+                aggressive_savings=bool(coordinator.config.get("aggressive_savings", False)),
+                pre_condition_achieved=bool(getattr(ae, "_pre_condition_achieved", False)),
+            )
+            _ca_target_heat = _band.floor
+            _ca_target_cool = _band.ceiling
         else:
-            _ca_target_heat = coordinator.config.get("comfort_heat")
-            _ca_target_cool = coordinator.config.get("comfort_cool")
+            # No classification yet (e.g., right after HA restart, before the first
+            # classification cycle completes) — fall back to the old sleep/day-only
+            # heuristic so the field is never simply absent.
+            if _in_sleep_window(dt_util.now(), coordinator.config):
+                _ca_target_heat = coordinator.config.get("sleep_heat", coordinator.config.get("comfort_heat"))
+                _ca_target_cool = coordinator.config.get("sleep_cool", coordinator.config.get("comfort_cool"))
+            else:
+                _ca_target_heat = coordinator.config.get("comfort_heat")
+                _ca_target_cool = coordinator.config.get("comfort_cool")
 
         # Issue #402 follow-up: surface the WHF fan's actual on/off cycling band so the
         # Natural Vent status card can show it instead of a single static midpoint number

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,21 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.9"
+VERSION = "0.5.10"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.10": [
+        "Fix #462: the dashboard's setpoint-divergence indicator (ca_target_heat/cool)"
+        " could show the wrong intended target while the home was in away or vacation"
+        " mode — it never accounted for occupancy at all, so it displayed the comfort or"
+        " sleep band even though the thermostat was actually being held at the (wider)"
+        " setback band. Routed through the same select_comfort_band() function every"
+        " real setpoint-writing code path already uses, so this indicator can no longer"
+        " silently drift from what the thermostat is actually doing. Also corrected the"
+        " fallback used when sleep_heat/sleep_cool aren't explicitly configured, from the"
+        " flat daytime comfort temps to the documented sleep defaults (64/72°F), matching"
+        " what the thermostat is actually set to overnight in that configuration.",
+    ],
     "0.5.9": [
         "Fix #460: no user-visible change (confirmed via unit tests and a positive"
         " control). Consolidated the 'should this comfort/setback code path defer"
@@ -945,6 +957,33 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    462: {
+        "version_fixed": "0.5.10",
+        "title": "Route api.py's ca_target_heat/cool through the canonical select_comfort_band() resolver",
+        "scope_covered": (
+            "api.py: ClimateAdvisorStatusView.get()'s ca_target_heat/cool computation (Issue #402)"
+            " replaced its own third independent implementation of the sleep/day band branch with a"
+            " call to automation.py's select_comfort_band() — the same resolver apply_classification(),"
+            " handle_bedtime(), handle_pre_cool(), handle_morning_wakeup(), and the occupancy handlers"
+            " already use to decide the live floor/ceiling. Deliberately NOT compute_bedtime_setback()"
+            " (the chart/briefing's adaptive resolver — a different, documented split per const.py's"
+            " #333 changelog): this field exists to detect divergence from the ACTUAL live setpoint,"
+            " which is select_comfort_band()'s job. Falls back to the old sleep/day-only heuristic only"
+            " when coordinator.current_classification is None (e.g. right after HA restart, before the"
+            " first classification cycle). Fixed two real gaps the old inline branch had: (1) it ignored"
+            " occupancy mode entirely, so away/vacation setback was never reflected even though the"
+            " thermostat was really being held at the setback band; (2) its unconfigured-sleep-temp"
+            " fallback was comfort_heat/comfort_cool, not the documented DEFAULT_SLEEP_HEAT/"
+            " DEFAULT_SLEEP_COOL (64/72°F) select_comfort_band() actually uses."
+        ),
+        "scope_not_covered": (
+            "Does not change select_comfort_band() itself or any live setpoint-writing behavior — this"
+            " endpoint is read-only display. Does not touch _compute_target_band_schedule() (the chart's"
+            " band-schedule builder, already a separate concern per #333) or compute_bedtime_setback()"
+            " (the adaptive resolver) — those remain intentionally distinct from the live-setpoint"
+            " resolver this fix routes through."
+        ),
+    },
     460: {
         "version_fixed": "0.5.9",
         "title": "Consolidate the occupancy-defer predicate (3 formulations across automation.py)",

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.9"
+  "version": "0.5.10"
 }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -298,7 +298,37 @@ def _simulate_learning_get(coordinator):
     return resp.json_data
 
 
-def _status_get_with_climate_state(config: dict, climate_state, indoor_temp=70.0, outdoor_temp=None):
+def _make_classification(**overrides):
+    """Build a DayClassification bypassing __post_init__, for select_comfort_band() tests."""
+    from custom_components.climate_advisor.classifier import DayClassification
+
+    c = object.__new__(DayClassification)
+    defaults = {
+        "day_type": "mild",
+        "trend_direction": "stable",
+        "trend_magnitude": 0,
+        "today_high": 78,
+        "today_low": 58,
+        "tomorrow_high": 79,
+        "tomorrow_low": 59,
+        "hvac_mode": "heat",
+        "pre_condition": False,
+        "pre_condition_target": None,
+        "windows_recommended": False,
+        "window_open_time": None,
+        "window_close_time": None,
+        "setback_modifier": 0.0,
+        "window_opportunity_morning": False,
+        "window_opportunity_evening": False,
+    }
+    defaults.update(overrides)
+    c.__dict__.update(defaults)
+    return c
+
+
+def _status_get_with_climate_state(
+    config: dict, climate_state, indoor_temp=70.0, outdoor_temp=None, occupancy_mode="home", classification=None
+):
     """Build a minimal coordinator and drive the real status view, for setpoint/ca-target tests."""
     coord = MagicMock()
     coord.config = config
@@ -306,11 +336,13 @@ def _status_get_with_climate_state(config: dict, climate_state, indoor_temp=70.0
     coord._get_indoor_temp.return_value = indoor_temp
     coord._last_outdoor_temp = outdoor_temp
     coord.automation_enabled = True
-    coord._occupancy_mode = "home"
+    coord._occupancy_mode = occupancy_mode
+    coord.current_classification = classification if classification is not None else _make_classification()
     ae = MagicMock()
     ae._manual_override_active = False
     ae._override_confirm_pending = False
     ae._fan_override_active = False
+    ae._pre_condition_achieved = False
     ae.is_paused_by_door = False
     coord.automation_engine = ae
     coord._compute_contact_details.return_value = []
@@ -318,12 +350,13 @@ def _status_get_with_climate_state(config: dict, climate_state, indoor_temp=70.0
 
 
 class TestCATargetSleepAware:
-    """Issue #402: ca_target_heat/cool must reflect the sleep band during the sleep window,
-
-    not always the flat daytime comfort_heat/comfort_cool — otherwise both the heat_cool
-    and single-setpoint divergence indicators compare the real thermostat setpoint against
-    the wrong value all night, masking exactly the kind of stuck/frozen-target bug #402
-    covers.
+    """Issue #402/#462: ca_target_heat/cool must reflect the real live-setpoint band
+    (via select_comfort_band(), the same resolver every setpoint-writing code path
+    uses) during the sleep window and for away/vacation occupancy — not the flat
+    daytime comfort_heat/comfort_cool, and not the display-only sleep/day heuristic
+    that used to ignore occupancy mode entirely. Otherwise the divergence indicators
+    compare the real thermostat setpoint against the wrong value, masking exactly the
+    kind of stuck/frozen-target bug #402 covers.
     """
 
     _CONFIG = {
@@ -335,7 +368,7 @@ class TestCATargetSleepAware:
         "wake_time": "07:00",
     }
 
-    def _get_ca_targets(self, config: dict, now):
+    def _get_ca_targets(self, config: dict, now, occupancy_mode="home"):
         """Drive the real ClimateAdvisorStatusView.get(), patching dt_util.now()."""
         from unittest.mock import patch
 
@@ -345,7 +378,7 @@ class TestCATargetSleepAware:
         state.state = "heat"
         state.attributes = {"temperature": 70, "target_temp_low": None, "target_temp_high": None}
         with patch.object(dt_util, "now", return_value=now):
-            response = _status_get_with_climate_state(config, state)
+            response = _status_get_with_climate_state(config, state, occupancy_mode=occupancy_mode)
         return response["ca_target_heat"], response["ca_target_cool"]
 
     def test_daytime_uses_comfort_band(self):
@@ -366,14 +399,44 @@ class TestCATargetSleepAware:
         assert heat != 68.0, "must not fall back to the flat daytime comfort_heat overnight"
         assert cool != 74.0, "must not fall back to the flat daytime comfort_cool overnight"
 
-    def test_sleep_window_falls_back_to_comfort_when_sleep_not_configured(self):
+    def test_sleep_window_falls_back_to_default_sleep_temps_when_not_configured(self):
+        """Issue #462: select_comfort_band()'s sleep-branch fallback is DEFAULT_SLEEP_HEAT/
+        DEFAULT_SLEEP_COOL (64/72), not comfort_heat/comfort_cool (68/74) — the old inline
+        implementation's fallback didn't match the live setpoint resolver's actual default."""
         from datetime import datetime
 
         config = {"comfort_heat": 68.0, "comfort_cool": 74.0, "sleep_time": "22:30", "wake_time": "07:00"}
         now = datetime(2026, 7, 21, 2, 0, 0)
         heat, cool = self._get_ca_targets(config, now)
-        assert heat == 68.0
-        assert cool == 74.0
+        assert heat == 64.0
+        assert cool == 72.0
+
+    def test_away_mode_uses_setback_band_not_comfort_or_sleep(self):
+        """Issue #462 regression: the old inline branch ignored occupancy entirely, so
+        away mode showed the comfort/sleep band even though the thermostat was really
+        being held at the setback band."""
+        from datetime import datetime
+
+        now = datetime(2026, 7, 21, 14, 0, 0)  # daytime — old code would have shown comfort band
+        config = {**self._CONFIG, "setback_heat": 60.0, "setback_cool": 80.0}
+        heat, cool = self._get_ca_targets(config, now, occupancy_mode="away")
+        assert heat == 60.0
+        assert cool == 80.0
+        assert heat != 68.0
+        assert cool != 74.0
+
+    def test_vacation_mode_uses_deep_setback_band(self):
+        """Issue #462 regression: vacation mode must show the wider vacation setback
+        (setback ± VACATION_SETBACK_EXTRA), not the comfort/sleep band."""
+        from datetime import datetime
+
+        from custom_components.climate_advisor.const import VACATION_SETBACK_EXTRA
+
+        now = datetime(2026, 7, 21, 14, 0, 0)
+        config = {**self._CONFIG, "setback_heat": 60.0, "setback_cool": 80.0}
+        heat, cool = self._get_ca_targets(config, now, occupancy_mode="vacation")
+        assert heat == 60.0 - VACATION_SETBACK_EXTRA
+        assert cool == 80.0 + VACATION_SETBACK_EXTRA
 
 
 class TestStatusSetpointExtraction:


### PR DESCRIPTION
## Summary
Continues the architecture-consolidation direction (#441, #452, #454, #456, #458, #460) — the last of the four Phase A decision-logic extractions. `api.py`'s `ClimateAdvisorStatusView.get()` computed `ca_target_heat`/`ca_target_cool` (the setpoint-divergence indicator, Issue #402) via its own **third** independent implementation of the sleep/day band branch, instead of the canonical `select_comfort_band()` every real setpoint-writing code path (`apply_classification`, `handle_bedtime`, `handle_pre_cool`, `handle_morning_wakeup`, occupancy handlers) already uses.

Deliberately routed through `select_comfort_band()` and **not** `compute_bedtime_setback()` (the chart/briefing's adaptive resolver — a different, documented split per `const.py`'s #333 changelog): this field exists to detect divergence from what the thermostat is **actually** being driven to, which is `select_comfort_band()`'s job, not the adaptive/display resolver's.

This consolidation surfaced two real gaps in the old inline branch:
1. **It ignored occupancy mode entirely** — away/vacation setback was never reflected here even though the thermostat was really being held at the (wider) setback band, exactly the divergence this field exists to catch.
2. **Its unconfigured-sleep-temp fallback was wrong** — `comfort_heat`/`comfort_cool`, not the documented `DEFAULT_SLEEP_HEAT`/`DEFAULT_SLEEP_COOL` (64/72°F) `select_comfort_band()` actually falls back to.

Falls back to the old sleep/day-only heuristic only when `coordinator.current_classification` is `None` (e.g. right after HA restart, before the first classification cycle).

## Test plan
- [x] Unit tests proving the new call matches `select_comfort_band()`'s real output for home+sleep, home+day, away, and vacation occupancy modes (the away/vacation cases are new regression coverage for the gap this fix closes)
- [x] Positive control: corrupted the `occupancy_mode` wiring and confirmed it was caught by both new regression tests. Restored and reverified clean before this PR.
- [x] `python -m ruff check`/`format` clean
- [x] 3324/3324 unit tests pass, including with `-W error::pytest.PytestUnraisableExceptionWarning -W error::RuntimeWarning`
- [x] 56/56 golden simulation scenarios pass (`api.py` is outside the golden harness's scope, which only drives `AutomationEngine` — unit tests are the correct verification layer here)
- [x] `test_version_sync.py` passes (0.5.10 in both `const.py` and `manifest.json`)