### PR TITLE
Fix #502: ha_logs.py silently truncated to ha CLI's 100-line default

### DIFF
--- a/tests/test_deploy_security.py
+++ b/tests/test_deploy_security.py
@@ -207,13 +207,18 @@ class TestShellSanitization:
 
     @patch("ha_logs.subprocess.run")
     def test_no_filter_no_grep(self, mock_run):
-        """full_dump=True must produce a bare 'ha core logs' command with no grep."""
+        """full_dump=True must produce an unfiltered 'ha core logs --lines N' command with no grep.
+
+        Issue #502: `ha core logs` with no `--lines` silently defaults to only its last
+        100 lines on HAOS, so full_dump must always pass an explicit `--lines` — a bare
+        `ha core logs` is not actually a full dump.
+        """
         mock_run.return_value = MagicMock(returncode=0, stdout="lots of logs", stderr="")
 
-        fetch_logs(_MOCK_SSH_CONFIG, full_dump=True)
+        fetch_logs(_MOCK_SSH_CONFIG, lines=50, full_dump=True)
 
         cmd = mock_run.call_args[0][0]
         remote_cmd = cmd[-1]
 
-        assert remote_cmd.strip() == "ha core logs", f"Expected bare 'ha core logs', got: {remote_cmd!r}"
+        assert remote_cmd.strip() == "ha core logs --lines 50", f"Expected explicit --lines, got: {remote_cmd!r}"
         assert "grep" not in remote_cmd, f"Expected no grep in full_dump mode, got: {remote_cmd!r}"

