### PR TITLE
Feat #486: QuietCool RF remote timer sets fan override grace duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Supports whole-house fan and/or HVAC fan mode integration:
 - **Dual-entity WHF support**: An optional separate `fan_state_entity` lets CA read ground-truth physical state independently of the command entity (Type 2 installations)
 - **Command-only mode** (`fan_state_feedback` off, default): CA asserts the desired fan state idempotently without reading back entity state, avoiding false override detection on command-echo entities. Turn on `fan_state_feedback` for installations with a dedicated state sensor.
 - Integrated with the economizer two-phase cooling strategy (cool-down with AC, maintain with ventilation)
+- **QuietCool RF remote timer support** (optional, `fan_remote_entity`): if you flash your QuietCool whole-house fan's ESP32 controller with the [`gunkl/quietcool-house-fan`](https://github.com/gunkl/quietcool-house-fan) firmware, CA can hear physical wall-remote timer presses (1/2/4/8/12 hours) via an HA event entity and honor them as the fan's manual-override grace duration — see [docs/fan-remote-spec.md](docs/fan-remote-spec.md) (Issue #486). Leave the field blank if you don't use this hardware; nothing changes.
 
 ### Learning Engine
 
@@ -501,6 +502,7 @@ See [Issue #11](https://github.com/gunkl/ClimateAdvisor/issues/11) for full trac
 - [x] AI Activity Report and Investigator's thermal-model sections no longer show an empty learning-health summary when the dashboard's Comfort Score sensor has real data for the same moment (#468)
 - [x] Chart's predicted-indoor curve can no longer silently disagree with its own displayed target band overnight when sleep temperatures aren't explicitly configured (#470)
 - [x] Continued consolidating the natural-ventilation decision surface (#429) into the rest of the codebase — a nat-vent floor formula, a fan-status suppression check, an occupancy-defer gate, and the dashboard's target-band resolver each converged from 2-4 independent copies down to one tested implementation, plus supporting test-infrastructure and coordinator-data cleanup (#452, #454, #456, #460, #464, #466)
+- [x] QuietCool RF wall-remote timer selections (1/2/4/8/12 hours) can now set the fan manual-override grace duration, so a physical remote timer press is honored instead of being overridden by CA's own automation partway through — optional, requires the `gunkl/quietcool-house-fan` firmware and a configured `fan_remote_entity` (#486)
 
 ### Phase 4: Seasonal & Cost Intelligence (v0.5+) — Future
 - [ ] Seasonal performance baselines (after 1 year of data)

--- a/custom_components/climate_advisor/api.py
+++ b/custom_components/climate_advisor/api.py
@@ -219,6 +219,10 @@ class ClimateAdvisorStatusView(HomeAssistantView):
             "contact_sensors": coordinator._compute_contact_details(),
             "manual_override_active": ae._manual_override_active or ae._override_confirm_pending,
             "fan_override_active": ae._fan_override_active,
+            # Issue #486: QuietCool RF remote timer selection, null unless a timer set the
+            # active fan override's grace duration.
+            "fan_remote_timer_hours": data.get("fan_remote_timer_hours"),
+            "fan_remote_timer_ends": data.get("fan_remote_timer_ends"),
             "paused_by_door": ae.is_paused_by_door,
             "ca_target_heat": _ca_target_heat,
             "ca_target_cool": _ca_target_cool,

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -530,6 +530,10 @@ class AutomationEngine:
         self._fan_on_since: str | None = None  # ISO timestamp
         self._fan_override_active: bool = False
         self._fan_override_time: str | None = None
+        # RF remote timer selection in hours, for observability only (Issue #486).
+        # None when the active override wasn't started by a remote timer, or the
+        # remote selected "no timer" (falls back to configured manual_grace_seconds).
+        self._fan_remote_timer_hours: float | None = None
         self._fan_command_pending: bool = False  # transient: distinguishes integration vs manual changes
         # HVAC mode captured before whole-house fan activation (Issue #277 Fix C).
         # Restored when the whole-house fan deactivates so AC/heat resumes.
@@ -799,12 +803,25 @@ class AutomationEngine:
             return 0.0
 
     def handle_fan_manual_override(
-        self, fan_before: str = "", fan_after: str = "", event_context_id: str | None = None
+        self,
+        fan_before: str = "",
+        fan_after: str = "",
+        event_context_id: str | None = None,
+        duration_override: float | None = None,
+        remote_timer_hours: float | None = None,
     ) -> None:
         """Handle a manual fan state change — sets fan override flag + grace (Issue #327).
 
         Idempotent: safe to call even if an override is already active (re-stamps the
         time and restarts the grace period so the timer is always fresh).
+
+        This is also the single entry point for QuietCool RF remote timer selections
+        (Issue #486, coordinator._async_fan_remote_changed) — a remote timer press is a
+        manual fan override just like any other, it just supplies its own grace
+        duration instead of using the configured default. Deliberately NOT a separate
+        method: the two callers must share the same override/grace bookkeeping so a
+        future change to one path can't silently stop covering the other (the
+        "sibling threshold drift" failure mode from #400/#402/#417/#456/#458).
 
         Args:
             fan_before: Fan state before the manual change (e.g. "on", "auto").
@@ -813,15 +830,24 @@ class AutomationEngine:
                 any (Issue #482) — surfaced in the Activity Report payload as diagnostic
                 provenance data so a future investigation of a genuinely-external fan
                 event doesn't need cross-source timestamp archaeology.
+            duration_override: When set (seconds), the grace period lasts exactly this
+                long instead of the configured manual_grace_seconds. Supplied by an RF
+                remote timer selection; None means "use the configured default"
+                (also the case for a plain physical fan-on with no timer info).
+            remote_timer_hours: The RF remote's selected timer duration in hours, for
+                observability only (dashboard/status display + serialized state). None
+                for a non-remote-triggered override, or when the remote picked "no timer".
         """
         self._stop_fan_min_runtime_cycles()
         self._fan_override_active = True
         self._fan_override_time = dt_util.now().isoformat()
+        self._fan_remote_timer_hours = remote_timer_hours
         _LOGGER.info(
-            "Fan override: set — manual fan change detected %s->%s, override active since %s, grace period starting",
+            "Fan override: set — manual fan change detected %s->%s, override active since %s, grace period starting%s",
             fan_before or "?",
             fan_after or "?",
             self._fan_override_time,
+            f" (RF remote timer: {remote_timer_hours}h)" if remote_timer_hours is not None else "",
         )
         if self._emit_event_callback:
             self._emit_event_callback(
@@ -832,9 +858,10 @@ class AutomationEngine:
                     "override_active_since": self._fan_override_time,
                     "fan_device": _fan_device_label(self.config),
                     "event_context_id": event_context_id,
+                    "remote_timer_hours": remote_timer_hours,
                 },
             )
-        self._start_grace_period("manual", trigger="fan_manual_override")
+        self._start_grace_period("manual", trigger="fan_manual_override", duration_override=duration_override)
 
     def on_fan_turned_off(self, fan_before: str = "", fan_after: str = "", event_context_id: str | None = None) -> None:
         """Handle the user turning the fan OFF — clears fan state and gates nat-vent re-activation (Issue #359).
@@ -869,6 +896,7 @@ class AutomationEngine:
             )
             self._fan_override_active = False
             self._fan_override_time = None
+            self._fan_remote_timer_hours = None
 
         if self._emit_event_callback:
             self._emit_event_callback(
@@ -956,6 +984,7 @@ class AutomationEngine:
             )
             self._fan_override_active = False
             self._fan_override_time = None
+            self._fan_remote_timer_hours = None
             # Restart the min-runtime cycle that was suspended when override was set
             self.hass.async_create_task(self.start_min_fan_runtime_cycles())
 
@@ -3056,13 +3085,27 @@ class AutomationEngine:
             return
 
         if self._fan_override_active:
-            _LOGGER.debug(
-                "Fan thermostat check: trigger=%s indoor=%s outdoor=%s active=%s decision=keep",
-                trigger,
-                f"{indoor:.1f}" if indoor is not None else "unavailable",
-                f"{outdoor:.1f}" if outdoor is not None else "unavailable",
-                True,
-            )
+            if self._fan_remote_timer_hours is not None:
+                # Issue #486: this is the second suppression choke point (fan_thermostat_check
+                # never reaches _deactivate_fan() when overridden — it returns "keep" directly),
+                # so it needs its own WARNING mirroring the one in _deactivate_fan() for the
+                # absolute-timer behavior to be observable regardless of which guard fires.
+                _LOGGER.warning(
+                    "Fan thermostat cycle-off suppressed by active RF remote timer (%sh):"
+                    " trigger=%s indoor=%s outdoor=%s",
+                    self._fan_remote_timer_hours,
+                    trigger,
+                    f"{indoor:.1f}" if indoor is not None else "unavailable",
+                    f"{outdoor:.1f}" if outdoor is not None else "unavailable",
+                )
+            else:
+                _LOGGER.debug(
+                    "Fan thermostat check: trigger=%s indoor=%s outdoor=%s active=%s decision=keep",
+                    trigger,
+                    f"{indoor:.1f}" if indoor is not None else "unavailable",
+                    f"{outdoor:.1f}" if outdoor is not None else "unavailable",
+                    True,
+                )
             return
 
         comfort_heat = float(self.config.get("comfort_heat", DEFAULT_COMFORT_HEAT))
@@ -3406,12 +3449,17 @@ class AutomationEngine:
         self._start_grace_period("manual", trigger="dashboard_resume")
         return restore_mode
 
-    def _start_grace_period(self, source: str, trigger: str = "") -> None:
+    def _start_grace_period(self, source: str, trigger: str = "", duration_override: float | None = None) -> None:
         """Start a grace period after HVAC is resumed.
 
         Args:
             source: "manual" for user-initiated overrides,
                     "automation" for Climate Advisor resumptions.
+            duration_override: When set (seconds), bypasses the configured manual
+                grace duration and uses this value instead. Used by RF-remote timer
+                selections (Issue #486) to make the grace period last exactly as
+                long as the user asked at the physical remote. Only meaningful when
+                source == "manual"; ignored otherwise.
 
         Architecture-reset Step 2 (session state machine slice): the
         duration/should_notify RESOLUTION now lives in
@@ -3424,9 +3472,14 @@ class AutomationEngine:
         self._cancel_grace_timers()
 
         now = dt_util.now()
+        manual_duration = (
+            duration_override
+            if (source == "manual" and duration_override is not None)
+            else self.config.get(CONF_MANUAL_GRACE_PERIOD, DEFAULT_MANUAL_GRACE_SECONDS)
+        )
         grace = decide_grace_start(
             source=source,
-            manual_duration_seconds=self.config.get(CONF_MANUAL_GRACE_PERIOD, DEFAULT_MANUAL_GRACE_SECONDS),
+            manual_duration_seconds=manual_duration,
             manual_should_notify=self.config.get(CONF_MANUAL_GRACE_NOTIFY, True),
             automation_duration_seconds=self.config.get(CONF_AUTOMATION_GRACE_PERIOD, DEFAULT_AUTOMATION_GRACE_SECONDS),
             automation_should_notify=self.config.get(CONF_AUTOMATION_GRACE_NOTIFY, True),
@@ -4818,7 +4871,18 @@ class AutomationEngine:
             return
 
         if self._fan_override_active:
-            _LOGGER.info("Fan override active — skipping fan deactivation")
+            if self._fan_remote_timer_hours is not None:
+                # Issue #486: the override is absolute while an RF remote timer is active —
+                # this shutoff (nat-vent exit, comfort-floor breach, cycle-off, etc.) is
+                # suppressed and logged as a WARNING (not silently dropped at INFO) so the
+                # "log-only" absolute-timer behavior is observable in HA logs.
+                _LOGGER.warning(
+                    "Fan deactivation suppressed by active RF remote timer (%sh) — reason: %s",
+                    self._fan_remote_timer_hours,
+                    reason,
+                )
+            else:
+                _LOGGER.info("Fan override active — skipping fan deactivation")
             return
 
         # Issue #392 Fix 1c: idempotency guard — collapse redundant re-decisions from
@@ -5192,6 +5256,9 @@ class AutomationEngine:
         # reconcile_fan_on_startup() runs shortly after and decides adopt-on / turn-off.
         self._fan_override_active = False
         self._fan_override_time = None
+        # Issue #486: an RF remote timer selection is part of the override it started —
+        # not persisted/restored, same as the rest of the override/grace clean slate above.
+        self._fan_remote_timer_hours = None
         _LOGGER.info(
             "Fan override: restart clean-slate — _fan_override_active and _fan_override_time "
             "cleared (Issue #327); reconcile will decide fan disposition"
@@ -5229,6 +5296,9 @@ class AutomationEngine:
             "fan_on_since": self._fan_on_since,
             "fan_override_active": self._fan_override_active,
             "fan_override_time": self._fan_override_time,
+            # Issue #486: RF remote timer hours, for observability only — like the two
+            # fields above, always cleared on restore() (clean-slate policy), not restored.
+            "fan_remote_timer_hours": self._fan_remote_timer_hours,
             "fan_min_runtime_active": self._fan_min_runtime_active,
             "pre_fan_hvac_mode": self._pre_fan_hvac_mode,
             "last_welcome_home_notified": (

--- a/custom_components/climate_advisor/config_flow.py
+++ b/custom_components/climate_advisor/config_flow.py
@@ -38,6 +38,7 @@ from .const import (
     CONF_FAN_ENTITY,
     CONF_FAN_MIN_RUNTIME_PER_HOUR,
     CONF_FAN_MODE,
+    CONF_FAN_REMOTE_ENTITY,
     CONF_FAN_STATE_ENTITY,
     CONF_FAN_STATE_FEEDBACK,
     CONF_GITHUB_REPO,
@@ -481,6 +482,10 @@ class ClimateAdvisorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         description={"suggested_value": False},
                     ): selector.BooleanSelector(),
                     vol.Optional(
+                        CONF_FAN_REMOTE_ENTITY,
+                        description={"suggested_value": None},
+                    ): selector.EntitySelector(selector.EntitySelectorConfig(domain="event")),
+                    vol.Optional(
                         CONF_FAN_MIN_RUNTIME_PER_HOUR,
                         default=DEFAULT_FAN_MIN_RUNTIME_PER_HOUR,
                     ): selector.NumberSelector(
@@ -863,7 +868,7 @@ class ClimateAdvisorOptionsFlow(config_entries.OptionsFlow):
             ):
                 if key in user_input:
                     user_input[key] = int(user_input[key] * 60)
-            self._apply_step_input(user_input, (CONF_FAN_ENTITY, CONF_FAN_STATE_ENTITY))
+            self._apply_step_input(user_input, (CONF_FAN_ENTITY, CONF_FAN_STATE_ENTITY, CONF_FAN_REMOTE_ENTITY))
             return await self.async_step_init()
 
         current = self.config_entry.data
@@ -962,6 +967,10 @@ class ClimateAdvisorOptionsFlow(config_entries.OptionsFlow):
                             )
                         },
                     ): selector.BooleanSelector(),
+                    vol.Optional(
+                        CONF_FAN_REMOTE_ENTITY,
+                        description={"suggested_value": current.get(CONF_FAN_REMOTE_ENTITY)},
+                    ): selector.EntitySelector(selector.EntitySelectorConfig(domain="event")),
                     vol.Optional(
                         CONF_FAN_MIN_RUNTIME_PER_HOUR,
                         default=current.get(CONF_FAN_MIN_RUNTIME_PER_HOUR, DEFAULT_FAN_MIN_RUNTIME_PER_HOUR),

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,21 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.18"
+VERSION = "0.5.19"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.19": [
+        "Feat #486: Climate Advisor can now hear the QuietCool whole-house fan's physical RF"
+        " wall remote (via the gunkl/quietcool-house-fan ESPHome firmware's event entity) and"
+        " honor a timer selection made at the remote. Previously, pressing '8 hours' on the"
+        " remote had no effect on CA's own automatic fan-off timing — CA would still shut the"
+        " fan off on its usual ~30-90 minute grace period, contradicting what the person just"
+        " told the fan to do. Now, when an optional Fan RF Remote Event Entity is configured,"
+        " a 1/2/4/8/12-hour remote timer selection sets the duration of CA's fan manual-override"
+        " grace period, so CA backs off for exactly as long as the user asked. Fully optional and"
+        " non-breaking: leave the field blank and nothing changes. See docs/fan-remote-spec.md"
+        " for the firmware event contract and mapping.",
+    ],
     "0.5.18": [
         "Fix #434: optional entity settings can now actually be cleared. Previously, if you'd set"
         " a Home/Away toggle, Vacation toggle, Guest toggle, fan entity, fan-state entity, or a"
@@ -1090,6 +1102,45 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    486: {
+        "version_fixed": "0.5.19",
+        "title": "QuietCool RF remote timer events set the fan manual-override grace duration",
+        "scope_covered": (
+            "Adds an optional CONF_FAN_REMOTE_ENTITY ('fan_remote_entity') config field (an HA"
+            " event entity, e.g. event.quietcool_remote from the gunkl/quietcool-house-fan"
+            " firmware). When set, coordinator._async_fan_remote_changed subscribes via"
+            " async_track_state_change_event and parses attributes['event_type'] with the new"
+            " pure helper fan_status.parse_remote_timer_event() against the single-source mapping"
+            " const.REMOTE_TIMER_EVENT_HOURS. Recognized timer tokens (timer_1h/2h/4h/8h/12h,"
+            " timer_none) call the EXISTING automation.handle_fan_manual_override(), extended with"
+            " an optional duration_override parameter (seconds) that is threaded through to the"
+            " existing _start_grace_period(); when set it bypasses decide_grace_start() and uses"
+            " the RF-supplied duration instead of the configured manual_grace_seconds. No new"
+            " override predicate or new suppression guard was added — the RF timer is a manual"
+            " override, so all existing suppression already funnels through the existing"
+            " _fan_override_active guard in _deactivate_fan() (nat-vent exit, comfort-floor"
+            " breach, standard cycle-off, min-runtime cycle-off all covered for free). A WARNING"
+            " is now logged at that guard when the suppressed reason is a comfort/hard-floor exit,"
+            " so absolute-timer behavior is observable. timer_none uses the configured grace"
+            " duration (no new default constant). Non-recognized event_type tokens (on/off/speed)"
+            " are explicitly out of scope for this feature and are ignored. Clearing/expiry rides"
+            " entirely on the existing physical fan-off detection and grace-expiry paths — no new"
+            " persistence; the RF timer state does not survive an HA restart, consistent with the"
+            " existing clean-slate override/grace reset in restore_state() (Issue #327/#282)."
+        ),
+        "scope_not_covered": (
+            "Speed tokens (low/medium/high) and explicit on/off event handling are NOT decoded or"
+            " acted on in this feature — only the timer_* family. The off/clear path depends on"
+            " fan_entity/fan_state_entity already being configured for physical fan-off detection;"
+            " if the WHF entity isn't configured, an RF-started override will only clear via grace"
+            " expiry, never via the remote's own hardware timer completing early. Because firmware"
+            " events are edge-triggered, a bare power-on that does not also change the timer field"
+            " may not emit timer_none, so CA may not start a grace period from a plain 'on' press"
+            " until an explicit timer token is sent. No safety-exception path was added: the"
+            " timer is fully absolute per the locked #486 decision — genuine safety conditions are"
+            " not modeled here and will log-only, same as any other manual fan override today."
+        ),
+    },
     434: {
         "version_fixed": "0.5.18",
         "title": "Optional entity config fields can be cleared (leaving a field blank now unsets it)",
@@ -4349,6 +4400,19 @@ DEFAULT_FAN_MODE = FAN_MODE_DISABLED
 CONF_FAN_MIN_RUNTIME_PER_HOUR = "fan_min_runtime_per_hour"
 DEFAULT_FAN_MIN_RUNTIME_PER_HOUR = 0  # minutes; 0 = disabled
 
+# QuietCool RF remote timer events (Issue #486)
+# Optional `event.*` entity from the gunkl/quietcool-house-fan ESPHome firmware.
+# See docs/fan-remote-spec.md for the full firmware event contract.
+CONF_FAN_REMOTE_ENTITY = "fan_remote_entity"
+REMOTE_TIMER_EVENT_HOURS = {
+    "timer_1h": 1.0,
+    "timer_2h": 2.0,
+    "timer_4h": 4.0,
+    "timer_8h": 8.0,
+    "timer_12h": 12.0,
+    "timer_none": None,  # remote's default: use configured manual_grace_seconds
+}
+
 # Natural ventilation mode (door/window open + outdoor air within comfort range)
 CONF_NATURAL_VENT_DELTA = "natural_vent_delta"
 # Ceiling tolerance above comfort_cool for nat vent.
@@ -4623,6 +4687,18 @@ CONFIG_METADATA = {
             "The fan or switch entity to control for whole-house ventilation."
             " Only used when fan mode is 'whole_house_fan' or 'both'."
         ),
+        "category": "fan",
+    },
+    "fan_remote_entity": {
+        "label": "Fan RF Remote Event Entity",
+        "description": (
+            "Optional event entity (e.g. from the gunkl/quietcool-house-fan ESPHome firmware) that"
+            " fires when the physical RF wall remote is pressed. When set, a remote timer selection"
+            " (1/2/4/8/12 hours) sets the duration of the fan manual-override grace period, so CA"
+            " honors the user's chosen runtime instead of the configured default. Leave blank to"
+            " disable — no subscription is created and behavior is unchanged."
+        ),
+        "sensitive": False,
         "category": "fan",
     },
     "fan_state_entity": {

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -82,6 +82,7 @@ from .const import (
     CONF_AUTOMATION_GRACE_PERIOD,
     CONF_FAN_ENTITY,
     CONF_FAN_MODE,
+    CONF_FAN_REMOTE_ENTITY,
     CONF_FAN_STATE_ENTITY,
     CONF_FAN_STATE_FEEDBACK,
     CONF_GUEST_TOGGLE,
@@ -217,7 +218,7 @@ from .const import (
     VACATION_SETBACK_EXTRA,
     VERSION,
 )
-from .fan_status import is_ca_fan_running
+from .fan_status import is_ca_fan_running, parse_remote_timer_event
 from .learning import DailyRecord, LearningEngine, compute_k_passive_blocks
 from .nat_vent_gate import NatVentGateInputs, decide_nat_vent_gate
 from .state import StatePersistence
@@ -533,6 +534,19 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                     self.hass,
                     _fan_state_entity,
                     self._async_fan_entity_changed,
+                )
+            )
+
+        # Listeners: fan RF remote event entity (Issue #486). Optional — when unset, no
+        # subscription is created and behavior is byte-for-byte unchanged from before this
+        # feature existed. See docs/fan-remote-spec.md for the firmware event contract.
+        fan_remote_entity = self.config.get(CONF_FAN_REMOTE_ENTITY)
+        if fan_remote_entity:
+            self._unsub_listeners.append(
+                async_track_state_change_event(
+                    self.hass,
+                    fan_remote_entity,
+                    self._async_fan_remote_changed,
                 )
             )
 
@@ -3681,6 +3695,43 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 fan_before=str(old_state.state), fan_after=str(new_state.state), event_context_id=event_context_id
             )
 
+    async def _async_fan_remote_changed(self, event: Event) -> None:
+        """Handle a QuietCool RF wall remote event (Issue #486).
+
+        `event` is a state-changed event for the configured ``fan_remote_entity`` (an
+        HA ``event.*`` entity — each remote press fires as a state change to a new
+        timestamp, with the decoded command in ``attributes['event_type']``). See
+        docs/fan-remote-spec.md for the firmware contract
+        (gunkl/quietcool-house-fan).
+
+        Only timer tokens are acted on this cut (timer_1h..timer_12h, timer_none);
+        everything else (on/off/speed, unknown, unavailable) is ignored — deliberately
+        not routed through a separate entry point (see handle_fan_manual_override()'s
+        docstring for why).
+        """
+        new_state = event.data.get("new_state")
+        if not new_state or new_state.state in ("unknown", "unavailable"):
+            return
+
+        event_type = new_state.attributes.get("event_type")
+        is_timer_event, hours = parse_remote_timer_event(event_type)
+        if not is_timer_event:
+            return
+
+        duration_seconds = hours * 3600 if hours is not None else None
+        _LOGGER.info(
+            "Fan RF remote timer event: event_type=%s -> duration=%s",
+            event_type,
+            f"{hours}h" if hours is not None else "configured default",
+        )
+        self.automation_engine.handle_fan_manual_override(
+            fan_before="?",
+            fan_after="on",
+            duration_override=duration_seconds,
+            remote_timer_hours=hours,
+        )
+        await self.async_request_refresh()
+
     async def _async_reassert_setpoint_after_fan_off(self) -> None:
         """Re-assert CA's intended setpoint after an ecobee fan-off echo (Issue #359 Fix A).
 
@@ -6790,6 +6841,9 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             "fan_runtime_minutes": ae._get_fan_runtime_minutes(),
             "fan_override_active": ae._fan_override_active,
             "fan_override_time": ae._fan_override_time,
+            # Issue #486: QuietCool RF remote timer selection, for status-card display only.
+            "fan_remote_timer_hours": ae._fan_remote_timer_hours,
+            "fan_remote_timer_ends": (ae._grace_end_time if ae._fan_remote_timer_hours is not None else None),
             "fan_mode_config": ae.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED),
             "economizer_active": ae._economizer_active,
             "economizer_phase": ae._economizer_phase,

--- a/custom_components/climate_advisor/fan_status.py
+++ b/custom_components/climate_advisor/fan_status.py
@@ -14,6 +14,8 @@ dependency-free utility module imported by both ``coordinator.py`` and
 
 from __future__ import annotations
 
+from .const import REMOTE_TIMER_EVENT_HOURS
+
 FAN_STATUS_ACTIVE_VALUES: frozenset[str] = frozenset(
     {
         "active",
@@ -39,3 +41,24 @@ def is_ca_fan_running(fan_status: str) -> bool:
     in that state to be misreported as a contradiction.
     """
     return fan_status in FAN_STATUS_ACTIVE_VALUES
+
+
+def parse_remote_timer_event(event_type: str | None) -> tuple[bool, float | None]:
+    """Parse a QuietCool RF remote ``event_type`` token into a timer decision.
+
+    `event_type` is read from an ``event.*`` entity's
+    ``attributes["event_type"]`` (see docs/fan-remote-spec.md for the firmware
+    contract — ``gunkl/quietcool-house-fan``). This is the single source of
+    truth for the token-to-hours mapping (``const.REMOTE_TIMER_EVENT_HOURS``);
+    callers must not re-implement the mapping inline (Issue #486, following the
+    "sibling threshold drift" lesson from #400/#402/#417/#456/#458).
+
+    Returns ``(is_timer_event, hours)``:
+    - Recognized timer token (``timer_1h``..``timer_12h``) -> ``(True, <hours>)``
+    - ``timer_none`` -> ``(True, None)`` (use CA's configured grace duration)
+    - Any other token (``on``, ``off``, speed tokens, unknown, ``None``) ->
+      ``(False, None)`` — out of scope for this feature; caller should ignore.
+    """
+    if event_type not in REMOTE_TIMER_EVENT_HOURS:
+        return False, None
+    return True, REMOTE_TIMER_EVENT_HOURS[event_type]

--- a/custom_components/climate_advisor/frontend/index.html
+++ b/custom_components/climate_advisor/frontend/index.html
@@ -982,18 +982,21 @@
         <div class="status-item">
           <div class="label">Fan (WHF)</div>
           <div class="value">${escapeHtml(String(data.whf_status))}</div>
+          ${data.fan_remote_timer_hours != null ? `<div class="value" style="font-size:0.85rem">remote timer: ${data.fan_remote_timer_hours}h${data.fan_remote_timer_ends ? ' (ends ' + new Date(data.fan_remote_timer_ends).toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'}) + ')' : ''}</div>` : ''}
         </div>
         ` : ''}
         ${data.hvac_fan_status != null ? `
         <div class="status-item">
           <div class="label">Fan (HVAC)</div>
           <div class="value">${escapeHtml(String(data.hvac_fan_status))}</div>
+          ${data.fan_remote_timer_hours != null ? `<div class="value" style="font-size:0.85rem">remote timer: ${data.fan_remote_timer_hours}h${data.fan_remote_timer_ends ? ' (ends ' + new Date(data.fan_remote_timer_ends).toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'}) + ')' : ''}</div>` : ''}
         </div>
         ` : ''}
         ${data.whf_status == null && data.hvac_fan_status == null ? `
         <div class="status-item">
           <div class="label">Fan</div>
           <div class="value">${escapeHtml(data.fan_status || 'disabled')}</div>
+          ${data.fan_remote_timer_hours != null ? `<div class="value" style="font-size:0.85rem">remote timer: ${data.fan_remote_timer_hours}h${data.fan_remote_timer_ends ? ' (ends ' + new Date(data.fan_remote_timer_ends).toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'}) + ')' : ''}</div>` : ''}
         </div>
         ` : ''}
         ${data.contact_sensors && data.contact_sensors.length > 0 ? `

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.18"
+  "version": "0.5.19"
 }

--- a/custom_components/climate_advisor/strings.json
+++ b/custom_components/climate_advisor/strings.json
@@ -71,6 +71,7 @@
           "override_confirm_seconds": "Override confirmation delay (minutes)",
           "fan_mode": "Fan Control Mode",
           "fan_entity": "Fan Entity",
+          "fan_remote_entity": "Fan RF Remote Event Entity",
           "fan_min_runtime_per_hour": "Fan Minimum Runtime Per Hour"
         },
         "data_description": {
@@ -82,6 +83,7 @@
           "override_confirm_seconds": "Time between system changes and confirmation of manual override. Transient events (thermostat restart, fan cycles) that resolve within this window are ignored automatically. Set to 0 to confirm overrides immediately.",
           "fan_mode": "How to control fans for ventilation. 'Whole house fan' controls a dedicated fan entity. 'HVAC fan' uses the thermostat fan mode.",
           "fan_entity": "The fan or switch entity to control (only needed for whole house fan mode).",
+          "fan_remote_entity": "Optional event entity that fires when the physical RF wall remote is pressed (e.g. from the gunkl/quietcool-house-fan firmware). A remote timer selection (1/2/4/8/12 hours) sets the fan override grace duration. Leave blank to disable.",
           "fan_min_runtime_per_hour": "Minutes of fan runtime per hour (0 = disabled, 60 = always on). The cycle is not clock-aligned \u00e2\u20ac\u201d it offsets naturally based on when HA started."
         }
       },
@@ -210,6 +212,7 @@
           "override_confirm_seconds": "Override confirmation delay (minutes)",
           "fan_mode": "Fan Control Mode",
           "fan_entity": "Fan Entity",
+          "fan_remote_entity": "Fan RF Remote Event Entity",
           "fan_min_runtime_per_hour": "Fan Minimum Runtime Per Hour",
           "natural_vent_delta": "Natural ventilation window (\u00c2\u00b0F above comfort)"
         },
@@ -222,6 +225,7 @@
           "override_confirm_seconds": "Time between system changes and confirmation of manual override. Transient events (thermostat restart, fan cycles) that resolve within this window are ignored automatically. Set to 0 to confirm overrides immediately.",
           "fan_mode": "How to control fans for ventilation. 'Whole house fan' controls a dedicated fan entity. 'HVAC fan' uses the thermostat fan mode.",
           "fan_entity": "The fan or switch entity to control (only needed for whole house fan mode).",
+          "fan_remote_entity": "Optional event entity that fires when the physical RF wall remote is pressed (e.g. from the gunkl/quietcool-house-fan firmware). A remote timer selection (1/2/4/8/12 hours) sets the fan override grace duration. Leave blank to disable.",
           "fan_min_runtime_per_hour": "Minutes of fan runtime per hour (0 = disabled, 60 = always on). The cycle is not clock-aligned \u00e2\u20ac\u201d it offsets naturally based on when HA started.",
           "natural_vent_delta": "When a door or window opens and outdoor temperature is within this many degrees above your cooling comfort setpoint, Climate Advisor uses the fan for natural ventilation instead of pausing HVAC. Default is 3\u00c2\u00b0F."
         }

