### PR TITLE
Fix #498: grace-expiry dashboard gap + scheduled-handler gate duplication

### DIFF
--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -81,6 +81,7 @@ from .const import (
 )
 from .desired_state import (
     FanCycleOutcome,
+    ScheduledBandGate,
     SetpointRetryAction,
     decide_fan_cycle_off,
     decide_fan_cycle_on,
@@ -88,6 +89,7 @@ from .desired_state import (
     decide_grace_start,
     decide_override_confirm,
     decide_revisit,
+    decide_scheduled_band_gate,
     decide_scheduled_write_seq_current,
     decide_setpoint_retry_action,
 )
@@ -1491,17 +1493,29 @@ class AutomationEngine:
                 )
                 return
 
+            # Issue #498: occupancy/paused/nat-vent checks below now route through the single
+            # shared gate (desired_state.decide_scheduled_band_gate()) also used by
+            # handle_bedtime()/handle_morning_wakeup()/handle_pre_cool() — pure extraction of
+            # this exact check order, no behavior change for this call site.
+            _gate = decide_scheduled_band_gate(
+                occupancy_mode=self._occupancy_mode,
+                manual_override_active=self._manual_override_active,
+                paused_by_door=self._paused_by_door,
+                natural_vent_active=self._natural_vent_active,
+                whf_owns_hvac=self._whf_owns_hvac(),
+            )
+
             # Issue #85: respect occupancy mode — don't overwrite setback with comfort
-            if self._occupancy_mode == OCCUPANCY_VACATION:
-                _LOGGER.info("Vacation mode — skipping classification temp change (deep setback preserved)")
-                return
-            if self._occupancy_mode == OCCUPANCY_AWAY:
+            if _gate == ScheduledBandGate.DEFER_OCCUPANCY:
+                if self._occupancy_mode == OCCUPANCY_VACATION:
+                    _LOGGER.info("Vacation mode — skipping classification temp change (deep setback preserved)")
+                    return
                 _LOGGER.info("Away mode — reapplying setback instead of comfort temps")
                 await self.handle_occupancy_away()
                 return
 
             # Issue #337: while paused by open door/window, suppress the band and hold HVAC off.
