### PR TITLE
Fix #464: add coordinator.get_hvac_runtime_today() to kill 3x copy-pasted formula (v0.5.11)

### DIFF
--- a/custom_components/climate_advisor/ai_skills_activity.py
+++ b/custom_components/climate_advisor/ai_skills_activity.py
@@ -1170,14 +1170,8 @@ async def async_build_activity_context(
     day_type = data.get(ATTR_DAY_TYPE, "unknown")
     trend = data.get(ATTR_TREND, "unknown")
     hvac_action = data.get(ATTR_HVAC_ACTION, "unknown")
-    # Compute fresh runtime -- coordinator.data may be up to 30 min stale
-    _base_runtime = coordinator._today_record.hvac_runtime_minutes if coordinator._today_record is not None else 0.0
-    _session_elapsed = (
-        (dt_util.now() - coordinator._hvac_on_since).total_seconds() / 60.0
-        if coordinator._hvac_on_since is not None
-        else 0.0
-    )
-    hvac_runtime_today = round(_base_runtime + _session_elapsed, 1)
+    # Compute fresh runtime -- coordinator.data may be up to 30 min stale (Issue #464)
+    hvac_runtime_today = coordinator.get_hvac_runtime_today()
 
     climate_entity_id: str = options.get("climate_entity", "")
     hvac_mode = "unknown"

--- a/custom_components/climate_advisor/ai_skills_context.py
+++ b/custom_components/climate_advisor/ai_skills_context.py
@@ -20,8 +20,6 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from homeassistant.util import dt as dt_util
-
 if TYPE_CHECKING:
     pass
 
@@ -410,14 +408,8 @@ async def build_current_state_context(hass: Any, coordinator: Any, **kwargs: Any
         day_type = data.get(ATTR_DAY_TYPE, "unknown")
         trend = data.get(ATTR_TREND, "unknown")
         hvac_action = data.get(ATTR_HVAC_ACTION, "unknown")
-        # Compute fresh runtime — coordinator.data may be up to 30 min stale
-        _base_runtime = coordinator._today_record.hvac_runtime_minutes if coordinator._today_record is not None else 0.0
-        _session_elapsed = (
-            (dt_util.now() - coordinator._hvac_on_since).total_seconds() / 60.0
-            if coordinator._hvac_on_since is not None
-            else 0.0
-        )
-        hvac_runtime_today = round(_base_runtime + _session_elapsed, 1)
+        # Compute fresh runtime — coordinator.data may be up to 30 min stale (Issue #464)
+        hvac_runtime_today = coordinator.get_hvac_runtime_today()
         automation_status = data.get(ATTR_AUTOMATION_STATUS, "unknown")
         last_action_time = data.get(ATTR_LAST_ACTION_TIME, "unknown")
         last_action_reason = data.get(ATTR_LAST_ACTION_REASON, "unknown")

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,20 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.10"
+VERSION = "0.5.11"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.11": [
+        "Fix #464: no user-visible change. Starts Phase B of the architecture-"
+        " consolidation direction (coordinator single-source) by adding"
+        " coordinator.get_hvac_runtime_today() as the one place today's live HVAC"
+        " runtime is computed, replacing an identical formula that was copy-pasted"
+        " byte-for-byte in coordinator.py, ai_skills_context.py, and"
+        " ai_skills_activity.py. No drift had occurred yet, but any future change"
+        " to the formula (e.g. excluding paused/away time) would have needed to be"
+        " applied in 3 places to avoid the AI Activity Report and Investigator"
+        " silently diverging from the dashboard.",
+    ],
     "0.5.10": [
         "Fix #462: the dashboard's setpoint-divergence indicator (ca_target_heat/cool)"
         " could show the wrong intended target while the home was in away or vacation"
@@ -957,6 +968,28 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    464: {
+        "version_fixed": "0.5.11",
+        "title": "Add coordinator.get_hvac_runtime_today() to kill the 3x copy-pasted formula",
+        "scope_covered": (
+            "coordinator.py: new get_hvac_runtime_today() method — base runtime from today's"
+            " record plus elapsed minutes of any in-progress HVAC session, computed live (not"
+            " from the up-to-30-min-stale coordinator.data snapshot). Routed coordinator.py's own"
+            " _async_update_data() inline computation through it, plus the two AI-context copies"
+            " (ai_skills_context.py build_current_state_context(),"
+            " ai_skills_activity.py async_build_activity_context()) that previously reached into"
+            " coordinator._today_record/_hvac_on_since directly. Verified via unit tests covering"
+            " no-record/no-session, base-only, active-session, and rounding cases, plus updated 3"
+            " tests in test_ai_investigator.py that previously patched dt_util on the now-unused"
+            " ai_skills_context module directly instead of configuring the new method."
+        ),
+        "scope_not_covered": (
+            "Does not change the runtime formula itself (still base + elapsed session time, no"
+            " exclusion for paused/away time). Does not address Phase B's remaining sub-items"
+            " (setpoint fields on coordinator.data, learning_health threading, target-band-schedule"
+            " dedup) — those are separate issues."
+        ),
+    },
     462: {
         "version_fixed": "0.5.10",
         "title": "Route api.py's ca_target_heat/cool through the canonical select_comfort_band() resolver",

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -1956,9 +1956,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                         _last_cmd,
                     )
 
-        _base_runtime = self._today_record.hvac_runtime_minutes if self._today_record else 0.0
-        _session_elapsed = (dt_util.now() - self._hvac_on_since).total_seconds() / 60 if self._hvac_on_since else 0.0
-        hvac_runtime_today = round(_base_runtime + _session_elapsed, 1)
+        hvac_runtime_today = self.get_hvac_runtime_today()
 
         # --- Thermal observation pipeline sampling ---
         self._update_pre_heat_buffer()
@@ -6141,6 +6139,22 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
     def today_record(self) -> DailyRecord | None:
         """Return today's learning record."""
         return self._today_record
+
+    def get_hvac_runtime_today(self) -> float:
+        """Return today's HVAC runtime in minutes, computed live (Issue #464).
+
+        `coordinator.data[ATTR_HVAC_RUNTIME_TODAY]` is only refreshed once per
+        update cycle (up to ~30 min stale) — this method is the single source of
+        truth for consumers that need the current value right now (AI context
+        builders previously hand-copied this exact formula for that reason).
+        Adds the accumulated base runtime from today's record to the elapsed
+        time of any HVAC session currently in progress.
+        """
+        base_runtime = self._today_record.hvac_runtime_minutes if self._today_record is not None else 0.0
+        session_elapsed = (
+            (dt_util.now() - self._hvac_on_since).total_seconds() / 60.0 if self._hvac_on_since is not None else 0.0
+        )
+        return round(base_runtime + session_elapsed, 1)
 
     @property
     def yesterday_record(self) -> dict | None:

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.10"
+  "version": "0.5.11"
 }

--- a/tests/test_ai_investigator.py
+++ b/tests/test_ai_investigator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import datetime
 import sys
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 # ── HA module stubs must be in place before importing climate_advisor modules ──
 if "homeassistant" not in sys.modules:
@@ -1013,63 +1013,43 @@ class TestInvestigationReportPersistence:
 
 
 class TestFreshHvacRuntime:
-    """Tests for the fresh hvac_runtime_today calculation in context builders."""
+    """Tests for the fresh hvac_runtime_today calculation in context builders.
+
+    Issue #464: the live computation moved into coordinator.get_hvac_runtime_today()
+    (a single source of truth shared with ai_skills_activity.py and coordinator.py's
+    own _async_update_data()) — ai_skills_context.py now just calls it directly instead
+    of reaching into _today_record/_hvac_on_since and dt_util.now() itself.
+    """
 
     def test_investigator_context_uses_live_session_elapsed(self):
-        """Context includes accumulated runtime when an HVAC session is active.
-
-        Coordinator has _today_record.hvac_runtime_minutes=5.0 and
-        _hvac_on_since set to 20 minutes ago.  The context should report ~25 min,
-        not the stale coordinator.data value of 0.
-        """
+        """Context includes the live value from get_hvac_runtime_today(), not the
+        (possibly stale) coordinator.data value."""
         coord = _make_coordinator(data_overrides={"hvac_runtime_today": 0})
+        coord.get_hvac_runtime_today = MagicMock(return_value=25.0)
         hass = _make_hass()
 
-        # Set up the fresh-runtime fields
-        now = datetime.datetime.now(datetime.UTC)
-        on_since = now - datetime.timedelta(minutes=20)
-        coord._today_record = MagicMock()
-        coord._today_record.hvac_runtime_minutes = 5.0
-        coord._hvac_on_since = on_since
+        context = asyncio.run(async_build_investigator_context(hass, coord))
 
-        import custom_components.climate_advisor.ai_skills_context as _ctx_mod
-
-        with patch.object(_ctx_mod.dt_util, "now", return_value=now):
-            context = asyncio.run(async_build_investigator_context(hass, coord))
-
-        # Expected: 5.0 + 20.0 = 25.0 min
         assert "25.0" in context
 
     def test_investigator_context_no_active_session(self):
-        """When _hvac_on_since is None, only base runtime is used."""
+        """Base-runtime-only value from get_hvac_runtime_today() is used verbatim."""
         coord = _make_coordinator(data_overrides={"hvac_runtime_today": 0})
+        coord.get_hvac_runtime_today = MagicMock(return_value=42.0)
         hass = _make_hass()
 
-        now = datetime.datetime.now(datetime.UTC)
-        coord._today_record = MagicMock()
-        coord._today_record.hvac_runtime_minutes = 42.0
-        coord._hvac_on_since = None
-
-        import custom_components.climate_advisor.ai_skills_context as _ctx_mod
-
-        with patch.object(_ctx_mod.dt_util, "now", return_value=now):
-            context = asyncio.run(async_build_investigator_context(hass, coord))
+        context = asyncio.run(async_build_investigator_context(hass, coord))
 
         assert "42.0" in context
 
     def test_investigator_context_no_today_record(self):
-        """When _today_record is None, runtime defaults to 0.0."""
+        """When get_hvac_runtime_today() returns 0.0 (no record, no session), the
+        stale coordinator.data value must NOT be used instead."""
         coord = _make_coordinator(data_overrides={"hvac_runtime_today": 99})
+        coord.get_hvac_runtime_today = MagicMock(return_value=0.0)
         hass = _make_hass()
 
-        now = datetime.datetime.now(datetime.UTC)
-        coord._today_record = None
-        coord._hvac_on_since = None
-
-        import custom_components.climate_advisor.ai_skills_context as _ctx_mod
-
-        with patch.object(_ctx_mod.dt_util, "now", return_value=now):
-            context = asyncio.run(async_build_investigator_context(hass, coord))
+        context = asyncio.run(async_build_investigator_context(hass, coord))
 
         # Stale coordinator.data value (99) must NOT appear; fresh value (0.0) must appear
         assert "hvac_runtime_today:  0.0 min" in context

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1735,3 +1735,52 @@ class TestChartLogPredIndoorSource:
             hourly_forecast_temps=[55.0],
         )
         assert result["pred_indoor"] is None, f"Expected None when cache is empty, got {result['pred_indoor']!r}."
