### PR TITLE
Fix #489: Doors/Windows status card refreshes immediately on sensor close

### DIFF
--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,18 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.19"
+VERSION = "0.5.20"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.20": [
+        "Fix #489: the Doors/Windows status card could show a stale 'N open' reading for"
+        " up to 30 minutes after a monitored door or window was actually closed again."
+        " Brief real door use (a few seconds) was always detected correctly, but closing"
+        " it back up didn't force the dashboard to refresh — only opening did. Now every"
+        " sensor transition, open or closed, refreshes the status display immediately."
+        " Automation timing is unaffected: the existing debounce still exclusively"
+        " governs when HVAC actually pauses or resumes for a door/window event.",
+    ],
     "0.5.19": [
         "Feat #486: Climate Advisor can now hear the QuietCool whole-house fan's physical RF"
         " wall remote (via the gunkl/quietcool-house-fan ESPHome firmware's event entity) and"
@@ -1102,6 +1111,33 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    489: {
+        "version_fixed": "0.5.20",
+        "title": "Doors/Windows status card refreshes immediately on sensor close, not just open",
+        "scope_covered": (
+            "coordinator._async_door_window_changed() now requests an immediate coordinator"
+            " refresh (async_request_refresh) at the top of the function on every raw sensor"
+            " transition — open or closed — so contact_status/contact_sensors reflect live"
+            " state right away regardless of debounce. This is purely a display refresh;"
+            " it does not change CONF_SENSOR_DEBOUNCE timing or the _paused_by_door /"
+            " _natural_vent_active decision logic, which are unaffected. Previously only the"
+            " open branch requested an immediate refresh (line ~2986 pre-fix); the close"
+            " branch had none, so a stale 'N open' reading could persist until the next"
+            " 30-minute coordinator update_interval. Also added a post-decision refresh"
+            " after handle_all_doors_windows_closed() in the close branch, mirroring the"
+            " existing post-handle_door_window_open() refresh in the open branch — covers"
+            " a real, debounce-confirmed pause/resume cycle (HVAC mode/temp restored, grace"
+            " started) getting reflected promptly too, not just the raw contact reading."
+        ),
+        "scope_not_covered": (
+            "Does not touch CONF_SENSOR_DEBOUNCE, pause/resume decision timing, nat-vent"
+            " logic, or any HVAC command behavior. Does not address the separate, confirmed"
+            " pre-existing test-order-dependent flakiness in"
+            " TestGracePeriodDuration/TestGracePeriodExpiry in test_door_window.py (fails"
+            " when that file is run in isolation, passes in the full suite) — unrelated to"
+            " this fix, reproduces identically on main before this change."
+        ),
+    },
     486: {
         "version_fixed": "0.5.19",
         "title": "QuietCool RF remote timer events set the fan manual-override grace duration",

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -2922,6 +2922,12 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         if not new_state:
             return
 
+        # Issue #489: refresh immediately on every raw transition (open or closed) so
+        # contact_status/contact_sensors reflect live sensor state right away. This is
+        # display-only — it does not affect the debounce below, which still exclusively
+        # gates the HVAC pause/resume and nat-vent decision.
+        self.hass.async_create_task(self.async_request_refresh())
+
         if self._is_sensor_open(entity_id):
             # Sensor transitioned to open — start debounce timer if not already running
             if entity_id in self._door_open_timers:
@@ -2982,8 +2988,6 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
 
             cancel = async_call_later(self.hass, debounce_sec, _debounce_expired)
             self._door_open_timers[entity_id] = cancel
-            # Trigger coordinator refresh so next_automation sensor shows debounce pending state
-            self.hass.async_create_task(self.async_request_refresh())
         else:
             # Sensor transitioned to closed — cancel any pending debounce timer
             cancel = self._door_open_timers.pop(entity_id, None)
@@ -3010,6 +3014,11 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 ):
                     self._today_record.window_physical_close_time = dt_util.now().isoformat()
                 await self.automation_engine.handle_all_doors_windows_closed()
+                # Issue #489: post-decision refresh, mirroring the open path's
+                # post-handle_door_window_open refresh above — covers the real-pause-
+                # resume case (HVAC mode/temp restored, grace started), not just the
+                # display-only case already handled by the top-of-function refresh.
+                self.hass.async_create_task(self.async_request_refresh())
                 await self._async_save_state()
 
     async def _async_thermostat_changed(self, event: Event) -> None:

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.19"
+  "version": "0.5.20"
 }

