### PR TITLE
Fix #466: add target_temp fields to coordinator.data; route AI-context sites (v0.5.12)

### DIFF
--- a/custom_components/climate_advisor/ai_skills_activity.py
+++ b/custom_components/climate_advisor/ai_skills_activity.py
@@ -1173,20 +1173,22 @@ async def async_build_activity_context(
     # Compute fresh runtime -- coordinator.data may be up to 30 min stale (Issue #464)
     hvac_runtime_today = coordinator.get_hvac_runtime_today()
 
+    # Issue #466: hvac_mode/target_temp* read from coordinator.data (populated once
+    # per update cycle in _async_update_data()) instead of independently re-fetching
+    # hass.states.get() here — this context doesn't need sub-cycle freshness (every
+    # other field in this function already reads from the same coordinator.data
+    # snapshot). current_temp still needs a live read: it isn't one of the fields
+    # coordinator.data exposes.
     climate_entity_id: str = options.get("climate_entity", "")
-    hvac_mode = "unknown"
+    hvac_mode = data.get("hvac_mode") or "unknown"
+    target_temp: float | None = data.get("target_temp")
+    target_temp_low: float | None = data.get("target_temp_low")
+    target_temp_high: float | None = data.get("target_temp_high")
     current_temp = "unknown"
-    target_temp: float | None = None
-    target_temp_low: float | None = None
-    target_temp_high: float | None = None
     if climate_entity_id:
         climate_state = hass.states.get(climate_entity_id)
         if climate_state is not None:
-            hvac_mode = climate_state.state
             current_temp = climate_state.attributes.get("current_temperature", "unknown")
-            target_temp = climate_state.attributes.get("temperature")
-            target_temp_low = climate_state.attributes.get("target_temp_low")
-            target_temp_high = climate_state.attributes.get("target_temp_high")
 
     # --- Automation state ---
     automation_status = data.get(ATTR_AUTOMATION_STATUS, "unknown")

--- a/custom_components/climate_advisor/ai_skills_context.py
+++ b/custom_components/climate_advisor/ai_skills_context.py
@@ -442,20 +442,27 @@ async def build_current_state_context(hass: Any, coordinator: Any, **kwargs: Any
 
 
 async def build_hvac_entity_context(hass: Any, coordinator: Any, **kwargs: Any) -> str:
-    """Build HVAC ENTITY section from HA state."""
+    """Build HVAC ENTITY section from HA state.
+
+    Issue #466: hvac_mode/target_temp_low/target_temp_high read from
+    coordinator.data (populated once per update cycle) instead of independently
+    re-fetching hass.states.get() here — this investigator context doesn't need
+    sub-cycle freshness. current_temp still needs a live read: it isn't one of
+    the fields coordinator.data exposes.
+    """
     try:
+        data: dict[str, Any] = coordinator.data or {}
         climate_entity_id: str = (coordinator.config or {}).get("climate_entity", "")
-        hvac_mode = "unknown"
+        hvac_mode = data.get("hvac_mode") or "unknown"
+        _target_temp_low = data.get("target_temp_low")
+        target_temp_low = "unknown" if _target_temp_low is None else _target_temp_low
+        _target_temp_high = data.get("target_temp_high")
+        target_temp_high = "unknown" if _target_temp_high is None else _target_temp_high
         current_temp = "unknown"
-        target_temp_low = "unknown"
-        target_temp_high = "unknown"
         if climate_entity_id:
             climate_state = hass.states.get(climate_entity_id)
             if climate_state is not None:
-                hvac_mode = climate_state.state
                 current_temp = climate_state.attributes.get("current_temperature", "unknown")
-                target_temp_low = climate_state.attributes.get("target_temp_low", "unknown")
-                target_temp_high = climate_state.attributes.get("target_temp_high", "unknown")
 
         lines = [
             "=== HVAC ENTITY ===",

--- a/custom_components/climate_advisor/api.py
+++ b/custom_components/climate_advisor/api.py
@@ -93,6 +93,11 @@ class ClimateAdvisorStatusView(HomeAssistantView):
 
         data = coordinator.data or {}
         ae = coordinator.automation_engine
+        # Issue #466: deliberately NOT read from coordinator.data (which is only refreshed
+        # once per ~30-min update cycle) — this powers the ca_target_heat/cool divergence
+        # check (#402/#462), whose entire purpose is comparing CA's computed target against
+        # the REAL thermostat right now. Reading a stale cached setpoint here would mask
+        # exactly the kind of stuck/frozen-target bug that check exists to catch.
         climate_state = hass.states.get(coordinator.config.get("climate_entity", ""))
         hvac_mode = climate_state.state if climate_state else "unknown"
 

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,20 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.11"
+VERSION = "0.5.12"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.12": [
+        "Fix #466: no user-visible change. Continues Phase B (coordinator single-"
+        " source): added target_temp/target_temp_low/target_temp_high to"
+        " coordinator.data so ai_skills_activity.py and ai_skills_context.py stop"
+        " independently re-fetching the thermostat entity to derive the same"
+        " values. api.py's dashboard status endpoint deliberately keeps its own"
+        " live read — it powers the ca_target_heat/cool divergence check (#402/"
+        " #462), whose entire purpose is comparing CA's computed target against"
+        " the real thermostat right now, not a snapshot that can be up to 30 min"
+        " old.",
+    ],
     "0.5.11": [
         "Fix #464: no user-visible change. Starts Phase B of the architecture-"
         " consolidation direction (coordinator single-source) by adding"
@@ -968,6 +979,30 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    466: {
+        "version_fixed": "0.5.12",
+        "title": "Add target_temp fields to coordinator.data; route AI-context sites through it",
+        "scope_covered": (
+            "coordinator.py: added target_temp/target_temp_low/target_temp_high to the"
+            " _async_update_data() return dict, read from the same climate-entity state (_cs) already"
+            " fetched there for hvac_mode/hvac_action. ai_skills_activity.py"
+            " (async_build_activity_context()) and ai_skills_context.py (build_hvac_entity_context())"
+            " now read hvac_mode/target_temp/target_temp_low/target_temp_high from coordinator.data"
+            " instead of independently calling hass.states.get() — each kept a minimal live"
+            " hass.states.get() call only for current_temperature, which is out of this issue's scope"
+            " and not exposed on coordinator.data. Explicit scope decision (confirmed with the project"
+            " owner, not a silent merge): api.py's status endpoint keeps its own live hass.states.get()"
+            " call unchanged — it powers the ca_target_heat/cool divergence check (#402/#462), whose"
+            " entire purpose is comparing CA's computed target against the REAL thermostat right now;"
+            " routing it through coordinator.data's ~30-min-stale cache would compare CA's belief"
+            " against CA's own stale snapshot of the thermostat, defeating the check."
+        ),
+        "scope_not_covered": (
+            "Does not touch current_temperature (out of scope — not one of the 3 setpoint fields, and"
+            " both AI-context sites still need a live read for it). Does not change api.py's setpoint"
+            " display behavior at all — deliberately left live."
+        ),
+    },
     464: {
         "version_fixed": "0.5.11",
         "title": "Add coordinator.get_hvac_runtime_today() to kill the 3x copy-pasted formula",

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -1790,6 +1790,16 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         _cs = self.hass.states.get(_climate_entity_id) if _climate_entity_id else None
         hvac_action = _cs.attributes.get("hvac_action", "") if _cs else ""
         hvac_mode = _cs.state if _cs else ""
+        # Issue #466: setpoint fields, so consumers that don't need live sub-cycle
+        # freshness (ai_skills_activity.py/ai_skills_context.py) can read from
+        # coordinator.data instead of independently re-fetching hass.states.get().
+        # api.py's own status endpoint deliberately keeps its own live read — it
+        # powers the ca_target_heat/cool divergence check (#402/#462), which exists
+        # to compare CA's computed target against the REAL thermostat right now, not
+        # against a snapshot that can be up to ~30 min old.
+        _target_temp = _cs.attributes.get("temperature") if _cs else None
+        _target_temp_low = _cs.attributes.get("target_temp_low") if _cs else None
+        _target_temp_high = _cs.attributes.get("target_temp_high") if _cs else None
 
         # Issue #96 Root Cause D: Late-start thermal session for HVAC running at HA startup.
         # _hvac_on_since is only set via state transitions in _async_thermostat_changed.
@@ -2007,6 +2017,9 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             ATTR_FAN_RUNNING: fan_running,
             ATTR_HVAC_ACTION: hvac_action,
             "hvac_mode": hvac_mode,
+            "target_temp": _target_temp,
+            "target_temp_low": _target_temp_low,
+            "target_temp_high": _target_temp_high,
             ATTR_HVAC_RUNTIME_TODAY: hvac_runtime_today,
             ATTR_CONTACT_STATUS: self._compute_contact_status(),
             ATTR_AI_STATUS: self.claude_client.get_status()["status"] if self.claude_client else "disabled",

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.11"
+  "version": "0.5.12"
 }

--- a/tests/test_activity_report.py
+++ b/tests/test_activity_report.py
@@ -815,10 +815,21 @@ def _make_hass_with_setpoints(
 
 
 def _build_context_for_setpoint_test(hass: MagicMock) -> str:
-    """Call async_build_activity_context with the given hass mock."""
+    """Call async_build_activity_context with the given hass mock.
+
+    Issue #466: hvac_mode/target_temp/target_temp_low/target_temp_high are read
+    from coordinator.data now, not hass.states.get() — mirror the hass mock's
+    climate_state attributes onto coord.data so these tests still exercise the
+    scenario they were written for.
+    """
     import asyncio
 
     coord = _make_mock_coordinator_for_activity()
+    climate_state = hass.states.get.return_value
+    coord.data["hvac_mode"] = climate_state.state
+    coord.data["target_temp"] = climate_state.attributes.get("temperature")
+    coord.data["target_temp_low"] = climate_state.attributes.get("target_temp_low")
+    coord.data["target_temp_high"] = climate_state.attributes.get("target_temp_high")
     import custom_components.climate_advisor.ai_skills_activity as _act_mod
 
     now = datetime.now(tz=UTC)

--- a/tests/test_ai_activity.py
+++ b/tests/test_ai_activity.py
@@ -53,10 +53,13 @@ def _make_coordinator(
     comfort_heat: float = 68.0,
     comfort_cool: float = 76.0,
     fan_status: str = "inactive",
+    hvac_mode: str = "heat",
 ) -> MagicMock:
     """Build a minimal coordinator mock."""
     coord = MagicMock()
-    coord.data = {ATTR_HVAC_ACTION: hvac_action, ATTR_FAN_STATUS: fan_status}
+    # Issue #466: hvac_mode is read from coordinator.data now, not hass.states.get() —
+    # must be set here to match the hvac_mode passed to _make_hass() for the same scenario.
+    coord.data = {ATTR_HVAC_ACTION: hvac_action, ATTR_FAN_STATUS: fan_status, "hvac_mode": hvac_mode}
     coord.config = {
         "climate_entity": "climate.thermostat",
         "comfort_heat": comfort_heat,
@@ -96,6 +99,7 @@ def _build_context(
         comfort_heat=comfort_heat,
         comfort_cool=comfort_cool,
         fan_status=fan_status,
+        hvac_mode=hvac_mode,
     )
     return asyncio.run(async_build_activity_context(hass, coord))
 
@@ -285,3 +289,36 @@ class TestActivityCrossValidationSection:
         idx_cv = ctx.index("## STATE CROSS-VALIDATION")
         idx_cl = ctx.index("## CLASSIFICATION")
         assert idx_cv < idx_cl
+
+
+class TestHvacModeAndSetpointsFromCoordinatorData:
+    """Issue #466: hvac_mode/target_temp/target_temp_low/target_temp_high are read
+    from coordinator.data now, not hass.states.get() — only current_temp still
+    needs a live read (it isn't one of the fields coordinator.data exposes)."""
+
+    def test_hvac_mode_read_from_coordinator_data_not_hass(self):
+        """hass.states.get()'s climate_state.state must be ignored for hvac_mode —
+        only coordinator.data['hvac_mode'] is authoritative."""
+        hass = _make_hass(hvac_mode="cool", current_temp=72.0)
+        coord = _make_coordinator(hvac_action="heating", hvac_mode="heat")
+        ctx = asyncio.run(async_build_activity_context(hass, coord))
+        # hvac_mode=heat + hvac_action=heating is CONSISTENT -> no contradiction warning,
+        # proving "heat" (from coordinator.data) was used, not "cool" (from hass mock).
+        assert "[WARNING]" not in ctx
+
+    def test_target_temps_appear_from_coordinator_data(self):
+        coord = _make_coordinator()
+        coord.data["target_temp"] = 71.0
+        coord.data["target_temp_low"] = 68.0
+        coord.data["target_temp_high"] = 76.0
+        hass = _make_hass()
+        ctx = asyncio.run(async_build_activity_context(hass, coord))
+        assert "71.0" in ctx or "68.0" in ctx or "76.0" in ctx
+
+    def test_only_one_hass_states_get_call_for_current_temp(self):
+        """Regression guard: hvac_mode/target_temp* must not silently reintroduce a
+        second independent hass.states.get() call."""
+        coord = _make_coordinator()
+        hass = _make_hass()
+        asyncio.run(async_build_activity_context(hass, coord))
+        assert hass.states.get.call_count == 1

--- a/tests/test_ai_skills_context_hvac_entity.py
+++ b/tests/test_ai_skills_context_hvac_entity.py
@@ -1,0 +1,84 @@
+"""Tests for build_hvac_entity_context() (Issue #466).
+
+hvac_mode/target_temp_low/target_temp_high now read from coordinator.data
+(populated once per update cycle) instead of independently re-fetching
+hass.states.get() — these tests prove the new call path produces the same
+output the old live-fetch path did, for present/missing/off-mode cases.
+current_temp is unaffected (still a live hass.states.get() read — not one of
+the 3 fields moved to coordinator.data under this issue).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+from custom_components.climate_advisor.ai_skills_context import build_hvac_entity_context
+
+
+def _make_coordinator(data: dict, climate_entity: str = "climate.thermostat") -> MagicMock:
+    coord = MagicMock()
+    coord.data = data
+    coord.config = {"climate_entity": climate_entity}
+    return coord
+
+
+def _make_hass(current_temperature=72.0) -> MagicMock:
+    hass = MagicMock()
+    climate_state = MagicMock()
+    climate_state.attributes = {"current_temperature": current_temperature}
+    hass.states.get.return_value = climate_state
+    return hass
+
+
+class TestBuildHvacEntityContext:
+    def test_present_values_appear_in_context(self):
+        coord = _make_coordinator({"hvac_mode": "heat", "target_temp_low": 68.0, "target_temp_high": 76.0})
+        hass = _make_hass(current_temperature=71.5)
+
+        ctx = asyncio.run(build_hvac_entity_context(hass, coord))
+
+        assert "hvac_mode:        heat" in ctx
+        assert "current_temp:     71.5" in ctx
+        assert "target_temp_low:  68.0" in ctx
+        assert "target_temp_high: 76.0" in ctx
+
+    def test_missing_hvac_mode_falls_back_to_unknown(self):
+        """coordinator.data['hvac_mode'] == '' (climate entity unavailable) must
+        still display 'unknown', matching the pre-#466 live-fetch fallback."""
+        coord = _make_coordinator({"hvac_mode": "", "target_temp_low": None, "target_temp_high": None})
+        hass = _make_hass()
+
+        ctx = asyncio.run(build_hvac_entity_context(hass, coord))
+
+        assert "hvac_mode:        unknown" in ctx
+
+    def test_missing_target_temps_fall_back_to_unknown(self):
+        coord = _make_coordinator({"hvac_mode": "cool", "target_temp_low": None, "target_temp_high": None})
+        hass = _make_hass()
+
+        ctx = asyncio.run(build_hvac_entity_context(hass, coord))
+
+        assert "target_temp_low:  unknown" in ctx
+        assert "target_temp_high: unknown" in ctx
+
+    def test_no_climate_entity_configured(self):
+        coord = _make_coordinator({"hvac_mode": "", "target_temp_low": None, "target_temp_high": None}, "")
+        hass = _make_hass()
+
+        ctx = asyncio.run(build_hvac_entity_context(hass, coord))
+
+        assert "entity_id:        not configured" in ctx
+        assert "hvac_mode:        unknown" in ctx
+
+    def test_does_not_call_hass_states_get_for_hvac_mode_or_targets(self):
+        """Regression guard: the removed live hass.states.get() call for
+        hvac_mode/target_temp_low/target_temp_high must not silently come back —
+        only current_temp still needs a live read, and only when a climate_entity
+        is configured."""
+        coord = _make_coordinator({"hvac_mode": "heat", "target_temp_low": 68.0, "target_temp_high": 76.0})
+        hass = _make_hass(current_temperature=70.0)
+
+        asyncio.run(build_hvac_entity_context(hass, coord))
+
+        assert hass.states.get.call_count == 1, "must call hass.states.get() exactly once, for current_temp only"


### PR DESCRIPTION
## Summary
Continues Phase B (coordinator single-source), following #464. `coordinator.data` already exposed `hvac_mode` but not the thermostat's setpoint fields, so three consumers each independently called `hass.states.get(climate_entity)` to re-derive them: `api.py`, `ai_skills_activity.py`, and `ai_skills_context.py`.

## Scope decision (explicit, not a silent merge)
Investigating this surfaced a real freshness tradeoff a naive "just consolidate everything" approach would have broken: `api.py`'s setpoint fields power the `ca_target_heat`/`ca_target_cool` divergence check (#402/#462), whose entire purpose is comparing what CA computed as the target against what the **real thermostat currently has**, to catch a stuck/frozen/manually-overridden setpoint. `coordinator.data` is only refreshed once per ~30-min update cycle — routing that comparison through the same cache would compare CA's belief against CA's own stale snapshot of the thermostat, not live ground truth, defeating the check. The two AI-context sites have no such requirement — everything else in those same functions already reads from `coordinator.data`.

**Decision (confirmed with the project owner):**
- `coordinator.py`: add `target_temp`/`target_temp_low`/`target_temp_high` to the `_async_update_data()` return dict, reading from the climate-entity state already fetched there for `hvac_mode`/`hvac_action`.
- `ai_skills_activity.py` / `ai_skills_context.py`: read `hvac_mode`/`target_temp*` from `coordinator.data` instead of re-fetching; kept a minimal live `hass.states.get()` call only for `current_temperature` (out of scope, not exposed on `coordinator.data`).
- `api.py`: no functional change — added a comment explaining why its live read stays as-is.

## Test plan
- [x] New unit tests for `build_hvac_entity_context()` covering present/missing/off-mode cases and a call-count regression guard
- [x] New regression tests in `test_ai_activity.py` proving `hvac_mode` is read from `coordinator.data`, not the (now-irrelevant) hass mock
- [x] Fixed test-fixture staleness in `test_ai_activity.py`/`test_activity_report.py` where mock coordinators didn't set `coordinator.data["hvac_mode"]`/`target_temp*` to match the scenario's intended `hass.states.get()` mock
- [x] `python -m ruff check`/`format` clean
- [x] 3336/3336 unit tests pass, including with `-W error::pytest.PytestUnraisableExceptionWarning -W error::RuntimeWarning`
- [x] 56/56 golden simulation scenarios pass
- [x] `test_version_sync.py` passes (0.5.12 in both `const.py` and `manifest.json`)