--- a/custom_components/climate_advisor/translations/en.json
+++ b/custom_components/climate_advisor/translations/en.json
@@ -73,6 +73,7 @@
           "fan_entity": "Fan Entity",
           "fan_state_entity": "Fan State Entity",
           "fan_state_feedback": "Fan state feedback reliable",
+          "fan_remote_entity": "Fan RF Remote Event Entity",
           "fan_min_runtime_per_hour": "Fan Minimum Runtime Per Hour"
         },
         "data_description": {
@@ -86,6 +87,7 @@
           "fan_entity": "The fan or switch entity to control (only needed for whole house fan mode).",
           "fan_state_entity": "Optional separate sensor to read the physical fan state (for dual-entity whole-house fans). Leave blank to use the Fan Entity for state as well.",
           "fan_state_feedback": "Turn ON if your fan entity or state sensor reports actual motor state (not just the last command sent). Leave OFF if unsure \u2014 CA will command the fan to the desired state on each cycle.",
+          "fan_remote_entity": "Optional event entity that fires when the physical RF wall remote is pressed (e.g. from the gunkl/quietcool-house-fan firmware). A remote timer selection (1/2/4/8/12 hours) sets the fan override grace duration. Leave blank to disable.",
           "fan_min_runtime_per_hour": "Minutes of fan runtime per hour (0 = disabled, 60 = always on). The cycle is not clock-aligned \u00e2\u20ac\u201d it offsets naturally based on when HA started."
         }
       },
