### PR TITLE
Fix #491: false WHF manual-override/grace-period + coordinator crash at HA restart

### DIFF
--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,25 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.20"
+VERSION = "0.5.21"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.21": [
+        "Fix #491: two restart-time bugs found immediately after the 0.5.20 deploy, both"
+        " pre-existing and unrelated to #489. (1) The dashboard could show a false"
+        " 'Fan manual override' and a bogus multi-hour manual grace period right after"
+        " every HA restart — the whole-house fan never turned on and nobody touched the"
+        " remote; the QuietCool RF remote's device entity can re-announce its last"
+        " retained state while HA is still settling after restart, and neither fan"
+        " listener had the same 5-minute startup-suppression guard the thermostat"
+        " listener already had (Issue #321). Both fan listeners now share that guard."
+        " (2) A 'Climate Advisor unavailable' error banner could appear after routine"
+        " restarts/deploys with nothing actually wrong — a plumbing bug in the thermal"
+        " observation pipeline (present since April) crashed the coordinator update"
+        " whenever a pending thermal observation was abandoned right as HVAC started,"
+        " which is common at restart. Fixed; no HVAC or automation timing behavior"
+        " changed by either fix.",
+    ],
     "0.5.20": [
         "Fix #489: the Doors/Windows status card could show a stale 'N open' reading for"
         " up to 30 minutes after a monitored door or window was actually closed again."
@@ -1111,6 +1127,44 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    491: {
+        "version_fixed": "0.5.21",
+        "title": "False WHF manual-override/grace-period + coordinator crash at HA restart",
+        "scope_covered": (
+            "Two independent restart-time bugs, both pre-existing (not introduced by #489)"
+            " and both diagnosed from a real restart after the 0.5.20 deploy. (1) New shared"
+            " coordinator._suppress_during_startup_coalescing() helper, used by"
+            " _async_thermostat_changed() (refactored from its Issue #321 inline check),"
+            " _async_fan_entity_changed(), and _async_fan_remote_changed() — all three"
+            " override-detection listeners now suppress detection for the same 5-minute"
+            " startup-coalescing window (_startup_coalesce_active). Before this fix, only the"
+            " thermostat listener had this guard; a QuietCool RF remote event.* entity"
+            " re-announcing its last retained event_type during HA's restart/reconnect"
+            " sequence was misread by _async_fan_remote_changed() as a fresh timer press,"
+            " producing a false 'Fan manual override: whf: ?->on' and a real (but bogus)"
+            " manual grace period — confirmed via live HA logs showing the fan status as"
+            " 'off (manual override)' (override flag set, _fan_active=False — no real command"
+            " was ever issued, matching the fact the WHF never physically ran)."
+            " _async_fan_entity_changed() had the identical gap and is fixed for the same"
+            " reason (no incident confirmed for that specific path, but the defect class"
+            " already shipped one). (2) coordinator._abandon_observation() no longer wraps"
+            " hass.async_add_executor_job(self.learning.save_state) — already a scheduled"
+            " awaitable — in hass.async_create_task() (which requires a coroutine); the"
+            " double-wrap raised 'TypeError: a coroutine was expected, got <Future ...>' on"
+            " every restart that hit this HVAC-started thermal-observation-abandonment path,"
+            " crashing the coordinator update and surfacing as the '⚠ Climate Advisor"
+            " unavailable' status banner (added by Fix #480/0.5.17, which is what made this"
+            " 2.5-month-old bug, from Issue #121, visible for the first time)."
+        ),
+        "scope_not_covered": (
+            "Does not change CONF_SENSOR_DEBOUNCE, grace-period duration semantics, or any"
+            " HVAC command/decision logic — both fixes are restart-timing/plumbing-only."
+            " A real remote press or real manual fan/thermostat use in the first 5 minutes"
+            " after a restart is still not detected as an override during that window — the"
+            " same accepted tradeoff Issue #321 established for the thermostat listener,"
+            " now applied consistently instead of partially."
+        ),
+    },
     489: {
         "version_fixed": "0.5.20",
         "title": "Doors/Windows status card refreshes immediately on sensor close, not just open",

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -3021,6 +3021,20 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 self.hass.async_create_task(self.async_request_refresh())
                 await self._async_save_state()
 
+    def _suppress_during_startup_coalescing(self, description: str) -> bool:
+        """Return True (and log why) if the caller should bail due to active startup
+        coalescing.
+
+        Issue #321 established this suppression for _async_thermostat_changed; Issue
+        #491 generalizes it to every override-detection listener via a single shared
+        implementation, so a future new listener can't independently forget it — the
+        exact gap that let #491 ship (neither fan listener had this guard).
+        """
+        if not self._startup_coalesce_active:
+            return False
+        _LOGGER.debug("Startup coalescing active — suppressing %s", description)
+        return True
+
     async def _async_thermostat_changed(self, event: Event) -> None:
         """Track thermostat changes for learning (detect manual overrides)."""
         new_state = event.data.get("new_state")
@@ -3029,11 +3043,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             return
 
         # Bug 1 (Issue #321): Suppress override detection during startup coalescing window
-        if self._startup_coalesce_active:
-            _LOGGER.debug(
-                "Startup coalescing active — suppressing thermostat override detection for %s",
-                new_state.state if new_state else "unknown",
-            )
+        if self._suppress_during_startup_coalescing(f"thermostat override detection for {new_state.state}"):
             return
 
         # Bug 3 (Issue #321): Per-temperature-tick nat-vent cycling re-evaluation.
@@ -3608,6 +3618,12 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         if not new_state or not old_state:
             return
 
+        # Issue #491: suppress fan-entity override detection during startup coalescing —
+        # a real WHF entity can report a transient state blip while HA is still settling
+        # right after restart, which was previously misread as a fresh manual override.
+        if self._suppress_during_startup_coalescing(f"fan override detection for {new_state.state}"):
+            return
+
         if new_state.state == old_state.state:
             return
 
@@ -3725,6 +3741,12 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         event_type = new_state.attributes.get("event_type")
         is_timer_event, hours = parse_remote_timer_event(event_type)
         if not is_timer_event:
+            return
+
+        # Issue #491: suppress during startup coalescing — the QuietCool remote's event.*
+        # entity can re-announce its last retained event_type (a stale timer press) while
+        # HA is still settling right after restart, indistinguishable from a fresh press.
+        if self._suppress_during_startup_coalescing(f"fan remote event_type={event_type}"):
             return
 
         duration_seconds = hours * 3600 if hours is not None else None
@@ -5402,7 +5424,11 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             bucket.pop(0)
         # Sync to LearningState so rejection_log is persisted by save_state()
         self.learning._state.rejection_log = self._rejection_log
-        self.hass.async_create_task(self.hass.async_add_executor_job(self.learning.save_state))
+        # Issue #491: async_add_executor_job() already returns a scheduled awaitable —
+        # wrapping it in async_create_task() (which requires a coroutine, not a Future)
+        # raised "TypeError: a coroutine was expected, got <Future ...>" on every restart
+        # that hit this abandonment path, crashing the whole coordinator update.
+        self.hass.async_add_executor_job(self.learning.save_state)
 
     def _build_learning_health(self) -> dict:
         """Aggregate _rejection_log into a per-obs-type health dict for get_thermal_model().

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.20"
+  "version": "0.5.21"
 }

--- a/docs/08-COMPUTATION-REFERENCE.md
+++ b/docs/08-COMPUTATION-REFERENCE.md
@@ -1493,6 +1493,16 @@ The occupant experienced this as: a fan running through the night while outdoor 
 
 There is no fourth state. Any post-coalesce `fan_mode="on"` or fan-entity change that CA did not command is detected as a manual override (§9b) → timed, not indefinite. A post-coalesce `hvac_action="fan"` (thermostat-autonomous fan-on between AC cycles) is reconciled by `reconcile_fan_on_startup` via the post-startup detection path (Issue #347) → adopt-on or turn-off, never indefinite limbo.
 
+"Post-coalesce" is enforced by `_suppress_during_startup_coalescing()` (Issue #491), a
+single shared guard called from `_async_thermostat_changed()`, `_async_fan_entity_changed()`,
+and `_async_fan_remote_changed()` — every listener capable of detecting a manual override
+bails out while `_startup_coalesce_active` is True. Before #491, the two fan listeners had
+no such guard, so a device re-announcing its last retained state during HA's restart/
+reconnect sequence (confirmed for the QuietCool RF remote's `event.*` entity) could be
+misread as a fresh manual override within the coalescing window, contradicting this
+section's claim. Verify this claim against `_suppress_during_startup_coalescing()`'s call
+sites directly if it is ever suspected of drifting again.
+
 #### A. Restart = Clean Fan Slate
 
 `restore_state()` now clears `_fan_override_active` and `_fan_override_time` on restart, matching the clean-slate treatment of HVAC override/grace state (§11). Fan ownership is fully reconsidered by the coalesce reconciliation step rather than reconstructed from stale persisted flags.

--- a/docs/fan-remote-spec.md
+++ b/docs/fan-remote-spec.md
@@ -158,6 +158,17 @@ active RF timer does **not** survive an HA restart:
 - After a restart, `reconcile_fan_on_startup()` (unchanged) decides the fan's disposition
   from physical state, the same as it always has.
 
+**Incoming device-originated events are also suppressed during the restart window (Issue
+#491).** The above covers CA's *own* override/grace state resetting cleanly — but the
+QuietCool remote's underlying `event.*` entity can independently re-announce its last
+retained `event_type` (e.g. a stale `timer_2h`) while HA is still settling right after
+restart, as the ESPHome device reconnects. `_async_fan_remote_changed()` cannot tell that
+apart from a fresh button press by inspecting the event alone, so it now calls
+`_suppress_during_startup_coalescing()` before processing any timer token — the same
+5-minute window `_async_thermostat_changed()` already used (Issue #321), now shared. A
+real remote press in the first 5 minutes after a restart is not acted on during that
+window — an accepted tradeoff, consistent with the existing thermostat-override behavior.
+
 ---
 
 ## Clearing

--- a/tests/test_fan_cancel.py
+++ b/tests/test_fan_cancel.py
@@ -122,6 +122,11 @@ def _make_coordinator_stub(config: dict | None = None) -> MagicMock:
     coord._get_indoor_temp = MagicMock(return_value=71.0)
     coord._last_outdoor_temp = 57.0
     coord._fan_state_entity_unavailable_warned = False
+    # Issue #491: _async_fan_entity_changed now calls the real
+    # _suppress_during_startup_coalescing() guard; coord being a bare MagicMock would
+    # otherwise return a truthy MagicMock and silently suppress every dispatch test
+    # below. These tests exercise post-coalescing (normal) dispatch behavior.
+    coord._suppress_during_startup_coalescing = MagicMock(return_value=False)
 
     return coord
 

--- a/tests/test_fan_remote.py
+++ b/tests/test_fan_remote.py
@@ -133,6 +133,11 @@ def _make_coordinator_stub(config: dict | None = None) -> MagicMock:
     coord.config = config
     coord.automation_engine = _make_mock_engine()
     coord.async_request_refresh = AsyncMock()
+    # Issue #491: _async_fan_remote_changed now calls the real
+    # _suppress_during_startup_coalescing() guard; coord being a bare MagicMock would
+    # otherwise return a truthy MagicMock and silently suppress every dispatch test
+    # below. These tests exercise post-coalescing (normal) dispatch behavior.
+    coord._suppress_during_startup_coalescing = MagicMock(return_value=False)
     return coord
 
 

--- a/tests/test_restart_coalescing_fan_guard.py
+++ b/tests/test_restart_coalescing_fan_guard.py
@@ -1,0 +1,283 @@
+"""Regression tests for Issue #491.
+
+Two independent restart-time bugs, both surfaced by a real HA restart after
+deploying #489 (0.5.20), neither caused by #489 itself:
+
+1. False WHF manual override + grace period: `_async_fan_entity_changed()` and
+   `_async_fan_remote_changed()` had no guard against firing during the 5-minute
+   startup-coalescing window, unlike `_async_thermostat_changed()` (Issue #321). A
+   physical device (WHF entity, or the QuietCool RF remote's `event.*` entity) can
+   report/re-announce state while HA is still settling right after restart, which was
+   misread as a fresh manual override. Fixed via one shared
+   `_suppress_during_startup_coalescing()` helper used by all three listeners, instead
+   of copy-pasting the guard (the "sibling copies drift" defect class this codebase has
+   paid for repeatedly).
+
+2. Coordinator crash / "Climate Advisor unavailable" banner: `_abandon_observation()`
+   wrapped `hass.async_add_executor_job(...)` (already a scheduled awaitable) in
+   `hass.async_create_task(...)` (which requires a coroutine), raising
+   `TypeError: a coroutine was expected, got <Future ...>` on every restart that hit
+   this abandonment path.
+
+Occupant framing: without fix 1, a user could see the dashboard falsely claim they (or
+someone) manually turned on the whole-house fan and started a 2-hour grace period,
+right after every restart, blocking automation for no reason and misrepresenting what
+actually happened in their home. Without fix 2, the dashboard could show a scary
+"Climate Advisor unavailable" error after routine restarts/deploys, with no real
+problem to fix.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+import types
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+if "homeassistant" not in sys.modules:
+    from conftest import _install_ha_stubs
+
+    _install_ha_stubs()
+
+sys.modules["homeassistant.util.dt"].now = lambda: datetime(2026, 7, 12, 17, 0, 0)
+
+from custom_components.climate_advisor.const import CONF_FAN_REMOTE_ENTITY  # noqa: E402
+
+
+def _get_coordinator_class():
+    mod = importlib.import_module("custom_components.climate_advisor.coordinator")
+    return mod.ClimateAdvisorCoordinator
+
+
+def _consume_coroutine(coro):
+    coro.close()
+
+
+def _make_state(state_value: str, attributes: dict | None = None) -> MagicMock:
+    s = MagicMock()
+    s.state = state_value
+    s.attributes = attributes or {}
+    return s
+
+
+def _make_event(data: dict) -> MagicMock:
+    event = MagicMock()
+    event.data = data
+    return event
+
+
+# ---------------------------------------------------------------------------
+# Shared helper: _suppress_during_startup_coalescing()
+# ---------------------------------------------------------------------------
+
+
+class TestSuppressDuringStartupCoalescing:
+    """Direct unit tests for the shared helper — single source of truth for all
+    three override-detection listeners."""
+
+    def _make_coord(self, *, startup_coalesce_active: bool) -> object:
+        ClimateAdvisorCoordinator = _get_coordinator_class()
+        coord = object.__new__(ClimateAdvisorCoordinator)
+        coord._startup_coalesce_active = startup_coalesce_active
+        coord._suppress_during_startup_coalescing = types.MethodType(
+            ClimateAdvisorCoordinator._suppress_during_startup_coalescing, coord
+        )
+        return coord
+
+    def test_returns_true_and_logs_when_active(self):
+        coord = self._make_coord(startup_coalesce_active=True)
+        with patch("custom_components.climate_advisor.coordinator._LOGGER") as mock_logger:
+            result = coord._suppress_during_startup_coalescing("test description")
+        assert result is True
+        mock_logger.debug.assert_called_once()
+        assert "test description" in mock_logger.debug.call_args[0]
+
+    def test_returns_false_when_inactive(self):
+        coord = self._make_coord(startup_coalesce_active=False)
+        with patch("custom_components.climate_advisor.coordinator._LOGGER") as mock_logger:
+            result = coord._suppress_during_startup_coalescing("test description")
+        assert result is False
+        mock_logger.debug.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _async_fan_entity_changed() — coalescing suppression
+# ---------------------------------------------------------------------------
+
+
+def _make_fan_entity_coord(*, startup_coalesce_active: bool) -> object:
+    ClimateAdvisorCoordinator = _get_coordinator_class()
+    coord = object.__new__(ClimateAdvisorCoordinator)
+
+    hass = MagicMock()
+    hass.async_create_task = MagicMock(side_effect=_consume_coroutine)
+    coord.hass = hass
+    coord.config = {"fan_state_feedback": True}
+
+    ae = MagicMock()
+    ae._fan_command_pending = False
+    ae._fan_override_active = False
+    ae._fan_active = False
+    ae._fan_command_context_id = None
+    ae.handle_fan_manual_override = MagicMock()
+    ae.on_fan_turned_off = MagicMock()
+    coord.automation_engine = ae
+
+    coord._is_recent_fan_command = MagicMock(return_value=False)
+    coord._startup_coalesce_active = startup_coalesce_active
+    coord.async_request_refresh = AsyncMock()
+
+    coord._suppress_during_startup_coalescing = types.MethodType(
+        ClimateAdvisorCoordinator._suppress_during_startup_coalescing, coord
+    )
+    coord._async_fan_entity_changed = types.MethodType(ClimateAdvisorCoordinator._async_fan_entity_changed, coord)
+    return coord
+
+
+class TestFanEntityChangedCoalescingGuard:
+    def test_no_override_during_coalesce_window(self):
+        """A real WHF entity state blip during the restart window must NOT be
+        detected as a manual override.
+
+        Occupant impact: without this fix, a restart-time state blip on the whole-
+        house fan entity triggered a spurious manual override and grace period,
+        blocking automation for no reason.
+        """
+        coord = _make_fan_entity_coord(startup_coalesce_active=True)
+        event = _make_event({"old_state": _make_state("off"), "new_state": _make_state("on")})
+
+        asyncio.run(coord._async_fan_entity_changed(event))
+
+        coord.automation_engine.handle_fan_manual_override.assert_not_called()
+
+    def test_override_detection_works_after_coalesce(self):
+        """After the coalescing window closes, a real fan-on is still detected.
+
+        Occupant impact: genuine manual fan use after startup must still be
+        recognised and start the grace period.
+        """
+        coord = _make_fan_entity_coord(startup_coalesce_active=False)
+        event = _make_event({"old_state": _make_state("off"), "new_state": _make_state("on")})
+
+        asyncio.run(coord._async_fan_entity_changed(event))
+
+        coord.automation_engine.handle_fan_manual_override.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _async_fan_remote_changed() — coalescing suppression
+# ---------------------------------------------------------------------------
+
+
+def _make_fan_remote_coord(*, startup_coalesce_active: bool) -> object:
+    ClimateAdvisorCoordinator = _get_coordinator_class()
+    coord = object.__new__(ClimateAdvisorCoordinator)
+
+    hass = MagicMock()
+    hass.async_create_task = MagicMock(side_effect=_consume_coroutine)
+    coord.hass = hass
+    coord.config = {CONF_FAN_REMOTE_ENTITY: "event.quietcool_remote"}
+
+    ae = MagicMock()
+    ae.handle_fan_manual_override = MagicMock()
+    coord.automation_engine = ae
+
+    coord._startup_coalesce_active = startup_coalesce_active
+    coord.async_request_refresh = AsyncMock()
+
+    coord._suppress_during_startup_coalescing = types.MethodType(
+        ClimateAdvisorCoordinator._suppress_during_startup_coalescing, coord
+    )
+    coord._async_fan_remote_changed = types.MethodType(ClimateAdvisorCoordinator._async_fan_remote_changed, coord)
+    return coord
+
+
+class TestFanRemoteChangedCoalescingGuard:
+    def test_no_override_during_coalesce_window(self):
+        """A stale QuietCool RF timer event re-announced at restart must NOT be acted
+        on — this is the exact incident: "Fan manual override: whf: ?->on" and a
+        120-minute grace period appeared at the restart boundary with no real remote
+        press and the whole-house fan never physically turning on.
+
+        Occupant impact: without this fix, every restart risked a false "you turned
+        the fan on" grace period blocking automation for up to the RF timer's full
+        duration (up to 12 hours), even though nobody touched the remote and the fan
+        never ran.
+        """
+        coord = _make_fan_remote_coord(startup_coalesce_active=True)
+        new_state = _make_state("2026-07-12T16:58:00+00:00", {"event_type": "timer_2h"})
+        event = _make_event({"new_state": new_state})
+
+        asyncio.run(coord._async_fan_remote_changed(event))
+
+        coord.automation_engine.handle_fan_manual_override.assert_not_called()
+
+    def test_timer_event_works_after_coalesce(self):
+        """After the coalescing window closes, a real remote press is still honored.
+
+        Occupant impact: genuine remote use after startup must still set the fan
+        override grace duration as documented in docs/fan-remote-spec.md.
+        """
+        coord = _make_fan_remote_coord(startup_coalesce_active=False)
+        new_state = _make_state("2026-07-12T16:58:00+00:00", {"event_type": "timer_2h"})
+        event = _make_event({"new_state": new_state})
+
+        asyncio.run(coord._async_fan_remote_changed(event))
+
+        coord.automation_engine.handle_fan_manual_override.assert_called_once_with(
+            fan_before="?", fan_after="on", duration_override=7200.0, remote_timer_hours=2.0
+        )
+
+
+# ---------------------------------------------------------------------------
+# _abandon_observation() — executor-job crash
+# ---------------------------------------------------------------------------
+
+
+class TestAbandonObservationExecutorJob:
+    def test_does_not_wrap_executor_job_in_create_task(self):
+        """_abandon_observation() must call hass.async_add_executor_job() directly,
+        not wrap it in hass.async_create_task() — the latter raised
+        'TypeError: a coroutine was expected, got <Future ...>' on every restart that
+        hit this abandonment path, crashing the whole coordinator update
+        (surfaced to the user as the "Climate Advisor unavailable" status banner).
+
+        Occupant impact: without this fix, the dashboard showed a scary "Climate
+        Advisor unavailable" error after routine restarts/deploys, even though
+        nothing was actually broken.
+        """
+        ClimateAdvisorCoordinator = _get_coordinator_class()
+        coord = object.__new__(ClimateAdvisorCoordinator)
+
+        hass = MagicMock()
+        # A bare MagicMock (not a coroutine/Future) — if _abandon_observation ever
+        # wraps this in hass.async_create_task() again, asyncio.iscoroutine() inside
+        # HA's real async_create_task would reject it exactly like production does;
+        # here we assert the wrapper is never called at all.
+        hass.async_add_executor_job = MagicMock(return_value=MagicMock())
+        hass.async_create_task = MagicMock()
+        coord.hass = hass
+
+        learning = MagicMock()
+        learning.save_state = MagicMock()
+        learning._state = MagicMock()
+        learning._state.rejection_log = {}
+        coord.learning = learning
+        coord._rejection_log = {}
+        coord._pending_observations = {
+            "passive_decay": {
+                "obs_type": "passive_decay",
+                "start_time": "2026-07-12T16:30:00+00:00",
+                "samples": [],
+            }
+        }
+
+        coord._abandon_observation = types.MethodType(ClimateAdvisorCoordinator._abandon_observation, coord)
+
+        # Must not raise — the original bug crashed here with a TypeError.
+        coord._abandon_observation("passive_decay", "test_reason")
+
+        hass.async_add_executor_job.assert_called_once_with(learning.save_state)
+        hass.async_create_task.assert_not_called()

--- a/tests/test_thermal_event.py
+++ b/tests/test_thermal_event.py
@@ -88,8 +88,20 @@ def _make_v3_coord(
 
     hass.async_create_task = MagicMock(side_effect=_consume_coroutine)
 
-    async def _exec_job(fn, *args):
-        return fn(*args)
+    def _exec_job(fn, *args):
+        # Issue #491: mirrors real HA semantics for both calling conventions used in
+        # coordinator.py — some call sites `await hass.async_add_executor_job(...)`
+        # (needs an awaitable Future), others (_abandon_observation, sync, fire-and-
+        # forget) call it with no running loop at all. asyncio.get_running_loop()
+        # tells us which context we are in; Python 3.14 removed the implicit event
+        # loop, so this cannot unconditionally use get_event_loop().
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return fn(*args)
+        fut = loop.create_future()
+        fut.set_result(fn(*args))
+        return fut
 
     hass.async_add_executor_job = _exec_job
 

--- a/tests/test_thermal_observation_pipeline.py
+++ b/tests/test_thermal_observation_pipeline.py
@@ -105,8 +105,20 @@ def _make_hvac_coord(
     hass = MagicMock()
     hass.async_create_task = MagicMock(side_effect=_consume_coroutine)
 
-    async def _exec_job(fn, *args):
-        return fn(*args)
+    def _exec_job(fn, *args):
+        # Issue #491: mirrors real HA semantics for both calling conventions used in
+        # coordinator.py — some call sites `await hass.async_add_executor_job(...)`
+        # (needs an awaitable Future), others (_abandon_observation, sync, fire-and-
+        # forget) call it with no running loop at all. asyncio.get_running_loop()
+        # tells us which context we are in; Python 3.14 removed the implicit event
+        # loop, so this cannot unconditionally use get_event_loop().
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return fn(*args)
+        fut = loop.create_future()
+        fut.set_result(fn(*args))
+        return fut
 
     hass.async_add_executor_job = _exec_job
 

--- a/tests/test_thermal_observations.py
+++ b/tests/test_thermal_observations.py
@@ -114,8 +114,20 @@ def _make_obs_coord(
 
     hass.async_create_task = MagicMock(side_effect=_consume_coroutine)
 
-    async def _exec_job(fn, *args):
-        return fn(*args)
+    def _exec_job(fn, *args):
+        # Issue #491: mirrors real HA semantics for both calling conventions used in
+        # coordinator.py — some call sites `await hass.async_add_executor_job(...)`
+        # (needs an awaitable Future), others (_abandon_observation, sync, fire-and-
+        # forget) call it with no running loop at all. asyncio.get_running_loop()
+        # tells us which context we are in; Python 3.14 removed the implicit event
+        # loop, so this cannot unconditionally use get_event_loop().
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return fn(*args)
+        fut = loop.create_future()
+        fut.set_result(fn(*args))
+        return fut
 
     hass.async_add_executor_job = _exec_job
 
@@ -2444,8 +2456,21 @@ class TestHvacObservationLogging:
 
         hass.async_create_task = MagicMock(side_effect=_consume_coroutine)
 
-        async def _exec_job(fn, *args):
-            return fn(*args)
+        def _exec_job(fn, *args):
+            # Issue #491: mirrors real HA semantics for both calling conventions used
+            # in coordinator.py — some call sites
+            # `await hass.async_add_executor_job(...)` (needs an awaitable Future),
+            # others (_abandon_observation, sync, fire-and-forget) call it with no
+            # running loop at all. asyncio.get_running_loop() tells us which context
+            # we are in; Python 3.14 removed the implicit event loop, so this cannot
+            # unconditionally use get_event_loop().
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                return fn(*args)
+            fut = loop.create_future()
+            fut.set_result(fn(*args))
+            return fut
 
         hass.async_add_executor_job = _exec_job
         coord.hass = hass

--- a/tests/test_whf_command_only.py
+++ b/tests/test_whf_command_only.py
@@ -104,6 +104,14 @@ def _make_coord_stub(config: dict | None = None) -> MagicMock:
         mod.ClimateAdvisorCoordinator._fan_state_feedback_enabled, coord
     )
 
+    # Issue #491: same reasoning — bind the real _suppress_during_startup_coalescing()
+    # guard rather than let a bare MagicMock return a truthy value and silently
+    # suppress every dispatch test. Tests exercise post-coalescing (normal) dispatch.
+    coord._startup_coalesce_active = False
+    coord._suppress_during_startup_coalescing = types.MethodType(
+        mod.ClimateAdvisorCoordinator._suppress_during_startup_coalescing, coord
+    )
+
     return coord
 
 

--- a/tests/test_whf_dual_entity.py
+++ b/tests/test_whf_dual_entity.py
@@ -74,6 +74,10 @@ def _make_coord_stub(config: dict) -> MagicMock:
 
     coord._is_recent_fan_command = MagicMock(return_value=False)
     coord.async_request_refresh = AsyncMock()
+    # Issue #491: _async_fan_entity_changed now calls the real
+    # _suppress_during_startup_coalescing() guard; coord being a bare MagicMock would
+    # otherwise return a truthy MagicMock and silently suppress dispatch tests below.
+    coord._suppress_during_startup_coalescing = MagicMock(return_value=False)
 
     return coord
 


### PR DESCRIPTION
## Summary
- **False WHF manual override + grace period at restart**: `_async_fan_remote_changed()` (the QuietCool RF-remote handler from #486) and `_async_fan_entity_changed()` had no guard against the 5-minute startup-coalescing window that `_async_thermostat_changed()` already used (Issue #321). A physical device (e.g. the QuietCool remote's `event.*` entity) can re-announce its last retained state while HA is still settling right after restart — CA misread this as a fresh manual override, producing a real (but bogus) grace period. Extracted one shared `_suppress_during_startup_coalescing()` helper used by all three listeners, instead of copy-pasting the guard a third time (this codebase has repeatedly paid for exactly that "sibling copies drift" defect class — see #454/#456/#460/#464/#466/#468/#429).
- **"Climate Advisor unavailable" crash at restart**: `_abandon_observation()` wrapped an already-scheduled `hass.async_add_executor_job()` Future in `hass.async_create_task()` (which requires a coroutine), raising `TypeError: a coroutine was expected, got <Future ...>` whenever a pending thermal observation was abandoned right as HVAC started — common at restart. Predates #489 by 2.5 months (Issue #121, 2026-04-28); only became visible once Fix #480/0.5.17 added the "unavailable" banner.
- Neither bug was caused by #489 — confirmed via `git log -p -S` blame and code-path tracing, diagnosed with the `troubleshoot` skill using live HA logs.
- Updates `docs/08-COMPUTATION-REFERENCE.md` (corrects a "post-coalesce" claim that was aspirational until this fix) and `docs/fan-remote-spec.md`.
- Corrects several tests' `async_add_executor_job` stubs that modeled a coroutine-based contract instead of HA's real Future-based one — the same inaccurate mock shape that let bug #2 ship undetected for 2.5 months.
- Bumps version to 0.5.21 with `RELEASE_NOTES`/`KNOWN_FIXES` entries.

Closes #491

## Test plan
- [x] New `tests/test_restart_coalescing_fan_guard.py` (7 tests: shared helper, both fan listeners' coalescing suppression, executor-job crash), verified to fail without the fix (via revert) and pass with it
- [x] Fixed blast-radius breakage in 6 existing test files whose stubs assumed the old (buggy) `async_add_executor_job` contract or a bare `MagicMock` for the new coalescing guard
- [x] Full suite: `pytest tests/` — 3422 passed, 6 xfailed
- [x] `python tools/simulate.py` — 53/53 golden scenarios pass, no automation/timing regressions
- [x] `ruff check` / `ruff format` clean, `tools/validate.py` clean
- [x] `pytest tests/test_version_sync.py` passes