+
+
+class TestGetHvacRuntimeToday:
+    """Tests for get_hvac_runtime_today() (Issue #464) — the single source of truth
+    consolidating a formula previously copy-pasted in coordinator.py, ai_skills_context.py,
+    and ai_skills_activity.py."""
+
+    def _make_coord(self, hvac_runtime_minutes: float | None, hvac_on_since):
+        ClimateAdvisorCoordinator = _get_coordinator_class()
+        coord = object.__new__(ClimateAdvisorCoordinator)
+        if hvac_runtime_minutes is None:
+            coord._today_record = None
+        else:
+            record = MagicMock()
+            record.hvac_runtime_minutes = hvac_runtime_minutes
+            coord._today_record = record
+        coord._hvac_on_since = hvac_on_since
+        return coord
+
+    def test_no_today_record_and_no_session_returns_zero(self):
+        coord = self._make_coord(None, None)
+        assert coord.get_hvac_runtime_today() == 0.0
+
+    def test_base_runtime_only_when_no_active_session(self):
+        coord = self._make_coord(42.0, None)
+        assert coord.get_hvac_runtime_today() == 42.0
+
+    def test_active_session_adds_elapsed_minutes_to_base(self):
+        """5.0 base + 20 min active session (elapsed at query time) = 25.0."""
+        from unittest.mock import patch
+
+        from custom_components.climate_advisor import coordinator as _coord_mod
+
+        now = datetime.datetime(2026, 4, 8, 12, 0, 0)
+        on_since = now - datetime.timedelta(minutes=20)
+        coord = self._make_coord(5.0, on_since)
+        with patch.object(_coord_mod.dt_util, "now", return_value=now):
+            assert coord.get_hvac_runtime_today() == 25.0
+
+    def test_result_is_rounded_to_one_decimal(self):
+        from unittest.mock import patch
+
+        from custom_components.climate_advisor import coordinator as _coord_mod
+
+        now = datetime.datetime(2026, 4, 8, 12, 0, 0)
+        on_since = now - datetime.timedelta(seconds=100)  # 1.6667 min
+        coord = self._make_coord(0.0, on_since)
+        with patch.object(_coord_mod.dt_util, "now", return_value=now):
+            assert coord.get_hvac_runtime_today() == 1.7