@@ -216,6 +218,7 @@
           "fan_entity": "Fan Entity",
           "fan_state_entity": "Fan State Entity",
           "fan_state_feedback": "Fan state feedback reliable",
+          "fan_remote_entity": "Fan RF Remote Event Entity",
           "fan_min_runtime_per_hour": "Fan Minimum Runtime Per Hour",
           "natural_vent_delta": "Natural ventilation window (\u00c2\u00b0F above comfort)"
         },
@@ -230,6 +233,7 @@
           "fan_entity": "The fan or switch entity to control (only needed for whole house fan mode).",
           "fan_state_entity": "Optional separate sensor to read the physical fan state (for dual-entity whole-house fans). Leave blank to use the Fan Entity for state as well.",
           "fan_state_feedback": "Turn ON if your fan entity or state sensor reports actual motor state (not just the last command sent). Leave OFF if unsure \u2014 CA will command the fan to the desired state on each cycle.",
+          "fan_remote_entity": "Optional event entity that fires when the physical RF wall remote is pressed (e.g. from the gunkl/quietcool-house-fan firmware). A remote timer selection (1/2/4/8/12 hours) sets the fan override grace duration. Leave blank to disable.",
           "fan_min_runtime_per_hour": "Minutes of fan runtime per hour (0 = disabled, 60 = always on). The cycle is not clock-aligned \u00e2\u20ac\u201d it offsets naturally based on when HA started.",
           "natural_vent_delta": "When a door or window opens and outdoor temperature is within this many degrees above your cooling comfort setpoint, Climate Advisor uses the fan for natural ventilation instead of pausing HVAC. Default is 3\u00c2\u00b0F."
         }