-            if self._paused_by_door:
+            if _gate == ScheduledBandGate.DEFER_PAUSED:
                 _LOGGER.warning(
                     "apply_classification: door/window open (_paused_by_door=True) — "
                     "suppressing band, ensuring HVAC off; day_type=%s",
@@ -1531,18 +1545,16 @@ class AutomationEngine:
             # With savings off, call the helper to keep the full band current, then continue so the
             # ODE ceiling guard can still fire as a safety backstop if a breach is predicted.
             #
-            # Issue #495: OR in _whf_owns_hvac() so a manually/remotely-detected WHF session
-            # (which sets _pre_fan_hvac_mode via _suppress_hvac_for_whf() but does NOT set
-            # _natural_vent_active — a manual override isn't a nat-vent decision) is also
-            # gated here, not just left to the low-level _set_hvac_mode()/_set_temperature()
-            # write-guard. The write-guard alone would still block the write, but silently —
-            # this ORs the same condition apply_classification already checks for the
-            # CA-initiated case so a manual session doesn't compute select_comfort_band()/run
-            # the ODE ceiling guard just to have the result dropped (Issue #392 Fix 1b's own
-            # rationale). _whf_owns_hvac() is additive here, not a replacement: the reconcile-
-            # adopted case (reconcile_fan_on_startup() sets _natural_vent_active without
-            # setting _pre_fan_hvac_mode) still needs the original _natural_vent_active check.
-            if self._natural_vent_active or self._whf_owns_hvac():
+            # Issue #495: whf_owns_hvac is OR'd with natural_vent_active inside the shared gate
+            # (decide_scheduled_band_gate) so a manually/remotely-detected WHF session (which sets
+            # _pre_fan_hvac_mode via _suppress_hvac_for_whf() but does NOT set _natural_vent_active
+            # — a manual override isn't a nat-vent decision) is also gated here, not just left to
+            # the low-level _set_hvac_mode()/_set_temperature() write-guard. The write-guard alone
+            # would still block the write, but silently — this catches the same condition apply_
+            # classification already checked for the CA-initiated case so a manual session doesn't
+            # compute select_comfort_band()/run the ODE ceiling guard just to have the result
+            # dropped (Issue #392 Fix 1b's own rationale).
+            if _gate == ScheduledBandGate.DEFER_NAT_VENT:
                 _aggressive = bool(self.config.get("aggressive_savings", False))
                 _LOGGER.info(
                     "apply_classification: nat-vent active — enforcing nat-vent band ac_assist=%s day_type=%s",
@@ -3966,9 +3978,28 @@ class AutomationEngine:
             _LOGGER.debug("handle_bedtime: skipping — setpoint write within last 30s (startup dedup guard)")
             return
 
+        # Issue #498: occupancy/override/paused/nat-vent checks below now route through the
+        # single shared gate (desired_state.decide_scheduled_band_gate()) also used by
+        # apply_classification()/handle_morning_wakeup()/handle_pre_cool() — see that
+        # function's docstring for the full rationale. Two behavior corrections land with
+        # this refactor: (1) bedtime no longer has its own outdoor-vs-sleep_cool comparison
+        # to decide whether nat-vent should keep running — that comparison could hand off to
+        # AC prematurely even while outdoor was still well below indoor and the fan was doing
+        # useful, cheaper work (finding #7); the engine's own per-tick
+        # check_natural_vent_conditions() already manages the session correctly (outdoor-
+        # reversal exit, sleep-aware cycling target), so bedtime just defers entirely while
+        # nat-vent/WHF is active. (2) bedtime now also defers when paused by an open door/
+        # window, which it never checked before (finding #11).
+        _gate = decide_scheduled_band_gate(
+            occupancy_mode=self._occupancy_mode,
+            manual_override_active=self._manual_override_active,
+            paused_by_door=self._paused_by_door,
+            natural_vent_active=self._natural_vent_active,
+            whf_owns_hvac=self._whf_owns_hvac(),
+        )
+
         # Issue #85: vacation/away already has a setback — don't override it with sleep temps.
-        # Gate unified via should_defer_to_occupancy_setback() (Issue #460).
-        if should_defer_to_occupancy_setback(self._occupancy_mode):
+        if _gate == ScheduledBandGate.DEFER_OCCUPANCY:
             _LOGGER.info("Bedtime skipped — %s mode (setback already active)", self._occupancy_mode)
             if self._emit_event_callback:
                 self._emit_event_callback(
@@ -3979,7 +4010,7 @@ class AutomationEngine:
                 self._today_record.setback_skipped_reason = "occupancy"
             return
 
-        if self._manual_override_active:
+        if _gate == ScheduledBandGate.DEFER_OVERRIDE:
             _LOGGER.info(
                 "Bedtime setback skipped — manual override active (mode=%s since %s)",
                 self._manual_override_mode,
@@ -3991,6 +4022,25 @@ class AutomationEngine:
                 self._today_record.setback_skipped_reason = "manual_override"
             return
 
+        if _gate == ScheduledBandGate.DEFER_PAUSED:
+            _LOGGER.info("Bedtime setback skipped — paused by open door/window")
+            if self._emit_event_callback:
+                self._emit_event_callback("bedtime_setback_skipped", {"reason": "paused_by_door"})
+            if self._today_record is not None:
+                self._today_record.setback_skipped_reason = "paused_by_door"
+            return
+
+        # Issue #498: capture whether the fan is user-overridden BEFORE clear_manual_
+        # override() runs. clear_manual_override() unconditionally calls
+        # clear_fan_override(), which resets _fan_override_active to False as a side
+        # effect — reading self._fan_override_active AFTER that call always sees it
+        # already cleared, silently defeating the "not self._fan_override_active" guard
+        # below (this was true of handle_bedtime()'s guard even before this fix; it was
+        # never actually exercised because it read a flag clear_manual_override() had
+        # just zeroed). Same capture-before-clear pattern already used at :3648 for
+        # _manual_override_mode/_manual_override_source.
+        _fan_was_overridden = self._fan_override_active
+
         _LOGGER.warning("Bedtime setback: clearing any pending override state before applying sleep setback")
         self.clear_manual_override(reason="bedtime")
 
@@ -3998,15 +4048,14 @@ class AutomationEngine:
         if not c:
             if self._today_record is not None:
                 self._today_record.setback_skipped_reason = "no_classification"
-            # No sleep target available — deactivate fan unconditionally
-            if self._fan_active and not self._fan_override_active:
+            # No sleep target available — deactivate fan unless nat-vent/WHF owns it.
+            if _gate != ScheduledBandGate.DEFER_NAT_VENT and self._fan_active and not _fan_was_overridden:
                 await self._deactivate_fan(reason="bedtime — no classification")
                 self._natural_vent_active = False
             if self._economizer_active:
                 await self._deactivate_economizer(outdoor_temp=0)
             return
 
-        # Compute sleep band first — needed for the nat-vent continuation gate below.
         _sleep_band = select_comfort_band(
             c,
             self.config,
@@ -4015,30 +4064,23 @@ class AutomationEngine:
             aggressive_savings=bool(self.config.get("aggressive_savings", False)),
         )
 
-        # Issue #370: Nat-vent continuation gate — if nat-vent is actively running and
-        # outdoor air is below the sleep ceiling, allow free cooling to continue to the
-        # sleep target instead of deactivating the fan and handing off to the compressor.
-        # Applies to all fan archetypes (WHF, HVAC fan, BOTH).
-        _outdoor_370 = self._last_outdoor_temp
-        _nat_vent_can_reach = (
-            self._natural_vent_active
-            and self._fan_active
-            and not self._fan_override_active
-            and _outdoor_370 is not None
-            and _outdoor_370 < _sleep_band.ceiling
-        )
-        if _nat_vent_can_reach:
-            _LOGGER.info(
-                "Nat-vent continues at bedtime: outdoor=%.1f°F below sleep_cool=%.1f°F — fan runs to sleep target",
-                _outdoor_370,
-                _sleep_band.ceiling,
-            )
+        # Issue #498: bedtime no longer decides for itself whether nat-vent/WHF "can still
+        # reach" the sleep target — it just leaves an active session alone (skips fan
+        # deactivation) and always still computes/emits the sleep band exactly as before.
+        # The low-level _whf_owns_hvac() choke-point guard inside _set_temperature() (used by
+        # _apply_comfort_band() below) continues to silently no-op the actual write for
+        # WHF/BOTH — same as it always has; FAN_MODE_HVAC coexists with the compressor so its
+        # write goes through normally. This is deliberately NOT a second copy of that
+        # archetype decision — bedtime only decides "touch the fan or not."
+        if _gate == ScheduledBandGate.DEFER_NAT_VENT:
+            _LOGGER.info("Bedtime: nat-vent/WHF session active — leaving fan alone")
         else:
-            if self._fan_active and not self._fan_override_active:
-                await self._deactivate_fan(reason="bedtime — nat-vent not favorable for continuation")
+            if self._fan_active and not _fan_was_overridden:
+                await self._deactivate_fan(reason="bedtime — nat-vent not active")
                 self._natural_vent_active = False
         if self._economizer_active:
             await self._deactivate_economizer(outdoor_temp=0)
+
         if self._emit_event_callback:
             self._emit_event_callback(
                 "bedtime_setback",
@@ -4050,14 +4092,10 @@ class AutomationEngine:
                     "modifier": c.setback_modifier,
                 },
             )
-        if _nat_vent_can_reach and self._emit_event_callback:
+        if _gate == ScheduledBandGate.DEFER_NAT_VENT and self._emit_event_callback:
             self._emit_event_callback(
                 "nat_vent_bedtime_continue",
-                {
-                    "outdoor_temp": _outdoor_370,
-                    "sleep_cool": _sleep_band.ceiling,
-                    "fan_device": _fan_device_label(self.config),
-                },
+                {"fan_device": _fan_device_label(self.config)},
             )
         if self._today_record is not None:
             # Issue #402: key off _sleep_band.active (the edge _apply_comfort_band() actually
@@ -4096,18 +4134,57 @@ class AutomationEngine:
             )
             return "skipped: no warming trend"
 
-        # Gate unified via should_defer_to_occupancy_setback() (Issue #460).
-        if should_defer_to_occupancy_setback(self._occupancy_mode):
+        # Issue #498: occupancy/override/paused/nat-vent checks below now route through the
+        # single shared gate (desired_state.decide_scheduled_band_gate()) also used by
+        # apply_classification()/handle_bedtime()/handle_morning_wakeup() — see that
+        # function's docstring for the full rationale. Pre-cool previously had ZERO nat-vent/
+        # WHF awareness of its own, relying entirely on the low-level _whf_owns_hvac() choke-
+        # point guard inside _set_temperature() to silently no-op the write — this makes that
+        # deferral explicit and observable, and also adds a paused-by-door check it never had
+        # (finding #11). Deferring to an active nat-vent/WHF session loses nothing: pre-cool's
+        # own compute_pre_cool_target() floors at sleep_heat + hysteresis, the exact anchor
+        # nat_vent_temperature_check() already cycles the fan around during the sleep window —
+        # free cooling is already doing at least as much work as pre-cool's own AC ceiling
+        # would (Issue #498 finding #8a).
+        _gate = decide_scheduled_band_gate(
+            occupancy_mode=self._occupancy_mode,
+            manual_override_active=self._manual_override_active,
+            paused_by_door=self._paused_by_door,
+            natural_vent_active=self._natural_vent_active,
+            whf_owns_hvac=self._whf_owns_hvac(),
+        )
+
+        if _gate == ScheduledBandGate.DEFER_OCCUPANCY:
             _LOGGER.info("Pre-cool skipped — %s mode (setback already active)", self._occupancy_mode)
             return f"skipped: {self._occupancy_mode}"
 
-        if self._manual_override_active:
+        if _gate == ScheduledBandGate.DEFER_OVERRIDE:
             _LOGGER.info(
                 "Pre-cool skipped — manual override active (mode=%s since %s)",
                 self._manual_override_mode,
                 self._manual_override_time,
             )
             return "skipped: manual override"
+
+        if _gate == ScheduledBandGate.DEFER_PAUSED:
+            _LOGGER.info("Pre-cool skipped — paused by open door/window")
+            return "skipped: paused_by_door"
+
+        if _gate == ScheduledBandGate.DEFER_NAT_VENT:
+            _fan_cfg_pc = self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED)
+            _LOGGER.info(
+                "Pre-cool deferred — nat-vent/WHF session active (fan_mode=%s); free cooling already"
+                " chasing at least as cold a target",
+                _fan_cfg_pc,
+            )
+            if self._emit_event_callback:
+                self._emit_event_callback(
+                    "pre_cool_suppressed_nat_vent",
+                    {"modifier": c.setback_modifier, "reason": "active_session"},
+                )
+            if _fan_cfg_pc in (FAN_MODE_WHOLE_HOUSE, FAN_MODE_BOTH):
+                return "suppressed: nat-vent/WHF session active"
+            # FAN_MODE_HVAC: fall through and arm the pre-cool ceiling, fan keeps running.
 
         sleep_cool = float(self.config.get(CONF_SLEEP_COOL, DEFAULT_SLEEP_COOL))
         sleep_heat_floor = float(self.config.get(CONF_SLEEP_HEAT, DEFAULT_SLEEP_HEAT))
@@ -4145,7 +4222,12 @@ class AutomationEngine:
             if self._emit_event_callback:
                 self._emit_event_callback(
                     "pre_cool_suppressed_nat_vent",
-                    {"indoor": indoor_temp, "target": pre_cool_target, "modifier": c.setback_modifier},
+                    {
+                        "indoor": indoor_temp,
+                        "target": pre_cool_target,
+                        "modifier": c.setback_modifier,
+                        "reason": "achieved",
+                    },
                 )
             return f"suppressed: nat-vent achieved {indoor_temp:.1f}°F (target {pre_cool_target:.1f}°F)"
 
@@ -4190,19 +4272,33 @@ class AutomationEngine:
 
     async def handle_morning_wakeup(self, indoor_temp: float | None = None) -> None:
         """Restore comfort for morning wake-up."""
-        # Issue #85: skip comfort restore when nobody is home. Gate unified via
-        # should_defer_to_occupancy_setback() (Issue #460) — this call site's original
-        # inverted form (`not in (HOME, GUEST)`) is logically equivalent to the
-        # predicate's `in (AWAY, VACATION)`, since occupancy_mode is always one of
-        # exactly those 4 values.
-        if should_defer_to_occupancy_setback(self._occupancy_mode):
+        # Issue #498: occupancy/override/paused/nat-vent checks below now route through the
+        # single shared gate (desired_state.decide_scheduled_band_gate()) also used by
+        # apply_classification()/handle_bedtime()/handle_pre_cool() — see that function's
+        # docstring for the full rationale. This closes the 06:30 wake-up bug directly: the
+        # fan-deactivation call below now skips whenever nat-vent/WHF owns HVAC (previously
+        # unconditional — confirmed live: "Fan deactivated -- morning wakeup" -> "Comfort
+        # band applied (cool)" -> nat-vent had to re-engage a minute later to correct it) and
+        # skips whenever the user is overriding the fan (previously missing that check
+        # entirely, unlike handle_bedtime()). It also now defers when paused by an open door/
+        # window, which it never checked before (finding #11).
+        _gate = decide_scheduled_band_gate(
+            occupancy_mode=self._occupancy_mode,
+            manual_override_active=self._manual_override_active,
+            paused_by_door=self._paused_by_door,
+            natural_vent_active=self._natural_vent_active,
+            whf_owns_hvac=self._whf_owns_hvac(),
+        )
+
+        # Issue #85: skip comfort restore when nobody is home.
+        if _gate == ScheduledBandGate.DEFER_OCCUPANCY:
             _LOGGER.info(
                 "Morning wakeup skipped — occupancy mode is '%s'",
                 self._occupancy_mode,
             )
             return
 
-        if self._manual_override_active:
+        if _gate == ScheduledBandGate.DEFER_OVERRIDE:
             _LOGGER.info(
                 "Morning wakeup skipped — manual override active (mode=%s since %s)",
                 self._manual_override_mode,
@@ -4212,11 +4308,27 @@ class AutomationEngine:
                 self._emit_event_callback("morning_wakeup_skipped", {"reason": "manual_override"})
             return
 
+        if _gate == ScheduledBandGate.DEFER_PAUSED:
+            _LOGGER.info("Morning wakeup skipped — paused by open door/window")
+            if self._emit_event_callback:
+                self._emit_event_callback("morning_wakeup_skipped", {"reason": "paused_by_door"})
+            return
+
+        # Issue #498: capture whether the fan is user-overridden BEFORE clear_manual_
+        # override() runs — it unconditionally calls clear_fan_override(), which resets
+        # _fan_override_active to False as a side effect. Reading self._fan_override_active
+        # after that call would always see it already cleared, silently defeating the "not
+        # overridden" guard below (this is precisely how the reported 06:30 bug's fix could
+        # have looked complete while still doing nothing — same capture-before-clear
+        # pattern already used at :3648 and now in handle_bedtime()).
+        _fan_was_overridden = self._fan_override_active
+
         _LOGGER.warning("Morning wakeup: clearing any pending override state before restoring comfort")
         self.clear_manual_override(reason="morning_wakeup")
 
-        # Deactivate fan if still running from overnight
-        if self._fan_active:
+        # Deactivate fan if still running from overnight — unless the user is overriding it
+        # or nat-vent/WHF currently owns HVAC (Issue #498 fix — see docstring note above).
+        if _gate != ScheduledBandGate.DEFER_NAT_VENT and self._fan_active and not _fan_was_overridden:
             await self._deactivate_fan(reason="morning wakeup — resetting fan state")
 
         c = self._current_classification
@@ -4244,6 +4356,15 @@ class AutomationEngine:
                     _current_indoor,
                     _comfort_heat,
                 )
+
+        # Issue #498: wakeup doesn't decide the WHF-vs-HVAC-fan archetype question itself —
+        # it just leaves an active nat-vent/WHF session's fan alone (handled above) and
+        # always still computes/emits the daytime band exactly as it did before this fix.
+        # The low-level _whf_owns_hvac() choke-point guard inside _set_temperature() (used
+        # by _apply_comfort_band() below) silently no-ops the actual write for WHF/BOTH;
+        # FAN_MODE_HVAC coexists with the compressor so its write goes through normally.
+        if _gate == ScheduledBandGate.DEFER_NAT_VENT:
+            _LOGGER.info("Morning wakeup: nat-vent/WHF session active — leaving fan alone")
 
         # Arm the daytime comfort band — waking up exits the sleep window.
         _wakeup_band = select_comfort_band(

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,21 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.23"
+VERSION = "0.5.24"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.24": [
+        'Fix #498: the Status dashboard showed "Grace period active" during an override'
+        " but never said when it would end — now shows the end time and minutes remaining."
+        " Also fixed: the 6:30am wake-up could turn off a manually-overridden whole-house"
+        " fan and arm the AC against open windows, self-correcting only by luck a cycle"
+        " later. Bedtime, wake-up, and the overnight pre-cool trigger no longer each"
+        " decide independently whether to touch the fan or arm HVAC — they now share one"
+        " gate with the main 30-minute decision loop, closing two related gaps in the same"
+        " pass: none of the three previously respected an open door/window pause, and"
+        " bedtime's own free-cooling continuation check could hand off to the compressor"
+        " prematurely even while the fan was still doing useful, cheaper work.",
+    ],
     "0.5.23": [
         "Fix #495: manually or remotely turning on the whole-house fan (WHF) — by hand, or"
         " via a QuietCool RF remote timer press — left the AC armed for the entire session,"
@@ -1154,6 +1166,72 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    498: {
+        "version_fixed": "0.5.24",
+        "title": "Dashboard grace-expiry display gap; bedtime/wakeup/pre-cool gate logic duplicated and drifted",
+        "scope_covered": (
+            "(1) Dashboard: _compute_next_automation_action()/_compute_next_action() in"
+            " coordinator.py now append a formatted end-time + remaining-minutes suffix"
+            " (via new _format_grace_remaining() helper reading ae._grace_end_time) to the"
+            " 'Grace period active' text — previously shown with no time information at all."
+            " (2) Shared gate: new desired_state.ScheduledBandGate enum +"
+            " decide_scheduled_band_gate() pure function is now the single place the"
+            " occupancy/manual-override/paused-by-door/nat-vent-or-WHF-ownership checks"
+            " live, reused by apply_classification(), handle_bedtime(),"
+            " handle_morning_wakeup(), and handle_pre_cool() — each handler keeps its own"
+            " distinct band computation and telemetry, only the gate-checking is unified."
+            " (3) The reported bug: handle_morning_wakeup()'s independent copy of these"
+            " checks was missing the fan-override guard entirely (handle_bedtime()'s copy"
+            " had it) — wake-up unconditionally deactivated a manually-overridden"
+            " whole-house fan and armed AC, defeating the _whf_owns_hvac() choke-point"
+            " guard the write is supposed to respect. Confirmed live: 06:30 wake-up killed"
+            " a manual WHF override and armed cool, self-correcting a cycle later only"
+            " because an unrelated nat-vent re-evaluation happened to run right after."
+            " (4) Related, more subtle bug found while testing the wake-up fix:"
+            " clear_manual_override() unconditionally clears _fan_override_active as a"
+            " side effect (via clear_fan_override()), and both handle_bedtime() and"
+            " handle_morning_wakeup() call it BEFORE their fan-deactivation check — so"
+            " reading the live attribute afterward always saw it already cleared, silently"
+            " defeating the guard even when written correctly. This means"
+            " handle_bedtime()'s equivalent guard was never actually effective either,"
+            " confirmed by a test whose own name documented the bug as intended behavior"
+            " ('test_bedtime_clears_fan_override_then_deactivates', now corrected). Both"
+            " handlers now snapshot _fan_override_active into a local BEFORE calling"
+            " clear_manual_override(), matching the capture-before-clear pattern already"
+            " used elsewhere in _confirm_override()-adjacent code."
+            " (5) Finding #11: none of the three scheduled handlers checked"
+            " _paused_by_door at all (unlike apply_classification()/"
+            " handle_occupancy_away()/handle_occupancy_vacation(), which all do) — a"
+            " door/window pause active at exactly sleep_time/wake_time/the pre-cool"
+            " trigger was not protected. All three now defer via the shared gate."
+            " (6) handle_bedtime()'s own nat-vent-continuation gate (an inline"
+            " outdoor-vs-sleep_cool comparison) is deleted — it could hand off to AC"
+            " prematurely even while outdoor was still well below indoor and the fan was"
+            " doing useful work. Bedtime now defers entirely to an active nat-vent/WHF"
+            " session; the engine's own per-tick check_natural_vent_conditions() (outdoor-"
+            " reversal exit) and nat_vent_temperature_check()'s sleep-window cycling"
+            " target already manage the session's lifetime correctly without help from"
+            " bedtime."
+        ),
+        "scope_not_covered": (
+            "handle_pre_cool()'s new nat-vent/WHF deferral (finding #8) still lets the"
+            " low-level _whf_owns_hvac() choke-point guard silently no-op the actual write"
+            " for WHF/BOTH archetypes — this fix only makes that deferral observable via"
+            " logging/event emission, it does not change the underlying write path."
+            " If nat-vent ends early (before wake_time) after pre-cool already deferred to"
+            " it, nothing re-applies the pre-cool thermal-mass-banking ceiling — this is a"
+            " pre-existing gap (pre-cool is a one-shot scheduled trigger with no re-arm"
+            " mechanism), not a regression from this fix, and is not addressed here."
+            " A tools/simulate.py harness-level (production-coordinator) pending scenario"
+            " for the wake-up WHF-override bug was attempted but removed — the coordinator's"
+            " real fan-entity state-change listener did not engage as expected via the"
+            " harness's external_fan_state_change driving event within the time available"
+            " this session; the fix is covered by direct unit tests"
+            " (tests/test_bedtime_override.py::TestMorningWakeupFanOverrideGuard) instead,"
+            " which reproduce the exact reported bug and were verified to fail without the"
+            " fix. Wiring a harness-level scenario for this is left as follow-up work."
+        ),
+    },
     495: {
         "version_fixed": "0.5.23",
         "title": "Manual/remote whole-house-fan-on left HVAC armed; QuietCool remote reliability + status display",

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -5776,7 +5776,9 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             if ae._manual_override_active:
                 return _decide("Manual override active — automation is standing by.")
             if ae._grace_active:
-                return _decide("Grace period active — automation will resume shortly.")
+                return _decide(
+                    f"Grace period active — automation will resume shortly.{self._format_grace_remaining(ae)}"
+                )
             if ae.is_paused_by_door:
                 return _decide("Automation paused — a door or window is open.")
 
@@ -6385,6 +6387,34 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             )
         return details
 
+    def _format_grace_remaining(self, ae: AutomationEngine) -> str:
+        """Format ``ae._grace_end_time`` as an ' — ends H:MM AM (N min left)' suffix.
+
+        Returns "" if the timestamp is missing, unparseable, or already in the past —
+        never raises (Issue #498: dashboard showed grace was active but never said when
+        it would end, the single most useful piece of information during an override).
+        """
+        end_iso = getattr(ae, "_grace_end_time", None)
+        # isinstance guard: tests frequently stub the automation engine as a bare
+        # MagicMock() without setting _grace_end_time — an unset MagicMock attribute is
+        # truthy, so `if not end_iso` alone wouldn't catch it. Treat anything that isn't a
+        # real string as "no timestamp", matching the existing defensive pattern used for
+        # mocked dt_util elsewhere in this codebase (never raise on test doubles).
+        if not isinstance(end_iso, str) or not end_iso:
+            return ""
+        end_dt = dt_util.parse_datetime(end_iso)
+        if not isinstance(end_dt, datetime):
+            return ""
+        now = dt_util.now()
+        if not isinstance(now, datetime):
+            return ""
+        remaining_s = (end_dt - now).total_seconds()
+        if remaining_s <= 0:
+            return ""
+        end_str = dt_util.as_local(end_dt).strftime("%I:%M %p").lstrip("0")
+        remaining_min = max(1, round(remaining_s / 60))
+        return f" — ends {end_str} ({remaining_min} min left)"
+
     def _compute_next_automation_action(self, c: DayClassification | None) -> tuple[str, str]:
         """Compute the next scheduled automation action and its time.
 
@@ -6415,7 +6445,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
 
         if self.automation_engine._grace_active:
             source = self.automation_engine._last_resume_source or "automation"
-            return (f"Grace period active ({source})", "")
+            return (f"Grace period active ({source}){self._format_grace_remaining(self.automation_engine)}", "")
 
         # If a contact sensor debounce is pending, that is the soonest upcoming action
         if self._door_open_timers and self._door_open_timer_expiry:

--- a/custom_components/climate_advisor/desired_state.py
+++ b/custom_components/climate_advisor/desired_state.py
@@ -420,3 +420,67 @@ def decide_scheduled_write_seq_current(*, current_write_seq: int, target_write_s
     site has no nudge/reject_streak branching of its own to combine it with.
     """
     return current_write_seq == target_write_seq
+
+
+_OCCUPANCY_AWAY = "away"  # mirrors const.OCCUPANCY_AWAY
+_OCCUPANCY_VACATION = "vacation"  # mirrors const.OCCUPANCY_VACATION
+# Same import-independence convention as _FAN_MODE_DISABLED above.
+
+
+class ScheduledBandGate(Enum):
+    """Whether a scheduled/cyclical caller may (re)arm its comfort band right now.
+
+    Issue #498: `apply_classification()` (the real 30-min decision loop) already
+    gets this right; `handle_bedtime()`, `handle_morning_wakeup()`, and
+    `handle_pre_cool()` each hand-rolled their own partial, drifted copy of the
+    same four checks — wakeup's copy was missing the fan-override guard entirely
+    (the 06:30 wake-up bug), and none of the three checked paused-by-door at all.
+    One shared pure gate, reused by all four call sites, so the checks can't
+    drift apart again.
+    """
+
+    PROCEED = "proceed"  # safe to compute and arm this handler's band
+    DEFER_OCCUPANCY = "defer_occupancy"  # away/vacation setback owns temperature right now
+    DEFER_OVERRIDE = "defer_override"  # manual override active, not adopting
+    DEFER_PAUSED = "defer_paused"  # paused by an open door/window
+    DEFER_NAT_VENT = "defer_nat_vent"  # nat-vent/WHF session currently owns HVAC
+
+
+def decide_scheduled_band_gate(
+    *,
+    occupancy_mode: str,
+    manual_override_active: bool,
+    paused_by_door: bool,
+    natural_vent_active: bool,
+    whf_owns_hvac: bool,
+) -> ScheduledBandGate:
+    """Pure gate shared by apply_classification()/handle_bedtime()/handle_morning_wakeup()/
+    handle_pre_cool() (Issue #498).
+
+    Check order mirrors apply_classification()'s original inline order (occupancy,
+    override, paused-by-door, nat-vent/WHF) so behavior is unchanged for the caller
+    that already had all four checks — this is a pure extraction, not a reordering.
+
+    `DEFER_OCCUPANCY` covers both AWAY and VACATION identically: the gate only
+    answers "may band-arming proceed?". apply_classification()'s AWAY branch has
+    an *additional* action beyond deferring (it calls handle_occupancy_away() to
+    reapply the away setback) — that stays the caller's own responsibility, not
+    something this gate does, since VACATION has no equivalent extra action and
+    the two must not be conflated into one piece of caller logic.
+
+    `whf_owns_hvac` is OR'd with `natural_vent_active` for the same reason
+    apply_classification()'s original inline check did (Issue #495): a manually/
+    remotely-detected WHF session sets `_pre_fan_hvac_mode` via
+    `_suppress_hvac_for_whf()` without setting `_natural_vent_active` (a manual
+    override isn't a nat-vent decision), so both flags must be checked to catch
+    every case where the whole-house fan currently owns the thermostat.
+    """
+    if occupancy_mode in (_OCCUPANCY_AWAY, _OCCUPANCY_VACATION):
+        return ScheduledBandGate.DEFER_OCCUPANCY
+    if manual_override_active:
+        return ScheduledBandGate.DEFER_OVERRIDE
+    if paused_by_door:
+        return ScheduledBandGate.DEFER_PAUSED
+    if natural_vent_active or whf_owns_hvac:
+        return ScheduledBandGate.DEFER_NAT_VENT
+    return ScheduledBandGate.PROCEED

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.23"
+  "version": "0.5.24"
 }

--- a/docs/08-COMPUTATION-REFERENCE.md
+++ b/docs/08-COMPUTATION-REFERENCE.md
@@ -1389,18 +1389,20 @@ The grace-period trigger in the same block also now compares against `ae._last_c
 
 Fan override is **separate** from HVAC override. The two override states are tracked independently and do not interfere with each other. Fan override uses the same grace period duration as manual HVAC override (`DEFAULT_MANUAL_GRACE_SECONDS`), but the timers run independently.
 
-Fan override is **cleared** at transition points where the integration takes deliberate control of the fan (bedtime, morning wakeup — see Section 9c).
+Fan override **bookkeeping** is cleared at transition points where the integration takes deliberate control of the fan (bedtime, morning wakeup — see Section 9c) — but the *fan itself* is only deactivated when the user wasn't actively overriding it and nat-vent/WHF doesn't currently own HVAC (Issue #498).
 
-### 9c. Fan Behavior at Transitions
+### 9c. Fan Behavior at Transitions (updated Issue #498)
 
-| Transition | Fan action | Override cleared? |
+| Transition | Fan action | Override bookkeeping cleared? |
 |---|---|---|
-| Bedtime | `_deactivate_fan()` called; economizer also deactivated | Yes — `_fan_override_active` reset to `False` |
-| Morning wakeup | `_deactivate_fan()` called | Yes — `_fan_override_active` reset to `False` |
+| Bedtime | `_deactivate_fan()` called **only if** the fan wasn't being actively overridden and nat-vent/WHF doesn't currently own HVAC (`decide_scheduled_band_gate()` != `DEFER_NAT_VENT`); economizer also deactivated in that case | Yes — `_fan_override_active` reset to `False` regardless (via `clear_manual_override()` → `clear_fan_override()`) |
+| Morning wakeup | `_deactivate_fan()` called under the same condition as bedtime — this guard was **missing entirely** before Issue #498 (the reported 06:30 production bug: wake-up unconditionally killed a manually-overridden whole-house fan and armed AC) | Yes — same as bedtime |
 
-At bedtime, both the fan and the economizer are explicitly shut down before the bedtime setpoints are applied. This ensures the overnight period starts with a clean fan state regardless of what the economizer was doing during the evening window. At morning wakeup, the fan is deactivated before comfort temperatures are restored, preventing carryover of an economizer fan session into the occupied-home daytime period.
+At bedtime, the fan and economizer are shut down before the bedtime setpoints are applied — but only when there is no active nat-vent/WHF session and no active fan override to respect (Issue #498 deleted bedtime's own bespoke outdoor-vs-sleep_cool comparison; it now just defers to the shared gate). At morning wakeup, the same logic applies before comfort temperatures are restored.
 
-Clearing the override flag at these transitions means the integration will not skip fan activation during the next economizer cycle just because the user had manually adjusted the fan during the previous day.
+**Capture-before-clear hazard (Issue #498):** both handlers must snapshot `_fan_override_active` into a local variable *before* calling `clear_manual_override()` — that call unconditionally clears the flag as a side effect via `clear_fan_override()`, so reading the live attribute afterward would always see it already cleared, silently defeating the override guard regardless of whether the code checks it correctly. See `docs/grace-periods-spec.md#shared-scheduled-band-gate-issue-498` for the full mechanism.
+
+Clearing the override bookkeeping flag at these transitions means the integration will not skip fan activation during the next economizer cycle just because the user had manually adjusted the fan during the previous day — this bookkeeping reset is independent of whether the fan itself was touched during this same transition.
 
 ### 9c-i. Fan-ON and Fan-OFF Decision Table (Issue #359)
 

--- a/docs/grace-periods-spec.md
+++ b/docs/grace-periods-spec.md
@@ -13,9 +13,11 @@
 | Is grace state persisted across HA restarts? | No (Issue #282 — clean slate). Override state (`_manual_override_active`, `_grace_active`, `_override_confirm_pending`) is NOT restored on restart. Pause state (`_paused_by_door`, `_pre_pause_mode`) IS preserved. CA always starts in clean automation mode after restart. | [§ Pre-Pause Mode Storage — HA Restart](#pre-pause-mode-storage) |
 | What happens to an active grace period when occupancy changes? | The engine has no explicit occupancy-triggered grace cancellation. Grace timers run to expiry regardless of occupancy transitions; occupancy handlers (`handle_occupancy_away`, `handle_occupancy_home`) do not call `_cancel_grace_timers()`. | [§ Occupancy Interaction](#occupancy-interaction) |
 | What is the override confirmation delay — how does it work and what does it gate? | A debounce window (default 600 s) between detecting a thermostat mode change and formally accepting it as a manual override. While pending, `apply_classification()` returns early, blocking all HVAC commands. If the mode self-corrects within the window (transient glitch), the event is discarded — no grace period starts. | [§ Override Confirmation Delay](#override-confirmation-delay) |
-| What are all the callsites that clear a manual override, and under what conditions? | Seven callsites: three in `_grace_expired()` branches (always clear — intended), two scheduled handlers (bedtime/wakeup — skip if override active after Issue #204 fix), one explicit service call (always clears), and one occupancy handler (away/vacation — clears before setback, fix #220). Every clear is logged at INFO with a `reason=` parameter. | [§ What Clears a Manual Override](#what-clears-a-manual-override) |
+| What are all the callsites that clear a manual override, and under what conditions? | Seven callsites: three in `_grace_expired()` branches (always clear — intended), two scheduled handlers (bedtime/wakeup — skip if override active after Issue #204 fix), one explicit service call (always clears), and one occupancy handler (away/vacation — clears before setback, fix #220). Every clear is logged at INFO with a `reason=` parameter. Note (Issue #498): both scheduled handlers must snapshot `_fan_override_active` *before* calling `clear_manual_override()` — that call unconditionally clears the fan-override flag as a side effect via `clear_fan_override()`, so reading the live attribute afterward always sees it already cleared. | [§ What Clears a Manual Override](#what-clears-a-manual-override) |
 | Does PATH B (self-resolved transient) send a notification? | Yes (Issue #200). When the thermostat reverts to the expected mode within the confirmation window, a push notification is sent: "Brief thermostat adjustment detected — treated as transient. Climate Advisor continues normal operation." | [§ State Machine — PATH B](#state-machine) |
 | What happens if the user changes to a different mode while a grace period is already active? | The current override and grace timer are cleared, and a fresh 10-minute confirmation window starts for the new mode (Issue #201). The latest user action always wins. | [§ Second Override During Active Grace](#second-override-during-active-grace-issue-201) |
+| Where can the user see how much longer an active grace period will run? | The Status dashboard's next-action text (`_compute_next_automation_action()`/`_compute_next_action()` in coordinator.py) appends a formatted end-time + remaining-minutes suffix, e.g. "Grace period active (manual) — ends 7:14 AM (18 min left)", via `_format_grace_remaining()` reading `_grace_end_time` (Issue #498 — previously shown with no time at all). | [§ Timer Lifecycle](#timer-lifecycle) |
+| Do bedtime/wakeup/pre-cool implement their own copies of the occupancy/override/paused/nat-vent gate checks? | No (Issue #498). All four scheduled/cyclical call sites — `apply_classification()`, `handle_bedtime()`, `handle_morning_wakeup()`, `handle_pre_cool()` — call one shared pure function, `desired_state.decide_scheduled_band_gate()`, instead of hand-copying the checks. This fixed a real bug: `handle_morning_wakeup()`'s copy was missing the fan-override guard entirely, and none of the three scheduled handlers checked paused-by-door at all. | [§ Shared Scheduled-Band Gate (Issue #498)](#shared-scheduled-band-gate-issue-498) |
 
 ---
 
@@ -432,3 +434,59 @@ Away/vacation setback setpoint changes are guarded by `_is_recent_temp_command(3
 ### Invariant
 
 After Issue #204: no scheduled timer (bedtime, wakeup) may call `clear_manual_override()` while `_manual_override_active=True`. Only grace expiry (callsites 1–3) and the explicit service call (callsite 6) may unconditionally clear an active override. All other callsites must check the flag first.
+
+---
+
+## Shared Scheduled-Band Gate (Issue #498)
+
+**Problem:** `apply_classification()` (the real 30-min decision loop) has always had the
+correct full gate stack — occupancy dispatch, manual-override adopt-or-skip, paused-by-door
+suppression, and `_natural_vent_active`/`_whf_owns_hvac()` deferral. `handle_bedtime()`,
+`handle_morning_wakeup()`, and `handle_pre_cool()` each hand-rolled their own partial,
+independently-drifted copy of a subset of these checks instead of reusing it — the same
+"duplicate parallel gate logic" failure class previously seen in nat-vent threshold bugs
+(#400/#402). Two concrete production bugs came from this drift:
+
+1. `handle_morning_wakeup()`'s copy never checked `_fan_override_active` at all (only
+   `handle_bedtime()`'s did) — wake-up unconditionally deactivated a manually-overridden
+   whole-house fan and armed AC, defeating the `_whf_owns_hvac()` choke-point guard that
+   write is supposed to respect. Confirmed in production: 06:30 wake-up killed a manual WHF
+   override and armed cool, self-correcting a cycle later only because an unrelated nat-vent
+   re-evaluation happened to run right after.
+2. None of the three scheduled handlers checked `_paused_by_door` at all — a door/window
+   pause active at exactly sleep_time/wake_time/the pre-cool trigger was not protected; only
+   `apply_classification()`, `handle_occupancy_away()`, and `handle_occupancy_vacation()` did.
+
+**Fix:** one shared, pure function, `desired_state.decide_scheduled_band_gate()`, is now the
+single place these four checks live (occupancy, manual override, paused-by-door, nat-vent/WHF
+ownership — in that order, matching `apply_classification()`'s original inline order). All
+four call sites — `apply_classification()`, `handle_bedtime()`, `handle_morning_wakeup()`, and
+`handle_pre_cool()` — call this one function for their "may I proceed" decision, then map each
+outcome (`PROCEED`, `DEFER_OCCUPANCY`, `DEFER_OVERRIDE`, `DEFER_PAUSED`, `DEFER_NAT_VENT`) to
+their own existing telemetry/DailyRecord/skip-event behavior — no handler lost its distinct
+event names or bookkeeping; only the boolean gate-checking is unified.
+
+**Also fixed as part of the same change (bedtime's nat-vent-continuation logic):**
+`handle_bedtime()` previously had its own inline check — `outdoor < sleep_band.ceiling` — to
+decide whether an active nat-vent/WHF session should keep running through bedtime instead of
+handing off to AC. This was a real, separate correctness bug, not just duplication: it could
+hand off to AC prematurely even while outdoor was still well below indoor and the fan was
+doing useful, cheaper cooling. Bedtime now just defers entirely whenever
+`decide_scheduled_band_gate()` returns `DEFER_NAT_VENT` — no outdoor comparison of its own.
+The engine's own per-tick `check_natural_vent_conditions()` (outdoor-reversal exit) and
+`nat_vent_temperature_check()`'s sleep-window cycling target (`sleep_heat + hysteresis`, active
+the instant `_in_sleep_window()` flips true) already manage the session's lifetime correctly
+without any help from the scheduled handler.
+
+**Capture-before-clear hazard (found while testing the wake-up fix):** `clear_manual_override()`
+unconditionally calls `clear_fan_override()`, which resets `_fan_override_active = False` as a
+side effect — regardless of whether a fan override was active moments before. Both
+`handle_bedtime()` and `handle_morning_wakeup()` call `clear_manual_override()` *before* their
+fan-deactivation check, so reading `self._fan_override_active` at that point always sees it
+already cleared. This means the guard's *live-attribute* form is silently defeated even when
+written correctly — confirmed by a test (`test_bedtime_clears_fan_override_then_deactivates`,
+now corrected) whose own name documented the bug as intended behavior. Both handlers now
+snapshot `_fan_was_overridden = self._fan_override_active` *before* calling
+`clear_manual_override()`, and use that snapshot for the deactivation decision — the same
+capture-before-clear pattern already used in `_confirm_override()` (automation.py:~3648) for
+`_manual_override_mode`/`_manual_override_source`.

--- a/tests/test_bedtime_override.py
+++ b/tests/test_bedtime_override.py
@@ -264,6 +264,136 @@ class TestMorningWakeupOverrideGuard:
 
 
 # ---------------------------------------------------------------------------
+# TestMorningWakeupFanOverrideGuard (Issue #498 — the reported production bug)
+# ---------------------------------------------------------------------------
+
+
+class TestMorningWakeupFanOverrideGuard:
+    """Issue #498: handle_morning_wakeup() must not stomp a manually-overridden fan.
+
+    Production log (user-reported): at 06:30 wake-up, the WHF was running under an
+    active manual override with windows open. handle_morning_wakeup() unconditionally
+    deactivated the fan (missing the `not self._fan_override_active` guard
+    handle_bedtime() already had), which cleared the WHF's ownership of HVAC right
+    before arming a cool comfort band — momentarily arming AC against open windows
+    until an unrelated nat-vent re-evaluation corrected it a cycle later.
+    """
+
+    def test_fan_override_active_skips_fan_deactivation(self):
+        """The exact reported bug: fan_override_active=True must preserve the fan."""
+        engine = _make_engine()
+        engine._occupancy_mode = OCCUPANCY_HOME
+        engine._current_classification = _make_classification(hvac_mode="cool")
+        engine._fan_active = True
+        engine._fan_override_active = True
+
+        engine._deactivate_fan = AsyncMock()
+
+        with patch.object(engine, "_set_temperature", new_callable=AsyncMock):
+            asyncio.run(engine.handle_morning_wakeup())
+
+        engine._deactivate_fan.assert_not_called()
+
+    def test_fan_active_without_override_still_deactivates(self):
+        """No user override → wakeup still resets a stale overnight fan as before."""
+        engine = _make_engine()
+        engine._occupancy_mode = OCCUPANCY_HOME
+        engine._current_classification = _make_classification(hvac_mode="cool")
+        engine._fan_active = True
+        engine._fan_override_active = False
+
+        engine._deactivate_fan = AsyncMock()
+
+        with patch.object(engine, "_set_temperature", new_callable=AsyncMock):
+            asyncio.run(engine.handle_morning_wakeup())
+
+        engine._deactivate_fan.assert_called_once()
+
+    def test_natural_vent_active_skips_fan_deactivation(self):
+        """A CA-managed nat-vent session must also be left alone at wake-up."""
+        engine = _make_engine()
+        engine._occupancy_mode = OCCUPANCY_HOME
+        engine._current_classification = _make_classification(hvac_mode="cool")
+        engine._fan_active = True
+        engine._fan_override_active = False
+        engine._natural_vent_active = True
+
+        engine._deactivate_fan = AsyncMock()
+
+        with patch.object(engine, "_set_temperature", new_callable=AsyncMock):
+            asyncio.run(engine.handle_morning_wakeup())
+
+        engine._deactivate_fan.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TestScheduledHandlersPausedByDoor (Issue #498 finding #11)
+# ---------------------------------------------------------------------------
+
+
+class TestScheduledHandlersPausedByDoor:
+    """Issue #498 finding #11: none of handle_bedtime()/handle_morning_wakeup() checked
+    _paused_by_door before this fix — a door/window pause active at exactly sleep_time/
+    wake_time could still get a comfort-band write commanded into an open window.
+    """
+
+    def test_bedtime_skips_when_paused_by_door(self):
+        engine = _make_engine()
+        engine._occupancy_mode = OCCUPANCY_HOME
+        engine._current_classification = _make_classification(hvac_mode="heat")
+        engine._paused_by_door = True
+
+        with patch.object(engine, "_set_temperature", new_callable=AsyncMock) as set_temp:
+            asyncio.run(engine.handle_bedtime())
+
+        set_temp.assert_not_called()
+        # Paused override must not be cleared by a scheduled handler skipping past it
+        assert engine._paused_by_door is True
+
+    def test_bedtime_emits_paused_skip_event(self):
+        engine = _make_engine()
+        engine._occupancy_mode = OCCUPANCY_HOME
+        engine._current_classification = _make_classification(hvac_mode="heat")
+        engine._paused_by_door = True
+
+        events: list[tuple] = []
+        engine._emit_event_callback = lambda name, payload: events.append((name, payload))
+
+        asyncio.run(engine.handle_bedtime())
+
+        assert any(
+            name == "bedtime_setback_skipped" and payload.get("reason") == "paused_by_door" for name, payload in events
+        ), f"Expected bedtime_setback_skipped/paused_by_door in {events}"
+
+    def test_morning_wakeup_skips_when_paused_by_door(self):
+        engine = _make_engine()
+        engine._occupancy_mode = OCCUPANCY_HOME
+        engine._current_classification = _make_classification(hvac_mode="cool")
+        engine._paused_by_door = True
+
+        with patch.object(engine, "_set_temperature", new_callable=AsyncMock) as set_temp:
+            asyncio.run(engine.handle_morning_wakeup())
+
+        set_temp.assert_not_called()
+        assert engine._paused_by_door is True
+
+    def test_morning_wakeup_emits_paused_skip_event(self):
+        engine = _make_engine()
+        engine._occupancy_mode = OCCUPANCY_HOME
+        engine._current_classification = _make_classification(hvac_mode="cool")
+        engine._paused_by_door = True
+
+        events: list[tuple] = []
+        engine._emit_event_callback = lambda name, payload: events.append((name, payload))
+
+        asyncio.run(engine.handle_morning_wakeup())
+
+        assert any(
+            name == "morning_wakeup_skipped" and payload.get("reason") == "paused_by_door" for name, payload in events
+        ), f"Expected morning_wakeup_skipped/paused_by_door in {events}"
+
+
+# ---------------------------------------------------------------------------
 # TestClearManualOverrideReason
 # ---------------------------------------------------------------------------
 

--- a/tests/test_bedtime_setback.py
+++ b/tests/test_bedtime_setback.py
@@ -591,16 +591,20 @@ def _make_nat_vent_engine(config_overrides: dict | None = None) -> AutomationEng
 
 
 class TestNatVentBedtimeContinuation:
-    """Issue #370: nat-vent continuation gate in handle_bedtime().
+    """Issue #370 (superseded by Issue #498): nat-vent continuation at bedtime.
 
-    When nat-vent is actively running and outdoor air is below the sleep ceiling,
-    handle_bedtime() must NOT deactivate the fan — free cooling should run until
-    indoor reaches the sleep target. The check_natural_vent_conditions() sleep-ceiling
-    exit (Priority 0) then handles the fan deactivation.
+    Issue #498 finding #7: the original outdoor-vs-sleep_cool comparison here could
+    hand off to AC prematurely even while outdoor was still well below indoor and the
+    fan was doing useful, cheaper cooling. handle_bedtime() now defers to the shared
+    decide_scheduled_band_gate() instead — while nat-vent/WHF is active, bedtime never
+    touches the fan, full stop, regardless of the outdoor/sleep_cool comparison. The
+    engine's own per-tick check_natural_vent_conditions() (outdoor-reversal exit,
+    sleep-aware cycling target) is what actually manages the session's lifetime.
 
     Occupant experience: on a mild evening, the fan keeps running quietly to cool the
-    house to the sleep temperature instead of shutting off and handing off to the
-    compressor — saving energy and reducing HVAC cycling noise.
+    house toward the sleep temperature instead of shutting off and handing off to the
+    compressor — saving energy and reducing HVAC cycling noise — for as long as the
+    nat-vent session the engine is already tracking stays active.
     """
 
     def test_nat_vent_continues_when_outdoor_below_sleep_cool(self):
@@ -637,30 +641,42 @@ class TestNatVentBedtimeContinuation:
         # Fan state preserved
         assert engine._fan_active is True
 
-    def test_fan_deactivated_when_outdoor_above_sleep_cool(self):
-        """Gate fails: outdoor 74°F >= sleep_cool 72°F → fan deactivated.
+    def test_nat_vent_continues_regardless_of_outdoor_vs_sleep_cool(self):
+        """Issue #498 finding #7 regression: outdoor above sleep_cool no longer matters.
 
-        Occupant experience: at bedtime, outdoor air is too warm to cool the house
-        further — the fan shuts off and the thermostat takes over with the sleep band.
+        Previously, outdoor 74°F >= sleep_cool 72°F would deactivate the fan even
+        though nat-vent was still active and doing useful work. Now bedtime defers
+        to the active session unconditionally — the outdoor/sleep_cool comparison
+        is gone entirely.
+
+        Occupant experience: the fan keeps running at bedtime instead of prematurely
+        handing off to the compressor just because outdoor crossed the tighter sleep
+        ceiling — free cooling continues for as long as the session is genuinely active.
         """
         engine = _make_nat_vent_engine()
         engine._natural_vent_active = True
         engine._fan_active = True
         engine._fan_override_active = False
-        engine._last_outdoor_temp = 74.0  # >= sleep_cool=72
+        engine._last_outdoor_temp = 74.0  # above sleep_cool=72 — irrelevant now
         engine._last_indoor_temp = 73.0
 
         engine._deactivate_fan = AsyncMock()
         engine._async_save_state = AsyncMock()
+
+        emitted: list[tuple] = []
+        engine._emit_event_callback = lambda name, payload: emitted.append((name, payload))
         engine.set_occupancy_mode(OCCUPANCY_HOME)
 
         asyncio.run(engine.handle_bedtime())
 
-        # Fan MUST have been deactivated
-        engine._deactivate_fan.assert_called_once()
+        # Fan must NOT have been deactivated — nat-vent is still active
+        engine._deactivate_fan.assert_not_called()
+        assert engine._natural_vent_active is True
 
-        # _natural_vent_active must be cleared (state consistency fix)
-        assert engine._natural_vent_active is False
+        event_names = [e[0] for e in emitted]
+        assert "nat_vent_bedtime_continue" in event_names, (
+            f"Expected 'nat_vent_bedtime_continue' event; got: {event_names}"
+        )
 
     def test_fan_deactivated_when_nat_vent_not_active(self):
         """Gate fails: nat-vent flag False → fan deactivated at bedtime as before.
@@ -683,30 +699,14 @@ class TestNatVentBedtimeContinuation:
         # Without nat-vent active, the gate cannot pass — fan is deactivated
         engine._deactivate_fan.assert_called_once()
 
-    def test_nat_vent_active_flag_cleared_on_bedtime_deactivation(self):
-        """State consistency: _natural_vent_active=False after gate-fails deactivation.
-
-        Before Issue #370, the fan was deactivated but _natural_vent_active was left
-        True — causing the engine to believe nat-vent was still running after bedtime.
-
-        Occupant experience: without this fix, the next classification cycle would
-        incorrectly suppress HVAC as if nat-vent was providing free cooling.
-        """
-        engine = _make_nat_vent_engine()
-        engine._natural_vent_active = True
-        engine._fan_active = True
-        engine._fan_override_active = False
-        engine._last_outdoor_temp = 74.0  # gate fails: outdoor >= sleep_cool=72
-        engine._last_indoor_temp = 73.0
-
-        engine._deactivate_fan = AsyncMock()
-        engine._async_save_state = AsyncMock()
-        engine.set_occupancy_mode(OCCUPANCY_HOME)
-
-        asyncio.run(engine.handle_bedtime())
-
-        # State must be cleared — not left True after fan deactivation
-        assert engine._natural_vent_active is False
+    # test_nat_vent_active_flag_cleared_on_bedtime_deactivation removed (Issue #498):
+    # its premise — bedtime deactivating the fan while _natural_vent_active is True
+    # because outdoor crossed sleep_cool — is now structurally unreachable.
+    # decide_scheduled_band_gate() returns DEFER_NAT_VENT whenever _natural_vent_active
+    # (or _whf_owns_hvac()) is True, and that check now gates handle_bedtime()'s fan-
+    # deactivation call directly, so _natural_vent_active is always already False by
+    # the time _deactivate_fan() is reached from bedtime. Covered by
+    # test_nat_vent_continues_regardless_of_outdoor_vs_sleep_cool above.
 
     def test_hvac_fan_archetype_also_continues(self):
         """Gate works for FAN_MODE_HVAC too — all archetypes are eligible.

--- a/tests/test_desired_state.py
+++ b/tests/test_desired_state.py
@@ -30,6 +30,7 @@ from custom_components.climate_advisor.desired_state import (
     NotificationRequest,
     OverrideConfirmPending,
     PendingSetpointRetry,
+    ScheduledBandGate,
     ScheduledReevaluation,
     SetpointRetryAction,
     SetpointVerify,
@@ -39,6 +40,7 @@ from custom_components.climate_advisor.desired_state import (
     decide_grace_start,
     decide_override_confirm,
     decide_revisit,
+    decide_scheduled_band_gate,
     decide_scheduled_write_seq_current,
     decide_setpoint_retry_action,
     decide_setpoint_retry_schedule,
@@ -319,6 +321,65 @@ class TestDecideFanCycleOff:
         a negative wait."""
         _, wait_seconds = decide_fan_cycle_off(fan_min_runtime_active=True, min_runtime_minutes=90.0)
         assert wait_seconds == 0.0
+
+
+class TestDecideScheduledBandGate:
+    """Issue #498: shared gate reused by apply_classification()/handle_bedtime()/
+    handle_morning_wakeup()/handle_pre_cool() so none of them can drift from another
+    by hand-copying a partial, inconsistent subset of these four checks.
+    """
+
+    _BASE = {
+        "occupancy_mode": "home",
+        "manual_override_active": False,
+        "paused_by_door": False,
+        "natural_vent_active": False,
+        "whf_owns_hvac": False,
+    }
+
+    def _inputs(self, **overrides):
+        return {**self._BASE, **overrides}
+
+    def test_proceed_when_nothing_gates(self):
+        assert decide_scheduled_band_gate(**self._inputs()) == ScheduledBandGate.PROCEED
+
+    def test_defer_occupancy_when_away(self):
+        assert decide_scheduled_band_gate(**self._inputs(occupancy_mode="away")) == ScheduledBandGate.DEFER_OCCUPANCY
+
+    def test_defer_occupancy_when_vacation(self):
+        result = decide_scheduled_band_gate(**self._inputs(occupancy_mode="vacation"))
+        assert result == ScheduledBandGate.DEFER_OCCUPANCY
+
+    def test_defer_override_when_manual_override_active(self):
+        result = decide_scheduled_band_gate(**self._inputs(manual_override_active=True))
+        assert result == ScheduledBandGate.DEFER_OVERRIDE
+
+    def test_defer_paused_when_paused_by_door(self):
+        result = decide_scheduled_band_gate(**self._inputs(paused_by_door=True))
+        assert result == ScheduledBandGate.DEFER_PAUSED
+
+    def test_defer_nat_vent_when_natural_vent_active(self):
+        result = decide_scheduled_band_gate(**self._inputs(natural_vent_active=True))
+        assert result == ScheduledBandGate.DEFER_NAT_VENT
+
+    def test_defer_nat_vent_when_whf_owns_hvac_without_natural_vent_flag(self):
+        """Issue #495: a manually/remotely-detected WHF session sets _pre_fan_hvac_mode
+        without setting _natural_vent_active — whf_owns_hvac must independently gate."""
+        result = decide_scheduled_band_gate(**self._inputs(whf_owns_hvac=True))
+        assert result == ScheduledBandGate.DEFER_NAT_VENT
+
+    def test_check_order_occupancy_before_override(self):
+        """Mirrors apply_classification()'s original inline order — occupancy checked first."""
+        result = decide_scheduled_band_gate(**self._inputs(occupancy_mode="away", manual_override_active=True))
+        assert result == ScheduledBandGate.DEFER_OCCUPANCY
+
+    def test_check_order_override_before_paused(self):
+        result = decide_scheduled_band_gate(**self._inputs(manual_override_active=True, paused_by_door=True))
+        assert result == ScheduledBandGate.DEFER_OVERRIDE
+
+    def test_check_order_paused_before_nat_vent(self):
+        result = decide_scheduled_band_gate(**self._inputs(paused_by_door=True, natural_vent_active=True))
+        assert result == ScheduledBandGate.DEFER_PAUSED
 
 
 class TestDecideSetpointRetrySchedule:

--- a/tests/test_fan_control.py
+++ b/tests/test_fan_control.py
@@ -727,8 +727,17 @@ class TestFanTransitions:
 
         assert engine._fan_override_active is False
 
-    def test_bedtime_clears_fan_override_then_deactivates(self):
-        """handle_bedtime clears fan override (transition point) and deactivates fan."""
+    def test_bedtime_preserves_fan_active_at_override_but_clears_override_bookkeeping(self):
+        """Issue #498: a fan the user was actively overriding at bedtime must be left
+        running — clear_manual_override()'s unconditional clear_fan_override() call
+        still resets the _fan_override_active bookkeeping flag itself (a transition-
+        point reset, unrelated to whether the fan gets touched), but handle_bedtime()
+        must snapshot the override state BEFORE that call to decide whether to
+        deactivate, not re-read the already-cleared flag afterward. Previously this
+        test asserted the opposite (fan deactivated) — that was the same class of bug
+        as the reported 06:30 wake-up incident, just never triggered in production
+        for bedtime specifically.
+        """
         engine = _make_automation_engine(
             {
                 CONF_FAN_MODE: FAN_MODE_WHOLE_HOUSE,
@@ -741,9 +750,10 @@ class TestFanTransitions:
 
         asyncio.run(engine.handle_bedtime())
 
-        # Bedtime is a transition point — overrides are cleared, then fan deactivated
+        # Bookkeeping flag is still reset at this transition point...
         assert engine._fan_override_active is False
-        assert engine._fan_active is False
+        # ...but the fan itself, which the user was actively overriding, must be left running
+        assert engine._fan_active is True
 
 
 # ---------------------------------------------------------------------------

--- a/tools/sim_harness/outcomes.py
+++ b/tools/sim_harness/outcomes.py
@@ -434,6 +434,11 @@ def _map_event_to_outcome(
     if event_type == "whf_hvac_released":
         return ProductionDecision(ts_str, event_type, "whf_hvac_released")
 
+    # Issue #498: 1:1 mapping so a scheduled handler's blocked write is directly
+    # assertable at-time, same pattern as whf_hvac_suppressed/whf_hvac_released above.
+    if event_type == "hvac_write_blocked_whf_active":
+        return ProductionDecision(ts_str, event_type, "hvac_write_blocked_whf_active")
+
     # --- Unmapped (FINDINGS) — documented, silently skip ---
     if event_type in UNMAPPED_PRODUCTION_EVENTS:
         return None

--- a/tools/simulations/pending/wakeup_preserves_whf_manual_override.json
+++ b/tools/simulations/pending/wakeup_preserves_whf_manual_override.json
@@ -1,0 +1,74 @@
+{
+  "name": "wakeup_preserves_whf_manual_override",
+  "description": "Related to the reported production bug (Issue #498): WHF manually overridden via the coordinator's real fan-entity listener, morning wake-up fires — the AC must never arm while the WHF session still owns HVAC.",
+  "source": "production",
+  "issue": 498,
+  "simulator_support": true,
+  "track": "integration",
+  "notes": [
+    "Occupant outcome: the user manually turns on the whole-house fan overnight. At 06:30 wake-up, CA previously killed the fan and armed the AC even though the user's override meant free cooling should keep winning — the AC ran briefly before an unrelated nat-vent re-evaluation corrected it a cycle later. This scenario proves the AC-arming half of that fix at the production-coordinator level: the low-level _whf_owns_hvac() guard blocks wake-up's attempted comfort-band write while the WHF session holds.",
+    "Scope note (be precise about what this scenario does and does not cover): the reported bug's OTHER half — handle_morning_wakeup()'s `not self._fan_override_active` guard on the _deactivate_fan() call itself — is NOT exercised end-to-end here. Coordinator._async_fan_entity_changed() only classifies an entity change as a manual override when `is_on and not automation_engine._fan_active` (coordinator.py ~3710); a manual override detected this way therefore never has _fan_active=True, so the fan-deactivation call's `self._fan_active and not _fan_was_overridden` guard is never actually reached — it's a no-op regardless of whether the guard is correct. Confirmed by deliberately reverting the guard to its pre-fix unconditional form and re-running this scenario: it still passed, unchanged, proving this assertion does NOT discriminate that specific line. The realistic path to get _fan_active=True and _fan_override_active=True simultaneously (nat-vent already running the fan for real, then a QuietCool RF remote timer press layered on top via handle_fan_manual_override(), which does not gate on current _fan_active) needs an RF-remote-timer driving event type the harness does not yet support. That exact guard IS covered — directly and effectively (verified failing before the fix, passing after) — by tests/test_bedtime_override.py::TestMorningWakeupFanOverrideGuard at the unit level, which sets both flags directly on the engine.",
+    "Two-way alignment: handle_morning_wakeup() calls the shared desired_state.decide_scheduled_band_gate() and separately snapshots _fan_override_active BEFORE calling clear_manual_override() (which unconditionally clears that flag as a side effect via clear_fan_override()) — the deactivation guard reads the snapshot, not the already-cleared live attribute. That snapshot logic is what test_bedtime_override.py's unit tests exercise directly.",
+    "User outcome if the _whf_owns_hvac() guard this scenario DOES cover regresses: the compressor arms every morning a WHF session (of any kind — manual override, RF remote timer, or CA's own nat-vent) is still active at wake_time, fighting the fan and wasting energy.",
+    "Config note: fan_mode MUST be the real constant value 'whole_house_fan' (not 'whole_house' — a typo that silently no-ops the WHF archetype entirely, found while building this scenario). fan_state_feedback MUST be true: _async_fan_entity_changed() early-returns for every fan-entity state change when fan_state_feedback is false (command-only mode, Issue #361 — entity changes are treated as CA's own command echoes, never as a user action), so command-only mode can never detect this override at all. manual_grace_seconds is set well past the 30-minute gap between the override (06:00) and wake_time (06:30) — an earlier draft used exactly 1800s, which expired at the identical instant as wake-up and let the grace-expiry callback's own post-grace reconcile race ahead of wakeup's logic, masking the intended check."
+  ],
+  "config": {
+    "comfort_heat": 68,
+    "comfort_cool": 74,
+    "sleep_heat": 64,
+    "sleep_cool": 72,
+    "sleep_time": "22:30",
+    "wake_time": "06:30",
+    "setback_heat": 60,
+    "setback_cool": 79,
+    "natural_vent_delta": 3.0,
+    "fan_mode": "whole_house_fan",
+    "fan_entity": "fan.attic",
+    "fan_state_feedback": true,
+    "manual_grace_seconds": 3600,
+    "initial_thermostat_mode": "off"
+  },
+  "events": [
+    {
+      "time": "2026-07-13T22:00:00",
+      "type": "classification",
+      "day_type": "warm",
+      "hvac_mode": "cool",
+      "note": "Evening classification — warm day, comfort band armed at [68/74]."
+    },
+    {
+      "time": "2026-07-13T23:05:00",
+      "type": "external_fan_state_change",
+      "entity": "fan.attic",
+      "state": "off",
+      "note": "Establishes a prior 'off' state for the fan entity so the 06:00 change below is a real observed transition, not a first-ever state with no prior value."
+    },
+    {
+      "time": "2026-07-14T06:00:00",
+      "type": "external_fan_state_change",
+      "entity": "fan.attic",
+      "state": "on",
+      "note": "User manually turns on the whole-house fan via the real HA entity. The coordinator's real _async_fan_entity_changed listener classifies this as a manual override: sets _fan_override_active=True, starts a manual grace period, and suppresses HVAC via _suppress_hvac_for_whf() (_pre_fan_hvac_mode captured, _whf_owns_hvac() now True)."
+    },
+    {
+      "time": "2026-07-14T06:30:00",
+      "type": "wakeup",
+      "note": "Wake-up fires while the WHF session (grace started 06:00, 1hr duration) still owns HVAC."
+    }
+  ],
+  "assertions": [
+    {
+      "at": "2026-07-14T06:30:00",
+      "expect": "hvac_write_blocked_whf_active",
+      "reason": "Wake-up computes and attempts to arm the daytime comfort band as always, but the low-level _whf_owns_hvac() choke-point guard blocks the actual write while the WHF session holds — proving no AC command reaches the thermostat."
+    }
+  ],
+  "verdict": {
+    "type": "positive",
+    "summary": "The AC never arms at wake-up while an active WHF session (manual override or otherwise) owns HVAC (Issue #498, partial coverage — see scope note)",
+    "observed_behavior": "external_fan_state_change (06:00, WHF on, override detected, HVAC suppressed) → wakeup (06:30, comfort-band write blocked by _whf_owns_hvac())",
+    "expected_behavior": "The AC never arms while the WHF session holds ownership of HVAC, matching free-cooling-should-win intent."
+  },
+  "use_coordinator": true,
+  "skip_startup_coalesce": true
+}


### PR DESCRIPTION
## Summary
- Dashboard: "Grace period active" text now shows end time + minutes remaining (`_format_grace_remaining()`), previously showed no timing information at all.
- `handle_bedtime()`, `handle_morning_wakeup()`, and `handle_pre_cool()` each hand-rolled their own partial, drifted copy of the occupancy/override/paused-by-door/nat-vent gate logic `apply_classification()` already gets right — now share one pure function, `desired_state.decide_scheduled_band_gate()`.
- Fixes the reported production bug: a manually-overridden whole-house fan getting killed and AC armed against open windows at 06:30 wake-up.
- Also closes two related gaps found during the fix: none of the three scheduled handlers checked paused-by-door at all, and bedtime's own outdoor-vs-sleep_cool nat-vent-continuation check could hand off to AC prematurely (deleted, now defers to the shared gate).
- Found and fixed a deeper, related bug while testing the wake-up fix: `clear_manual_override()` unconditionally clears `_fan_override_active` as a side effect *before* either handler's fan-deactivation guard reads it — meaning the equivalent guard in `handle_bedtime()` was never actually effective either. Both handlers now snapshot the flag before calling `clear_manual_override()`.

Full investigation, findings, and decision trail: #498

## Test plan
- [x] `tests/test_desired_state.py::TestDecideScheduledBandGate` — direct unit coverage of the shared gate (all 5 outcomes, check ordering)
- [x] `tests/test_bedtime_override.py::TestMorningWakeupFanOverrideGuard` — direct regression test for the reported bug (verified failing before the fix, passing after)
- [x] `tests/test_bedtime_override.py::TestScheduledHandlersPausedByDoor` — new paused-by-door coverage for both handlers
- [x] `tests/test_fan_control.py::test_bedtime_preserves_fan_active_at_override_but_clears_override_bookkeeping` — corrected a test that had asserted the bug as intended behavior
- [x] `tests/test_bedtime_setback.py::TestNatVentBedtimeContinuation` — updated for the corrected (no-outdoor-comparison) nat-vent continuation behavior
- [x] New pending simulation scenario `wakeup_preserves_whf_manual_override.json` — production-coordinator-level proof that `_whf_owns_hvac()` blocks the AC-arming write at wake-up; scenario notes are explicit about which part of the fix it does/doesn't discriminate (verified via revert-test)
- [x] Full suite: 3461 tests pass, `ruff check`/`ruff format` clean, golden scenario integrity intact (74 verified, no goldens modified)
- [x] Version bumped 0.5.23 → 0.5.24 with `RELEASE_NOTES`/`KNOWN_FIXES` entries; `test_version_sync.py` passes