### PR TITLE
Fix #495: manual/remote whole-house-fan-on left HVAC armed; QuietCool remote reliability + status display

### DIFF
--- a/custom_components/climate_advisor/ai_skills_activity.py
+++ b/custom_components/climate_advisor/ai_skills_activity.py
@@ -537,6 +537,27 @@ def _render_hvac_write_blocked_whf_active(p: dict, unit: str) -> tuple[str, str]
     return label, settings
 
 
+def _render_whf_hvac_suppressed(p: dict, unit: str) -> tuple[str, str]:
+    """Issue #495: HVAC suppressed for a whole-house-fan session — CA-initiated OR a
+    manual/remote fan-on detection (both now route through the same suppress helper).
+    """
+    prior_mode = str(p.get("prior_mode", "")).strip()
+    reason = str(p.get("reason", "")).strip()
+    label = f"HVAC suppressed (whole-house fan) -- {reason}" if reason else "HVAC suppressed (whole-house fan)"
+    settings = f"hvac: {prior_mode}->off" if prior_mode else "hvac: ->off"
+    return label, settings
+
+
+def _render_whf_hvac_released(p: dict, unit: str) -> tuple[str, str]:
+    """Issue #495: a manual/remote WHF session ended — HVAC suppression released and CA's
+    current classification reasserted (not a blind restore of the mode captured at activation,
+    since a remote-timer session can span hours).
+    """
+    reason = str(p.get("reason", "")).strip()
+    label = f"HVAC suppression released -- {reason}" if reason else "HVAC suppression released"
+    return label, "hvac: reclassifying"
+
+
 def _render_fan_manual_override(p: dict, unit: str) -> tuple[str, str]:
     fan_before = str(p.get("fan_before", "")).strip()
     fan_after = str(p.get("fan_after", "")).strip()
@@ -886,6 +907,8 @@ EVENT_RENDERERS: dict[str, Callable[[dict, str], tuple[str, str]]] = {
     "fan_deactivated": _render_fan_deactivated,
     "fan_manual_override": _render_fan_manual_override,
     "hvac_write_blocked_whf_active": _render_hvac_write_blocked_whf_active,
+    "whf_hvac_suppressed": _render_whf_hvac_suppressed,
+    "whf_hvac_released": _render_whf_hvac_released,
     "fan_running_untracked": _render_fan_running_untracked,
     "fan_untracked_cleared": _render_fan_untracked_cleared,
     "fan_cancel": _render_fan_cancel,

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -601,6 +601,14 @@ class AutomationEngine:
         # Set by coordinator after construction.
         self._post_grace_fan_check_callback: Callable[[], None] | None = None
 
+        # Reclassify callback — called by _release_whf_and_reclassify() when a manual/remote
+        # WHF session ends, so the coordinator re-runs apply_classification() with its own
+        # current classification/predicted-indoor state (Issue #495). AutomationEngine has no
+        # direct handle on that coordinator-owned state, so this mirrors the existing
+        # callback-injection pattern above rather than reaching into the coordinator directly.
+        # Set by coordinator after construction.
+        self._reclassify_callback: Callable[[], None] | None = None
+
         # Today's DailyRecord — set by coordinator; used for bedtime setback tracking
         self._today_record: Any | None = None
 
@@ -809,6 +817,7 @@ class AutomationEngine:
         event_context_id: str | None = None,
         duration_override: float | None = None,
         remote_timer_hours: float | None = None,
+        is_remote_event: bool = False,
     ) -> None:
         """Handle a manual fan state change — sets fan override flag + grace (Issue #327).
 
@@ -837,17 +846,36 @@ class AutomationEngine:
             remote_timer_hours: The RF remote's selected timer duration in hours, for
                 observability only (dashboard/status display + serialized state). None
                 for a non-remote-triggered override, or when the remote picked "no timer".
+            is_remote_event: True when this call originates from the RF remote (Issue #495)
+                — disambiguates a genuine "no timer" remote selection (``remote_timer_hours=
+                None`` from a real ``timer_none`` press, which SHOULD revert the stored value
+                to None) from a plain non-remote fan-on re-detection also passing
+                ``remote_timer_hours=None`` (which should NOT clobber an already-active
+                remote timer — see the preserve-on-restamp comment below).
         """
+        was_override_active = self._fan_override_active
         self._stop_fan_min_runtime_cycles()
         self._fan_override_active = True
         self._fan_override_time = dt_util.now().isoformat()
-        self._fan_remote_timer_hours = remote_timer_hours
+        # Issue #495: only overwrite the remote-timer value when the caller has a genuine
+        # opinion about it. This method is the SHARED entry point for both remote-timer
+        # presses and plain (non-remote) fan-on detections; a plain re-stamp of an
+        # already-active override (e.g. the WHF fan entity re-reporting "on" after a brief
+        # unavailable flap) must not clobber an active remote timer to None. Confirmed live:
+        # the status API returned fan_remote_timer_hours=None seconds after an 8h remote
+        # press while the persisted state still held 8.0 — the fan entity's own
+        # re-detection had nulled it. `is_remote_event` covers the one case that would
+        # otherwise be indistinguishable from that non-remote re-detection: a deliberate
+        # `timer_none` remote press, which also passes remote_timer_hours=None but SHOULD
+        # clear the stored value (revert to the configured default duration).
+        if is_remote_event or remote_timer_hours is not None or not was_override_active:
+            self._fan_remote_timer_hours = remote_timer_hours
         _LOGGER.info(
             "Fan override: set — manual fan change detected %s->%s, override active since %s, grace period starting%s",
             fan_before or "?",
             fan_after or "?",
             self._fan_override_time,
-            f" (RF remote timer: {remote_timer_hours}h)" if remote_timer_hours is not None else "",
+            f" (RF remote timer: {self._fan_remote_timer_hours}h)" if self._fan_remote_timer_hours is not None else "",
         )
         if self._emit_event_callback:
             self._emit_event_callback(
@@ -862,6 +890,17 @@ class AutomationEngine:
                 },
             )
         self._start_grace_period("manual", trigger="fan_manual_override", duration_override=duration_override)
+
+        # Issue #495: whole-house fan and HVAC are mutually exclusive — this was previously
+        # only enforced for CA-initiated activation (_activate_fan()). A manually/remotely
+        # detected WHF-on left the AC armed for the life of the override. Scoped to
+        # WHOLE_HOUSE/BOTH; FAN_MODE_HVAC coexists with the compressor by design.
+        if self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED) in (FAN_MODE_WHOLE_HOUSE, FAN_MODE_BOTH):
+            self.hass.async_create_task(
+                self._suppress_hvac_for_whf(
+                    reason="whole-house fan manually turned on — suppressing HVAC to prevent AC/fan fighting"
+                )
+            )
 
     def on_fan_turned_off(self, fan_before: str = "", fan_after: str = "", event_context_id: str | None = None) -> None:
         """Handle the user turning the fan OFF — clears fan state and gates nat-vent re-activation (Issue #359).
@@ -915,6 +954,10 @@ class AutomationEngine:
             trigger_label="fan_off",
             preserve_nat_vent_session=False,
         )
+        # Issue #495: release any WHF HVAC suppression this session was holding (manual
+        # override OR a nat-vent session the user stopped physically) and reclassify —
+        # the fan is confirmed off by the very event that triggered this method.
+        self._release_whf_and_reclassify(reason=f"fan turned off by user ({fan_before or '?'}->{fan_after or '?'})")
 
     def _clear_fan_flags_and_start_grace(
         self,
@@ -987,6 +1030,11 @@ class AutomationEngine:
             self._fan_remote_timer_hours = None
             # Restart the min-runtime cycle that was suspended when override was set
             self.hass.async_create_task(self.start_min_fan_runtime_cycles())
+            # Issue #495: release any WHF HVAC suppression this override was holding.
+            # _release_whf_and_reclassify() itself checks physical fan state and no-ops
+            # if the WHF is still running (e.g. grace expired but the timer hasn't) —
+            # the post-grace fan reconcile owns that case instead.
+            self._release_whf_and_reclassify(reason="fan override cleared")
 
     async def start_min_fan_runtime_cycles(self) -> None:
         """Start rolling minimum fan runtime cycles (not clock-aligned).
@@ -1482,7 +1530,19 @@ class AutomationEngine:
             # 30-minute cycle cannot re-arm the ceiling (compressor) through open windows.
             # With savings off, call the helper to keep the full band current, then continue so the
             # ODE ceiling guard can still fire as a safety backstop if a breach is predicted.
-            if self._natural_vent_active:
+            #
+            # Issue #495: OR in _whf_owns_hvac() so a manually/remotely-detected WHF session
+            # (which sets _pre_fan_hvac_mode via _suppress_hvac_for_whf() but does NOT set
+            # _natural_vent_active — a manual override isn't a nat-vent decision) is also
+            # gated here, not just left to the low-level _set_hvac_mode()/_set_temperature()
+            # write-guard. The write-guard alone would still block the write, but silently —
+            # this ORs the same condition apply_classification already checks for the
+            # CA-initiated case so a manual session doesn't compute select_comfort_band()/run
+            # the ODE ceiling guard just to have the result dropped (Issue #392 Fix 1b's own
+            # rationale). _whf_owns_hvac() is additive here, not a replacement: the reconcile-
+            # adopted case (reconcile_fan_on_startup() sets _natural_vent_active without
+            # setting _pre_fan_hvac_mode) still needs the original _natural_vent_active check.
+            if self._natural_vent_active or self._whf_owns_hvac():
                 _aggressive = bool(self.config.get("aggressive_savings", False))
                 _LOGGER.info(
                     "apply_classification: nat-vent active — enforcing nat-vent band ac_assist=%s day_type=%s",
@@ -4367,6 +4427,63 @@ class AutomationEngine:
         fan_mode = self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED)
         return fan_mode in (FAN_MODE_WHOLE_HOUSE, FAN_MODE_BOTH) and self._pre_fan_hvac_mode is not None
 