--- a/docs/00-PROJECT-INSTRUCTIONS.md
+++ b/docs/00-PROJECT-INSTRUCTIONS.md
@@ -37,6 +37,7 @@ You are helping David build, iterate on, and improve **Climate Advisor**, a cust
 | How does the production simulation harness work — what replaced the old ClimateSimulator, and what are Tier A vs Tier B? | Issue #236 eliminated the standalone simulator. `tools/sim_harness/` drives the real `AutomationEngine` headless (FakeHass + FakeScheduler). Tier A runs every commit; Tier B (HeadlessTarry) covers coordinator state-listener timing and restart behavior. | [Sim Harness Brief](sim-harness-brief.md) |
 | What are the harness modules — FakeHass, FakeScheduler, build_engine, run_production, outcomes — and how do they fit together? | FakeHass intercepts service calls → action_log; FakeScheduler is a virtual clock priority queue; build_engine assembles the headless engine; run_production dispatches scenario events; outcomes maps event_log to legacy assertion vocab. | [Sim Harness Spec](sim-harness-spec.md) |
 | hacs-compliance | HACS compliance requirements, manifest fields, review process, maintenance rules | [docs/hacs-compliance.md](hacs-compliance.md) |
+| How does CA hear a QuietCool RF wall remote timer selection, and what does it do? | Optional `fan_remote_entity` (HA `event.*` entity from the `gunkl/quietcool-house-fan` firmware). A timer press calls the SAME `handle_fan_manual_override()` as physical fan-on detection, with an optional duration override — no new predicate, absolute/log-only suppression via the existing override guard. | [Fan Remote Spec](fan-remote-spec.md) |
 
 ## Context
 