--- a/tests/test_contact_status_refresh.py
+++ b/tests/test_contact_status_refresh.py
@@ -1,0 +1,153 @@
+"""Tests for Issue #489 — Doors/Windows status card refresh symmetry.
+
+`_async_door_window_changed()` in coordinator.py must request a coordinator refresh
+on every raw sensor transition (open or closed) so `contact_status` displays live
+state promptly, decoupled from the debounce that gates the HVAC pause/resume and
+nat-vent decision. It must also request a post-decision refresh after
+`handle_all_doors_windows_closed()` when all sensors are confirmed closed, mirroring
+the existing post-decision refresh on the open path (after `handle_door_window_open()`).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+if "homeassistant" not in sys.modules:
+    from conftest import _install_ha_stubs
+
+    _install_ha_stubs()
+
+from datetime import datetime
+
+sys.modules["homeassistant.util.dt"].now = lambda: datetime(2026, 4, 5, 10, 0, 0)
+
+
+def _get_coordinator_class():
+    mod = importlib.import_module("custom_components.climate_advisor.coordinator")
+    return mod.ClimateAdvisorCoordinator
+
+
+_SENSOR_A = "binary_sensor.front_door"
+_SENSOR_B = "binary_sensor.back_door"
+
+_PATCH_CALL_LATER = "custom_components.climate_advisor.coordinator.async_call_later"
+_PATCH_CALLBACK = "custom_components.climate_advisor.coordinator.callback"
+
+
+def _consume_coroutine(coro):
+    coro.close()
+
+
+def _make_event(entity_id: str, state_value: str) -> MagicMock:
+    state = MagicMock()
+    state.state = state_value
+    event = MagicMock()
+    event.data = {"entity_id": entity_id, "new_state": state}
+    return event
+
+
+def _make_coordinator_stub(*, resolved_sensors: list[str], states: dict[str, str]) -> MagicMock:
+    """Build a minimal coordinator-like object for testing refresh symmetry.
+
+    `states` maps entity_id -> "on"/"off" and is read live by `_is_sensor_open`,
+    same pattern as test_daily_record_accuracy.py's stub.
+    """
+    hass = MagicMock()
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+    hass.async_create_task = MagicMock(side_effect=_consume_coroutine)
+
+    ClimateAdvisorCoordinator = _get_coordinator_class()
+    coord = object.__new__(ClimateAdvisorCoordinator)
+    coord.hass = hass
+    coord.config = {"sensor_debounce_seconds": 0}
+
+    ae = MagicMock()
+    ae._is_within_planned_window_period = MagicMock(return_value=False)
+    ae.handle_door_window_open = AsyncMock()
+    ae.handle_all_doors_windows_closed = AsyncMock()
+    ae._temp_command_pending = False
+    coord.automation_engine = ae
+
+    coord._current_classification = None
+    coord._today_record = None
+    coord._resolved_sensors = list(resolved_sensors)
+    coord._door_open_timers = {}
+    coord._door_open_timer_expiry = {}
+    coord._async_save_state = AsyncMock()
+
+    def _is_sensor_open(entity_id: str) -> bool:
+        return states.get(entity_id) == "on"
+
+    coord._is_sensor_open = _is_sensor_open
+
+    # Overrides the base DataUpdateCoordinator method for this instance — lets us
+    # assert call count directly instead of inspecting closed coroutines. Calling an
+    # AsyncMock() records the call immediately, before the returned coroutine is ever
+    # awaited/closed, so this is safe to use with hass.async_create_task consuming it.
+    coord.async_request_refresh = AsyncMock()
+
+    coord._async_door_window_changed = types.MethodType(ClimateAdvisorCoordinator._async_door_window_changed, coord)
+
+    return coord
+
+
+class TestImmediateRefreshOnTransition:
+    """The top-of-function refresh must fire on every raw transition, open or closed,
+    regardless of debounce state or whether other sensors are still open."""
+
+    def test_sensor_opens_triggers_immediate_refresh(self):
+        coord = _make_coordinator_stub(resolved_sensors=[_SENSOR_A], states={_SENSOR_A: "on"})
+        event = _make_event(_SENSOR_A, "on")
+
+        with patch(_PATCH_CALL_LATER) as mock_call_later, patch(_PATCH_CALLBACK, side_effect=lambda fn: fn):
+            mock_call_later.return_value = MagicMock()
+            asyncio.run(coord._async_door_window_changed(event))
+
+        assert coord.async_request_refresh.call_count == 1
+
+    def test_sensor_closes_triggers_immediate_refresh(self):
+        coord = _make_coordinator_stub(resolved_sensors=[_SENSOR_A], states={_SENSOR_A: "off"})
+        event = _make_event(_SENSOR_A, "off")
+
+        asyncio.run(coord._async_door_window_changed(event))
+
+        # Immediate (top-of-function) + post-decision (all_closed) refresh = 2.
+        assert coord.async_request_refresh.call_count == 2
+
+    def test_sensor_closes_while_another_still_open_still_refreshes_display(self):
+        """Regression guard for the original bug: a close on one of several monitored
+        sensors must still refresh the display even though all_closed is False and no
+        automation decision is made."""
+        coord = _make_coordinator_stub(
+            resolved_sensors=[_SENSOR_A, _SENSOR_B],
+            states={_SENSOR_A: "off", _SENSOR_B: "on"},
+        )
+        event = _make_event(_SENSOR_A, "off")
+
+        asyncio.run(coord._async_door_window_changed(event))
+
+        # Only the immediate top-of-function refresh — no post-decision refresh,
+        # since handle_all_doors_windows_closed() is gated behind all_closed.
+        assert coord.async_request_refresh.call_count == 1
+        coord.automation_engine.handle_all_doors_windows_closed.assert_not_called()
+
+
+class TestPostDecisionRefreshOnClose:
+    """The close branch must request a second refresh after
+    handle_all_doors_windows_closed() completes, mirroring the open branch's
+    post-handle_door_window_open refresh — so a real pause/resume outcome (HVAC mode,
+    grace period) is reflected promptly, not just the raw contact_status."""
+
+    def test_all_sensors_closed_calls_handler_then_refreshes(self):
+        coord = _make_coordinator_stub(resolved_sensors=[_SENSOR_A], states={_SENSOR_A: "off"})
+        event = _make_event(_SENSOR_A, "off")
+
+        asyncio.run(coord._async_door_window_changed(event))
+
+        coord.automation_engine.handle_all_doors_windows_closed.assert_called_once()
+        assert coord.async_request_refresh.call_count == 2


### PR DESCRIPTION
## Summary
- The Doors/Windows status card could show a stale "N open" reading for up to 30 minutes after a monitored sensor was actually closed again — opening always forced an immediate coordinator refresh, closing never did.
- `_async_door_window_changed()` now requests a display-only refresh on every raw transition (open or closed), decoupled from the existing 5-minute debounce that continues to exclusively gate HVAC pause/resume and nat-vent decisions.
- Also adds the missing post-decision refresh after `handle_all_doors_windows_closed()`, mirroring the existing one on the open path, so a real (debounce-confirmed) pause/resume cycle's outcome is reflected promptly too.
- Bumps version to 0.5.20 with `RELEASE_NOTES`/`KNOWN_FIXES` entries.

Diagnosed via the `troubleshoot` skill using live HA sensor/battery/history data — ruled out a wrong-sensor-mapping bug and a hardware fault before confirming the refresh asymmetry in code.

Closes #489

## Test plan
- [x] Added `tests/test_contact_status_refresh.py` (4 tests), verified to fail without the fix (via revert) and pass with it
- [x] Full suite: `pytest tests/` — 3415 passed, 6 xfailed (3 pre-existing, order-dependent failures in `test_door_window.py` reproduce identically on unmodified `main`, unrelated to this change)
- [x] `python tools/simulate.py` — 53/53 golden scenarios pass, no automation/timing regressions
- [x] `ruff check` / `ruff format` clean
- [x] `pytest tests/test_version_sync.py` passes