+    async def _suppress_hvac_for_whf(self, *, reason: str) -> None:
+        """Capture current HVAC mode and turn it off for a whole-house-fan session (Issue #495).
+
+        Scoped to WHOLE_HOUSE/BOTH only — FAN_MODE_HVAC coexists with the compressor by
+        design (that fan IS the thermostat's own blower). Idempotent: a session that already
+        owns HVAC (``_pre_fan_hvac_mode is not None``) is not re-captured, so a repeated call
+        (e.g. two manual-override re-stamps in quick succession — the live incident showed a
+        physical fan-on at 20:45:32 followed by an RF remote press at 20:48:40) never clobbers
+        the captured mode with "off".
+
+        Shared by ``_activate_fan()`` (CA-initiated) and ``handle_fan_manual_override()``
+        (manual/remote-detected) so the WHF/HVAC mutual-exclusion rule has exactly one
+        suppression path — see the #400/#402/#417/#456/#458 "sibling threshold drift" history
+        for why a second copy of this rule is the wrong move.
+        """
+        fan_mode = self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED)
+        if fan_mode not in (FAN_MODE_WHOLE_HOUSE, FAN_MODE_BOTH):
+            return
+        if self._pre_fan_hvac_mode is not None:
+            return
+        _cs = self.hass.states.get(self.climate_entity)
+        prior_mode = _cs.state if _cs else None
+        self._pre_fan_hvac_mode = prior_mode
+        await self._set_hvac_mode("off", reason=reason)
+        if self._emit_event_callback:
+            self._emit_event_callback("whf_hvac_suppressed", {"prior_mode": prior_mode, "reason": reason})
+
+    def _release_whf_and_reclassify(self, *, reason: str) -> None:
+        """End a WHF HVAC-suppression session: release ownership, then reclassify (Issue #495).
+
+        A manual/remote WHF session can run for hours (an 8h QuietCool RF remote timer
+        selection), so the HVAC mode captured in ``_pre_fan_hvac_mode`` at activation time is
+        often stale by exit — the session can span a sleep-setback transition. Rather than
+        blindly restoring that captured mode (what ``_deactivate_fan()`` does for the short
+        CA-initiated nat-vent cycle), this releases ownership and lets classification compute
+        the correct current mode AND setpoint in one shot, via the coordinator's existing
+        fan-off reassert path (``_async_reassert_setpoint_after_fan_off``, Issue #359 Fix A).
+
+        Guard: no-op if the WHF is still physically running, checked via the same ground-truth
+        callback ``_reconcile_fan_physical_drift()`` already uses
+        (``_get_fan_physical_state_callback`` — returns True/False when feedback is available,
+        None in command-only mode). The post-grace fan reconcile
+        (``_on_post_grace_fan_check`` -> ``reconcile_fan_on_startup``) owns the "still running"
+        case; releasing here too would race it.
+        """
+        if self._pre_fan_hvac_mode is None:
+            return  # no suppression session to release
+        if self._get_fan_physical_state_callback and self._get_fan_physical_state_callback():
+            _LOGGER.debug("WHF release-and-reclassify skipped (%s) — fan still physically on", reason)
+            return
+        self._pre_fan_hvac_mode = None  # release _whf_owns_hvac() BEFORE the reclassify write
+        _LOGGER.info("WHF session ended (%s) — releasing HVAC suppression, reclassifying current state", reason)
+        if self._emit_event_callback:
+            self._emit_event_callback("whf_hvac_released", {"reason": reason})
+        if self._reclassify_callback:
+            self._reclassify_callback()
+
     async def _apply_nat_vent_hvac_state(self) -> None:
         """Apply the correct HVAC state when nat-vent is active.
 
@@ -4571,14 +4688,10 @@ class AutomationEngine:
         self._fan_command_pending = True
         try:
             if fan_mode in (FAN_MODE_WHOLE_HOUSE, FAN_MODE_BOTH):
-                # Capture current HVAC mode before suppressing it (Issue #277 Fix C).
                 # Whole-house fan exchanges outdoor air directly — running AC/heat
-                # simultaneously fights the fan and wastes energy.
-                _cs = self.hass.states.get(self.climate_entity)
-                self._pre_fan_hvac_mode = _cs.state if _cs else None
-                await self._set_hvac_mode(
-                    "off",
-                    reason="whole-house fan active — suppressing HVAC to prevent fighting outdoor air exchange",
+                # simultaneously fights the fan and wastes energy (Issue #277 Fix C).
+                await self._suppress_hvac_for_whf(
+                    reason="whole-house fan active — suppressing HVAC to prevent fighting outdoor air exchange"
                 )
 
                 fan_entity = self.config.get(CONF_FAN_ENTITY)

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,25 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.22"
+VERSION = "0.5.23"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.23": [
+        "Fix #495: manually or remotely turning on the whole-house fan (WHF) — by hand, or"
+        " via a QuietCool RF remote timer press — left the AC armed for the entire session,"
+        " fighting the fan and wasting energy while windows were open. Only Climate"
+        " Advisor's own fan activation suppressed HVAC; a user-initiated fan-on did not."
+        " Fixed: both paths now share one HVAC-suppression helper, and ending a manual"
+        " session reclassifies (rather than blindly restoring a potentially hours-stale"
+        " captured mode — an RF-remote-timer session can run up to 12 hours). Also fixes"
+        " two QuietCool remote bugs found while investigating: (1) the remote's status"
+        " entity can flap unavailable and re-announce a stale timer selection with no user"
+        " action, which was previously processed as a fresh press — confirmed live as a"
+        " phantom 2-hour override with zero button presses; (2) the dashboard's remote-timer"
+        " display could go blank within seconds of a real press. And: the dashboard could"
+        " show two contradicting status lines at once when a fan override and a pending"
+        " thermostat-override confirmation overlapped — now reconciled.",
+    ],
     "0.5.22": [
         "Fix #493: found while verifying #491's restart fix on a real HA restart —"
         " learning.save_state() could occasionally log 'Failed to save learning state:"
@@ -1138,6 +1154,71 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    495: {
+        "version_fixed": "0.5.23",
+        "title": "Manual/remote whole-house-fan-on left HVAC armed; QuietCool remote reliability + status display",
+        "scope_covered": (
+            "(1) HVAC suppression on WHF-on (the core bug): _pre_fan_hvac_mode capture +"
+            " _set_hvac_mode('off') previously lived only in the CA-initiated _activate_fan()"
+            " path. New shared automation.AutomationEngine._suppress_hvac_for_whf() helper is"
+            " now called by BOTH _activate_fan() (refactored to use it, no behavior change)"
+            " AND handle_fan_manual_override() (new — scoped to FAN_MODE_WHOLE_HOUSE/BOTH"
+            " only; FAN_MODE_HVAC is unaffected by design). Idempotent: a second override call"
+            " while a suppression session is already active does not re-capture the mode."
+            " (2) Exit is reclassify, not restore: new _release_whf_and_reclassify() releases"
+            " _pre_fan_hvac_mode and reuses the existing coordinator fan-off reassert path"
+            " (_async_reassert_setpoint_after_fan_off, Issue #359 Fix A) instead of blindly"
+            " restoring the mode captured at activation — a manual/RF-remote-timer session can"
+            " run up to 12 hours, so the captured mode is often stale by exit. Wired into"
+            " on_fan_turned_off() (fan confirmed off by the triggering event) and"
+            " clear_fan_override() (grace expiry / user cancel — first checks physical fan"
+            " state via the existing _get_fan_physical_state_callback ground truth used by"
+            " _reconcile_fan_physical_drift(), and no-ops if the fan is still running, so it"
+            " does not race the post-grace fan reconcile). (3) apply_classification()'s"
+            " nat-vent early-return now also checks _whf_owns_hvac() (additive OR, not a"
+            " replacement for _natural_vent_active) so a manual WHF session — which sets"
+            " _pre_fan_hvac_mode but not _natural_vent_active — is covered without weakening"
+            " the pre-existing reconcile_fan_on_startup()-adopted-session case."
+            " (4) QuietCool remote stale-event dedup: the event.* entity flaps to unavailable"
+            " at arbitrary times (not just restart) and re-announces its stale last"
+            " event_type with the SAME state (the entity's state field IS the event"
+            " timestamp) — confirmed live as a phantom 2-hour override with zero user action."
+            " New coordinator._last_fan_remote_event_ts tracks the last acted-on timestamp;"
+            " _async_fan_remote_changed() ignores a re-announced identical value. Generalizes"
+            " the Issue #491 restart-only guard to every unavailable-then-restore flap."
+            " (5) Remote-timer display durability: handle_fan_manual_override() previously"
+            " unconditionally overwrote _fan_remote_timer_hours on every call, including a"
+            " plain non-remote re-stamp (e.g. the fan entity re-reporting 'on') — nulling an"
+            " active remote timer within seconds of a genuine press (confirmed live via the"
+            " status API). New is_remote_event parameter disambiguates a genuine remote call"
+            " (including a deliberate timer_none 'no timer' press, which correctly clears the"
+            " value) from a non-remote re-stamp, which now preserves the existing value."
+            " (6) Dashboard status reconciliation: _compute_next_action() gained an"
+            " _override_confirm_pending branch (checked before _grace_active, mirroring"
+            " _compute_automation_status()'s existing ordering) so a concurrent setpoint-"
+            " override-confirm and fan-override-grace no longer produce two contradictory"
+            " status lines — display-only, the two override mechanisms remain independent."
+        ),
+        "scope_not_covered": (
+            "Does not change _deactivate_fan()'s restore-mode behavior for the short"
+            " CA-initiated nat-vent cycle — only the NEW manual-path exit uses reclassify;"
+            " unifying _deactivate_fan() onto the same reclassify pattern is a reasonable but"
+            " separate, test-heavy follow-up (30+ existing tests assert restore-mode"
+            " semantics for that path). Does not fix a genuinely dropped remote press (the RF"
+            " link/entity never producing an HA event at all) — confirmed via live remote"
+            " event history as a device/firmware reliability issue outside CA's scope; CA"
+            " cannot act on an event it never receives. Does not persist _fan_remote_timer_hours"
+            " across HA restart — this remains intentionally cleared on restart per the"
+            " existing clean-slate policy (Issue #327/#282); only in-session durability"
+            " (surviving unrelated re-stamps) was fixed. Does not address the unrelated"
+            " ecobee/HomeKit presence-driven comfort-program setpoint conflict observed"
+            " during the originating investigation (CA sleep-band 72°F vs. ecobee 'Home'"
+            " comfort-program 77°F) — investigated and confirmed external to CA and any HA"
+            " automation, deliberately left out of scope for this fix; turning HVAC off"
+            " during the WHF session (this fix) makes that setpoint conflict moot regardless"
+            " of which value wins."
+        ),
+    },
     493: {
         "version_fixed": "0.5.22",
         "title": "learning.save_state() race on shared .tmp filename under concurrent calls",

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -287,6 +287,11 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         # Issue #423: physical fan ground-truth callbacks for _reconcile_fan_physical_drift()
         self.automation_engine._get_fan_physical_state_callback = self._get_fan_physical_state
         self.automation_engine._is_recent_fan_command_callback = self._is_recent_fan_command
+        # Issue #495: reclassify callback — called by _release_whf_and_reclassify() when a
+        # manual/remote WHF session ends, reusing the existing fan-off reassert path (Issue
+        # #359 Fix A) so the thermostat converges on CA's current classification rather than
+        # a blindly-restored, potentially hours-stale captured mode.
+        self.automation_engine._reclassify_callback = self._on_whf_release_reclassify
         _LOGGER.debug(
             "Climate Advisor startup: temp_unit=%s, comfort_heat=%.1f, comfort_cool=%.1f",
             config.get("temp_unit", "fahrenheit"),
@@ -382,6 +387,11 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         self._untracked_fan_active: bool = False  # Issue #331 follow-up: entry/exit dedup for fan_running_untracked
         self._fan_state_entity_unavailable_warned: bool = False  # Issue #359: WHF Type 2 fallback warning dedup
         self._last_commanded_fan_state: bool | None = None  # Issue #361: command-only mode — last on/off commanded
+        # Issue #495: last QuietCool RF remote event.* state (== the event's own timestamp)
+        # that was actually acted on — dedups a stale unavailable->restore re-announcing an
+        # old event as if it were a fresh press. Not persisted: a stale restore right after
+        # restart is already covered by _suppress_during_startup_coalescing.
+        self._last_fan_remote_event_ts: str | None = None
         self._last_violation_check: datetime | None = None
         # Chart_log endpoint estimator backfill flags (Issue #137)
         self._passive_k_backfilled: bool = False  # True after chart_log passive windows processed
@@ -3738,6 +3748,23 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         if not new_state or new_state.state in ("unknown", "unavailable"):
             return
 
+        # Issue #495: dedup on the event's own timestamp (the entity's `state` field IS the
+        # firmware event timestamp — confirmed via live history: e.g. state=
+        # "2026-07-13T03:48:40.960+00:00"). The QuietCool event.* entity flaps to
+        # `unavailable` at arbitrary times (observed independent of restart — 08:13, 08:46,
+        # 16:58, 17:40, 18:03, 19:05 in one day) and restores its STALE last event_type with
+        # the SAME timestamp. Without this guard, that restore is processed as a fresh press:
+        # confirmed live — a phantom 2h override (`fan_manual_override
+        # {remote_timer_hours: 2.0}`) fired at 16:58:02 with zero user action, exactly when
+        # the entity restored to its stale timer_2h (frozen since 06:41). This generalizes
+        # Issue #491's restart-only stale-event guard to every unavailable->restore flap.
+        if new_state.state == self._last_fan_remote_event_ts:
+            _LOGGER.debug(
+                "Fan RF remote event ignored — already acted on this event (ts=%s, stale unavailable->restore)",
+                new_state.state,
+            )
+            return
+
         event_type = new_state.attributes.get("event_type")
         is_timer_event, hours = parse_remote_timer_event(event_type)
         if not is_timer_event:
@@ -3749,6 +3776,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         if self._suppress_during_startup_coalescing(f"fan remote event_type={event_type}"):
             return
 
+        self._last_fan_remote_event_ts = new_state.state
         duration_seconds = hours * 3600 if hours is not None else None
         _LOGGER.info(
             "Fan RF remote timer event: event_type=%s -> duration=%s",
@@ -3760,6 +3788,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             fan_after="on",
             duration_override=duration_seconds,
             remote_timer_hours=hours,
+            is_remote_event=True,
         )
         await self.async_request_refresh()
 
@@ -3791,6 +3820,18 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 "Setpoint re-assertion after fan-off failed — thermostat left as-is",
                 exc_info=True,
             )
+
+    @callback
+    def _on_whf_release_reclassify(self) -> None:
+        """Called by the engine when a manual/remote WHF session releases HVAC suppression
+        (Issue #495, ``AutomationEngine._release_whf_and_reclassify``).
+
+        Reuses ``_async_reassert_setpoint_after_fan_off`` (Issue #359 Fix A) rather than a
+        separate reclassify path — both scenarios are "a WHF-related HVAC suppression just
+        ended, push CA's current classification back to the thermostat" and share the same
+        5s-settle-then-reclassify mechanics.
+        """
+        self.hass.async_create_task(self._async_reassert_setpoint_after_fan_off())
 
     @callback
     def _on_post_grace_fan_check(self) -> None:
@@ -5713,6 +5754,25 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         # than a scheduled reminder that ignores it (see plan's "Guard ordering"
         # decision, Issue #428).
         if ae is not None:
+            # Issue #495: _override_confirm_pending (the 10-min setpoint-override confirm
+            # window) and _grace_active (the fan-override grace) are independent tracks that
+            # can legitimately overlap — a manual WHF-on starts its grace immediately while a
+            # concurrent setpoint override is still only pending confirmation. Without this
+            # branch, a pending-confirm setpoint override with no fan override active fell
+            # through silently to no guard at all, and one WITH a concurrent fan-override
+            # grace fell through to the grace_active branch below, which then described the
+            # fan's grace as if it were the (still-unconfirmed) setpoint override's own —
+            # narrating two different overrides as one. This mirrors
+            # _compute_automation_status()'s "override pending (confirming...)" check
+            # (checked ahead of its own grace_active check there too) so the two dashboard
+            # status lines agree instead of contradicting each other.
+            if ae._override_confirm_pending:
+                if ae._grace_active:
+                    return _decide(
+                        "Confirming your thermostat change; whole-house fan override also active.",
+                        fan_override_active=ae._fan_override_active,
+                    )
+                return _decide("Confirming your thermostat change before automation resumes.")
             if ae._manual_override_active:
                 return _decide("Manual override active — automation is standing by.")
             if ae._grace_active:

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.22"
+  "version": "0.5.23"
 }

--- a/docs/07-AUTOMATION-FLOWCHART.md
+++ b/docs/07-AUTOMATION-FLOWCHART.md
@@ -274,7 +274,9 @@ graph TD
 
 Fan state changes are monitored by two listeners. A dedicated fan entity listener watches for direct on/off changes. The existing thermostat listener in `_async_thermostat_changed()` also detects `fan_mode` attribute changes. Both paths call `handle_fan_manual_override()` in the automation engine.
 
-Fan override is tracked separately from HVAC override — `_fan_override_active` is independent of `_manual_override_active`. Both can be active simultaneously.
+Fan override is tracked separately from HVAC override — `_fan_override_active` is independent of `_manual_override_active`. Both can be active simultaneously — this independence is also why the two could previously produce contradictory-looking dashboard status text at once (fixed in `_compute_next_action()`, Issue #495 — see [08-COMPUTATION-REFERENCE.md](08-COMPUTATION-REFERENCE.md)).
+
+**HVAC suppression on manual fan-on (Issue #495):** for `FAN_MODE_WHOLE_HOUSE`/`BOTH`, `handle_fan_manual_override()` now also suppresses HVAC — the same `_suppress_hvac_for_whf()` helper `_activate_fan()` (CA-initiated activation) uses. Before this fix, only CA-initiated activation suppressed HVAC; a manually or remotely detected fan-on left the AC armed for the life of the override. `FAN_MODE_HVAC` is unaffected (the thermostat's own blower coexists with the compressor by design). See [fan-remote-spec.md § HVAC Suppression on Manual/Remote Fan-On](fan-remote-spec.md#hvac-suppression-on-manualremote-fan-on).
 
 ```mermaid
 graph TD
@@ -287,13 +289,21 @@ graph TD
     F -->|Yes| D
 
     D --> H[_fan_override_active = True\nRecord override time]
-    H --> I[Start fan grace period\ndefault manual_grace_seconds]
+    H --> H2{fan_mode WHOLE_HOUSE\nor BOTH?}
+    H2 -->|Yes| H3[_suppress_hvac_for_whf\nHVAC set off, mode captured]
+    H2 -->|No| I
+    H3 --> I[Start fan grace period\ndefault manual_grace_seconds]
     I --> J[Fan automation skips\nfan activation until cleared]
-    J --> K[Fan override cleared at:\nBedtime or Wakeup schedule boundary\nvia clear_fan_override]
+    J --> K[Fan override cleared at:\nBedtime/Wakeup boundary, physical\nfan-off, or grace expiry]
 
     L[clear_manual_override called\nat schedule boundary] --> M[clear_fan_override]
     M --> N[_fan_override_active = False]
+    M --> O{Suppression session\nactive AND fan not\nphysically running?}
+    O -->|Yes| P[_release_whf_and_reclassify\nrelease + reclassify, not blind restore]
+    O -->|No, fan still on| Q[Left suppressed — post-grace\nfan reconcile owns this case]
 ```
+
+`on_fan_turned_off()` (physical fan confirmed off by the triggering event) reaches the same `_release_whf_and_reclassify()` unconditionally — no physical-state re-check needed there, since the event itself confirms the fan is off.
 
 ---
 

--- a/docs/08-COMPUTATION-REFERENCE.md
+++ b/docs/08-COMPUTATION-REFERENCE.md
@@ -54,6 +54,7 @@ The automation logic table and all threshold constants in this document are expr
 | Which nat-vent exit sites still bypass the `_exit_nat_vent()` choke point, and what changed when the last two were fixed? | None remain. `handle_all_doors_windows_closed()` (Priority 1 sensor-all-close) and `fan_thermostat_check()`'s fast-loop Check 1 (outdoor-rise mirror of Priority 3) were the last two, unified in Issue #418. The fast-loop site had a live bug (set `_paused_by_door=True` but still restored HVAC via the default `restore_hvac=True`); the sensor-all-close site traded an instant classification-aware re-arm for the same eventual state via a grace period, an accepted tradeoff. | [Exit Hierarchy — Unified exit handoff](08-COMPUTATION-REFERENCE.md#exit-hierarchy) |
 | Why did a whole-house fan stay "adopted" (`_fan_active=True`) for 3.5+ hours while physically off, showing `"active (unconfirmed)"` all night? | `reconcile_fan_on_startup()`'s callers derived "is a fan running" from the thermostat's own attributes even for `FAN_MODE_WHOLE_HOUSE` — a physically separate device. A thermostat-internal fan blip got "adopted" as the WHF without ever checking the real fan entity's state, and nothing ever compared belief against reality to self-correct (only the dashboard status computation did that comparison, purely for display). Fixed by an archetype-aware ground-truth signal (Issue #423 Fix A) plus a new 2-tick self-healing check in the 5-min backstop (Issue #423 Fix B). | [§9e-B and §9e-E](08-COMPUTATION-REFERENCE.md#9e-thermostatic-fan-loop-and-startup-reconciliation-issue-327) |
 | Why did an overnight nat-vent session get torn down and re-adopted every 5-15 minutes for hours, showing "fan running (untracked)" and repeated "startup reconcile" adoptions with no window ever closing? | `check_natural_vent_conditions()`'s Phase 2 proactive floor exit (a prediction from the thermal model, distinct from the Issue #417 reactivation gates) still read the flat daytime `comfort_heat` instead of the sleep-aware `_nat_vent_reactivation_floor()`. Overnight, indoor between `sleep_heat` and `comfort_heat` made its `time_to_floor` go negative — which always satisfied the exit threshold — tearing the session down every ~5 min; the physical fan kept running independently and got "adopted" as a brand-new session each time, which Phase 2 then re-exited on the next tick. Fixed by reading the canonical floor and guarding the block to only fire when `time_to_floor >= 0`. | [Exit Hierarchy — Issue #427](08-COMPUTATION-REFERENCE.md#exit-hierarchy) |
+| Why did the AC stay armed the whole time a user manually ran the whole-house fan, fighting it while windows were open? | HVAC suppression (`_pre_fan_hvac_mode` capture + `_set_hvac_mode("off")`) previously lived only in the CA-initiated `_activate_fan()` path. `handle_fan_manual_override()` (manual fan-entity or QuietCool RF remote detection) set the override flag and grace timer but never suppressed HVAC. Fixed by routing both through a shared `_suppress_hvac_for_whf()` helper (Issue #495); exit reclassifies rather than blindly restoring the potentially hours-stale captured mode. | [§9 Fan Archetype Behavioral Contract](08-COMPUTATION-REFERENCE.md#fan-archetype-behavioral-contract-issue-277) · [§9d Setpoint/Fan Status Reconciliation](08-COMPUTATION-REFERENCE.md#9d-reconciling-the-setpoint-override-and-fan-override-status-lines-issue-495) |
 
 ## 1. Day Classification
 
@@ -1205,8 +1206,8 @@ The whole-house fan is a dedicated appliance (e.g., `fan.*` or `switch.*` entity
 
 | Behavior | Detail |
 |---|---|
-| On activation | Fan entity turned on; **HVAC set to `off`**; current thermostat mode captured in `_pre_fan_hvac_mode` |
-| On deactivation | Fan entity turned off; HVAC mode restored from `_pre_fan_hvac_mode` (then `_pre_fan_hvac_mode` cleared) |
+| On activation | Fan entity turned on; **HVAC set to `off`**; current thermostat mode captured in `_pre_fan_hvac_mode`. Applies whether CA initiated the activation (`_activate_fan()`) **or** a manual/remote fan-on was detected (`handle_fan_manual_override()`, Issue #495) — both funnel through the shared `_suppress_hvac_for_whf()` helper, so the mutual-exclusion rule has exactly one suppression path. |
+| On deactivation | Fan entity turned off; HVAC mode restored from `_pre_fan_hvac_mode` (then `_pre_fan_hvac_mode` cleared) for a CA-initiated session (`_deactivate_fan()`). A manual/remote session instead **reclassifies** (`_release_whf_and_reclassify()`, Issue #495) rather than blindly restoring the captured mode — an RF-remote-timer session can span hours (up to 12h), so the mode captured at activation is often stale by exit (e.g. it can straddle a sleep-setback transition). |
 | Stops when windows close? | **Yes** — when ALL monitored sensors close, the fan deactivates and HVAC is restored, regardless of `_natural_vent_active` value |
 | HVAC mode captured? | Yes — `_pre_fan_hvac_mode: str \| None` holds the thermostat mode at activation time (e.g., `"heat_cool"`, `"cool"`) |
 
@@ -1246,7 +1247,7 @@ if mode != "off" and self._whf_owns_hvac():
 Key properties:
 - **`mode == "off"` is never blocked** — the guard only intercepts attempts to arm an *active* mode (`heat`, `cool`, `heat_cool`) while WHF owns the thermostat. Turning HVAC off is always allowed (it's what a WHF session wants anyway).
 - **Silent drops are made visible.** A blocked write logs a `WARNING` and emits `hvac_write_blocked_whf_active` (payload: `attempted_mode`, `reason`) so the Activity Log shows the interception rather than the write simply vanishing — per this project's Observability Requirements.
-- **`apply_classification()` also short-circuits before reaching the guard.** For `FAN_MODE_WHOLE_HOUSE`/`FAN_MODE_BOTH`, the nat-vent branch (`if self._natural_vent_active:`) returns immediately after `_apply_nat_vent_hvac_state()` — the same early-return pattern already used for `aggressive_savings=True` — so the classification cycle does not even attempt (and log) a band-arm the choke-point guard would silently drop, and does not waste a cycle computing `select_comfort_band()` or running the ODE ceiling guard while WHF owns the thermostat. `FAN_MODE_HVAC` keeps falling through to the comfort-band write exactly as before, because fan and compressor coexist for that archetype (see §6c).
+- **`apply_classification()` also short-circuits before reaching the guard.** For `FAN_MODE_WHOLE_HOUSE`/`FAN_MODE_BOTH`, the nat-vent branch — as of Issue #495, `if self._natural_vent_active or self._whf_owns_hvac():` — returns immediately after `_apply_nat_vent_hvac_state()` — the same early-return pattern already used for `aggressive_savings=True` — so the classification cycle does not even attempt (and log) a band-arm the choke-point guard would silently drop, and does not waste a cycle computing `select_comfort_band()` or running the ODE ceiling guard while WHF owns the thermostat. The `_whf_owns_hvac()` disjunct is additive, not a replacement: it covers a manual/remote WHF session (which sets `_pre_fan_hvac_mode` via `_suppress_hvac_for_whf()` but is not a nat-vent decision, so `_natural_vent_active` stays `False`) without weakening coverage for the pre-existing `reconcile_fan_on_startup()` adopted-session case, which sets `_natural_vent_active` directly without touching `_pre_fan_hvac_mode`. `FAN_MODE_HVAC` keeps falling through to the comfort-band write exactly as before, because fan and compressor coexist for that archetype (see §6c).
 
 **This closes Root Cause #2 of Issue #392 directly.** Because both writer functions share this one choke point, no future caller — however it decides to call `_set_hvac_mode()` or `_set_temperature()` — can bypass WHF/AC mutual exclusion. The answer to "can WHF and AC ever both be on" is now enforced at exactly one place, not re-derived correctly (or incorrectly) at every call site.
 
@@ -1408,8 +1409,8 @@ This table enumerates the six key fan lifecycle scenarios, including the new `on
 | Scenario | Trigger | CA decision | Flags / state change | Event emitted | Test ref |
 |---|---|---|---|---|---|
 | Fan-ON + nat-vent eligible | User turns fan on; `outdoor < indoor`, sensors open, gate passes | Adopt as nat-vent — do NOT set override | `_fan_active = True`, `_natural_vent_active = True`, `_fan_override_active` stays `False` | `fan_activated` (nat-vent adoption) | `test_fan_control.py` |
-| Fan-ON + nat-vent ineligible | User turns fan on; conditions gate does not pass | Manual override — start grace timer | `_fan_override_active = True`, `_fan_override_time = now()` | `fan_manual_override` | `test_fan_control.py` |
-| Fan-OFF (user) | User physically turns the fan off (fan_mode → auto) | `on_fan_turned_off()`: clear fan flags, start fan-off grace — **no** `_fan_override_active` set | `_fan_active = False`, `_natural_vent_active = False`, `_fan_override_active = False`; fan-off grace timer starts | `fan_cancel` | `test_fan_cancel.py` |
+| Fan-ON + nat-vent ineligible | User turns fan on; conditions gate does not pass | Manual override — start grace timer. **Issue #495:** for `FAN_MODE_WHOLE_HOUSE`/`BOTH`, also suppresses HVAC (`_suppress_hvac_for_whf()`) — previously only the CA-initiated (`_activate_fan()`) path did this, leaving the AC armed for the life of a manual/remote override | `_fan_override_active = True`, `_fan_override_time = now()`; `_pre_fan_hvac_mode` captured + `set_hvac_mode("off")` for WHF/BOTH | `fan_manual_override` | `test_fan_control.py`, `test_whole_house_fan_hvac_suppression.py::TestManualWhfOnSuppressesHvac` |
+| Fan-OFF (user) | User physically turns the fan off (fan_mode → auto) | `on_fan_turned_off()`: clear fan flags, start fan-off grace — **no** `_fan_override_active` set. **Issue #495:** if a WHF suppression session was active (`_pre_fan_hvac_mode is not None`, from either the nat-vent-adopted OR the manual-override case above), release it and reclassify (`_release_whf_and_reclassify()`) rather than leaving HVAC suppressed indefinitely | `_fan_active = False`, `_natural_vent_active = False`, `_fan_override_active = False`; fan-off grace timer starts; `_pre_fan_hvac_mode` released if set | `fan_cancel` | `test_fan_cancel.py`, `test_whole_house_fan_hvac_suppression.py::TestManualWhfOffReleasesAndReclassifies` |
 | Fan-OFF + ecobee setpoint echo | Ecobee or cloud thermostat echoes setpoint change within 5 s of fan-off | Setpoint suppressed; re-assertion fires after 5 s delay | `_setpoint_reassert_pending = True`; scheduled callback re-applies commanded setpoint | _(none — suppression is silent)_ | `test_fan_cancel.py` |
 | Post-grace reconciliation | Fan-off grace period expires | `reconcile_fan_on_startup()` called; re-evaluate physical state | Adopt fan as nat-vent (eligible) or confirm fan is off (ineligible) | `fan_activated` or _(no event if off)_ | `test_fan_cancel.py` |
 | Periodic backstop (`_async_update_data()`) | 30-min coordinator poll fires while fan is `"running (untracked)"` and no override or grace active | Same reconciliation path — adopt-on or turn-off | `_fan_active` and `_natural_vent_active` updated accordingly | `fan_activated` or `fan_deactivated` | `test_fan_cancel.py` |
@@ -1723,6 +1724,34 @@ See `_compute_automation_status()` in `coordinator.py`.
 **Test coverage:** `tests/test_nat_vent_activation.py::TestDecisionLockHolderTracking` — holder set
 during a pass and cleared after, cleared even when the pass body raises, and a second (waiting) pass
 can see the first pass's holder name while blocked.
+
+---
+
+### 9d. Reconciling the Setpoint-Override and Fan-Override Status Lines (Issue #495)
+
+`_compute_automation_status()` and `_compute_next_action()` read two **independent** flags:
+the setpoint-override confirmation window (`_override_confirm_pending`, set immediately on a
+detected setpoint change, cleared only once PATH A's 10-minute confirm timer elapses) and the
+fan-override grace (`_grace_active`, started immediately on a detected manual/remote WHF-on).
+These can legitimately overlap — e.g. a user opens windows (triggering an external setpoint
+change CA flags as pending confirmation) and then turns on the whole-house fan (starting its
+own grace immediately, no confirmation delay).
+
+Before this fix, `_compute_automation_status()` checked `_override_confirm_pending` (returning
+`"override pending (confirming...)"`) but `_compute_next_action()` had no equivalent branch —
+during the overlap window it fell through to the `_grace_active` check and returned `"Grace
+period active — automation will resume shortly."`, describing the *fan's* grace as if it were
+the still-unconfirmed setpoint override's own. The two dashboard lines then narrated two
+different overrides as one. Fix: `_compute_next_action()` gained an `_override_confirm_pending`
+branch, checked before `_grace_active` (mirroring `_compute_automation_status()`'s ordering),
+that names a concurrent fan override honestly rather than conflating the two.
+
+Display-only — the two override mechanisms (setpoint-confirm and fan-grace) remain independent;
+this only makes what's already true readable on the dashboard.
+
+**Test coverage:** `tests/test_coordinator.py::TestComputeNextAction` (`_make_ae_stub()` now also
+defaults `_override_confirm_pending`/`_fan_override_active` to `False`, per the MagicMock-truthy
+pitfall this project has hit before — see CLAUDE.md's async-mock testing rules).
 
 ---
 

--- a/docs/fan-remote-spec.md
+++ b/docs/fan-remote-spec.md
@@ -13,6 +13,9 @@
 | What happens to an active RF timer across an HA restart? | Nothing survives — it is not persisted. This matches CA's existing clean-slate policy for all override/grace state (Issue #327/#282); `restore_state()` resets `_fan_remote_timer_hours` to `None` alongside `_fan_override_active`. | [§ Restart Behavior](#restart-behavior) |
 | What clears an RF-timer-driven override? | The same two paths that clear any manual fan override: (1) the fan physically turns off (detected via `fan_entity`/`fan_state_entity`, routed to `on_fan_turned_off()`), or (2) the grace timer naturally expires (`_on_grace_expired()`). There is no separate "remote timer expired" detection — CA relies on the fan's own physical state. | [§ Clearing](#clearing) |
 | What is out of scope for this feature? | Speed tokens (`low`/`medium`/`high`) and explicit `on`/`off` event handling are not decoded or acted on. Only the `timer_*` family drives behavior. | [§ Scope](#scope) |
+| Does an RF timer press also suppress HVAC? | Yes, as of Issue #495 — for `FAN_MODE_WHOLE_HOUSE`/`BOTH`, `handle_fan_manual_override()` schedules `_suppress_hvac_for_whf()`, the same helper `_activate_fan()` uses. Previously ONLY CA-initiated activation suppressed HVAC; a manual/remote fan-on left the AC armed for the life of the override. | [§ HVAC Suppression on Manual/Remote Fan-On](#hvac-suppression-on-manualremote-fan-on) |
+| Can a stale/repeated remote event trigger a false override? | It used to. The `event.*` entity flaps to `unavailable` at arbitrary times (not just restart) and re-announces its STALE last `event_type` with the SAME state (the entity's `state` field IS the event timestamp). Issue #495 added a dedup guard (`_last_fan_remote_event_ts`) that ignores a re-announced identical timestamp — confirmed live: without it, a phantom 2h override fired with zero user action when the entity restored a 6-hour-stale `timer_2h`. | [§ Stale-Event Dedup](#stale-event-dedup) |
+| Does the dashboard's remote-timer display stay accurate? | As of Issue #495, yes. Previously `handle_fan_manual_override()` unconditionally overwrote `_fan_remote_timer_hours` on every call — including plain non-remote re-stamps (e.g. the WHF fan entity re-reporting "on") — which nulled an active remote timer within seconds of a genuine press. Fixed by only overwriting when the caller is the remote itself (`is_remote_event=True`) or supplies a genuine value. | [§ Timer Value Durability](#timer-value-durability) |
 
 ---
 
@@ -21,8 +24,8 @@
 **Files:**
 - `custom_components/climate_advisor/fan_status.py` — `parse_remote_timer_event()`, the single source of truth for the event-token → hours mapping
 - `custom_components/climate_advisor/const.py` — `CONF_FAN_REMOTE_ENTITY`, `REMOTE_TIMER_EVENT_HOURS`
-- `custom_components/climate_advisor/coordinator.py` — subscription (`async_setup`) + `_async_fan_remote_changed()` dispatch handler
-- `custom_components/climate_advisor/automation.py` — `handle_fan_manual_override(duration_override=...)`, `_start_grace_period(duration_override=...)`, the suppression WARNING at `_deactivate_fan()` and `fan_thermostat_check()`
+- `custom_components/climate_advisor/coordinator.py` — subscription (`async_setup`) + `_async_fan_remote_changed()` dispatch handler; `_last_fan_remote_event_ts` (Issue #495 stale-event dedup)
+- `custom_components/climate_advisor/automation.py` — `handle_fan_manual_override(duration_override=..., is_remote_event=...)`, `_start_grace_period(duration_override=...)`, the suppression WARNING at `_deactivate_fan()` and `fan_thermostat_check()`, `_suppress_hvac_for_whf()`/`_release_whf_and_reclassify()` (Issue #495 HVAC suppression + reclassify-on-exit)
 
 **Out of scope for this spec** (see [grace-periods-spec.md](grace-periods-spec.md) for the general grace-period mechanics this feature reuses):
 - Speed tokens (`low`/`medium`/`high`) — firmware decodes and emits these, CA does not act on them this cut
@@ -124,6 +127,38 @@ Remote press (event.quietcool_remote fires, event_type=timer_8h)
 
 ---
 
+## HVAC Suppression on Manual/Remote Fan-On (Issue #495)
+
+A remote timer press (or any manual fan-on detection) is a whole-house-fan-on event, and
+WHF/AC mutual exclusion is a structural rule (see
+[08-COMPUTATION-REFERENCE.md § Structural WHF/AC Mutual Exclusion](08-COMPUTATION-REFERENCE.md)),
+not something specific to CA-initiated activation. Before Issue #495, only `_activate_fan()`
+(the CA-initiated path) suppressed HVAC on WHF-on — `handle_fan_manual_override()` set the
+override flag and started the grace timer, but never touched `_pre_fan_hvac_mode` or
+`_set_hvac_mode`. A user manually turning on the fan (or pressing an RF timer) left the AC
+armed for the entire override duration — up to 12 hours for a `timer_12h` press.
+
+**Fix — reuse, don't duplicate:** `handle_fan_manual_override()` now schedules the same
+`_suppress_hvac_for_whf()` helper `_activate_fan()` calls, scoped to `FAN_MODE_WHOLE_HOUSE`/
+`BOTH` (never `FAN_MODE_HVAC` — the thermostat's own blower coexists with the compressor by
+design). Because `handle_fan_manual_override()` is sync and `_suppress_hvac_for_whf()` is
+async (it awaits `_set_hvac_mode()`), it is dispatched via `hass.async_create_task()` rather
+than awaited directly.
+
+**Exit is reclassify, not restore.** `_activate_fan()`'s counterpart, `_deactivate_fan()`,
+restores the HVAC mode captured at activation time. That is appropriate for CA's own short
+nat-vent cycles, but a manual/remote WHF session can run for hours — the captured mode is
+often stale by exit (e.g. the session spans a sleep-setback transition). Ending a manual
+session instead calls `_release_whf_and_reclassify()`, which releases `_pre_fan_hvac_mode`
+and reuses the existing fan-off reassert path (`_async_reassert_setpoint_after_fan_off`,
+Issue #359 Fix A) so the thermostat converges on CA's *current* classification. This fires
+from `on_fan_turned_off()` (fan confirmed off by the triggering event) and
+`clear_fan_override()` (grace expiry / user cancel) — the latter first checks the same
+physical-fan-state ground truth `_reconcile_fan_physical_drift()` uses, and no-ops if the
+fan is still running, so it doesn't race the post-grace fan reconcile.
+
+---
+
 ## Suppression Is Absolute
 
 Per the locked decision (2026-07-12), while an RF timer is active, hard comfort-floor and
@@ -171,6 +206,61 @@ window — an accepted tradeoff, consistent with the existing thermostat-overrid
 
 ---
 
+## Stale-Event Dedup (Issue #495)
+
+The `unavailable`-during-restart flap above turned out to be a special case of a broader
+problem: **the QuietCool `event.*` entity flaps to `unavailable` at arbitrary times, not
+just at restart**, and restores its stale last `event_type` with the SAME `state` value
+(the entity's `state` field IS the firmware event's own timestamp — e.g.
+`"2026-07-13T03:48:40.960+00:00"`). The Issue #491 guard only covers the restart window;
+outside it, nothing previously distinguished a genuine new press from a stale re-announce.
+
+**Confirmed live:** a real install's remote entity flapped `unavailable`→restore six times
+in one day at unrelated times (08:13, 08:46, 16:58, 17:40, 18:03, 19:05 — no restart
+involved), each restoring a `timer_2h` state frozen from an earlier press at 06:41. At
+16:58:02, this produced a `fan_manual_override(remote_timer_hours=2.0)` + a 2-hour grace
+period with **zero user action** — CA's own fan control was spuriously suppressed for 2
+hours, and because the grace re-stamps on every flap, a sufficiently flaky entity could
+keep an override alive indefinitely.
+
+**Fix:** the coordinator tracks `_last_fan_remote_event_ts` — the `state` (timestamp) of
+the last event actually acted on. `_async_fan_remote_changed()` compares the incoming
+`new_state.state` against it before doing anything else; an identical value is ignored
+(DEBUG-logged) as a re-announce, not a fresh press. This generalizes the Issue #491
+restart-only guard to every `unavailable`→restore flap, using the entity's own timestamp
+rather than a time-window heuristic. Not persisted — a stale restore immediately after a
+restart is already covered by `_suppress_during_startup_coalescing()`.
+
+---
+
+## Timer Value Durability (Issue #495)
+
+`_fan_remote_timer_hours` (the value the dashboard's "remote timer: Xh" line reads) used to
+get silently clobbered to `None` while a remote-timer override was still active.
+`handle_fan_manual_override()` is the single shared entry point for BOTH remote-timer
+presses AND plain non-remote fan-on detections (the WHF fan entity re-reporting `"on"`
+after its own brief `unavailable` flap, or the thermostat's `fan_mode` attribute changing)
+— and it unconditionally overwrote `_fan_remote_timer_hours = remote_timer_hours` on every
+call. A non-remote re-stamp always passes `remote_timer_hours=None`, so it nulled an active
+remote timer within seconds.
+
+**Confirmed live:** querying the status API and the persisted engine state within seconds
+of each other, during an active 8-hour RF timer override, showed the API returning
+`fan_remote_timer_hours: null` while the persisted state still held `8.0` — the value was
+oscillating, present only in the brief window between a remote press and the next
+unrelated fan-entity re-detection.
+
+**Fix:** `handle_fan_manual_override()` gained `is_remote_event: bool = False`. The stored
+value is only overwritten when the call is a genuine remote event (`is_remote_event=True`
+— covers both a real timer selection AND a deliberate `timer_none` "no timer" press, which
+correctly clears the value), when a genuine non-`None` value is supplied, or when there was
+no prior active override (the very first press, where `None` is the correct initial value).
+A plain non-remote re-stamp of an already-active override now preserves whatever remote
+timer was already recorded. `_async_fan_remote_changed()` passes `is_remote_event=True` on
+every dispatch; the pre-existing physical-fan-on and thermostat `fan_mode` callers do not.
+
+---
+
 ## Clearing
 
 There is no dedicated "remote timer expired" detection. An RF-timer-driven override clears
@@ -203,9 +293,11 @@ via the same two paths as any other manual fan override:
 
 - [`parse_remote_timer_event`](../custom_components/climate_advisor/fan_status.py) — token → hours mapping (pure)
 - [`REMOTE_TIMER_EVENT_HOURS`](../custom_components/climate_advisor/const.py) — the single-source mapping table
-- [`_async_fan_remote_changed`](../custom_components/climate_advisor/coordinator.py) — event dispatch
-- [`handle_fan_manual_override`](../custom_components/climate_advisor/automation.py) — shared entry point (RF + physical paths)
+- [`_async_fan_remote_changed`](../custom_components/climate_advisor/coordinator.py) — event dispatch; `_last_fan_remote_event_ts` dedup guard (Issue #495)
+- [`handle_fan_manual_override`](../custom_components/climate_advisor/automation.py) — shared entry point (RF + physical paths); `is_remote_event` (Issue #495)
+- [`_suppress_hvac_for_whf`](../custom_components/climate_advisor/automation.py) — shared HVAC-off helper, CA-initiated AND manual/remote (Issue #495)
+- [`_release_whf_and_reclassify`](../custom_components/climate_advisor/automation.py) — manual-session exit: release + reclassify, not blind restore (Issue #495)
 - [`_start_grace_period`](../custom_components/climate_advisor/automation.py) — `duration_override` resolution
 - [`_deactivate_fan`](../custom_components/climate_advisor/automation.py) — primary suppression choke point + WARNING
 - [`fan_thermostat_check`](../custom_components/climate_advisor/automation.py) — secondary suppression choke point + WARNING
-- Tests: `tests/test_fan_remote.py`
+- Tests: `tests/test_fan_remote.py`, `tests/test_whole_house_fan_hvac_suppression.py` (`TestManualWhfOnSuppressesHvac`, `TestManualWhfOffReleasesAndReclassifies`)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -93,6 +93,11 @@ def _make_ae_stub(**overrides):
     ae._manual_override_active = False
     ae._grace_active = False
     ae.is_paused_by_door = False
+    # Issue #495: _compute_next_action() added an _override_confirm_pending branch (with a
+    # _fan_override_active read inside it) — both must default False here for the same
+    # reason as the flags above.
+    ae._override_confirm_pending = False
+    ae._fan_override_active = False
     for key, value in overrides.items():
         setattr(ae, key, value)
     return ae

--- a/tests/test_fan_remote.py
+++ b/tests/test_fan_remote.py
@@ -323,10 +323,41 @@ class TestLastWinsRefresh:
             patch(_PATCH_DT_NOW, return_value=_FIXED_NOW),
         ):
             mock_call_later.return_value = MagicMock()
-            engine.handle_fan_manual_override(duration_override=28800, remote_timer_hours=8.0)
-            engine.handle_fan_manual_override(duration_override=None, remote_timer_hours=None)
+            engine.handle_fan_manual_override(duration_override=28800, remote_timer_hours=8.0, is_remote_event=True)
+            # Issue #495: a genuine remote "no timer" (timer_none) press must be marked
+            # is_remote_event=True to distinguish it from a plain non-remote re-detection —
+            # the latter now preserves an already-active remote timer instead of clobbering it.
+            engine.handle_fan_manual_override(duration_override=None, remote_timer_hours=None, is_remote_event=True)
         assert engine._grace_duration_seconds == 1800
         assert engine._fan_remote_timer_hours is None
+
+    def test_non_remote_restamp_preserves_active_remote_timer(self):
+        """Issue #495: a plain (non-remote) re-stamp of an already-active override — e.g.
+        the WHF fan entity re-reporting "on" after a brief unavailable flap — must NOT
+        clobber an active remote timer to None.
+
+        Confirmed live: the status API returned fan_remote_timer_hours=None seconds after
+        an 8h remote press while the persisted engine state still held 8.0 — the fan
+        entity's own re-detection (is_remote_event=False, remote_timer_hours=None) had
+        nulled it, so the dashboard's remote-timer card showed nothing during an active
+        8h override.
+        """
+        engine = _make_automation_engine()
+        with (
+            patch(_PATCH_CALL_LATER) as mock_call_later,
+            patch(_PATCH_CALLBACK, side_effect=lambda f: f),
+            patch(_PATCH_DT_NOW, return_value=_FIXED_NOW),
+        ):
+            mock_call_later.return_value = MagicMock()
+            engine.handle_fan_manual_override(duration_override=28800, remote_timer_hours=8.0, is_remote_event=True)
+            assert engine._fan_remote_timer_hours == 8.0
+
+            # Plain fan-entity re-detection: NOT a remote event, supplies no timer info.
+            engine.handle_fan_manual_override(fan_before="?", fan_after="on")
+
+        assert engine._fan_remote_timer_hours == 8.0, (
+            "A non-remote re-stamp must preserve the active remote timer, not clobber it to None"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -415,7 +446,7 @@ class TestCoordinatorFanRemoteDispatch:
         asyncio.run(method(event))
 
         ae.handle_fan_manual_override.assert_called_once_with(
-            fan_before="?", fan_after="on", duration_override=28800.0, remote_timer_hours=8.0
+            fan_before="?", fan_after="on", duration_override=28800.0, remote_timer_hours=8.0, is_remote_event=True
         )
 
     def test_timer_none_event_drives_shared_override_with_none_duration(self):
@@ -431,7 +462,7 @@ class TestCoordinatorFanRemoteDispatch:
         asyncio.run(method(event))
 
         ae.handle_fan_manual_override.assert_called_once_with(
-            fan_before="?", fan_after="on", duration_override=None, remote_timer_hours=None
+            fan_before="?", fan_after="on", duration_override=None, remote_timer_hours=None, is_remote_event=True
         )
 
     def test_non_timer_event_is_a_noop(self):
@@ -475,7 +506,62 @@ class TestCoordinatorFanRemoteDispatch:
 
 
 # ---------------------------------------------------------------------------
-# 8. Feature-off regression: subscription gate condition
+# 8. Issue #495: dedup on stale unavailable->restore re-announcing an old event
+# ---------------------------------------------------------------------------
+
+
+class TestStaleRemoteEventDedup:
+    """The QuietCool event.* entity's `state` field IS the firmware event timestamp.
+    The entity flaps to `unavailable` at arbitrary times (not just at restart) and
+    restores its STALE last event_type with the SAME timestamp — confirmed live: a
+    phantom fan_manual_override(remote_timer_hours=2.0) fired with zero user action,
+    exactly when the entity restored to a timer_2h state frozen from hours earlier.
+
+    Occupant effect: without this dedup, a flapping remote entity can spuriously start
+    (and, since every flap re-stamps the grace, indefinitely extend) a fan override that
+    suppresses CA's own fan control — with no user action at all.
+    """
+
+    def test_same_timestamp_resent_is_deduped(self):
+        """A genuine press is processed once; the SAME state re-announced (the
+        unavailable->stale-restore pattern) must NOT re-trigger the override."""
+        coord = _make_coordinator_stub()
+        ae = coord.automation_engine
+
+        mod = importlib.import_module("custom_components.climate_advisor.coordinator")
+        method = types.MethodType(mod.ClimateAdvisorCoordinator._async_fan_remote_changed, coord)
+
+        new_state = _make_fake_state("2026-07-12T13:41:10.440+00:00", {"event_type": "timer_2h"})
+        asyncio.run(method(_make_fake_event(new_state)))
+        assert ae.handle_fan_manual_override.call_count == 1
+
+        # Same entity `state` (== timestamp) re-announced, e.g. after an unavailable
+        # flap restores the stale last value — must be ignored.
+        stale_restore = _make_fake_state("2026-07-12T13:41:10.440+00:00", {"event_type": "timer_2h"})
+        asyncio.run(method(_make_fake_event(stale_restore)))
+        assert ae.handle_fan_manual_override.call_count == 1, (
+            "A re-announced identical event timestamp must not trigger a second override"
+        )
+
+    def test_two_genuinely_different_timestamps_both_fire(self):
+        """Two real presses at different times must both be processed — the dedup guard
+        must not become a blanket suppressor."""
+        coord = _make_coordinator_stub()
+        ae = coord.automation_engine
+
+        mod = importlib.import_module("custom_components.climate_advisor.coordinator")
+        method = types.MethodType(mod.ClimateAdvisorCoordinator._async_fan_remote_changed, coord)
+
+        first = _make_fake_state("2026-07-12T20:45:32.622+00:00", {"event_type": "timer_2h"})
+        asyncio.run(method(_make_fake_event(first)))
+        second = _make_fake_state("2026-07-12T20:48:40.960+00:00", {"event_type": "timer_8h"})
+        asyncio.run(method(_make_fake_event(second)))
+
+        assert ae.handle_fan_manual_override.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# 9. Feature-off regression: subscription gate condition
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_restart_coalescing_fan_guard.py
+++ b/tests/test_restart_coalescing_fan_guard.py
@@ -186,6 +186,9 @@ def _make_fan_remote_coord(*, startup_coalesce_active: bool) -> object:
 
     coord._startup_coalesce_active = startup_coalesce_active
     coord.async_request_refresh = AsyncMock()
+    # Issue #495: _async_fan_remote_changed() now dedups on the last acted-on event
+    # timestamp — object.__new__() skips __init__, so this must be set explicitly.
+    coord._last_fan_remote_event_ts = None
 
     coord._suppress_during_startup_coalescing = types.MethodType(
         ClimateAdvisorCoordinator._suppress_during_startup_coalescing, coord
@@ -227,7 +230,7 @@ class TestFanRemoteChangedCoalescingGuard:
         asyncio.run(coord._async_fan_remote_changed(event))
 
         coord.automation_engine.handle_fan_manual_override.assert_called_once_with(
-            fan_before="?", fan_after="on", duration_override=7200.0, remote_timer_hours=2.0
+            fan_before="?", fan_after="on", duration_override=7200.0, remote_timer_hours=2.0, is_remote_event=True
         )
 
 

--- a/tests/test_whole_house_fan_hvac_suppression.py
+++ b/tests/test_whole_house_fan_hvac_suppression.py
@@ -782,3 +782,176 @@ class TestFanActivateDeactivateIdempotency:
         assert hvac_calls_after_second.count("cool") == 1, (
             f"Expected exactly 1 HVAC restore write across both calls; got {hvac_calls_after_second}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Issue #495: manual/remote-detected WHF-on must suppress HVAC too
+# ---------------------------------------------------------------------------
+
+
+def _run_scheduled_suppress(engine) -> None:
+    """Capture and run the coroutine handle_fan_manual_override() schedules via
+    hass.async_create_task() for HVAC suppression (Issue #495).
+
+    handle_fan_manual_override() is sync but suppression is async
+    (_suppress_hvac_for_whf() awaits _set_hvac_mode()), so it is dispatched via
+    hass.async_create_task() rather than awaited directly — mirrors the existing
+    "capture coro, then asyncio.run() it" pattern used elsewhere in this suite for
+    other @callback-scheduled async work (see test_nat_vent_activation.py).
+    """
+    captured: list = []
+    engine.hass.async_create_task = MagicMock(side_effect=lambda c: captured.append(c))
+    return captured
+
+
+class TestManualWhfOnSuppressesHvac:
+    """Issue #495: a manually or remotely detected whole-house-fan-on must suppress HVAC,
+    exactly like CA-initiated activation (_activate_fan()) already does — previously only
+    the CA-initiated path did this, leaving the AC armed for the life of a manual override.
+
+    Occupant effect: without this fix, a user opening windows and turning on the WHF (by
+    hand, or via a QuietCool RF remote timer) could have the AC fire mid-session, wasting
+    energy and fighting the whole-house fan's outdoor-air exchange — the exact failure
+    mode nat-vent exists to prevent.
+    """
+
+    def test_manual_whole_house_fan_on_sets_hvac_off(self):
+        """handle_fan_manual_override() with FAN_MODE_WHOLE_HOUSE -> set_hvac_mode('off')."""
+        engine = _make_engine(fan_mode=FAN_MODE_WHOLE_HOUSE, current_hvac_mode="cool")
+        engine._emit_event_callback = MagicMock()
+        captured = _run_scheduled_suppress(engine)
+
+        engine.handle_fan_manual_override(fan_before="off", fan_after="on")
+
+        assert len(captured) == 1, "Expected _suppress_hvac_for_whf() to be scheduled"
+        asyncio.run(captured[0])
+
+        hvac_calls = _get_hvac_mode_calls(engine)
+        assert "off" in hvac_calls, f"Expected HVAC to be set to 'off' after manual WHF-on; got calls: {hvac_calls}"
+        assert engine._pre_fan_hvac_mode == "cool"
+
+    def test_manual_both_fan_on_sets_hvac_off(self):
+        """handle_fan_manual_override() with FAN_MODE_BOTH -> set_hvac_mode('off') too."""
+        engine = _make_engine(fan_mode=FAN_MODE_BOTH, current_hvac_mode="heat")
+        engine._emit_event_callback = MagicMock()
+        captured = _run_scheduled_suppress(engine)
+
+        engine.handle_fan_manual_override(fan_before="off", fan_after="on")
+        asyncio.run(captured[0])
+
+        hvac_calls = _get_hvac_mode_calls(engine)
+        assert "off" in hvac_calls, f"Expected HVAC to be set to 'off' for FAN_MODE_BOTH; got: {hvac_calls}"
+
+    def test_manual_hvac_fan_on_does_not_suppress_hvac(self):
+        """handle_fan_manual_override() with FAN_MODE_HVAC must NOT suppress HVAC —
+        the thermostat's own blower coexists with the compressor by design."""
+        engine = _make_engine(fan_mode=FAN_MODE_HVAC, current_hvac_mode="cool")
+        engine._emit_event_callback = MagicMock()
+        captured = _run_scheduled_suppress(engine)
+
+        engine.handle_fan_manual_override(fan_before="off", fan_after="on")
+
+        assert len(captured) == 0, "FAN_MODE_HVAC must not schedule HVAC suppression on a manual fan-on detection"
+        assert engine._pre_fan_hvac_mode is None
+
+    def test_two_rapid_manual_overrides_do_not_reclobber_pre_fan_hvac_mode(self):
+        """Two manual-override calls in quick succession (the live incident: a physical
+        fan-on at 20:45:32 followed by an RF remote press at 20:48:40) must not re-capture
+        _pre_fan_hvac_mode from a possibly-already-suppressed thermostat read."""
+        engine = _make_engine(fan_mode=FAN_MODE_WHOLE_HOUSE, current_hvac_mode="cool")
+        engine._emit_event_callback = MagicMock()
+        captured = _run_scheduled_suppress(engine)
+
+        engine.handle_fan_manual_override(fan_before="off", fan_after="on")
+        asyncio.run(captured[0])
+        assert engine._pre_fan_hvac_mode == "cool"
+
+        # Thermostat now reads "off" (already suppressed) — a naive second capture
+        # would clobber _pre_fan_hvac_mode with "off".
+        engine.hass.states.get = MagicMock(return_value=_make_thermostat_state("off"))
+        captured.clear()
+        engine.handle_fan_manual_override(fan_before="?", fan_after="on", remote_timer_hours=8.0, is_remote_event=True)
+        asyncio.run(captured[0])
+
+        assert engine._pre_fan_hvac_mode == "cool", (
+            f"Idempotency guard must prevent re-capture on the second override; got {engine._pre_fan_hvac_mode!r}"
+        )
+
+    def test_apply_classification_does_not_rearm_cool_during_manual_whf_session(self):
+        """A manual (non-nat-vent) WHF session sets _pre_fan_hvac_mode but NOT
+        _natural_vent_active — apply_classification()'s nat-vent branch must still gate
+        on it via _whf_owns_hvac(), or select_comfort_band() would compute a write that
+        the low-level choke-point guard then silently drops."""
+        engine = _make_engine(fan_mode=FAN_MODE_WHOLE_HOUSE, current_hvac_mode="off")
+        engine._pre_fan_hvac_mode = "cool"  # manual session owns HVAC
+        assert engine._natural_vent_active is False, "Precondition: not a nat-vent session"
+        engine._apply_nat_vent_hvac_state = AsyncMock()
+
+        classification = _make_classification()
+
+        with patch("custom_components.climate_advisor.automation.select_comfort_band") as mock_select:
+            asyncio.run(engine.apply_classification(classification))
+            mock_select.assert_not_called()
+
+
+class TestManualWhfOffReleasesAndReclassifies:
+    """Issue #495: ending a manual WHF session must release _pre_fan_hvac_mode and
+    reclassify (NOT blindly restore the mode captured at activation) — a manual session
+    can run for hours (an 8h QuietCool RF remote timer), so the captured mode is often
+    stale by exit (e.g. the session spanned a sleep-setback transition).
+    """
+
+    def test_fan_turned_off_releases_pre_fan_hvac_mode_and_reclassifies(self):
+        """on_fan_turned_off() with _pre_fan_hvac_mode set -> releases it and invokes
+        the reclassify callback (the fan is confirmed off by the very event)."""
+        engine = _make_engine(fan_mode=FAN_MODE_WHOLE_HOUSE, current_hvac_mode="off")
+        engine._pre_fan_hvac_mode = "cool"
+        engine._fan_override_active = True
+        engine._emit_event_callback = MagicMock()
+        engine._reclassify_callback = MagicMock()
+
+        engine.on_fan_turned_off(fan_before="on", fan_after="off")
+
+        assert engine._pre_fan_hvac_mode is None
+        engine._reclassify_callback.assert_called_once()
+
+    def test_clear_fan_override_releases_pre_fan_hvac_mode_and_reclassifies(self):
+        """clear_fan_override() (grace expiry / user cancel) releases suppression and
+        reclassifies when the fan is not physically running (default: no ground-truth
+        callback configured -> command-only mode -> proceeds)."""
+        engine = _make_engine(fan_mode=FAN_MODE_WHOLE_HOUSE, current_hvac_mode="off")
+        engine._pre_fan_hvac_mode = "cool"
+        engine._fan_override_active = True
+        engine._reclassify_callback = MagicMock()
+
+        engine.clear_fan_override()
+
+        assert engine._pre_fan_hvac_mode is None
+        engine._reclassify_callback.assert_called_once()
+
+    def test_clear_fan_override_does_not_release_while_fan_still_physically_on(self):
+        """When the WHF is still physically running (grace/timer expired but the fan
+        hasn't actually stopped), release-and-reclassify must NOT fire — the post-grace
+        fan reconcile owns that case, and releasing here would race it."""
+        engine = _make_engine(fan_mode=FAN_MODE_WHOLE_HOUSE, current_hvac_mode="off")
+        engine._pre_fan_hvac_mode = "cool"
+        engine._fan_override_active = True
+        engine._reclassify_callback = MagicMock()
+        engine._get_fan_physical_state_callback = MagicMock(return_value=True)  # confirmed still on
+
+        engine.clear_fan_override()
+
+        assert engine._pre_fan_hvac_mode == "cool", "Must not release suppression while fan is still on"
+        engine._reclassify_callback.assert_not_called()
+
+    def test_clear_fan_override_no_op_when_no_suppression_session(self):
+        """clear_fan_override() with no _pre_fan_hvac_mode set (e.g. FAN_MODE_HVAC override,
+        or override cleared with nothing to release) must not touch the reclassify callback."""
+        engine = _make_engine(fan_mode=FAN_MODE_HVAC, current_hvac_mode="cool")
+        engine._fan_override_active = True
+        engine._reclassify_callback = MagicMock()
+        assert engine._pre_fan_hvac_mode is None
+
+        engine.clear_fan_override()
+
+        engine._reclassify_callback.assert_not_called()

--- a/tools/sim_harness/outcomes.py
+++ b/tools/sim_harness/outcomes.py
@@ -424,6 +424,16 @@ def _map_event_to_outcome(
     if event_type == "pre_cool_suppressed_nat_vent":
         return ProductionDecision(ts_str, event_type, "pre_cool_suppressed_nat_vent")
 
+    # --- WHF HVAC suppression (Issue #495) ---
+    # Purely additive, same pattern as nat_vent_fan_off/nat_vent_fan_on above (no legacy
+    # equivalent — these events did not exist before Issue #495). Cannot silently pass a
+    # real regression because no pre-#495 scenario asserts these strings.
+    if event_type == "whf_hvac_suppressed":
+        return ProductionDecision(ts_str, event_type, "whf_hvac_suppressed")
+
+    if event_type == "whf_hvac_released":
+        return ProductionDecision(ts_str, event_type, "whf_hvac_released")
+
     # --- Unmapped (FINDINGS) — documented, silently skip ---
     if event_type in UNMAPPED_PRODUCTION_EVENTS:
         return None

--- a/tools/simulations/pending/manual_whf_on_suppresses_hvac.json
+++ b/tools/simulations/pending/manual_whf_on_suppresses_hvac.json
@@ -1,0 +1,119 @@
+{
+  "name": "manual_whf_on_suppresses_hvac",
+  "description": "A manually/externally detected whole-house-fan-on (not CA-initiated, not nat-vent-eligible) must suppress HVAC exactly like CA-initiated activation already does — previously only _activate_fan() did this, leaving the AC armed for the life of a manual override (Issue #495).",
+  "source": "issue-report",
+  "issue": 495,
+  "use_coordinator": true,
+  "skip_startup_coalesce": true,
+  "notes": [
+    "Reproduces the live incident (2026-07-12): a user opened windows and turned on the",
+    "whole-house fan to cool with outside air while the AC was actively armed in cool mode.",
+    "CA left the AC running the entire session because HVAC suppression (_pre_fan_hvac_mode",
+    "capture + set_hvac_mode('off')) previously lived ONLY in the CA-initiated _activate_fan()",
+    "path -- handle_fan_manual_override() (the manual/remote detection path) set the override",
+    "flag and grace timer but never touched HVAC. AC + whole-house fan + open windows running",
+    "simultaneously wastes energy and fights the fan's outdoor-air exchange -- the exact",
+    "failure mode nat-vent exists to prevent.",
+    "",
+    "This scenario deliberately makes outdoor (82F) WARMER than indoor (78F) so the fan-on is",
+    "NOT nat-vent-eligible -- it must be classified as a manual override, exercising the fixed",
+    "code path (handle_fan_manual_override -> _suppress_hvac_for_whf) rather than the",
+    "already-covered nat-vent-adoption path (whole_house_fan_hvac_suppression.json).",
+    "",
+    "external_fan_state_change dispatches states.async_set() directly with no HA Context --",
+    "modeling a genuine external actor (physical switch, or a QuietCool RF remote press,",
+    "which reaches the same handle_fan_manual_override() entry point via a different",
+    "coordinator listener -- see docs/fan-remote-spec.md) -- through the REAL coordinator",
+    "_async_fan_entity_changed listener.",
+    "",
+    "Scope note -- release/reclassify NOT exercised here: once _fan_override_active is True,",
+    "_async_fan_entity_changed()'s pre-existing 'override already active' guard",
+    "(coordinator.py, well above this fix) intercepts EVERY subsequent state change on the",
+    "fan entity -- including the fan turning back off -- and only requests a status refresh;",
+    "it never reaches on_fan_turned_off() for a command-only entity. That guard is not part",
+    "of Issue #495 and reproducing the release path end-to-end through the coordinator would",
+    "require untangling separate, pre-existing dispatch behavior outside this fix's scope.",
+    "The release/reclassify half of Issue #495 (_release_whf_and_reclassify(), including the",
+    "physical-fan-still-running guard) is instead covered directly and thoroughly at the unit",
+    "level: tests/test_whole_house_fan_hvac_suppression.py::TestManualWhfOffReleasesAndReclassifies",
+    "(4 tests, revert-verified).",
+    "",
+    "Three-exercise protocol (CLAUDE.md Sec 10):",
+    "(a) Scenario effectiveness: if _suppress_hvac_for_whf() were removed from",
+    "    handle_fan_manual_override()'s call, or the archetype guard were reversed, the",
+    "    whf_hvac_suppressed assertion at 07:05 would fail (no such event fires) -- this is",
+    "    the exact regression the live incident exposed, and the assertion targets the new",
+    "    event Issue #495 added specifically to make this action observable (matching this",
+    "    project's Observability Requirements -- 'silent drops are made visible', the same",
+    "    principle behind the pre-existing hvac_write_blocked_whf_active event).",
+    "(b) Docs-production alignment: docs/08-COMPUTATION-REFERENCE.md Sec 9 (Fan Archetype",
+    "    Behavioral Contract) and docs/fan-remote-spec.md (HVAC Suppression on Manual/Remote",
+    "    Fan-On) were updated in the same change describing exactly this suppress-then-",
+    "    reclassify behavior.",
+    "(c) User outcome: without this fix, the occupant runs AC and a whole-house fan",
+    "    simultaneously with windows open -- maximally wasteful, and the two systems",
+    "    physically fight. With the fix, the AC turns off the moment the fan is detected on."
+  ],
+  "config": {
+    "comfort_heat": 68,
+    "comfort_cool": 75,
+    "setback_heat": 62,
+    "setback_cool": 80,
+    "natural_vent_delta": 3.0,
+    "door_window_sensors": ["binary_sensor.front_door"],
+    "fan_mode": "whole_house_fan",
+    "fan_entity": "fan.whf",
+    "fan_state_feedback": true
+  },
+  "events": [
+    {
+      "time": "2026-07-12T07:00:00",
+      "type": "temp_update",
+      "indoor_f": 78.0,
+      "outdoor_f": 82.0,
+      "note": "Warm morning: indoor=78F, outdoor=82F -- outdoor WARMER than indoor, so a fan-on here is not nat-vent-eligible."
+    },
+    {
+      "time": "2026-07-12T07:01:00",
+      "type": "classification",
+      "day_type": "hot",
+      "hvac_mode": "cool",
+      "windows_recommended": false,
+      "note": "Hot day: hvac_mode=cool. apply_classification() arms the comfort-cool ceiling (75F) -- AC is actively commanded to cool."
+    },
+    {
+      "time": "2026-07-12T07:02:00",
+      "type": "external_fan_state_change",
+      "entity": "fan.whf",
+      "state": "off",
+      "note": "Seed the fan entity's initial state. _async_fan_entity_changed() requires BOTH old_state and new_state to process a transition -- without this seed event, the very first state.async_set() on a never-before-seen entity has old_state=None and the listener silently no-ops."
+    },
+    {
+      "time": "2026-07-12T07:05:00",
+      "type": "external_fan_state_change",
+      "entity": "fan.whf",
+      "state": "on",
+      "note": "User turns on the whole-house fan directly (no CA context, no nat-vent eligibility -- outdoor 82F > indoor 78F). Real coordinator._async_fan_entity_changed routes to handle_fan_manual_override(), which now also suppresses HVAC (Issue #495) via the shared _suppress_hvac_for_whf() helper."
+    }
+  ],
+  "assertions": [
+    {
+      "at": "2026-07-12T07:01:00",
+      "expect": "classification_applied",
+      "reason": "Hot-day classification applied: hvac_mode=cool, comfort ceiling armed at 75F."
+    },
+    {
+      "at": "2026-07-12T07:05:00",
+      "expect": "whf_hvac_suppressed",
+      "track": "integration",
+      "simulator_support": false,
+      "reason": "A manually-detected whole-house-fan-on (not nat-vent-eligible, outdoor > indoor) must suppress HVAC -- the core Issue #495 fix. Before the fix, no such event fires and the AC stays armed in cool mode for the life of the override."
+    }
+  ],
+  "verdict": {
+    "type": "positive",
+    "summary": "Manually/externally detected whole-house-fan-on suppresses HVAC exactly like CA-initiated activation (Issue #495)",
+    "observed_behavior": "classification_applied (cool @ 75F) -> external fan-on (not nat-vent-eligible) -> whf_hvac_suppressed (HVAC off)",
+    "expected_behavior": "AC never stays armed while a manually-controlled whole-house fan runs, regardless of whether the fan-on was CA-initiated or user/remote-initiated"
+  }
+}


### PR DESCRIPTION
## Summary
- HVAC suppression on whole-house-fan activation previously lived only in the CA-initiated `_activate_fan()` path. A manually or remotely detected fan-on (physical switch, or QuietCool RF remote timer press) left the AC armed for the entire session — fighting the fan and wasting energy while windows were open. Fixed via a shared `_suppress_hvac_for_whf()` helper used by both paths (`WHOLE_HOUSE`/`BOTH` only).
- Ending a manual session now reclassifies (`_release_whf_and_reclassify`) rather than blindly restoring a potentially hours-stale captured mode — an RF-remote-timer session can run up to 12 hours. Guarded against releasing while the fan is still physically running.
- `apply_classification()`'s nat-vent gate now also checks `_whf_owns_hvac()` (additive OR with `_natural_vent_active`) so a manual session is covered without weakening the pre-existing reconcile-adopted case.
- QuietCool RF remote: (1) dedup stale `event.*` `unavailable`→restore re-announces on the event's own timestamp — confirmed live as a phantom 2-hour override with zero user action; (2) the remote-timer dashboard display no longer gets clobbered to `None` by unrelated fan re-detections (confirmed live via the status API).
- Dashboard: reconciled two independent override/grace status lines (`_override_confirm_pending` vs `_grace_active`) that could previously show contradicting text when a fan override and a pending thermostat-override confirmation overlapped.
- New `whf_hvac_suppressed`/`whf_hvac_released` events for Activity Log observability (matches the existing `hvac_write_blocked_whf_active` pattern).

Version bumped to 0.5.23. Docs updated in `docs/08-COMPUTATION-REFERENCE.md`, `docs/fan-remote-spec.md`, `docs/07-AUTOMATION-FLOWCHART.md`.

## Test plan
- [x] Full unit suite: 3438 tests pass (12 new, all revert-verified against the actual regressions before writing the fix)
- [x] `ruff check` / `ruff format` clean
- [x] `python tools/simulate.py` — 53/53 golden scenarios pass
- [x] `python tools/simulate.py --pending` — 22/22 pass, including new `manual_whf_on_suppresses_hvac.json` reproducing the live incident through the real coordinator dispatch
- [x] `python tools/simulate.py --check-integrity` — clean
- [x] `pytest tests/test_version_sync.py` — passes