--- a/docs/08-COMPUTATION-REFERENCE.md
+++ b/docs/08-COMPUTATION-REFERENCE.md
@@ -2184,6 +2184,7 @@ This is the definitive reference for expected system behavior across all classif
 | E6 | Classification changes (e.g., warm→hot) |
 | E7 | User clicks "Resume HVAC (override pause)" |
 | E8 | HA restart — coalesce reconciliation fires (Issue #327) |
+| E9 | QuietCool RF remote timer event received (Issue #486) |
 
 ### Expected Outcomes
 
@@ -2206,6 +2207,8 @@ This is the definitive reference for expected system behavior across all classif
 **Thermostatic fan loop (Issue #327, §9e):** In all C1–C7 contexts, once the fan is CA-owned and running, `fan_thermostat_check()` re-evaluates on every indoor or outdoor temperature change. The fan is turned off immediately when `outdoor ≥ indoor` — it does not wait for the next 30-minute coordinator poll. See §9e for the full exit hierarchy and trigger-source table.
 
 **Restart reconciliation (E8, Issue #327, §9e):** `_fan_override_active` is always cleared on restart; `_do_startup_coalesce` decides adopt-on, turn-off, or no-fan based on live thermostat state. E8 applies uniformly to all contexts — the decision depends on current physical conditions, not the day classification.
+
+**RF remote timer event (E9, Issue #486):** Applies uniformly to all C1–C7 contexts — like E8, the decision does not depend on day classification. A recognized `timer_*` token calls the same `handle_fan_manual_override()` as E5 (fan manual change), with an optional `duration_override` that makes the grace period last exactly the remote-selected duration instead of the configured `manual_grace_seconds`. While that override is active, suppression is absolute (log-only WARNING) at both existing choke points (`_deactivate_fan()`, `fan_thermostat_check()`) — E1/E2/E3/E6's fan-off outcomes in every context above are suppressed exactly as they are for any other active manual fan override. See [fan-remote-spec.md](fan-remote-spec.md) for the full event contract.
 
 **Archetype-aware nat-vent ceiling and structural WHF/AC exclusion (Issue #392):** In C2/C3/C5, E1/E3 (reactivation) now consistently apply the archetype-aware ceiling threshold from §6c/§17 across all four reactivation gate sites (`handle_door_window_open()`, `check_natural_vent_conditions()`, `nat_vent_temperature_check()`, `_re_pause_for_open_sensor()`) — `FAN_MODE_HVAC` blocks reactivation once indoor exceeds `comfort_cool` (unchanged from before #392); `FAN_MODE_WHOLE_HOUSE`/`FAN_MODE_BOTH` reactivates purely on outdoor/indoor direction. In E5/E6, `apply_classification()` now short-circuits before the comfort-band write when a WHF session owns the thermostat (§9), and the `_whf_owns_hvac()` choke-point guard in `_set_hvac_mode()`/`_set_temperature()` (§9) makes WHF/AC mutual exclusion structural for every cell in this table, not just the ones exercised by nat-vent. All six automation entry points relevant to this table (`apply_classification`, `handle_door_window_open`, `handle_all_doors_windows_closed`, `check_natural_vent_conditions`, `_re_pause_for_open_sensor`, `nat_vent_temperature_check`) are additionally serialized by `self._decision_lock` (§9g) so that concurrent E1/E3/E5/E6 triggers cannot interleave on shared engine state.
 
@@ -2236,6 +2239,12 @@ This logic table MUST be kept current for any changes to automation behavior.
 | All×E1/E2/E3/E5/E6 (idempotent `_activate_fan()`/`_deactivate_fan()`; no duplicate `fan_activated`/`fan_deactivated` on redundant calls) | test_fan_control.py | Issue #392 Fix 1c — function names pending as of this doc pass |
 | All×E1/E2/E3/E5/E6 (`_decision_lock` serializes the six entry points; no interleaved execution under `asyncio.gather()`) | test_nat_vent_activation.py | Issue #392 Fix 3 — function names pending as of this doc pass |
 | Fan archetype activity-log labels (`fan_activated`/`fan_deactivated`/`fan_manual_override`/`fan_cancel` render `fan_device`) | test_activity_renderers.py | Issue #392 Fix 2 — function names pending as of this doc pass |
+| All×E9 (`event_type` → hours parse, all timer tokens + non-timer ignored) | test_fan_remote.py | TestParseRemoteTimerEvent |
+| All×E9 (`duration_override` sets exact grace duration; `timer_none`/physical path use configured default) | test_fan_remote.py | TestDurationWiring |
+| C1/C6/C7×E1/E3/E5/E6 (`_deactivate_fan`/`fan_thermostat_check` suppressed + WARNING while E9 timer active) | test_fan_remote.py | TestSuppressionAbsoluteWithRemoteTimer |
+| All×E9 (last-wins refresh; grace expiry clears override and resumes) | test_fan_remote.py | TestLastWinsRefresh, TestGraceExpiryResumes |
+| All×E8/E9 (RF timer does not survive restart — clean-slate) | test_fan_remote.py | TestRestartCleanSlate |
+| All×E9 (coordinator dispatch: event → shared `handle_fan_manual_override()`) | test_fan_remote.py | TestCoordinatorFanRemoteDispatch |
 
 ---
 

--- a/docs/fan-remote-spec.md
+++ b/docs/fan-remote-spec.md
@@ -1,0 +1,200 @@
+<!-- Nav: ← [grace-periods-spec.md](grace-periods-spec.md) | → [automation.py](../custom_components/climate_advisor/automation.py) + [coordinator.py](../custom_components/climate_advisor/coordinator.py) + [fan_status.py](../custom_components/climate_advisor/fan_status.py) | ↔ [08-COMPUTATION-REFERENCE.md](08-COMPUTATION-REFERENCE.md) -->
+
+# QuietCool RF Remote Timer Events — Territory Spec (Tier 3)
+
+## Anchors
+
+| Question | Short answer | → Full answer |
+|---|---|---|
+| What does the occupant experience when they press a timer on the physical remote? | The whole-house fan runs for exactly the selected duration (1/2/4/8/12 hours) without Climate Advisor's own automation shutting it off partway through, the way it would with an un-communicated manual override. | [§ Occupant Impact](#occupant-impact) |
+| What entity/attribute does the firmware expose, and what values does it emit? | An HA `event.*` entity (e.g. `event.quietcool_remote`). Each firmware-decoded remote press fires a state change with the command in `attributes["event_type"]`. Timer tokens: `timer_1h`, `timer_2h`, `timer_4h`, `timer_8h`, `timer_12h`, `timer_none`. | [§ Firmware Event Contract](#firmware-event-contract) |
+| How does a timer selection map onto CA's existing grace mechanics? | It does NOT create a new predicate. A timer press calls the SAME `handle_fan_manual_override()` the physical-fan-on detection path already uses, with an optional `duration_override` (seconds) that bypasses the configured `manual_grace_seconds` for that one override. | [§ Design — One Entry Point](#design--one-entry-point) |
+| Is the timer absolute, or can a safety/comfort condition still turn the fan off? | Fully absolute (log-only) by design decision (2026-07-12). Every existing fan-off decision path is suppressed exactly as it is for any other manual fan override; a WARNING is logged instead of silently dropping the suppressed decision, so the behavior is observable in HA logs. | [§ Suppression Is Absolute](#suppression-is-absolute) |
+| What happens to an active RF timer across an HA restart? | Nothing survives — it is not persisted. This matches CA's existing clean-slate policy for all override/grace state (Issue #327/#282); `restore_state()` resets `_fan_remote_timer_hours` to `None` alongside `_fan_override_active`. | [§ Restart Behavior](#restart-behavior) |
+| What clears an RF-timer-driven override? | The same two paths that clear any manual fan override: (1) the fan physically turns off (detected via `fan_entity`/`fan_state_entity`, routed to `on_fan_turned_off()`), or (2) the grace timer naturally expires (`_on_grace_expired()`). There is no separate "remote timer expired" detection — CA relies on the fan's own physical state. | [§ Clearing](#clearing) |
+| What is out of scope for this feature? | Speed tokens (`low`/`medium`/`high`) and explicit `on`/`off` event handling are not decoded or acted on. Only the `timer_*` family drives behavior. | [§ Scope](#scope) |
+
+---
+
+## Scope
+
+**Files:**
+- `custom_components/climate_advisor/fan_status.py` — `parse_remote_timer_event()`, the single source of truth for the event-token → hours mapping
+- `custom_components/climate_advisor/const.py` — `CONF_FAN_REMOTE_ENTITY`, `REMOTE_TIMER_EVENT_HOURS`
+- `custom_components/climate_advisor/coordinator.py` — subscription (`async_setup`) + `_async_fan_remote_changed()` dispatch handler
+- `custom_components/climate_advisor/automation.py` — `handle_fan_manual_override(duration_override=...)`, `_start_grace_period(duration_override=...)`, the suppression WARNING at `_deactivate_fan()` and `fan_thermostat_check()`
+
+**Out of scope for this spec** (see [grace-periods-spec.md](grace-periods-spec.md) for the general grace-period mechanics this feature reuses):
+- Speed tokens (`low`/`medium`/`high`) — firmware decodes and emits these, CA does not act on them this cut
+- Explicit `on`/`off` event tokens — CA relies on physical fan-entity state changes for on/off detection instead (see [§ Firmware Event Contract](#firmware-event-contract) for why)
+- Any change to the general manual-override/grace state machine — this feature only adds an optional duration override to the existing mechanism
+
+---
+
+## Occupant Impact
+
+Someone in the home presses "8 hours" on the QuietCool wall remote to run the whole-house
+fan overnight. Without this feature, Climate Advisor has no way to know a timer was
+selected — it only detects "the fan turned on," and after its own configured grace period
+(default 30 minutes; commonly configured longer, e.g. 90 minutes) its automation can shut
+the fan off, contradicting what the person just told the fan to do. With this feature, CA
+hears the remote's timer selection and backs off for exactly that long instead.
+
+---
+
+## Firmware Event Contract
+
+Source: [`gunkl/quietcool-house-fan`](https://github.com/gunkl/quietcool-house-fan) — an
+ESPHome component for QuietCool whole-house attic fans (ESP32 + CC1101 radio). The fork
+extends the upstream transmit-only component with **receive** capability: it decodes RF
+packets from the physical wall remote and exposes them to Home Assistant as an **event
+entity**.
+
+- **Entity:** `event.quietcool_remote` (HA `event` platform — user-configured entity ID
+  in CA via `fan_remote_entity`, see [§ Config](#config)).
+- **On each fire:** the entity's *state* becomes the ISO timestamp of the fire; the decoded
+  command is in `attributes["event_type"]`.
+- **Edge-triggered:** the firmware's `on_packet` handler fires the event only when a
+  decoded field's value *changes* from its last-held value — the remote periodically
+  re-broadcasts a beacon with the same command, and duplicates are suppressed in firmware,
+  not in CA.
+- **Recognized `event_type` tokens** (RF command codes in parentheses):
+
+  | Token | RF code | CA action this cut |
+  |---|---|---|
+  | `timer_1h` | `0x91` | Fan override, grace = 3600 s |
+  | `timer_2h` | `0x92` | Fan override, grace = 7200 s |
+  | `timer_4h` | `0x94` | Fan override, grace = 14400 s |
+  | `timer_8h` | `0x98` | Fan override, grace = 28800 s |
+  | `timer_12h` | `0x9C` | Fan override, grace = 43200 s |
+  | `timer_none` | `0x9F` | Fan override, grace = configured `manual_grace_seconds` |
+  | `on` | `0xBF` | Ignored this cut (see [§ Scope](#scope)) |
+  | `off` | `0x80`/`0xB0` | Ignored this cut — CA relies on physical fan-entity state instead |
+  | `low`/`medium`/`high` | `0x1F`/`0x2F`/`0x3F` | Ignored this cut |
+
+- **Known firmware guidance:** `off` is the only definitive power-down signal in the raw
+  protocol; any other token confirms the fan is active. CA does not rely on this for
+  power state — see the next point.
+
+**Why CA doesn't act on the `on`/`off` tokens:** because events are edge-triggered, a bare
+power-on that doesn't also change the timer field may not emit any token CA needs to react
+to, and a power-off might arrive out of order relative to the physical fan entity's own
+state change. CA already has a robust, tested physical-state detection path
+(`fan_entity`/`fan_state_entity` + `_async_fan_entity_changed()`) for on/off — duplicating
+that logic against a second, less deterministic signal would be exactly the kind of
+"sibling threshold drift" this codebase has been burned by before (#400/#402/#417/#456/#458).
+The remote integration's sole job is to supply the **duration** when a timer is pressed;
+everything else about fan on/off state continues to flow through the existing path.
+
+---
+
+## Design — One Entry Point
+
+**This section revises the original design in GitHub issue #486**, which proposed a
+separate absolute predicate (`_user_fan_timer_holds()`) and a new engine method. Neither
+was implemented. Instead:
+
+1. **A remote timer press is a manual fan override that supplies its own grace duration.**
+   `coordinator._async_fan_remote_changed()` parses the event and calls the SAME
+   `automation.handle_fan_manual_override()` the physical-fan-on detection path already
+   calls — passing an optional `duration_override` (seconds) and `remote_timer_hours`
+   (for observability only).
+2. **`_start_grace_period()`** gained a matching optional `duration_override` parameter.
+   When set (and `source == "manual"`), it bypasses `desired_state.decide_grace_start()`'s
+   normal resolution of `manual_grace_seconds` and uses the RF-supplied duration instead.
+   `duration_override=None` (the case for `timer_none` and for the pre-existing
+   physical-fan-on callsite) falls through to the configured default, unchanged.
+3. **The token → hours mapping lives once**, in `const.REMOTE_TIMER_EVENT_HOURS`, parsed by
+   the pure helper `fan_status.parse_remote_timer_event()`. No caller re-implements the
+   mapping inline.
+4. **Last-wins:** pressing a second timer while one is already active re-stamps the
+   override and restarts the grace period at the new duration (same idempotency guarantee
+   `handle_fan_manual_override()` already provided before this feature).
+
+```
+Remote press (event.quietcool_remote fires, event_type=timer_8h)
+  → coordinator._async_fan_remote_changed()
+      → fan_status.parse_remote_timer_event("timer_8h") -> (True, 8.0)
+      → automation_engine.handle_fan_manual_override(duration_override=28800, remote_timer_hours=8.0)
+          → _fan_override_active = True
+          → _fan_remote_timer_hours = 8.0
+          → _start_grace_period("manual", duration_override=28800)
+              → grace expires in exactly 28800s, not the configured manual_grace_seconds
+```
+
+---
+
+## Suppression Is Absolute
+
+Per the locked decision (2026-07-12), while an RF timer is active, hard comfort-floor and
+safety-adjacent shutoff decisions are suppressed — logged, never overridden. This is
+delivered by the **existing** override guard, not a new one:
+
+- `_deactivate_fan()` already returns early when `_fan_override_active` is `True` — this is
+  the choke point every CA-initiated fan-off funnels through (nat-vent exit, comfort-floor
+  breach in both `check_natural_vent_conditions()` and `nat_vent_temperature_check()`,
+  standard cycle-off, min-runtime cycle-off).
+- `fan_thermostat_check()` has its own equivalent guard (it returns `"keep"` directly
+  without ever reaching `_deactivate_fan()`), so it needs its own log line.
+
+Both guards now check `_fan_remote_timer_hours is not None` and, when true, log a WARNING
+(instead of the pre-existing INFO/DEBUG line used for a plain, non-RF manual override) —
+so a suppressed automatic shutoff while a remote timer is active is visible in HA logs, not
+silently dropped. No new predicate was added; a plain manual fan override (started by
+physically toggling the fan, not via a remote timer) is unaffected and continues to log at
+its pre-existing level.
+
+---
+
+## Restart Behavior
+
+Consistent with CA's clean-slate policy for override/grace state (Issue #327/#282), an
+active RF timer does **not** survive an HA restart:
+
+- `_fan_remote_timer_hours` is included in `get_serializable_state()` for observability
+  only (dashboard/status display), never restored.
+- `restore_state()` explicitly resets `_fan_remote_timer_hours = None` in the same
+  clean-slate block that resets `_fan_override_active`/`_fan_override_time`/`_grace_active`.
+- After a restart, `reconcile_fan_on_startup()` (unchanged) decides the fan's disposition
+  from physical state, the same as it always has.
+
+---
+
+## Clearing
+
+There is no dedicated "remote timer expired" detection. An RF-timer-driven override clears
+via the same two paths as any other manual fan override:
+
+1. **Physical fan-off** — when the QuietCool's own hardware timer completes (or the user
+   powers off at the remote/thermostat), the physical fan entity transitions to off. If
+   `fan_entity`/`fan_state_entity` is configured, `_async_fan_entity_changed()` detects
+   this and routes to `on_fan_turned_off()`, which clears the override.
+   **Dependency:** without a configured fan entity for physical-state detection, this path
+   does not fire — the override only clears via grace expiry (below).
+2. **Grace expiry** — `_on_grace_expired()` fires at the RF-supplied duration and clears
+   the override through the existing three-branch expiry logic (see
+   [grace-periods-spec.md § Timer Lifecycle](grace-periods-spec.md#timer-lifecycle)).
+
+---
+
+## Config
+
+- `fan_remote_entity` (`CONF_FAN_REMOTE_ENTITY`) — optional HA `event` domain entity
+  selector, in the same config-flow step (`sensors`) as the other fan fields. **Unset ⇒ no
+  subscription is created ⇒ zero behavior change** from before this feature existed.
+- No new default constants were added. `timer_none` and the pre-existing physical-fan-on
+  path both continue to use the already-configurable `manual_grace_seconds`
+  (`DEFAULT_MANUAL_GRACE_SECONDS = 1800`, i.e. 30 minutes).
+
+---
+
+## Code Reference
+
+- [`parse_remote_timer_event`](../custom_components/climate_advisor/fan_status.py) — token → hours mapping (pure)
+- [`REMOTE_TIMER_EVENT_HOURS`](../custom_components/climate_advisor/const.py) — the single-source mapping table
+- [`_async_fan_remote_changed`](../custom_components/climate_advisor/coordinator.py) — event dispatch
+- [`handle_fan_manual_override`](../custom_components/climate_advisor/automation.py) — shared entry point (RF + physical paths)
+- [`_start_grace_period`](../custom_components/climate_advisor/automation.py) — `duration_override` resolution
+- [`_deactivate_fan`](../custom_components/climate_advisor/automation.py) — primary suppression choke point + WARNING
+- [`fan_thermostat_check`](../custom_components/climate_advisor/automation.py) — secondary suppression choke point + WARNING
+- Tests: `tests/test_fan_remote.py`

--- a/docs/grace-periods-spec.md
+++ b/docs/grace-periods-spec.md
@@ -92,8 +92,9 @@ the fan's current state (command tracking vs. physical state read).
 2. User manually changes fan state — `handle_fan_manual_override()` calls `_start_grace_period("manual")` directly.
 3. User presses "Resume" on the dashboard — `resume_from_pause()` clears the pause and calls `_start_grace_period("manual")`.
 4. A manual thermostat override is confirmed after the `CONF_OVERRIDE_CONFIRM_PERIOD` window — `_confirm_override()` calls `_start_grace_period("manual")`.
+5. **(Issue #486)** User selects a timer duration on the QuietCool RF wall remote — `coordinator._async_fan_remote_changed()` calls the SAME `handle_fan_manual_override()` as trigger #2, but with an optional `duration_override` (seconds) that makes the grace period last exactly as long as the remote's selected timer instead of the configured default. See [fan-remote-spec.md](fan-remote-spec.md) for the full firmware event contract and mapping.
 
-**Duration:** Configurable via `CONF_MANUAL_GRACE_PERIOD` (`manual_grace_seconds`). Default: `DEFAULT_MANUAL_GRACE_SECONDS = 1800` seconds (30 minutes). A configured value of 0 disables manual grace entirely (timer is not started, `_grace_active` remains `False`).
+**Duration:** Configurable via `CONF_MANUAL_GRACE_PERIOD` (`manual_grace_seconds`). Default: `DEFAULT_MANUAL_GRACE_SECONDS = 1800` seconds (30 minutes). A configured value of 0 disables manual grace entirely (timer is not started, `_grace_active` remains `False`). **Exception:** an RF remote timer (trigger #5 above) overrides this with its own duration via `_start_grace_period(duration_override=...)`.
 
 **What it suppresses:** During active manual grace, `handle_door_window_open()` checks `self._grace_active` early (L1053–L1066). If grace is active AND outdoor temperature is at or above `nat_vent_threshold` (i.e., outdoor is NOT cool enough for natural ventilation), the method returns immediately without pausing HVAC. If outdoor is cool enough for natural ventilation, execution falls through to the nat-vent path — grace does not suppress nat-vent activation.
 

--- a/tests/test_config_metadata.py
+++ b/tests/test_config_metadata.py
@@ -34,6 +34,7 @@ EXPECTED_KEYS = {
     "fan_entity",
     "fan_state_entity",
     "fan_state_feedback",
+    "fan_remote_entity",
     "fan_min_runtime_per_hour",
     "wake_time",
     "sleep_time",

--- a/tests/test_fan_remote.py
+++ b/tests/test_fan_remote.py
@@ -1,0 +1,490 @@
+"""Tests for Issue #486: QuietCool RF remote timer events set the fan override grace duration.
+
+Covers:
+- fan_status.parse_remote_timer_event(): the single source of truth for token->hours mapping
+- handle_fan_manual_override(duration_override=...): shared entry point, RF path and physical
+  path both use it; RF supplies its own duration, physical path uses the configured default
+- Suppression is absolute while an RF timer is active, at BOTH existing choke points
+  (_deactivate_fan and fan_thermostat_check) — with a WARNING logged (not silently dropped
+  at INFO), so a future refactor that decouples the RF timer from _fan_override_active would
+  make one of these tests fail loudly instead of silently regressing (the #400/#402/#417/#456
+  "sibling threshold drift" failure mode this plan was explicitly designed to avoid).
+- Last-wins duration refresh, grace-expiry resumption, restart clean-slate
+- Coordinator dispatch: _async_fan_remote_changed() parses the event and drives the SAME
+  handle_fan_manual_override() the physical-detection path already uses (no new method)
+
+Coordinator infrastructure note: ClimateAdvisorCoordinator cannot be instantiated without a
+live HA instance (see test_fan_cancel.py). Coordinator-dispatch tests here follow the same
+minimal-stub + importlib pattern used there, to avoid stale __globals__ from test_occupancy.py
+module deletion.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+import types
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Ensure HA stubs are installed before any coordinator import.
+if "homeassistant" not in sys.modules:
+    from tools.sim_harness.ha_stubs import install_ha_stubs
+
+    install_ha_stubs()
+
+sys.modules["homeassistant.util.dt"].now = lambda: datetime(2026, 7, 12, 20, 0, 0)
+
+from custom_components.climate_advisor.automation import AutomationEngine  # noqa: E402
+from custom_components.climate_advisor.const import (  # noqa: E402
+    CONF_FAN_REMOTE_ENTITY,
+    CONF_MANUAL_GRACE_NOTIFY,
+    CONF_MANUAL_GRACE_PERIOD,
+    DEFAULT_MANUAL_GRACE_SECONDS,
+)
+from custom_components.climate_advisor.fan_status import parse_remote_timer_event  # noqa: E402
+
+_PATCH_CALL_LATER = "custom_components.climate_advisor.automation.async_call_later"
+_PATCH_CALLBACK = "custom_components.climate_advisor.automation.callback"
+_PATCH_DT_NOW = "custom_components.climate_advisor.automation.dt_util.now"
+_FIXED_NOW = datetime(2026, 7, 12, 20, 0, 0)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _consume_coroutine(coro):
+    """Close coroutine to prevent 'never awaited' warnings."""
+    coro.close()
+
+
+def _make_automation_engine(config_overrides: dict | None = None) -> AutomationEngine:
+    """Create a real AutomationEngine with mocked HA dependencies (mirrors test_grace_convergence.py)."""
+    hass = MagicMock()
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+    hass.async_create_task = MagicMock(side_effect=_consume_coroutine)
+    hass.states = MagicMock()
+
+    config = {
+        "comfort_heat": 70,
+        "comfort_cool": 75,
+        "setback_heat": 60,
+        "setback_cool": 80,
+        "notify_service": "notify.notify",
+        "fan_mode": "whole_house_fan",
+        CONF_MANUAL_GRACE_PERIOD: DEFAULT_MANUAL_GRACE_SECONDS,
+        CONF_MANUAL_GRACE_NOTIFY: False,
+    }
+    if config_overrides:
+        config.update(config_overrides)
+
+    return AutomationEngine(
+        hass=hass,
+        climate_entity="climate.thermostat",
+        weather_entity="weather.forecast_home",
+        door_window_sensors=["binary_sensor.front_door"],
+        notify_service=config["notify_service"],
+        config=config,
+    )
+
+
+def _make_mock_engine() -> MagicMock:
+    """Build a MagicMock engine with all boolean flags explicitly False (mirrors test_fan_cancel.py)."""
+    ae = MagicMock(spec=AutomationEngine)
+    ae._fan_active = False
+    ae._fan_override_active = False
+    ae._natural_vent_active = False
+    ae._grace_active = False
+    ae._fan_command_pending = False
+    ae._hvac_command_pending = False
+    ae._temp_command_pending = False
+    ae._manual_override_active = False
+    ae._override_confirm_pending = False
+    ae._fan_remote_timer_hours = None
+    ae.handle_fan_manual_override = MagicMock()
+    return ae
+
+
+def _make_fake_state(state_str: str, attributes: dict | None = None) -> MagicMock:
+    s = MagicMock()
+    s.state = state_str
+    s.attributes = attributes or {}
+    return s
+
+
+def _make_fake_event(new_state) -> MagicMock:
+    ev = MagicMock()
+    ev.data = {"new_state": new_state}
+    return ev
+
+
+def _make_coordinator_stub(config: dict | None = None) -> MagicMock:
+    """Minimal coordinator stub sufficient for _async_fan_remote_changed (mirrors test_fan_cancel.py)."""
+    config = config or {CONF_FAN_REMOTE_ENTITY: "event.quietcool_remote"}
+    hass = MagicMock()
+    hass.async_create_task = MagicMock(side_effect=_consume_coroutine)
+
+    coord = MagicMock()
+    coord.hass = hass
+    coord.config = config
+    coord.automation_engine = _make_mock_engine()
+    coord.async_request_refresh = AsyncMock()
+    return coord
+
+
+# ---------------------------------------------------------------------------
+# 1. parse_remote_timer_event()
+# ---------------------------------------------------------------------------
+
+
+class TestParseRemoteTimerEvent:
+    """fan_status.parse_remote_timer_event() — single source of truth for the token mapping."""
+
+    def test_all_timer_hours_tokens(self):
+        assert parse_remote_timer_event("timer_1h") == (True, 1.0)
+        assert parse_remote_timer_event("timer_2h") == (True, 2.0)
+        assert parse_remote_timer_event("timer_4h") == (True, 4.0)
+        assert parse_remote_timer_event("timer_8h") == (True, 8.0)
+        assert parse_remote_timer_event("timer_12h") == (True, 12.0)
+
+    def test_timer_none_uses_configured_default(self):
+        assert parse_remote_timer_event("timer_none") == (True, None)
+
+    def test_non_timer_tokens_ignored(self):
+        for token in ("on", "off", "low", "medium", "high"):
+            assert parse_remote_timer_event(token) == (False, None)
+
+    def test_unknown_and_missing_tokens_ignored(self):
+        assert parse_remote_timer_event("junk") == (False, None)
+        assert parse_remote_timer_event("") == (False, None)
+        assert parse_remote_timer_event(None) == (False, None)
+
+
+# ---------------------------------------------------------------------------
+# 2. Duration wiring — handle_fan_manual_override(duration_override=...)
+# ---------------------------------------------------------------------------
+
+
+class TestDurationWiring:
+    """The RF path and the physical-detection path share ONE entry point (Issue #486 dedup)."""
+
+    def test_duration_override_sets_grace_duration_seconds(self):
+        engine = _make_automation_engine()
+        with (
+            patch(_PATCH_CALL_LATER) as mock_call_later,
+            patch(_PATCH_CALLBACK, side_effect=lambda f: f),
+            patch(_PATCH_DT_NOW, return_value=_FIXED_NOW),
+        ):
+            mock_call_later.return_value = MagicMock()
+            engine.handle_fan_manual_override(duration_override=28800, remote_timer_hours=8.0)
+        assert engine._fan_override_active is True
+        assert engine._grace_duration_seconds == 28800
+        assert engine._fan_remote_timer_hours == 8.0
+
+    def test_duration_override_none_uses_configured_manual_grace(self):
+        engine = _make_automation_engine({CONF_MANUAL_GRACE_PERIOD: 1800})
+        with (
+            patch(_PATCH_CALL_LATER) as mock_call_later,
+            patch(_PATCH_CALLBACK, side_effect=lambda f: f),
+            patch(_PATCH_DT_NOW, return_value=_FIXED_NOW),
+        ):
+            mock_call_later.return_value = MagicMock()
+            engine.handle_fan_manual_override(duration_override=None, remote_timer_hours=None)
+        assert engine._grace_duration_seconds == 1800
+        assert engine._fan_remote_timer_hours is None
+
+    def test_physical_detection_path_still_uses_configured_default(self):
+        """The pre-existing physical-fan-on callsite (no duration_override arg) must be
+        unaffected by the new parameter — proves the shared entry point didn't regress
+        the path it already served."""
+        engine = _make_automation_engine({CONF_MANUAL_GRACE_PERIOD: 1800})
+        with (
+            patch(_PATCH_CALL_LATER) as mock_call_later,
+            patch(_PATCH_CALLBACK, side_effect=lambda f: f),
+            patch(_PATCH_DT_NOW, return_value=_FIXED_NOW),
+        ):
+            mock_call_later.return_value = MagicMock()
+            engine.handle_fan_manual_override(fan_before="auto", fan_after="on")
+        assert engine._grace_duration_seconds == 1800
+        assert engine._fan_remote_timer_hours is None
+
+
+# ---------------------------------------------------------------------------
+# 3. Suppression across BOTH existing choke points, with WARNING logging
+# ---------------------------------------------------------------------------
+
+
+class TestSuppressionAbsoluteWithRemoteTimer:
+    """While an RF timer is active, all CA-initiated fan-offs are suppressed and logged
+    as WARNING (not silently dropped at INFO) — Issue #486's "fully absolute (log-only)"
+    decision. Both _deactivate_fan (the choke point every other caller funnels through:
+    nat-vent exit, comfort-floor breach, cycle-off, min-runtime cycle-off) and
+    fan_thermostat_check (which returns "keep" directly without ever reaching
+    _deactivate_fan) need their own guard — this is why each has its own test.
+    """
+
+    def test_deactivate_fan_suppressed_and_warns_with_remote_timer(self, caplog):
+        import logging
+
+        engine = _make_automation_engine()
+        engine._fan_override_active = True
+        engine._fan_active = True
+        engine._fan_remote_timer_hours = 8.0
+
+        with caplog.at_level(logging.WARNING):
+            asyncio.run(engine._deactivate_fan(reason="nat-vent ceiling exit (away mode)"))
+
+        assert any("suppressed by active RF remote timer" in r.message for r in caplog.records)
+        assert engine._fan_active is True  # never turned off
+
+    def test_deactivate_fan_suppressed_info_only_without_remote_timer(self, caplog):
+        """A plain (non-RF) manual override still suppresses, but at INFO — no behavior
+        change for the pre-existing manual-override path."""
+        import logging
+
+        engine = _make_automation_engine()
+        engine._fan_override_active = True
+        engine._fan_active = True
+        engine._fan_remote_timer_hours = None
+
+        with caplog.at_level(logging.DEBUG):
+            asyncio.run(engine._deactivate_fan(reason="economizer off — fan no longer needed"))
+
+        assert not any("suppressed by active RF remote timer" in r.message for r in caplog.records)
+        assert (
+            any(
+                r.levelno == logging.WARNING and "suppressed by active RF remote timer" in r.message
+                for r in caplog.records
+            )
+            is False
+        )
+
+    def test_fan_thermostat_check_suppressed_and_warns_with_remote_timer(self, caplog):
+        import logging
+
+        engine = _make_automation_engine()
+        engine._fan_override_active = True
+        engine._fan_active = True
+        engine._fan_remote_timer_hours = 4.0
+
+        with caplog.at_level(logging.WARNING):
+            asyncio.run(engine.fan_thermostat_check(indoor=72.0, outdoor=68.0, trigger="indoor"))
+
+        assert any("cycle-off suppressed by active RF remote timer" in r.message for r in caplog.records)
+
+    def test_fan_thermostat_check_suppressed_debug_only_without_remote_timer(self, caplog):
+        import logging
+
+        engine = _make_automation_engine()
+        engine._fan_override_active = True
+        engine._fan_active = True
+        engine._fan_remote_timer_hours = None
+
+        with caplog.at_level(logging.DEBUG):
+            asyncio.run(engine.fan_thermostat_check(indoor=72.0, outdoor=68.0, trigger="indoor"))
+
+        assert not any("cycle-off suppressed by active RF remote timer" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# 4. Last-wins / refresh
+# ---------------------------------------------------------------------------
+
+
+class TestLastWinsRefresh:
+    def test_second_timer_overrides_first(self):
+        engine = _make_automation_engine()
+        with (
+            patch(_PATCH_CALL_LATER) as mock_call_later,
+            patch(_PATCH_CALLBACK, side_effect=lambda f: f),
+            patch(_PATCH_DT_NOW, return_value=_FIXED_NOW),
+        ):
+            mock_call_later.return_value = MagicMock()
+            engine.handle_fan_manual_override(duration_override=28800, remote_timer_hours=8.0)
+            assert engine._grace_duration_seconds == 28800
+            engine.handle_fan_manual_override(duration_override=7200, remote_timer_hours=2.0)
+        assert engine._grace_duration_seconds == 7200
+        assert engine._fan_remote_timer_hours == 2.0
+
+    def test_timer_none_after_timer_reverts_to_configured_default(self):
+        engine = _make_automation_engine({CONF_MANUAL_GRACE_PERIOD: 1800})
+        with (
+            patch(_PATCH_CALL_LATER) as mock_call_later,
+            patch(_PATCH_CALLBACK, side_effect=lambda f: f),
+            patch(_PATCH_DT_NOW, return_value=_FIXED_NOW),
+        ):
+            mock_call_later.return_value = MagicMock()
+            engine.handle_fan_manual_override(duration_override=28800, remote_timer_hours=8.0)
+            engine.handle_fan_manual_override(duration_override=None, remote_timer_hours=None)
+        assert engine._grace_duration_seconds == 1800
+        assert engine._fan_remote_timer_hours is None
+
+
+# ---------------------------------------------------------------------------
+# 5. Grace expiry resumes normal supervision
+# ---------------------------------------------------------------------------
+
+
+class TestGraceExpiryResumes:
+    def test_grace_expiry_clears_override_and_remote_timer(self):
+        engine = _make_automation_engine()
+        engine._is_within_planned_window_period = MagicMock(return_value=False)
+        engine._current_classification = None
+
+        with patch(_PATCH_CALL_LATER) as mock_call_later, patch(_PATCH_CALLBACK, side_effect=lambda f: f):
+            mock_call_later.return_value = MagicMock()
+            engine.handle_fan_manual_override(duration_override=7200, remote_timer_hours=2.0)
+            assert mock_call_later.call_count == 1
+            grace_callback = mock_call_later.call_args[0][2]
+
+        grace_callback(None)
+
+        assert engine._fan_override_active is False
+        assert engine._fan_remote_timer_hours is None
+
+    def test_cycle_off_allowed_again_after_expiry(self):
+        """After the RF-driven grace expires, a subsequent deactivation is no longer suppressed."""
+        engine = _make_automation_engine()
+        engine._is_within_planned_window_period = MagicMock(return_value=False)
+        engine._current_classification = None
+        engine._fan_active = True
+
+        with patch(_PATCH_CALL_LATER) as mock_call_later, patch(_PATCH_CALLBACK, side_effect=lambda f: f):
+            mock_call_later.return_value = MagicMock()
+            engine.handle_fan_manual_override(duration_override=7200, remote_timer_hours=2.0)
+            grace_callback = mock_call_later.call_args[0][2]
+
+        grace_callback(None)
+        assert engine._fan_override_active is False
+
+        asyncio.run(engine._deactivate_fan(reason="all sensors closed — stopping whole-house fan"))
+        assert engine._fan_active is False
+
+
+# ---------------------------------------------------------------------------
+# 6. Restart clean-slate
+# ---------------------------------------------------------------------------
+
+
+class TestRestartCleanSlate:
+    def test_restore_state_does_not_carry_remote_timer_across_restart(self):
+        engine = _make_automation_engine()
+        engine._fan_override_active = True
+        engine._fan_remote_timer_hours = 8.0
+
+        engine.restore_state({"fan_remote_timer_hours": 8.0, "fan_override_active": True})
+
+        assert engine._fan_override_active is False
+        assert engine._fan_remote_timer_hours is None
+
+    def test_get_serializable_state_includes_remote_timer_for_observability(self):
+        engine = _make_automation_engine()
+        engine._fan_remote_timer_hours = 4.0
+        state = engine.get_serializable_state()
+        assert state["fan_remote_timer_hours"] == 4.0
+
+
+# ---------------------------------------------------------------------------
+# 7. Coordinator dispatch: _async_fan_remote_changed
+# ---------------------------------------------------------------------------
+
+
+class TestCoordinatorFanRemoteDispatch:
+    """_async_fan_remote_changed parses the event and drives the SAME
+    handle_fan_manual_override() the physical-detection path already uses."""
+
+    def test_timer_8h_event_drives_shared_override_with_28800s(self):
+        coord = _make_coordinator_stub()
+        ae = coord.automation_engine
+
+        mod = importlib.import_module("custom_components.climate_advisor.coordinator")
+        method = types.MethodType(mod.ClimateAdvisorCoordinator._async_fan_remote_changed, coord)
+
+        new_state = _make_fake_state("2026-07-12T20:00:00+00:00", {"event_type": "timer_8h"})
+        event = _make_fake_event(new_state)
+
+        asyncio.run(method(event))
+
+        ae.handle_fan_manual_override.assert_called_once_with(
+            fan_before="?", fan_after="on", duration_override=28800.0, remote_timer_hours=8.0
+        )
+
+    def test_timer_none_event_drives_shared_override_with_none_duration(self):
+        coord = _make_coordinator_stub()
+        ae = coord.automation_engine
+
+        mod = importlib.import_module("custom_components.climate_advisor.coordinator")
+        method = types.MethodType(mod.ClimateAdvisorCoordinator._async_fan_remote_changed, coord)
+
+        new_state = _make_fake_state("2026-07-12T20:00:00+00:00", {"event_type": "timer_none"})
+        event = _make_fake_event(new_state)
+
+        asyncio.run(method(event))
+
+        ae.handle_fan_manual_override.assert_called_once_with(
+            fan_before="?", fan_after="on", duration_override=None, remote_timer_hours=None
+        )
+
+    def test_non_timer_event_is_a_noop(self):
+        coord = _make_coordinator_stub()
+        ae = coord.automation_engine
+
+        mod = importlib.import_module("custom_components.climate_advisor.coordinator")
+        method = types.MethodType(mod.ClimateAdvisorCoordinator._async_fan_remote_changed, coord)
+
+        for event_type in ("on", "off", "low", "high", None, "garbage"):
+            new_state = _make_fake_state("2026-07-12T20:00:00+00:00", {"event_type": event_type})
+            asyncio.run(method(_make_fake_event(new_state)))
+
+        ae.handle_fan_manual_override.assert_not_called()
+
+    def test_unavailable_state_is_a_noop(self):
+        coord = _make_coordinator_stub()
+        ae = coord.automation_engine
+
+        mod = importlib.import_module("custom_components.climate_advisor.coordinator")
+        method = types.MethodType(mod.ClimateAdvisorCoordinator._async_fan_remote_changed, coord)
+
+        for state_str in ("unavailable", "unknown"):
+            new_state = _make_fake_state(state_str, {"event_type": "timer_8h"})
+            asyncio.run(method(_make_fake_event(new_state)))
+
+        ae.handle_fan_manual_override.assert_not_called()
+
+    def test_missing_new_state_is_a_noop(self):
+        coord = _make_coordinator_stub()
+        ae = coord.automation_engine
+
+        mod = importlib.import_module("custom_components.climate_advisor.coordinator")
+        method = types.MethodType(mod.ClimateAdvisorCoordinator._async_fan_remote_changed, coord)
+
+        ev = MagicMock()
+        ev.data = {"new_state": None}
+        asyncio.run(method(ev))
+
+        ae.handle_fan_manual_override.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 8. Feature-off regression: subscription gate condition
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureOffRegression:
+    """Coordinator.async_setup() cannot be instantiated without a live HA instance
+    (see test_fan_cancel.py's note on this). This replicates the exact gate condition
+    from async_setup — `if self.config.get(CONF_FAN_REMOTE_ENTITY): subscribe` — the
+    same pattern TestFanCancelFlagComputation uses to unit-test a dispatch condition
+    without a live coordinator."""
+
+    def test_gate_is_false_when_unconfigured(self):
+        config = {"climate_entity": "climate.thermostat"}
+        assert bool(config.get(CONF_FAN_REMOTE_ENTITY)) is False
+
+    def test_gate_is_true_when_configured(self):
+        config = {CONF_FAN_REMOTE_ENTITY: "event.quietcool_remote"}
+        assert bool(config.get(CONF_FAN_REMOTE_ENTITY)) is True


### PR DESCRIPTION
## Summary

Climate Advisor can now hear the QuietCool whole-house fan's physical RF wall remote (via the `gunkl/quietcool-house-fan` firmware's event entity) and honor a timer selection made at the remote. Occupant impact: previously, pressing "8 hours" on the remote had no effect on CA's own automatic fan-off timing — CA would still shut the fan off on its usual grace period, contradicting what the person just told the fan to do. Now, when the optional `fan_remote_entity` is configured, a 1/2/4/8/12-hour remote timer selection sets the duration of CA's fan manual-override grace period, so CA backs off for exactly as long as the user asked.

## Design (revised from the original issue plan)

The original plan in #486 proposed a separate absolute predicate (`_user_fan_timer_holds()`) and a new engine state machine (`handle_remote_command()`, `_fan_user_timer_*` fields). Neither was implemented — this codebase has repeatedly been burned by parallel entry points and duplicated threshold logic (#400, #402, #417, #456, #458), so the design converges on the existing mechanism instead:

- **One shared entry point**: a remote timer press calls the SAME `automation.handle_fan_manual_override()` the existing physical-fan-on detection path already uses, via a new optional `duration_override` parameter threaded through `_start_grace_period()`.
- **No new suppression predicate**: the RF timer is a manual override, so it's suppressed exactly like any other via the EXISTING `_fan_override_active` guards in `_deactivate_fan()` (the choke point every CA-initiated fan-off funnels through — nat-vent exit, comfort-floor breach, cycle-off, min-runtime cycle-off) and `fan_thermostat_check()`. Both now log a WARNING (not silently INFO/DEBUG) when the suppressed decision happened while an RF timer is active, so "absolute until expiry" is observable in logs.
- **Single-source mapping**: `const.REMOTE_TIMER_EVENT_HOURS`, parsed by the pure helper `fan_status.parse_remote_timer_event()`.
- **Scope**: timer tokens only (`timer_1h`..`timer_12h`, `timer_none`). `on`/`off`/speed tokens are intentionally not decoded this cut — CA continues to rely on its existing, tested physical fan-entity detection for on/off rather than a second, edge-triggered signal for the same fact.
- **Clean-slate on restart**, matching the existing override/grace reset (#327/#282) — no new persistence.
- **Fully optional**: new `fan_remote_entity` config field (`event` domain selector). Unset ⇒ no subscription ⇒ zero behavior change for existing installs.

Full spec: `docs/fan-remote-spec.md` (new Tier 3 territory spec), cross-linked from `docs/grace-periods-spec.md` and the automation logic table in `docs/08-COMPUTATION-REFERENCE.md`.

## Test plan

- [x] `pytest tests/test_fan_remote.py -W error::pytest.PytestUnraisableExceptionWarning -W error::RuntimeWarning` — 24 passed (parse helper, duration wiring, suppression at both choke points w/ WARNING revert-tested, last-wins refresh, grace-expiry resumption, restart clean-slate, coordinator dispatch, feature-off regression)
- [x] `pytest tests/` — 3411 passed, 6 xfailed (pre-existing, unrelated to this change)
- [x] `python tools/simulate.py` — 53/53 golden scenarios pass unchanged
- [x] `pytest tests/test_version_sync.py` — passes (v0.5.19)
- [x] `ruff check` / `ruff format` — clean
- [x] Per-fix revert check on the WARNING-log suppression: reverted, confirmed the test failed, restored, confirmed green

Version bumped 0.5.18 → 0.5.19 with `RELEASE_NOTES` and `KNOWN_FIXES[486]`.

Fixes #486.