--- a/tests/test_ha_logs.py
+++ b/tests/test_ha_logs.py
@@ -1,0 +1,115 @@
+"""Regression tests for tools/ha_logs.py's remote `ha core logs` command construction.
+
+Issue #502: fetch_logs() previously ran bare `ha core logs` in every branch, which
+defaults to only the last 100 lines on HAOS with no `--lines` flag. Any local
+grep/tail filtering happened after that 100-line cap, so `--lines`/`--full`/
+`--thermal` silently returned far less history than requested. These tests assert
+the real `fetch_logs()` function always forwards an explicit `--lines <N>` to the
+remote command — no live SSH/network calls are made; `subprocess.run` is mocked.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+_TOOLS_DIR = Path(__file__).parent.parent / "tools"
+
+
+def _load_ha_logs_module():
+    """Load tools/ha_logs.py as a module without touching .deploy.env or SSH."""
+    spec = importlib.util.spec_from_file_location("ha_logs", _TOOLS_DIR / "ha_logs.py")
+    mod = importlib.util.module_from_spec(spec)
+    if str(_TOOLS_DIR) not in sys.path:
+        sys.path.insert(0, str(_TOOLS_DIR))
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_ha_logs = _load_ha_logs_module()
+
+
+def _fake_config() -> dict:
+    return {
+        "HA_HOST": "homeassistant.local",
+        "HA_SSH_PORT": "22",
+        "HA_SSH_USER": "hassio",
+        "HA_SSH_KEY": "",
+        "HA_CONFIG_PATH": "/config",
+        "HA_API_TOKEN": "",
+    }
+
+
+def _mock_subprocess_result() -> MagicMock:
+    result = MagicMock()
+    result.returncode = 0
+    result.stdout = ""
+    result.stderr = ""
+    return result
+
+
+def _captured_remote_cmd(mock_run: MagicMock) -> str:
+    """Extract the remote command string (last element of the ssh argv list)."""
+    (cmd_args,), _kwargs = mock_run.call_args
+    return cmd_args[-1]
+
+
+class TestFullDumpForwardsLines:
+    def test_full_dump_passes_explicit_lines_flag(self):
+        with patch.object(_ha_logs.subprocess, "run", return_value=_mock_subprocess_result()) as mock_run:
+            _ha_logs.fetch_logs(_fake_config(), lines=12345, full_dump=True)
+        remote_cmd = _captured_remote_cmd(mock_run)
+        assert "--lines 12345" in remote_cmd
+        assert remote_cmd.startswith("ha core logs --lines 12345")
+
+
+class TestFilteredModeForwardsRawLines:
+    def test_component_filter_pulls_generous_raw_depth_before_grep(self):
+        with patch.object(_ha_logs.subprocess, "run", return_value=_mock_subprocess_result()) as mock_run:
+            _ha_logs.fetch_logs(
+                _fake_config(),
+                lines=500,
+                component_filter="climate_advisor",
+                raw_lines=20000,
+            )
+        remote_cmd = _captured_remote_cmd(mock_run)
+        assert "--lines 20000" in remote_cmd
+        assert "grep -i climate_advisor" in remote_cmd
+        assert "tail -n 500" in remote_cmd
+
+    def test_extra_filter_still_applies_after_raw_pull(self):
+        with patch.object(_ha_logs.subprocess, "run", return_value=_mock_subprocess_result()) as mock_run:
+            _ha_logs.fetch_logs(
+                _fake_config(),
+                lines=200,
+                component_filter="climate_advisor",
+                extra_filter="paused-by-door",
+                raw_lines=20000,
+            )
+        remote_cmd = _captured_remote_cmd(mock_run)
+        assert "--lines 20000" in remote_cmd
+        assert "grep -i paused-by-door" in remote_cmd
+
+
+class TestUnfilteredAllModeForwardsRawLines:
+    def test_no_component_filter_still_requests_raw_lines(self):
+        with patch.object(_ha_logs.subprocess, "run", return_value=_mock_subprocess_result()) as mock_run:
+            _ha_logs.fetch_logs(
+                _fake_config(),
+                lines=500,
+                component_filter="",
+                raw_lines=20000,
+            )
+        remote_cmd = _captured_remote_cmd(mock_run)
+        assert "--lines 20000" in remote_cmd
+        assert "tail -n 500" in remote_cmd
+
+
+class TestDefaultRawLinesConstant:
+    def test_default_raw_lines_used_when_not_overridden(self):
+        with patch.object(_ha_logs.subprocess, "run", return_value=_mock_subprocess_result()) as mock_run:
+            _ha_logs.fetch_logs(_fake_config(), lines=500, component_filter="climate_advisor")
+        remote_cmd = _captured_remote_cmd(mock_run)
+        assert f"--lines {_ha_logs.DEFAULT_RAW_LINES}" in remote_cmd

--- a/tools/ha_logs.py
+++ b/tools/ha_logs.py
@@ -4,6 +4,11 @@
 Uses `ha core logs` on the remote (reads Docker log files from disk on HAOS).
 Reuses the SSH connection config from .deploy.env.
 
+The remote `ha core logs` command defaults to only its last 100 lines when no
+`--lines` is given, so every SSH-mode call here explicitly passes `--lines` to
+the remote command — a generous raw depth (DEFAULT_RAW_LINES) when filtering
+locally with grep/tail, or the user's requested count directly for --full.
+
 SSH mode (default):
     python3 tools/ha_logs.py                        # Last 500 climate_advisor lines
     python3 tools/ha_logs.py --all                   # Last 500 lines of full HA log
@@ -40,6 +45,14 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 ENV_FILE = REPO_ROOT / ".deploy.env"
 LOG_DIR = REPO_ROOT / "logs"
+
+# Raw line depth requested from the remote `ha core logs --lines N` call before local
+# grep/tail filtering. Must be generous — grep/tail can only find matches within whatever
+# the remote command actually returned, and `ha core logs` defaults to just 100 lines
+# with no --lines flag. At current DEBUG-level log volume, 100000 lines is needed to
+# reach back roughly 3 days (verified live against a production HAOS install); smaller
+# values (e.g. 20000) only reached back ~1 day. SSH round-trip at this depth is ~15s.
+DEFAULT_RAW_LINES = 100000
 
 # Regex to strip ANSI color codes from ha core logs output
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
@@ -312,19 +325,25 @@ def fetch_logs(
     component_filter: str = "climate_advisor",
     extra_filter: str = "",
     full_dump: bool = False,
+    raw_lines: int = DEFAULT_RAW_LINES,
 ) -> str:
-    """Fetch logs from HA via SSH using `ha core logs`. Returns cleaned log text."""
-    # ha core logs reads Docker log files from disk on HAOS; retention is typically days, not just a few hours.
-    # The command streams the full log, so we pipe through grep/tail on the remote side.
+    """Fetch logs from HA via SSH using `ha core logs`. Returns cleaned log text.
+
+    `ha core logs` defaults to only its last 100 lines when no `--lines` is given, so we
+    always pass `--lines` explicitly to the remote command. When filtering locally with
+    grep/tail, we pull `raw_lines` from the remote (a generous depth so grep can find
+    matches spread across days) and then trim to `lines` after filtering. For a full
+    dump (no filtering), the user's requested `lines` count is the raw pull size directly.
+    """
     if full_dump:
-        remote_cmd = "ha core logs"
+        remote_cmd = f"ha core logs --lines {lines}"
     elif component_filter:
-        remote_cmd = f"ha core logs 2>/dev/null | grep -i {shlex.quote(component_filter)}"
+        remote_cmd = f"ha core logs --lines {raw_lines} 2>/dev/null | grep -i {shlex.quote(component_filter)}"
         if extra_filter:
             remote_cmd += f" | grep -i {shlex.quote(extra_filter)}"
         remote_cmd += f" | tail -n {lines}"
     else:
-        remote_cmd = "ha core logs 2>/dev/null"
+        remote_cmd = f"ha core logs --lines {raw_lines} 2>/dev/null"
         if extra_filter:
             remote_cmd += f" | grep -i {shlex.quote(extra_filter)}"
         remote_cmd += f" | tail -n {lines}"
@@ -453,7 +472,12 @@ def main() -> None:
         if args.thermal:
             thermal_lines = args.lines if args.lines != 500 else 2000  # use 2000 unless user overrode --lines
             raw = fetch_logs(
-                config, lines=thermal_lines, component_filter="climate_advisor", extra_filter="", full_dump=False
+                config,
+                lines=thermal_lines,
+                component_filter="climate_advisor",
+                extra_filter="",
+                full_dump=False,
+                raw_lines=max(thermal_lines, DEFAULT_RAW_LINES),
             )
             thermal_keywords = re.compile(
                 r"Thermal|thermal|rolling window|keeping alive|max_window|commit|abandon|reject|pending obs|pipeline",
@@ -467,13 +491,19 @@ def main() -> None:
             output = "\n".join(lines_out)
         else:
             component = "" if args.all else "climate_advisor"
-            output = fetch_logs(
-                config,
-                lines=args.lines,
-                component_filter=component,
-                extra_filter=args.filter,
-                full_dump=args.full,
-            )
+            if args.full:
+                # Bare --full with no explicit --lines should dump a large window, not argparse's 500 default.
+                full_lines = args.lines if args.lines != 500 else DEFAULT_RAW_LINES
+                output = fetch_logs(config, lines=full_lines, component_filter=component, full_dump=True)
+            else:
+                output = fetch_logs(
+                    config,
+                    lines=args.lines,
+                    component_filter=component,
+                    extra_filter=args.filter,
+                    full_dump=False,
+                    raw_lines=max(args.lines, DEFAULT_RAW_LINES),
+                )
 
         if not output.strip():
             print("(no matching log lines found)")


### PR DESCRIPTION
## Summary
- `fetch_logs()` in `tools/ha_logs.py` never forwarded `--lines`/`--full` to the remote `ha core logs` call, so every SSH-mode request silently got the `ha` CLI's own 100-line default before any local grep/tail filtering ran.
- Discovered while investigating #372 (nat-vent paused-by-door log review): `--lines 5000` returned what looked like no history, when 36 real matching lines existed 2-3 days back.
- Now every branch (`--full`, filtered, unfiltered) explicitly passes `--lines` to the remote command. Filtered pulls use a generous raw depth (`DEFAULT_RAW_LINES = 100000`, verified live against the production HAOS box to reach ~3 days back at current DEBUG log volume) before trimming to the user's requested count; `--full` passes the user's requested count directly.

## Scope
Tooling-only (`tools/ha_logs.py`, a dev diagnostic script) — does not touch `custom_components/climate_advisor`, so no version bump / `RELEASE_NOTES` / `KNOWN_FIXES` entry.

## Test plan
- [x] `tests/test_ha_logs.py` (new): asserts the constructed remote command always includes an explicit `--lines <N>` in all three branches (`full_dump`, `component_filter`, unfiltered). Verified these tests fail against the pre-fix code (reverted locally, reran, confirmed failure) before restoring the fix.
- [x] Updated `tests/test_deploy_security.py::test_no_filter_no_grep`, which had encoded the bug (bare `"ha core logs"`) as expected behavior — now asserts `--lines` is present while still asserting no `grep`.
- [x] `python -m ruff check` / `ruff format` clean.
- [x] `pytest tests/test_ha_logs.py tests/test_deploy_security.py tests/test_learning_db_cli.py tests/test_solar_learning.py -v` — all pass.
- [x] Live end-to-end verification against the production HAOS box: `python3 tools/ha_logs.py --lines 5000 --filter "paused-by-door"` now returns the 36 previously-hidden lines under normal usage (not just a manual SSH one-liner).
