### PR TITLE
Fix #468: thread learning_health through 3 AI-context get_thermal_model() calls (v0.5.13)

### DIFF
--- a/custom_components/climate_advisor/ai_skills_activity.py
+++ b/custom_components/climate_advisor/ai_skills_activity.py
@@ -1267,7 +1267,10 @@ async def async_build_activity_context(
     _temp_unit = options.get("temp_unit", "fahrenheit")
     if hasattr(coordinator, "learning") and callable(getattr(coordinator.learning, "get_thermal_model", None)):
         try:
-            _thermal = coordinator.learning.get_thermal_model()
+            # Issue #468: pass learning_health so this call matches the canonical shape
+            # used everywhere else (coordinator.py, sensor.py) — otherwise the returned
+            # dict is structurally incomplete (learning_health always {}).
+            _thermal = coordinator.learning.get_thermal_model(learning_health=coordinator._build_learning_health())
             _swing_heat_f = _thermal.get("swing_heat_f_display", THERMAL_SWING_DEFAULT_F)
             _swing_cool_f = _thermal.get("swing_cool_f_display", THERMAL_SWING_DEFAULT_F)
             if _temp_unit == "celsius":

--- a/custom_components/climate_advisor/ai_skills_context.py
+++ b/custom_components/climate_advisor/ai_skills_context.py
@@ -514,7 +514,15 @@ async def build_learning_context(hass: Any, coordinator: Any, **kwargs: Any) -> 
 
         # Thermal model
         try:
-            thermal: dict[str, Any] = learning.get_thermal_model() or {}
+            # Issue #468: pass learning_health so this call matches the canonical shape
+            # used everywhere else (coordinator.py, sensor.py) — otherwise the returned
+            # dict is structurally incomplete (learning_health always {}).
+            _learning_health = (
+                coordinator._build_learning_health()
+                if callable(getattr(coordinator, "_build_learning_health", None))
+                else {}
+            )
+            thermal: dict[str, Any] = learning.get_thermal_model(learning_health=_learning_health) or {}
             section_lines += [
                 "=== LEARNING — THERMAL MODEL ===",
                 f"  heating_rate_f_per_hour:   {thermal.get('heating_rate_f_per_hour', 'unknown')}",
@@ -620,10 +628,13 @@ async def build_thermal_pipeline_context(hass: Any, coordinator: Any, **kwargs: 
     except Exception:
         health = {}
 
-    # Retrieve current thermal model so we can flag NEVER LEARNED parameters
+    # Retrieve current thermal model so we can flag NEVER LEARNED parameters.
+    # Issue #468: pass the `health` dict already computed above — this call previously
+    # omitted it entirely (computing the exact same value twice for no reason, once for
+    # display here and once discarded inside get_thermal_model()'s empty default).
     try:
         learning = getattr(coordinator, "learning", None)
-        thermal: dict = (learning.get_thermal_model() if learning is not None else {}) or {}
+        thermal: dict = (learning.get_thermal_model(learning_health=health) if learning is not None else {}) or {}
     except Exception:
         thermal = {}
 

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,21 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.12"
+VERSION = "0.5.13"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.13": [
+        "Fix #468: the AI Activity Report and Investigator's thermal-model sections"
+        " could show an empty learning-health summary and a blank thermal"
+        " equilibrium temperature even when the dashboard's Comfort Score sensor"
+        " showed real rejection/observation data for the same moment — three"
+        " AI-context call sites queried the thermal model without the"
+        " per-observation-type health data the dashboard already includes,"
+        " producing a structurally incomplete result for no reason. One of the"
+        " three had already computed that exact data a few lines above for its"
+        " own display and simply never passed it along. Now all three match what"
+        " the dashboard sees.",
+    ],
     "0.5.12": [
         "Fix #466: no user-visible change. Continues Phase B (coordinator single-"
         " source): added target_temp/target_temp_low/target_temp_high to"
@@ -979,6 +991,29 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    468: {
+        "version_fixed": "0.5.13",
+        "title": "Thread coordinator._build_learning_health() through 3 AI-context get_thermal_model() calls",
+        "scope_covered": (
+            "get_thermal_model(learning_health=...) is called two ways: canonically (coordinator.py's"
+            " 3 sites, sensor.py's ClimateAdvisorComplianceSensor) with learning_health passed, and"
+            " degraded (3 AI-context sites) with no arguments, producing learning_health: {} and"
+            " thermal_equilibrium_f: None always, per the function's own docstring. Fixed all 3:"
+            " ai_skills_activity.py's swing-acquisition call in async_build_activity_context(); "
+            " ai_skills_context.py's build_learning_context() THERMAL MODEL section; and"
+            " ai_skills_context.py's build_thermal_pipeline_context(), which already computed the exact"
+            " same health dict a few lines above for its own per-type display but never passed it to"
+            " the adjacent get_thermal_model() call. All three now receive the same"
+            " coordinator._build_learning_health() output the dashboard/sensor sees."
+        ),
+        "scope_not_covered": (
+            "Does not change get_thermal_model()'s own logic or return shape — only ensures callers"
+            " supply the same optional argument the canonical call sites already did. Does not add"
+            " outdoor_temp_f/solar_factor (the other two optional get_thermal_model() args) to these"
+            " 3 sites — thermal_equilibrium_f will populate once learning_health flows through, but"
+            " those two remaining args are a separate, not-yet-scoped concern."
+        ),
+    },
     466: {
         "version_fixed": "0.5.12",
         "title": "Add target_temp fields to coordinator.data; route AI-context sites through it",

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.12"
+  "version": "0.5.13"
 }

--- a/tests/test_ai_activity.py
+++ b/tests/test_ai_activity.py
@@ -322,3 +322,22 @@ class TestHvacModeAndSetpointsFromCoordinatorData:
         hass = _make_hass()
         asyncio.run(async_build_activity_context(hass, coord))
         assert hass.states.get.call_count == 1
+
+
+class TestSwingAcquisitionThreadsLearningHealth:
+    """Issue #468: the swing-acquisition get_thermal_model() call must pass
+    learning_health, matching the canonical shape used by coordinator.py/sensor.py."""
+
+    def test_get_thermal_model_called_with_learning_health(self):
+        _health = {"hvac_heat": {"attempts": 1, "committed": 1}}
+        coord = _make_coordinator()
+        coord._build_learning_health.return_value = _health
+        coord.learning.get_thermal_model.return_value = {
+            "swing_heat_f_display": 1.0,
+            "swing_cool_f_display": 1.0,
+        }
+        hass = _make_hass()
+
+        asyncio.run(async_build_activity_context(hass, coord))
+
+        coord.learning.get_thermal_model.assert_called_once_with(learning_health=_health)

--- a/tests/test_ai_skills_context_learning_health.py
+++ b/tests/test_ai_skills_context_learning_health.py
@@ -1,0 +1,73 @@
+"""Tests for learning_health being threaded through get_thermal_model() calls (Issue #468).
+
+Three AI-context call sites (ai_skills_activity.py's swing acquisition,
+ai_skills_context.py's build_learning_context() and
+build_thermal_pipeline_context()) previously called get_thermal_model() with no
+arguments, producing a structurally incomplete dict (learning_health always {})
+that differed from the canonical shape used by coordinator.py and sensor.py's
+ClimateAdvisorComplianceSensor for no principled reason. These tests prove the
+fix: each site now passes learning_health matching coordinator._build_learning_health().
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+from custom_components.climate_advisor.ai_skills_context import (
+    build_learning_context,
+    build_thermal_pipeline_context,
+)
+
+
+def _make_coordinator(learning_health: dict) -> MagicMock:
+    coord = MagicMock()
+    coord._build_learning_health.return_value = learning_health
+    coord.learning.get_compliance_summary.return_value = {}
+    coord.learning.get_weather_bias.return_value = {}
+    coord.learning.get_thermal_model.return_value = {
+        "heating_rate_f_per_hour": 2.0,
+        "cooling_rate_f_per_hour": 1.5,
+        "confidence": "medium",
+        "observation_count_heat": 5,
+        "observation_count_cool": 3,
+    }
+    coord._build_thermal_pipeline_summary.return_value = {}
+    coord.learning._state.thermal_model_cache = {}
+    return coord
+
+
+class TestBuildLearningContextThreadsLearningHealth:
+    def test_get_thermal_model_called_with_learning_health(self):
+        _health = {"hvac_heat": {"attempts": 3, "committed": 2}}
+        coord = _make_coordinator(_health)
+        hass = MagicMock()
+
+        asyncio.run(build_learning_context(hass, coord))
+
+        coord.learning.get_thermal_model.assert_called_once_with(learning_health=_health)
+
+    def test_no_build_learning_health_attribute_falls_back_gracefully(self):
+        """Coordinator without _build_learning_health (e.g. a bare stub) must not crash —
+        falls back to an empty dict, matching the pre-#468 behavior for that edge case."""
+        coord = _make_coordinator({})
+        del coord._build_learning_health
+        hass = MagicMock()
+
+        ctx = asyncio.run(build_learning_context(hass, coord))
+
+        assert "=== LEARNING — THERMAL MODEL ===" in ctx
+
+
+class TestBuildThermalPipelineContextThreadsLearningHealth:
+    def test_get_thermal_model_called_with_the_same_health_used_for_display(self):
+        """Issue #468: this call site already computed `health` for its own per-type
+        display — it must pass that SAME value into get_thermal_model(), not recompute
+        or omit it."""
+        _health = {"passive_decay": {"attempts": 10, "committed": 4}}
+        coord = _make_coordinator(_health)
+        hass = MagicMock()
+
+        asyncio.run(build_thermal_pipeline_context(hass, coord))
+
+        coord.learning.get_thermal_model.assert_called_once_with(learning_health=_health)


### PR DESCRIPTION
## Summary
Continues Phase B (coordinator single-source), following #464/#466. `get_thermal_model(learning_health=...)` is called two ways across the codebase: canonically (`coordinator.py`'s 3 sites, `sensor.py`'s `ClimateAdvisorComplianceSensor`) with `learning_health` passed, and degraded (3 AI-context sites) with no arguments at all — producing a structurally incomplete dict (`learning_health: {}`, `thermal_equilibrium_f: None` always, per the function's own docstring) that differs from what the dashboard/sensor sees for no principled reason.

- `ai_skills_activity.py`: pass `learning_health=coordinator._build_learning_health()` to the swing-acquisition `get_thermal_model()` call.
- `ai_skills_context.py`'s `build_learning_context()`: same, for the THERMAL MODEL section.
- `ai_skills_context.py`'s `build_thermal_pipeline_context()`: this one already computed the exact same `health` dict a few lines above for its own per-type display, but never passed that value into the adjacent `get_thermal_model()` call — the most concrete gap of the three.

## Test plan
- [x] New unit tests proving each of the 3 calls now receives `learning_health` matching `coordinator._build_learning_health()`'s output, including one confirming the pipeline-context site passes the SAME dict it already displays, not a recomputed or omitted one
- [x] `python -m ruff check`/`format` clean
- [x] 3340/3340 unit tests pass, including with `-W error::pytest.PytestUnraisableExceptionWarning -W error::RuntimeWarning`
- [x] 56/56 golden simulation scenarios pass
- [x] `test_version_sync.py` passes (0.5.13 in both `const.py` and `manifest.json`)