### PR TITLE
Fix #493: learning.save_state() races on shared .tmp filename under concurrent calls

### DIFF
--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,20 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.21"
+VERSION = "0.5.22"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.22": [
+        "Fix #493: found while verifying #491's restart fix on a real HA restart —"
+        " learning.save_state() could occasionally log 'Failed to save learning state:"
+        " No such file or directory' when two saves happened to run at the same moment"
+        " (common at restart). It wrote to a shared, fixed staging filename, so one save"
+        " could find the file already consumed by another. Non-fatal (the error was"
+        " already caught and logged; nothing was corrupted), but one save's data could be"
+        " silently skipped for that cycle. Each save now stages to its own uniquely-named"
+        " temp file, the same pattern already used by CA's other state file — eliminating"
+        " the collision entirely.",
+    ],
     "0.5.21": [
         "Fix #491: two restart-time bugs found immediately after the 0.5.20 deploy, both"
         " pre-existing and unrelated to #489. (1) The dashboard could show a false"
@@ -1127,6 +1138,35 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    493: {
+        "version_fixed": "0.5.22",
+        "title": "learning.save_state() race on shared .tmp filename under concurrent calls",
+        "scope_covered": (
+            "learning.LearningEngine.save_state() now stages its atomic write via"
+            " tempfile.mkstemp(dir=self._db_path.parent, prefix=f'{self._db_path.stem}_',"
+            " suffix='.tmp') instead of a fixed self._db_path.with_suffix('.tmp') path,"
+            " mirroring the already-proven pattern in state.py's save(). Each call now gets"
+            " a guaranteed-unique staging file, eliminating the ENOENT race where two"
+            " concurrent calls (9 call sites in coordinator.py, 8 awaited + 1"
+            " fire-and-forget from _abandon_observation) could both target the same tmp"
+            " path and one's os.replace() would find it already consumed by the other's."
+            " Found while verifying #491's fix on a real HA restart — that fix let"
+            " _abandon_observation()'s previously-crashing (TypeError) background save"
+            " actually execute for the first time, exposing this pre-existing race. On"
+            " OSError the orphaned unique tmp file is now cleaned up (os.unlink, errors"
+            " suppressed), matching state.py's failure-path behavior. Serialization"
+            " failures (TypeError/ValueError from json.dumps) are now caught separately"
+            " before any tmp file is created, also matching state.py."
+        ),
+        "scope_not_covered": (
+            "Does not add locking/synchronization to serialize concurrent save_state()"
+            " calls — under genuine concurrency, the last os.replace() to run still wins"
+            " (whichever save started last determines the final on-disk state), matching"
+            " state.py's existing accepted behavior for the same scenario. This fix"
+            " eliminates the crash/lost-save failure mode, not the (already accepted,"
+            " lower-severity) last-write-wins ordering under true concurrency."
+        ),
+    },
     491: {
         "version_fixed": "0.5.21",
         "title": "False WHF manual-override/grace-period + coordinator crash at HA restart",

--- a/custom_components/climate_advisor/learning.py
+++ b/custom_components/climate_advisor/learning.py
@@ -6,10 +6,12 @@ environmental outcomes to generate adaptive improvement suggestions.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
 import sys
+import tempfile
 import uuid
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime, timedelta
@@ -757,17 +759,36 @@ class LearningEngine:
         self._state = LearningState()
 
     def save_state(self) -> None:
-        """Persist learning state to disk (blocking I/O — run via executor)."""
+        """Persist learning state to disk (blocking I/O — run via executor).
+
+        Issue #493: uses tempfile.mkstemp() for a unique per-call temp filename,
+        mirroring state.py's save() — a fixed, shared ".tmp" path let concurrent
+        calls (9 call sites in coordinator.py, one of them fire-and-forget from
+        _abandon_observation) race on os.replace(), raising ENOENT for whichever
+        call lost the race.
+        """
         try:
             serialized = json.dumps(asdict(self._state), indent=2)
-            tmp_path = self._db_path.with_suffix(".tmp")
-            tmp_path.write_text(serialized)
+        except (TypeError, ValueError) as err:
+            _LOGGER.error("Failed to serialize learning state: %s", err)
+            return
+
+        tmp_fd, tmp_path_str = tempfile.mkstemp(
+            dir=self._db_path.parent,
+            prefix=f"{self._db_path.stem}_",
+            suffix=".tmp",
+        )
+        try:
+            with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+                f.write(serialized)
+            os.replace(tmp_path_str, self._db_path)
             if sys.platform != "win32":
-                os.chmod(tmp_path, 0o600)
-            os.replace(tmp_path, self._db_path)
+                os.chmod(self._db_path, 0o600)
             _LOGGER.debug("Saved learning state — %d records", len(self._state.records))
         except OSError as err:
             _LOGGER.error("Failed to save learning state: %s", err)
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_path_str)
 
     def record_day(self, record: DailyRecord) -> None:
         """Record a day's data for learning.

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.21"
+  "version": "0.5.22"
 }

--- a/tests/test_learning_io.py
+++ b/tests/test_learning_io.py
@@ -7,6 +7,7 @@ callers must explicitly invoke load_state() / save_state().
 from __future__ import annotations
 
 import json
+import os
 from datetime import date, timedelta
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -142,6 +143,71 @@ class TestSaveState:
         engine = LearningEngine(tmp_path)
         engine.accept_suggestion("frequent_overrides")
         assert not db_path.exists()
+
+    def test_concurrent_saves_use_distinct_tmp_paths(self, tmp_path: Path):
+        """Each save_state() call must stage to a distinct tmp path (Issue #493).
+
+        This is the causal property that eliminates the race: two concurrent
+        calls writing to the SAME tmp path can have one's os.replace() find it
+        already consumed by the other's, raising ENOENT (confirmed on a real
+        HA restart, 3 concurrent calls, 1 failed). A real threading race is
+        inherently flaky to provoke reliably in a fast local test environment
+        — a threading.Barrier-synchronized version of this test still passed
+        against the pre-fix code every time it was tried, since both the
+        write and the replace complete faster than genuine thread contention
+        materializes on local SSD/NTFS. Testing the property that structurally
+        prevents the race (uniqueness) is deterministic and mirrors why
+        state.py's save() (already using tempfile.mkstemp()) doesn't have
+        this bug.
+        """
+        engine = LearningEngine(tmp_path)
+        engine.record_day(_make_record())
+
+        seen_tmp_paths: list[str] = []
+        real_replace = os.replace
+
+        def _capture_replace(src, dst):
+            seen_tmp_paths.append(str(src))
+            return real_replace(src, dst)
+
+        with patch("custom_components.climate_advisor.learning.os.replace", side_effect=_capture_replace):
+            for _ in range(5):
+                engine.save_state()
+
+        assert len(seen_tmp_paths) == 5
+        assert len(set(seen_tmp_paths)) == 5, (
+            f"save_state() reused a tmp path across calls — the exact defect class that"
+            f" caused Issue #493's ENOENT race: {seen_tmp_paths}"
+        )
+
+    def test_concurrent_saves_no_enoent(self, tmp_path: Path):
+        """Overlapping save_state() calls must not raise ENOENT (Issue #493).
+
+        Best-effort integration-style companion to
+        test_concurrent_saves_use_distinct_tmp_paths above (which is the
+        reliable, deterministic regression guard) — real thread contention on
+        a fast local disk doesn't reliably reproduce the original race, but
+        this still exercises the real threading path end-to-end.
+        """
+        import concurrent.futures
+
+        db_path = tmp_path / LEARNING_DB_FILE
+        engine = LearningEngine(tmp_path)
+        engine.record_day(_make_record())
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+            futures = [pool.submit(engine.save_state) for _ in range(16)]
+            for f in concurrent.futures.as_completed(futures):
+                f.result()  # raises if save_state() raised
+
+        assert db_path.exists()
+
+    def test_save_is_atomic_no_tmp_left(self, tmp_path: Path):
+        """No leftover *_*.tmp staging file after a successful save."""
+        engine = LearningEngine(tmp_path)
+        engine.record_day(_make_record())
+        engine.save_state()
+        assert list(tmp_path.glob(f"{LEARNING_DB_FILE.removesuffix('.json')}_*.tmp")) == []
 
 
 class TestRoundTrip:

--- a/tests/test_occupancy.py
+++ b/tests/test_occupancy.py
@@ -1129,13 +1129,20 @@ class TestOccupancyAwayDelay:
 
     # ── Test 8 ────────────────────────────────────────────────────
 
-    def test_timer_cancelled_on_shutdown(self):
+    def test_timer_cancelled_on_shutdown(self, tmp_path):
         """async_shutdown cancels a pending occupancy away timer."""
         coord = _make_coordinator(
             config_overrides={CONF_HOME_TOGGLE: "input_boolean.home_mode"},
             state_map={"input_boolean.home_mode": "off"},
         )
         coord._occupancy_mode = OCCUPANCY_HOME
+        # Issue #493: learning.save_state() now uses tempfile.mkstemp(dir=...), which
+        # requires the directory to actually exist — unlike the old code, whose broad
+        # except OSError silently swallowed a write to a nonexistent directory. The
+        # mocked hass.config.config_dir (a bare MagicMock attribute) was never a real
+        # path; point _db_path at a real tmp_path directory so save_state() below
+        # exercises real disk I/O the way it does in production.
+        coord.learning._db_path = tmp_path / "climate_advisor_learning.json"
 
         cancel_mock = MagicMock()
 


### PR DESCRIPTION
## Summary
- Found while verifying #491's fix on a real HA restart: `Failed to save learning state: No such file or directory` for `climate_advisor_learning.tmp`.
- `save_state()` wrote to a fixed, shared temp path. Concurrent calls (9 call sites in `coordinator.py`, 8 awaited + 1 fire-and-forget from `_abandon_observation`) could both target it, and whichever `os.replace()` ran second found the tmp file already consumed by the first, raising `ENOENT`. Non-fatal (caught, logged, no corruption) but a silently dropped save.
- This specific call could never race before #491: the erroneous `async_create_task()` wrapper that PR removed had been crashing instantly with a `TypeError`, so the executor job never actually touched the filesystem. Fixing that crash let it run for real, exposing this pre-existing race for the first time.
- Rewrites `save_state()` to use `tempfile.mkstemp()` for a unique per-call temp filename, mirroring the already-proven pattern in `state.py`'s `save()` (which already has a passing `test_concurrent_saves_no_enoent` regression test).
- Also fixes `test_occupancy.py::test_timer_cancelled_on_shutdown`, whose mock `hass.config.config_dir` was never a real directory — previously masked by the old code's overly broad `except OSError` silently swallowing the write failure.
- Bumps version to 0.5.22 with `RELEASE_NOTES`/`KNOWN_FIXES` entries.

Closes #493

## Test plan
- [x] New `test_concurrent_saves_use_distinct_tmp_paths` (deterministic — asserts the causal fix property directly), verified to fail without the fix (via revert) and pass with it
- [x] A real-threading `test_concurrent_saves_no_enoent` companion test, mirroring `state.py`'s existing one, as a best-effort integration check (note: a `threading.Barrier`-synchronized version was tried first and found to NOT reliably reproduce the original race in this environment — documented in the test docstring)
- [x] `test_save_is_atomic_no_tmp_left` — no leftover staging file after a successful save
- [x] Full suite: `pytest tests/` — 3425 passed, 6 xfailed
- [x] `python tools/simulate.py` — 53/53 golden scenarios pass
- [x] `ruff check` / `ruff format` clean, `pytest tests/test_version_sync.py` passes