### PR TITLE
Fix #485: dedupe repeated occupancy setback entries in Activity Report

### DIFF
--- a/custom_components/climate_advisor/ai_skills_activity.py
+++ b/custom_components/climate_advisor/ai_skills_activity.py
@@ -997,7 +997,6 @@ _NO_DEDUP: frozenset[str] = frozenset(
         "comfort_band_applied",
         "bedtime_setback",
         "morning_wakeup",
-        "occupancy_setback",
         "occupancy_comfort_restored",
         "pre_cool_applied",
         "classification_applied",

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,18 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.24"
+VERSION = "0.5.25"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.25": [
+        'Fix #485: the Activity Report showed the same "Occupancy setback (away)" entry'
+        " repeated every ~5 minutes for hours at a time while nobody was home, drowning out"
+        " everything else in the log. The setpoint itself was never actually changing —"
+        " Climate Advisor just wasn't collapsing the repeats the way it already does for"
+        " other frequently-repeated entries. Now it shows one entry with a repeat count and"
+        " time range, and still shows a new entry right away whenever something real"
+        " changes (you come home, leave for vacation, etc.).",
+    ],
     "0.5.24": [
         'Fix #498: the Status dashboard showed "Grace period active" during an override'
         " but never said when it would end — now shows the end time and minutes remaining."
@@ -1166,6 +1175,44 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    485: {
+        "version_fixed": "0.5.25",
+        "title": "occupancy_setback Activity Report entries spammed every ~5 minutes while occupancy was unchanged",
+        "scope_covered": (
+            "Removed 'occupancy_setback' from ai_skills_activity.py's _NO_DEDUP exclusion"
+            " set, so build_event_timeline_table()'s existing consecutive-same-type-row"
+            " collapse mechanism (already used for nat_vent_fan_on/off,"
+            " occupancy_setback_suppressed_paused, etc.) now applies to it — repeated"
+            " identical occupancy_setback rows collapse to a single '×N (first-last)' row"
+            " with the last event's Settings cell preserved. Root cause traced: occupancy"
+            " transitions are already correctly event-driven"
+            " (coordinator._async_occupancy_toggle_changed, fires once per real transition"
+            " and no-ops otherwise) — the repeats came from apply_classification()'s"
+            " occupancy-defer gate (automation.py) unconditionally re-calling"
+            " handle_occupancy_away()/handle_occupancy_vacation() on every automation"
+            " cycle, which runs far more often than the documented 30-min interval due to"
+            " a self-perpetuating revisit chain (any HVAC action schedules a 5-min"
+            " revisit with no idempotency check). handle_occupancy_away/vacation() emit"
+            " occupancy_setback on every call with no dedup of their own — unlike"
+            " comfort_band_applied, which got a 10-min time-windowed dedup in #444."
+            " Confirmed via the cancel_override_then_resume golden scenario (which relies"
+            " on a genuine second occupancy_setback firing while occupancy mode is"
+            " unchanged, separated by intervening override events) that the fix does not"
+            " suppress legitimate re-applies — only truly consecutive identical rows"
+            " collapse."
+        ),
+        "scope_not_covered": (
+            "The underlying 5-minute revisit-after-any-action loop and the unconditional"
+            " climate.set_temperature re-assertion inside _apply_comfort_band() are"
+            " unchanged — both are deliberate, documented, shared design (revisit"
+            " plumbing is needed for nat-vent/pre-cool eligibility re-checks even while"
+            " away; free cooling is not occupancy-gated) and were explicitly scoped out"
+            " by the user. The real thermostat still receives a redundant"
+            " climate.set_temperature call roughly every 5-10 minutes while occupancy"
+            " stays away/vacation with nothing else changing; this fix only stops the"
+            " Activity Report from showing every one of those as a separate row."
+        ),
+    },
     498: {
         "version_fixed": "0.5.24",
         "title": "Dashboard grace-expiry display gap; bedtime/wakeup/pre-cool gate logic duplicated and drifted",

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.24"
+  "version": "0.5.25"
 }

--- a/docs/activity-report-table.md
+++ b/docs/activity-report-table.md
@@ -94,10 +94,10 @@ fields. Settings = `_format_band_setpoint(floor, ceiling, active, unit)`.
 
 | Event type | Emitter | Key payload fields | Event-column text | Settings-column rule |
 |---|---|---|---|---|
-| `comfort_band_applied` | `automation.py` `_apply_comfort_band` | `floor`, `ceiling`, `active`, `mode`, `reason` | "Comfort band applied" | `_format_band_setpoint(floor, ceiling, active, unit)` |
-| `bedtime_setback` | `automation.py` `handle_bedtime` | `mode`, `floor`, `ceiling`, `active`, `modifier` | "Bedtime setback — sleep band" | `_format_band_setpoint(floor, ceiling, active, unit)` |
-| `morning_wakeup` | `automation.py` `handle_morning_wakeup` | `mode`, `floor`, `ceiling`, `active` | "Morning wake-up — daytime band" | `_format_band_setpoint(floor, ceiling, active, unit)` |
-| `occupancy_setback` | `automation.py` `handle_occupancy_away` / `handle_occupancy_vacation` | `mode` (away/vacation), `floor`, `ceiling`, `occupancy` | "Occupancy setback — {occupancy} mode" | `_format_band_setpoint(floor, ceiling, active="ceiling", unit)` (ceiling preferred; floor used when active is explicit) |
+| `comfort_band_applied` | `automation.py` `_apply_comfort_band` | `floor`, `ceiling`, `active`, `mode`, `reason` | "Comfort band applied" | `_format_band_setpoint(floor, ceiling, active, unit)` — **excluded from dedup** (`_NO_DEDUP`): each application carries a distinct setpoint payload (#330). |
+| `bedtime_setback` | `automation.py` `handle_bedtime` | `mode`, `floor`, `ceiling`, `active`, `modifier` | "Bedtime setback — sleep band" | `_format_band_setpoint(floor, ceiling, active, unit)` — **excluded from dedup** (`_NO_DEDUP`). |
+| `morning_wakeup` | `automation.py` `handle_morning_wakeup` | `mode`, `floor`, `ceiling`, `active` | "Morning wake-up — daytime band" | `_format_band_setpoint(floor, ceiling, active, unit)` — **excluded from dedup** (`_NO_DEDUP`). |
+| `occupancy_setback` | `automation.py` `handle_occupancy_away` / `handle_occupancy_vacation` | `mode` (away/vacation), `floor`, `ceiling`, `occupancy` | "Occupancy setback — {occupancy} mode" | `_format_band_setpoint(floor, ceiling, active="ceiling", unit)` (ceiling preferred; floor used when active is explicit) — **dedup-eligible** (not in `_NO_DEDUP`, Issue #485): the emitter has no dedup of its own (unlike `comfort_band_applied`'s #444 time-windowed dedup), and re-fires every automation cycle while occupancy stays away/vacation, so consecutive identical rows collapse to `×N` per the [Dedup Contract](#dedup-contract). |
 | `occupancy_comfort_restored` | `automation.py` `handle_occupancy_home` | `mode`, `target_f` | "Occupancy — comfort restored" | `setpoint: {target_f} {mode.title()}` |
 | `pre_cool_applied` | `automation.py` `handle_pre_cool` | `target`, `modifier`, `sleep_cool`, `floor`, `indoor`, `nat_vent_suppressed` | "Pre-cool — thermal mass banking" | `setpoint: {target}°F Cool (sleep floor {floor}°F Heat)` |
 

--- a/tests/test_activity_renderers.py
+++ b/tests/test_activity_renderers.py
@@ -244,6 +244,61 @@ class TestBuildEventTimelineTable:
             f"Found {row_count} rows. Table:\n{table}"
         )
 
+    def test_consecutive_occupancy_setback_events_collapse(self):
+        """#485: repeated identical occupancy_setback (away) events collapse to xN.
+
+        Reported symptom: the automation engine re-asserts an unchanged away setback
+        every ~5 minutes (revisit loop), and occupancy_setback had no dedup — unlike
+        comfort_band_applied (#444) — so 11 identical rows showed up in the Activity
+        Record for a single unbroken away period. occupancy_setback was removed from
+        _NO_DEDUP so it uses the same collapse-consecutive-rows mechanism proven by
+        test_dedup_preserves_settings_cell.
+        """
+        events = [
+            _make_event(
+                "occupancy_setback",
+                hours_ago=1.0 - float(i) * 0.05,
+                mode="away",
+                occupancy="away",
+                floor=63,
+                ceiling=79,
+            )
+            for i in range(11)
+        ]
+        table = _build_table(events)
+
+        row_count = table.count("Occupancy setback")
+        assert row_count == 1, (
+            f"#485: 11 identical occupancy_setback events must collapse to a single row. "
+            f"Found {row_count} rows. Table:\n{table}"
+        )
+        assert "x11" in table or "×11" in table, f"#485: collapsed row must show the x11 repeat count. Table:\n{table}"
+        assert "setpoint:" in table, (
+            f"#485: collapsed occupancy_setback row must still show the setpoint. Table:\n{table}"
+        )
+
+    def test_occupancy_setback_breaks_run_on_mode_change(self):
+        """#485: an occupancy_setback for a DIFFERENT mode (e.g. vacation after away) must
+
+        not be silently merged into the prior run — two distinct rows, not one xN row,
+        because the underlying event_type is the same but this proves collapsing is
+        still based on consecutive same-type events only, matching every other
+        dedup-eligible type (e.g. nat_vent_fan_on) rather than payload equality.
+        """
+        events = [
+            _make_event("occupancy_setback", hours_ago=2.0, mode="away", occupancy="away", floor=63, ceiling=79),
+            _make_event(
+                "occupancy_comfort_restored", hours_ago=1.5, mode="cool", target_f=74
+            ),  # in _NO_DEDUP -- breaks any run
+            _make_event(
+                "occupancy_setback", hours_ago=1.0, mode="vacation", occupancy="vacation", floor=60, ceiling=85
+            ),
+        ]
+        table = _build_table(events)
+
+        assert "Occupancy setback (away)" in table
+        assert "Occupancy setback (vacation)" in table
+
     def test_single_fan_activated_event_shows_full_reason_in_event_column(self):
         """Issue #402 follow-up: a single (non-repeated) fan_activated event must show its
 


### PR DESCRIPTION
## Summary
- The Activity Report showed the same "Occupancy setback (away)" entry repeated every ~5 minutes for hours while occupancy was unchanged and the setpoint never changed.
- Root cause: `occupancy_setback` was excluded from `ai_skills_activity.py`'s existing `_NO_DEDUP` collapse mechanism (unlike `comfort_band_applied`, which got dedup in #444). The repeats themselves come from a documented, intentional revisit loop (needed for nat-vent/pre-cool eligibility re-checks even while away) re-triggering `apply_classification()`'s occupancy-defer gate — that part is unchanged and out of scope.
- Fix: removed `occupancy_setback` from `_NO_DEDUP`, so consecutive identical rows now collapse to `Occupancy setback ×N (first-last)`, same as `nat_vent_fan_on`/`nat_vent_fan_off`. A genuine re-apply (e.g. after `cancel_override`, verified against the `cancel_override_then_resume` golden scenario) still shows as a separate row since other event types intervene and break the run.
- Bumps version 0.5.24 → 0.5.25 with `RELEASE_NOTES`/`KNOWN_FIXES` entries.

## Test plan
- [x] `pytest tests/test_activity_renderers.py -v` — 59 passed, including 2 new regression tests
- [x] `pytest tests/` — 3463 passed
- [x] `python tools/simulate.py` — 74/74 golden scenarios passed (confirms no automation-engine behavior change)
- [x] `pytest tests/test_version_sync.py` — passed