### PR DESCRIPTION
## Summary
Starts Phase B of the architecture-consolidation direction (coordinator single-source), continuing #441/#452/#454/#456/#458/#460/#462. The `hvac_runtime_today` formula (base runtime from today's record + elapsed minutes of an in-progress HVAC session) was copy-pasted byte-for-byte in three places:

1. `coordinator.py`'s own `_async_update_data()`
2. `ai_skills_context.py`'s `build_current_state_context()`
3. `ai_skills_activity.py`'s `async_build_activity_context()`

The latter two reach into `coordinator._today_record`/`_hvac_on_since` directly because `coordinator.data`'s snapshot can be up to 30 min stale by the time an AI report is generated — a legitimate freshness concern, but the fix duplicated the formula instead of exposing a live-computing helper.

- `coordinator.py`: add `get_hvac_runtime_today()` — the single source of truth, computing the live value the same way the inline formula did.
- Route all three sites through it.

## Test plan
- [x] Unit tests covering no-record/no-session, base-only, active-session, and rounding cases
- [x] Updated 3 tests in `test_ai_investigator.py` that previously patched `dt_util` on the (now unused for this purpose) `ai_skills_context` module directly — they now configure the new method instead, matching the new call path
- [x] `python -m ruff check`/`format` clean
- [x] 3328/3328 unit tests pass, including with `-W error::pytest.PytestUnraisableExceptionWarning -W error::RuntimeWarning`
- [x] 56/56 golden simulation scenarios pass
- [x] `test_version_sync.py` passes (0.5.11 in both `const.py` and `manifest.json`)