### PR TITLE
Fix #508: cancelling a fan override didn't cancel grace, reconcile the fan, or log the action

### DIFF
--- a/custom_components/climate_advisor/ai_skills_activity.py
+++ b/custom_components/climate_advisor/ai_skills_activity.py
@@ -831,6 +831,10 @@ def _render_startup_coalesced(p: dict, unit: str) -> tuple[str, str]:
 
 def _render_stuck_grace_recovered(p: dict, unit: str) -> tuple[str, str]:
     grace_end = p.get("grace_end_time", "")
+    if p.get("reason") == "grace_without_override":
+        # Issue #508's watchdog mirror: grace_end_time is typically still in the future here
+        # (the timer would have fired correctly on its own) — "expired" would be misleading.
+        return "Stuck grace recovered (no override was active to protect it)", ""
     return f"Stuck grace recovered (expired {grace_end})", ""
 
 

--- a/custom_components/climate_advisor/api.py
+++ b/custom_components/climate_advisor/api.py
@@ -7,6 +7,7 @@ import json
 import logging
 from dataclasses import asdict
 from datetime import timedelta
+from typing import Any
 
 from aiohttp import web
 from homeassistant.components.http import HomeAssistantView
@@ -543,6 +544,26 @@ class ClimateAdvisorConfigView(HomeAssistantView):
         return self.json({"settings": settings})
 
 
+def _schedule_reclassify_after_cancel(hass: HomeAssistant, coordinator: Any, ae: Any) -> None:
+    """Re-run the full decision path shortly after a user cancels an override (Issue #508).
+
+    HVAC-mode-level counterpart to ``AutomationEngine.cancel_override()``'s fan-check/refresh
+    calls — mirrors what a natural grace expiry converges on, via ``apply_classification()``.
+    Shared by both cancel views so this scheduling logic can't drift between them a second time
+    (it previously existed only in ``ClimateAdvisorCancelOverrideView``, never in the fan-cancel
+    sibling).
+    """
+    from homeassistant.core import callback
+    from homeassistant.helpers.event import async_call_later
+
+    @callback
+    def _apply_after_delay(_now):
+        if coordinator._current_classification:
+            hass.async_create_task(ae.apply_classification(coordinator._current_classification))
+
+    async_call_later(hass, 10, _apply_after_delay)
+
+
 class ClimateAdvisorCancelOverrideView(HomeAssistantView):
     """Cancel manual override and resume automated HVAC control."""
 
@@ -557,23 +578,11 @@ class ClimateAdvisorCancelOverrideView(HomeAssistantView):
             return self.json({"error": "Climate Advisor not loaded"}, status_code=503)
 
         ae = coordinator.automation_engine
-        if not ae._manual_override_active:
+        cancelled = ae.cancel_override(reason="user_cancel_override")
+        if not cancelled:
             return self.json({"status": "ok", "message": "No active override to cancel"})
 
-        # Clear override and cancel grace timers
-        ae.clear_manual_override()
-        ae._cancel_grace_timers()
-
-        # Schedule re-application of current classification after 10 seconds
-        from homeassistant.core import callback
-        from homeassistant.helpers.event import async_call_later
-
-        @callback
-        def _apply_after_delay(_now):
-            if coordinator._current_classification:
-                hass.async_create_task(ae.apply_classification(coordinator._current_classification))
-
-        async_call_later(hass, 10, _apply_after_delay)
+        _schedule_reclassify_after_cancel(hass, coordinator, ae)
 
         return self.json(
             {
@@ -624,7 +633,12 @@ class ClimateAdvisorCancelFanOverrideView(HomeAssistantView):
             return self.json({"error": "Climate Advisor not loaded"}, status_code=503)
 
         ae = coordinator.automation_engine
-        ae.clear_fan_override()
+        cancelled = ae.cancel_override(reason="user_cancel_fan_override")
+        if not cancelled:
+            return self.json({"status": "ok", "message": "No active fan override to cancel."})
+
+        _schedule_reclassify_after_cancel(hass, coordinator, ae)
+
         return self.json({"status": "ok", "message": "Fan override cleared."})
 
 

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -796,6 +796,42 @@ class AutomationEngine:
         self._resumed_from_pause = False
         self.clear_fan_override()
 
+    def cancel_override(self, reason: str = "user_cancel") -> bool:
+        """User/system deliberately ends an override and its grace protection right now (Issue #508).
+
+        Mirrors the post-processing ``_on_grace_expired()`` performs at natural expiry (fan
+        reconcile, coordinator refresh) but on-demand instead of waiting for the grace timer.
+        ``clear_manual_override()`` unconditionally clears the fan-override flag too, so this one
+        method is the entry point for both dashboard "Cancel..." buttons — there is no separate
+        "kind" of cancellation, just one operation with two entry points.
+
+        Returns:
+            True if an override and/or grace period was actually cancelled; False if there was
+            nothing active (safe no-op — callers can use this to choose their response message).
+        """
+        had_manual = self._manual_override_active
+        had_fan = self._fan_override_active
+        had_grace = self._grace_active
+        if not (had_manual or had_fan or had_grace):
+            return False
+
+        self.clear_manual_override(reason=reason)
+        self._cancel_grace_timers()
+
+        # clear_manual_override() only emits "override_cleared" when a thermostat-mode override
+        # was active (guarded on _manual_override_active); a fan-only override cleared here would
+        # otherwise leave zero trace in the Activity Report.
+        if had_fan and not had_manual and self._emit_event_callback:
+            self._emit_event_callback("override_cleared", {"was_mode": None, "old_setpoint_f": None})
+
+        # Force the same reconciliation a natural grace expiry always performs, instead of
+        # relying on the next incidental event or the next 30-min classification cycle.
+        if self._post_grace_fan_check_callback:
+            self._post_grace_fan_check_callback()
+        if self._request_refresh_callback:
+            self._request_refresh_callback()
+        return True
+
     def _get_fan_runtime_minutes(self) -> float:
         """Return how many minutes the fan has been running, or 0.0 if inactive."""
         if not self._fan_active or not self._fan_on_since:
@@ -1476,8 +1512,7 @@ class AutomationEngine:
                                 "pre_expiry": True,
                             },
                         )
-                    self._cancel_grace_timers()
-                    self.clear_manual_override(reason="adopted_matching_decision")
+                    self.cancel_override(reason="adopted_matching_decision")
                     if self._post_grace_fan_check_callback:
                         self._post_grace_fan_check_callback()
                     # continue below — classification is applied normally this cycle
@@ -3632,11 +3667,7 @@ class AutomationEngine:
                 "%s grace expired during planned window period — sensors open as expected, clearing grace",
                 source,
             )
-            self._grace_active = False
-            self._last_resume_source = None
-            self._grace_end_time = None
-            self._manual_grace_cancel = None
-            self._automation_grace_cancel = None
+            self._cancel_grace_timers()
             self.clear_manual_override(reason="grace_expired")
             if self._request_refresh_callback:
                 self._request_refresh_callback()
@@ -3650,11 +3681,7 @@ class AutomationEngine:
                 "%s grace expired but sensor(s) still open — re-pausing HVAC",
                 source,
             )
-            self._grace_active = False
-            self._last_resume_source = None
-            self._grace_end_time = None
-            self._manual_grace_cancel = None
-            self._automation_grace_cancel = None
+            self._cancel_grace_timers()
             self.clear_manual_override(reason="grace_expired")
             if self._request_refresh_callback:
                 self._request_refresh_callback()
@@ -3691,11 +3718,7 @@ class AutomationEngine:
                 duration,
             )
 
-        self._grace_active = False
-        self._last_resume_source = None
-        self._grace_end_time = None
-        self._manual_grace_cancel = None
-        self._automation_grace_cancel = None
+        self._cancel_grace_timers()
         self.clear_manual_override(reason="adopted_matching_decision" if _adopted else "grace_expired")
         if self._request_refresh_callback:
             self._request_refresh_callback()

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,20 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.27"
+VERSION = "0.5.28"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.28": [
+        "Fix #508: pressing 'Cancel Fan Override' on the dashboard cleared the fan override"
+        " but left the grace-period countdown running for its full original duration — up to"
+        " 8 hours for a QuietCool RF remote timer — so the dashboard kept saying 'Grace period"
+        " active' long after you'd already cancelled it. The fan/HVAC state also had no"
+        " guaranteed way to re-sync immediately; it only worked today because an unrelated"
+        " door/window event happened to fire a minute later. Both dashboard 'Cancel...'"
+        " buttons now share one cancellation path that clears grace, re-checks the fan, and"
+        " logs the cancellation to the Activity Report every time. A background safety check"
+        " also self-heals any grace period left with no override behind it.",
+    ],
     "0.5.27": [
         "Fix #505: vacation mode's deep energy-saving setback was armed once when you"
         " turned vacation mode on, and never enforced again for the rest of the trip —"
@@ -1197,6 +1208,53 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    508: {
+        "version_fixed": "0.5.28",
+        "title": (
+            "Cancelling a fan override from the dashboard didn't cancel grace, didn't"
+            " force reconciliation, and left no activity trail"
+        ),
+        "scope_covered": (
+            "Three root causes traced to a real production incident (RF-remote WHF override,"
+            " cancelled 7 minutes in). (1) ClimateAdvisorCancelFanOverrideView.post() (api.py)"
+            " called only clear_fan_override(), never _cancel_grace_timers() — confirmed via"
+            " git log to be an original design gap from Issue #79 (2026-03-30), not a"
+            " regression; the sibling ClimateAdvisorCancelOverrideView (Issue #41) has always"
+            " called both. _grace_active stayed True for the rest of the original grace"
+            " duration (up to 8 hours for an RF-remote timer), so the dashboard's next-action"
+            " text kept saying 'Grace period active' long after the override was gone."
+            " (2) Neither cancel view forced the same reconciliation a natural grace expiry"
+            " always performs (_post_grace_fan_check_callback -> reconcile_fan_on_startup(),"
+            " _request_refresh_callback()); the fan-cancel view additionally never scheduled"
+            " apply_classification() the way the thermostat-cancel view already did — resuming"
+            " automation depended on an incidental unrelated event (a door/window debounce)"
+            " firing shortly after, which is what made the production incident look like it"
+            " 'worked' by luck. (3) clear_fan_override() never emitted an activity-log event,"
+            " so a fan-only cancellation was invisible in the Activity Report. Fix: a single"
+            " new AutomationEngine.cancel_override() method is the canonical 'deliberate"
+            " cancel' operation (clear override + cancel grace + fan-reconcile + coordinator"
+            " refresh + activity event) used by both dashboard buttons and the internal"
+            " adopted_matching_decision path, replacing hand-composed call pairs that had"
+            " already drifted out of sync once. _on_grace_expired()'s three inline 5-line"
+            " grace-flag resets were deduped to call the existing _cancel_grace_timers()."
+            " coordinator._check_orphaned_grace() (extended from the existing Issue #321"
+            " stuck-grace watchdog, same ~30s cycle) self-heals the mirror condition"
+            " (grace_active=True with no override active) as defense-in-depth beyond the two"
+            " known call sites. _render_stuck_grace_recovered() now distinguishes the two"
+            " watchdog shapes so the new condition doesn't render a misleading 'expired' label"
+            " when the grace timer was actually still validly scheduled in the future."
+        ),
+        "scope_not_covered": (
+            "handle_bedtime()/handle_morning_wakeup()/occupancy handlers' existing behavior of"
+            " clearing an override without cancelling its grace timer is unchanged by design —"
+            " docs/grace-periods-spec.md documents this as intentional (grace runs to natural"
+            " expiry regardless of occupancy transitions), not a gap. No frontend change was"
+            " required or made; index.html's cancelFanOverride() calling loadStatus() (not"
+            " loadAutomationState()) means the Debug tab's own grace-period row may lag the"
+            " Status tab's next-action text by one manual refresh — cosmetic, not investigated"
+            " further here."
+        ),
+    },
     505: {
         "version_fixed": "0.5.27",
         "title": "Vacation deep setback armed once at mode-entry, never re-applied for the rest of the trip",

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -1518,6 +1518,31 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         _LOGGER.info("Startup coalescing complete — startup grace period ended")
         self.hass.async_create_task(self.async_request_refresh())
 
+    def _check_orphaned_grace(self) -> None:
+        """Self-heal a grace period left active with no override to protect (Issue #508).
+
+        Mirror of the Issue #321 stuck-grace check (grace_end_time in the past while
+        grace_active=False) but the opposite shape: here grace_end_time is typically still in
+        the future — the timer would fire correctly on its own — but no override (thermostat or
+        fan) is currently active to justify keeping it. Defense-in-depth for anything that clears
+        an override without going through AutomationEngine.cancel_override() (e.g. an exception
+        mid-cancel, or a future third endpoint that bypasses it). Runs every regular update cycle
+        (~30s), so any residual inconsistency self-heals within one cycle instead of persisting
+        for hours.
+        """
+        ae = self.automation_engine
+        if not (ae._grace_active and not ae._manual_override_active and not ae._fan_override_active):
+            return
+        _LOGGER.error(
+            "Stuck grace detected: grace_active=True but no override is active — force-cancelling grace (Issue #508)."
+        )
+        _grace_end = ae._grace_end_time
+        ae._cancel_grace_timers()
+        self._emit_event(
+            "stuck_grace_recovered",
+            {"grace_end_time": _grace_end, "reason": "grace_without_override"},
+        )
+
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch forecast and update classification (runs every 30 min).
 
@@ -1795,6 +1820,8 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                     )
                     _ae.clear_manual_override(reason="stuck_grace_recovery")
                     self._emit_event("stuck_grace_recovered", {"grace_end_time": _ae._grace_end_time})
+
+            self._check_orphaned_grace()
 
             _LOGGER.debug("[coalesce-diag] before apply_classification() [regular cycle path]")
             await self.automation_engine.apply_classification(

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.27"
+  "version": "0.5.28"
 }

--- a/docs/activity-report-table.md
+++ b/docs/activity-report-table.md
@@ -116,7 +116,7 @@ These events signal a mode or setpoint change triggered by automation logic.
 
 | Event type | Emitter | Key payload fields | Event-column text | Settings-column rule |
 |---|---|---|---|---|
-| `override_cleared` | `automation.py` `clear_manual_override` | `was_mode`, `active_since`, `old_setpoint_f` | "Manual override cleared" | `was: {was_mode} since {active_since HH:MM}` |
+| `override_cleared` | `automation.py` `clear_manual_override` (thermostat-mode override was active) OR `automation.py` `cancel_override` (Issue #508 — fan-only override cancelled, `was_mode`/`old_setpoint_f` both `None`) | `was_mode`, `active_since`, `old_setpoint_f` | "Manual override cleared" | `was: {was_mode} since {active_since HH:MM}` (blank fields render gracefully when `was_mode` is `None`) |
 | `override_confirmed` | `automation.py` inner callback `_confirm_override_expired` (PATH A) | `mode`, `confirm_delay_seconds` | "Override confirmed — {mode}" | `grace: {confirm_delay_seconds//60} min delay elapsed` |
 | `override_self_resolved` | `automation.py` inner callback (PATH B) | `detected_mode`, `current_mode` | "Override self-resolved (transient)" | blank |
 | `grace_started` | `automation.py` `_start_grace_period` | `source`, `duration_seconds`, `trigger` | "Grace period started — {source}" | `duration: {duration_seconds//60} min, trigger: {trigger}` |
@@ -161,7 +161,7 @@ These events carry no HVAC action — Settings is blank.
 |---|---|---|---|---|
 | `system_restarted` | `coordinator.py` `async_restore_state` | `recovered_events` | "System restarted — HA restart boundary" | `{recovered_events} events recovered` |
 | `startup_coalesced` | `coordinator.py` `_complete_startup_coalesce` | `nat_vent_activated`, `hvac_commanded`, `sensors_open_count` | "Startup coalescing complete" | `nat-vent: {nat_vent_activated}, HVAC: {hvac_commanded}, open sensors: {sensors_open_count}` |
-| `stuck_grace_recovered` | `coordinator.py` `_async_update_data` | `grace_end_time` | "Stuck grace recovered — force-cleared" | `grace expired at: {grace_end_time}` |
+| `stuck_grace_recovered` | `coordinator.py` `_async_update_data` (original: override stuck active past its own due grace-end-time — Issue #321) OR `coordinator.py` `_check_orphaned_grace` (mirror: grace active with no override behind it — Issue #508) | `grace_end_time`, `reason` (only set by the Issue #508 call site, value `"grace_without_override"`) | "Stuck grace recovered — force-cleared" (no `reason`) or "Stuck grace recovered (no override was active to protect it)" (`reason="grace_without_override"`) | `grace expired at: {grace_end_time}` |
 | `state_contradiction_warning` | `coordinator.py` `_async_update_data` | `hvac_mode`, `hvac_action` | "State contradiction — mode/action mismatch" | `mode: {hvac_mode}, action: {hvac_action}` |
 | `thermal_learning_no_observations` | `coordinator.py` `_handle_end_of_day` | `hvac_runtime_minutes` | "Thermal learning — no observations today" | `HVAC ran {hvac_runtime_minutes} min with zero thermal observations` |
 | `incident_detected` | `automation.py` `_set_temperature` / `coordinator.py` `_emit_incident` | `incident_class`, `incident_id`, and class-specific fields | "Incident — {incident_class}" | class-specific fields formatted as `key: value` pairs |

--- a/docs/grace-periods-spec.md
+++ b/docs/grace-periods-spec.md
@@ -13,7 +13,9 @@
 | Is grace state persisted across HA restarts? | No (Issue #282 — clean slate). Override state (`_manual_override_active`, `_grace_active`, `_override_confirm_pending`) is NOT restored on restart. Pause state (`_paused_by_door`, `_pre_pause_mode`) IS preserved. CA always starts in clean automation mode after restart. | [§ Pre-Pause Mode Storage — HA Restart](#pre-pause-mode-storage) |
 | What happens to an active grace period when occupancy changes? | The engine has no explicit occupancy-triggered grace cancellation. Grace timers run to expiry regardless of occupancy transitions; occupancy handlers (`handle_occupancy_away`, `handle_occupancy_home`) do not call `_cancel_grace_timers()`. | [§ Occupancy Interaction](#occupancy-interaction) |
 | What is the override confirmation delay — how does it work and what does it gate? | A debounce window (default 600 s) between detecting a thermostat mode change and formally accepting it as a manual override. While pending, `apply_classification()` returns early, blocking all HVAC commands. If the mode self-corrects within the window (transient glitch), the event is discarded — no grace period starts. | [§ Override Confirmation Delay](#override-confirmation-delay) |
-| What are all the callsites that clear a manual override, and under what conditions? | Seven callsites: three in `_grace_expired()` branches (always clear — intended), two scheduled handlers (bedtime/wakeup — skip if override active after Issue #204 fix), one explicit service call (always clears), and one occupancy handler (away/vacation — clears before setback, fix #220). Every clear is logged at INFO with a `reason=` parameter. Note (Issue #498): both scheduled handlers must snapshot `_fan_override_active` *before* calling `clear_manual_override()` — that call unconditionally clears the fan-override flag as a side effect via `clear_fan_override()`, so reading the live attribute afterward always sees it already cleared. | [§ What Clears a Manual Override](#what-clears-a-manual-override) |
+| What are all the callsites that clear a manual override, and under what conditions? | Eight callsites: three in `_grace_expired()` branches (always clear — intended, one of them via `cancel_override()` as of Issue #508), two scheduled handlers (bedtime/wakeup — skip if override active after Issue #204 fix), the two dashboard cancel buttons (always clear, via `cancel_override()` as of Issue #508), and one occupancy handler (away/vacation — clears before setback, fix #220). Every clear is logged at INFO with a `reason=` parameter. Note (Issue #498): both scheduled handlers must snapshot `_fan_override_active` *before* calling `clear_manual_override()` — that call unconditionally clears the fan-override flag as a side effect via `clear_fan_override()`, so reading the live attribute afterward always sees it already cleared. | [§ What Clears a Manual Override](#what-clears-a-manual-override) |
+| What is the difference between `clear_manual_override()` and `cancel_override()`, and which should a new callsite use? | `clear_manual_override()` clears override flags only — used by scheduled handlers (bedtime/wakeup/occupancy) that supersede an override without touching its grace timer, by design. `cancel_override()` (Issue #508) additionally cancels grace and forces the same fan-reconcile + coordinator-refresh a natural grace expiry performs — it is the single entry point for "user/system deliberately ends this override right now" (both dashboard "Cancel..." buttons, and the `adopted_matching_decision` path). A new callsite meaning deliberate cancellation must call `cancel_override()`, not compose the primitives by hand. | [§ Deliberate Cancellation — `cancel_override()` (Issue #508)](#deliberate-cancellation-cancel_override-issue-508) |
+| What happens if grace is left active with no override behind it (e.g. a future callsite bypasses `cancel_override()`)? | `coordinator._check_orphaned_grace()` (Issue #508), run every regular update cycle (~30s), self-heals: if `_grace_active=True` and neither `_manual_override_active` nor `_fan_override_active` is set, it force-cancels grace and emits `stuck_grace_recovered` with `reason="grace_without_override"`. This is the mirror of the pre-existing Issue #321 stuck-grace check (which catches the opposite shape — an override stuck active past its own due grace-end-time); the two checks are independent and cannot both fire on the same state. | [§ Orphaned Grace Self-Heal (Issue #508)](#orphaned-grace-self-heal-issue-508) |
 | Does PATH B (self-resolved transient) send a notification? | Yes (Issue #200). When the thermostat reverts to the expected mode within the confirmation window, a push notification is sent: "Brief thermostat adjustment detected — treated as transient. Climate Advisor continues normal operation." | [§ State Machine — PATH B](#state-machine) |
 | What happens if the user changes to a different mode while a grace period is already active? | The current override and grace timer are cleared, and a fresh 10-minute confirmation window starts for the new mode (Issue #201). The latest user action always wins. | [§ Second Override During Active Grace](#second-override-during-active-grace-issue-201) |
 | Where can the user see how much longer an active grace period will run? | The Status dashboard's next-action text (`_compute_next_automation_action()`/`_compute_next_action()` in coordinator.py) appends a formatted end-time + remaining-minutes suffix, e.g. "Grace period active (manual) — ends 7:14 AM (18 min left)", via `_format_grace_remaining()` reading `_grace_end_time` (Issue #498 — previously shown with no time at all). | [§ Timer Lifecycle](#timer-lifecycle) |
@@ -28,23 +30,32 @@
 - `custom_components/climate_advisor/coordinator.py` — door/window state listeners, debounce timer scheduling, manual override detection during pause
 
 **Line ranges (automation.py):**
-- `_is_within_planned_window_period()`: L321–L340
-- `handle_door_window_open()`: L1045–L1186
-- `handle_all_doors_windows_closed()`: L1188–L1232
-- `handle_manual_override_during_pause()`: L1404–L1427
-- `resume_from_pause()`: L1429–L1460
-- `_start_grace_period()`: L1462–L1548
-- `_cancel_grace_timers()`: L1550–L1559
-- `_re_pause_for_open_sensor()`: L1561–L1613
-- `restore_state()`: L2038–L2079
-- `get_serializable_state()`: L2081–L2116
+- `_is_within_planned_window_period()`: L706
+- `clear_manual_override()`: L764–L797
+- `cancel_override()`: L799–L831 (Issue #508 — see [§ Deliberate Cancellation](#deliberate-cancellation-cancel_override-issue-508))
+- `clear_fan_override()`: L1058
+- `handle_door_window_open()`: L2408
+- `handle_all_doors_windows_closed()`: L2607
+- `handle_manual_override_during_pause()`: L3532
+- `resume_from_pause()`: L3557
+- `_start_grace_period()`: L3590
+- `_on_grace_expired()`: L3658 (its three branches now call `_cancel_grace_timers()` for the grace-flag
+  reset instead of inlining it — deduped in Issue #508)
+- `_cancel_grace_timers()`: L3781
+- `_re_pause_for_open_sensor()`: L3793
+- `restore_state()`: L5503
+- `get_serializable_state()`: L5588
 
 **Line ranges (coordinator.py):**
-- `_subscribe_door_window_listeners()`: L744
-- `_cancel_all_debounce_timers()`: L900–L914
-- `_any_sensor_open()`: L933–L935
-- `_async_door_window_changed()`: L1798–L1888
-- `_async_thermostat_changed()` (pause-override detection): L1890–L1926
+- `_subscribe_door_window_listeners()`: L1146
+- `_cancel_all_debounce_timers()`: L1302
+- `_any_sensor_open()`: L1350
+- `_check_orphaned_grace()`: L1521 (Issue #508 — see [§ Orphaned Grace Self-Heal](#orphaned-grace-self-heal-issue-508))
+- `_async_door_window_changed()`: L2960
+- `_async_thermostat_changed()` (pause-override detection): L3080
+
+**Note on line-number drift:** these are exact as of Issue #508 (v0.5.28) but will drift with future edits —
+treat them as a navigation aid, not a contract; if a line doesn't match, search for the function name.
 
 **Out of scope for this spec:**
 - Natural ventilation internal logic (see `check_natural_vent_conditions()`, `_re_evaluate_nat_vent()`)
@@ -192,10 +203,14 @@ Confirmed from code:
 
 **Start:** `async_call_later(self.hass, duration, _grace_expired)` at L1540. Returns a cancel callable stored in either `_manual_grace_cancel` (source=`"manual"`) or `_automation_grace_cancel` (source=`"automation"`). `_grace_active` is set to `True` before the timer starts (L1481). `_grace_end_time` is set to an ISO timestamp of `now + duration` (L1483).
 
-**Cancel:** `_cancel_grace_timers()` (L1550–L1559) invokes both cancel callables if present, then sets `_grace_active = False` and `_last_resume_source = None`. Called in:
+**Cancel:** `_cancel_grace_timers()` (L3781) invokes both cancel callables if present, then sets `_grace_active = False`, `_grace_end_time = None`, and `_last_resume_source = None`. Called in:
 - `_start_grace_period()` — beginning of every new grace (replaces previous timer)
-- `cleanup()` — coordinator/engine teardown (L2120)
-- Implicitly: any new call to `_start_grace_period()` cancels the previous via `_cancel_grace_timers()` at L1469
+- `cleanup()` — coordinator/engine teardown
+- `cancel_override()` (Issue #508) — the deliberate-cancellation entry point, see below
+- `coordinator._check_orphaned_grace()` (Issue #508) — the self-heal watchdog, see below
+- Each of `_on_grace_expired()`'s three branches (Issue #508 dedup — previously each branch
+  hand-inlined the same 5-field reset instead of calling this shared helper)
+- Implicitly: any new call to `_start_grace_period()` cancels the previous via `_cancel_grace_timers()`
 
 **Extend:** There is no explicit "extend" operation. A new `_start_grace_period()` call cancels the previous and starts a fresh full-duration timer. This is the effective extension mechanism, but it is not named or documented as such in code.
 
@@ -210,6 +225,87 @@ Confirmed from code:
 **`_re_pause_for_open_sensor()` (L1561–L1613):** Async method scheduled via `async_create_task`. Re-checks planned window period first (if within window, skips re-pause). Otherwise evaluates nat-vent conditions — if outdoor is cool enough for natural ventilation, activates nat-vent mode instead of re-pausing. Falls through to re-pause: captures `state.state` into `_pre_pause_mode`, sets `_paused_by_door = True`, calls HVAC off (unless already off), sends `grace_repause` notification.
 
 **`_sensor_check_callback`:** Set by the coordinator after engine construction. Points to `coordinator._any_sensor_open()` which reads live HA sensor states for all `_resolved_sensors`. If `None` (e.g., in unit tests), the re-pause branch is skipped and grace expires normally.
+
+---
+
+## Deliberate Cancellation — `cancel_override()` (Issue #508)
+
+**Problem:** Both dashboard "Cancel..." buttons ("Cancel Override" for a thermostat-mode override,
+"Cancel Fan Override" for a fan-only override) mean the same domain action — "stop protecting this
+override, hand control back to automation now" — but each API view composed
+`clear_manual_override()` + `_cancel_grace_timers()` by hand. `ClimateAdvisorCancelOverrideView`
+(Issue #41) got the pairing right from its first commit; `ClimateAdvisorCancelFanOverrideView`
+(Issue #79, added 11 days later) never called `_cancel_grace_timers()` at all, in any version —
+confirmed via `git log -p` to be an original design gap, not a regression. A user cancelling a
+fan-only override via the dashboard saw `_grace_active` stay `True` for the rest of the original
+grace duration (up to 8 hours for a QuietCool RF-remote timer selection), even though the override
+it protected was already gone.
+
+**Fix:** `AutomationEngine.cancel_override(reason: str = "user_cancel") -> bool`
+(`automation.py:799`) is now the single entry point for deliberate cancellation:
+
+1. No-op guard: if none of `_manual_override_active`, `_fan_override_active`, `_grace_active` is
+   set, returns `False` immediately — nothing to do.
+2. Calls `clear_manual_override(reason=reason)` (which unconditionally clears the fan-override
+   flag too via `clear_fan_override()`).
+3. Calls `_cancel_grace_timers()`.
+4. Activity-log parity: `clear_manual_override()` only emits `"override_cleared"` when
+   `_manual_override_active` was `True` — a fan-only cancellation would otherwise leave zero trace
+   in the Activity Report. `cancel_override()` emits `"override_cleared"` itself in that case
+   (`was_mode=None`, gracefully rendered by the existing `_render_override_cleared()`).
+5. Forces the same post-processing a *natural* grace expiry always performs (see the "Normal
+   expiry" row in the Timer Lifecycle table above), instead of relying on an incidental unrelated
+   event or the next 30-minute classification cycle: calls `_post_grace_fan_check_callback()` (→
+   `reconcile_fan_on_startup()`, re-evaluating live indoor/outdoor/sensor state) and
+   `_request_refresh_callback()` (immediate coordinator refresh).
+6. Returns `True` if something was actually cancelled.
+
+Both `ClimateAdvisorCancelOverrideView.post()` and `ClimateAdvisorCancelFanOverrideView.post()`
+(`api.py`) call `cancel_override()` with a distinct `reason` string
+(`"user_cancel_override"` / `"user_cancel_fan_override"`) and then call the shared
+`_schedule_reclassify_after_cancel()` helper, which schedules `apply_classification()` after a 10s
+settle delay — the HVAC-mode-level counterpart to `cancel_override()`'s fan-reconcile call. This
+scheduling logic previously existed only on the thermostat-cancel view; the fan-cancel view had no
+equivalent at all, so cancelling a fan override never forced reconciliation of anything.
+
+The internal `adopted_matching_decision` path inside `_on_grace_expired()`'s normal-expiry branch
+also now calls `cancel_override(reason="adopted_matching_decision")` instead of hand-composing
+`_cancel_grace_timers()` + `clear_manual_override()` in that order — the two existing call sites
+had drifted to opposite call orders, more evidence neither treated this as one canonical operation.
+
+**Not folded into `clear_manual_override()` itself:** `clear_manual_override()` remains the
+low-level primitive used by `handle_bedtime()`, `handle_morning_wakeup()`, and the occupancy
+handlers — none of which should cancel grace (see [§ Occupancy Interaction](#occupancy-interaction)
+and the "What Clears a Manual Override" callsite table below; this is deliberate, documented
+behavior, not a gap). `cancel_override()` sits one level above, composing the primitive plus grace
+cancellation plus reconciliation, only for callers that mean deliberate, immediate cancellation.
+
+---
+
+## Orphaned Grace Self-Heal (Issue #508)
+
+**Shape of the problem:** the opposite of the pre-existing Issue #321 stuck-grace check (below).
+Issue #321 catches `_grace_active=False` with `_grace_end_time` in the past (a timer that should
+have fired but didn't — override stuck active). This new check catches `_grace_active=True` with
+no override active at all — `_grace_end_time` is typically still validly in the future (the timer
+will fire correctly on its own), but nothing is being protected. Defense-in-depth for any path that
+clears an override without going through `cancel_override()` — an exception mid-cancel, or a future
+third endpoint that composes the primitives by hand again.
+
+**Implementation:** `coordinator._check_orphaned_grace()` (`coordinator.py:1521`), called once per
+regular `_async_update_data()` cycle (~30s). Condition: `ae._grace_active and not
+ae._manual_override_active and not ae._fan_override_active`. On match: logs an ERROR, calls
+`ae._cancel_grace_timers()`, and emits `"stuck_grace_recovered"` with
+`{"grace_end_time": ..., "reason": "grace_without_override"}`.
+
+**Renderer note:** `_render_stuck_grace_recovered()` (`ai_skills_activity.py`) branches on the
+`reason` field — the pre-existing Issue #321 call site never sets it and keeps its original
+`"Stuck grace recovered (expired {grace_end})"` label; this new call site renders `"Stuck grace
+recovered (no override was active to protect it)"` instead, since `grace_end` is misleadingly
+labeled "expired" when it's actually still in the future.
+
+**These two watchdog checks are mutually exclusive** — one requires `_grace_active=False`, the
+other requires `_grace_active=True` — and run independently in the same update cycle.
 
 ---
 
@@ -424,8 +520,9 @@ This makes every clear event attributable in `python tools/ha_logs.py --full` wi
 | 3 | `_grace_expired()` — normal expiry branch | `automation.py:~1520` | Grace timer fires; all sensors closed | Always clears — intended; grace window has elapsed normally |
 | 4 | `handle_bedtime_setback()` | `automation.py:1926` | Configured `sleep_time` fires | **Skips entirely if `_manual_override_active=True`** — emits `bedtime_setback_skipped` event; logs skip at INFO. Clears only if override is not active. |
 | 5 | `handle_morning_wakeup()` | `automation.py:2025` | Configured `wake_time` fires | **Skips entirely if `_manual_override_active=True`** — emits `morning_wakeup_skipped` event; logs skip at INFO. Clears only if override is not active. |
-| 6 | `clear_manual_override` HA service call | `automation.py` service handler | User explicitly calls the service from UI or automation | Always clears — explicit user intent |
-| 7 | `handle_occupancy_away()` / `handle_occupancy_vacation()` | `automation.py` occupancy handlers | Occupancy transitions to away/vacation while `_manual_override_active=True` | Calls `clear_manual_override(reason="occupancy_away")` / `clear_manual_override(reason="occupancy_vacation")` before applying setback. Fixed in staging (issue #220). Note: `handle_occupancy_home()` does **NOT** call `clear_manual_override()` — returning home restores comfort via `_set_temperature_for_mode()` without touching the override flag. |
+| 6 | Dashboard "Cancel Override" / "Cancel Fan Override" buttons | `api.py` `ClimateAdvisorCancelOverrideView` / `ClimateAdvisorCancelFanOverrideView` | User explicitly presses either dashboard button | Always clears — explicit user intent. As of Issue #508 both views call `cancel_override(reason="user_cancel_override"\|"user_cancel_fan_override")`, not `clear_manual_override()` directly — see [§ Deliberate Cancellation](#deliberate-cancellation-cancel_override-issue-508) for why this additionally cancels grace and forces reconciliation, which bare `clear_manual_override()` does not. |
+| 7 | `handle_occupancy_away()` / `handle_occupancy_vacation()` | `automation.py` occupancy handlers | Occupancy transitions to away/vacation while `_manual_override_active=True` | Calls `clear_manual_override(reason="occupancy_away")` / `clear_manual_override(reason="occupancy_vacation")` before applying setback. Fixed in staging (issue #220). Note: `handle_occupancy_home()` does **NOT** call `clear_manual_override()` — returning home restores comfort via `_set_temperature_for_mode()` without touching the override flag. Deliberately does NOT cancel grace (see [§ Occupancy Interaction](#occupancy-interaction)) — this is why occupancy handlers still call the bare primitive, not `cancel_override()`. |
+| 8 | `adopted_matching_decision` path inside `_on_grace_expired()`'s normal-expiry branch | `automation.py` `_on_grace_expired()` | Grace timer fires naturally and automation's current decision already matches the override | As of Issue #508, calls `cancel_override(reason="adopted_matching_decision")` (previously hand-composed `_cancel_grace_timers()` + `clear_manual_override()` in that order — the two pre-508 callsites had drifted to opposite call orders). |
 
 ### Note — Away/vacation setback and override detection (Issue #221)
 

--- a/tests/test_activity_renderers.py
+++ b/tests/test_activity_renderers.py
@@ -1003,3 +1003,31 @@ class TestFanOwnershipAnnotations:
         ]
         for row in nat_vent_fan_off_rows:
             assert "NOTE" not in row, f"nat_vent_fan_off when CA owns fan must NOT show NOTE. Row: {row!r}"
+
+
+class TestStuckGraceRecoveredRenderer:
+    """Issue #508: stuck_grace_recovered renders differently by `reason`.
+
+    The original Issue #321 call site (grace_end_time in the past, timer never fired) and
+    the new Issue #508 mirror call site (grace_active with no override, timer still pending)
+    are different failure shapes and must not share a misleading "(expired ...)" label.
+    """
+
+    def test_original_issue_321_shape_unchanged(self):
+        """No `reason` key (the pre-existing Issue #321 call site) → original 'expired' wording."""
+        ev, st = _act_mod.EVENT_RENDERERS["stuck_grace_recovered"](
+            {"grace_end_time": "2026-06-12T13:00:00+00:00"},
+            "fahrenheit",
+        )
+        assert "expired" in ev
+        assert "2026-06-12T13:00:00+00:00" in ev
+        assert st == ""
+
+    def test_grace_without_override_shape(self):
+        """reason=grace_without_override → distinct wording, no misleading 'expired' claim."""
+        ev, st = _act_mod.EVENT_RENDERERS["stuck_grace_recovered"](
+            {"grace_end_time": "2026-07-22T20:53:00+00:00", "reason": "grace_without_override"},
+            "fahrenheit",
+        )
+        assert "expired" not in ev
+        assert "no override" in ev.lower()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -579,3 +579,133 @@ class TestLearningViewCelsiusUnit:
         coord = self._make_coordinator(temp_unit="fahrenheit")
         response = _simulate_learning_get(coord)
         assert "unit" in response  # KeyError before fix
+
+
+class TestCancelViewsGraceCancellation:
+    """Issue #508: both Cancel-override API views must cancel grace, not just the override flag.
+
+    Regression guardrail — a future third cancel-style endpoint that composes primitives by
+    hand instead of calling ``AutomationEngine.cancel_override()`` is now the only way to
+    reintroduce this bug, and it would need its own omitted test to slip through silently.
+
+    Uses a real AutomationEngine (not a MagicMock) so the real cancel_override() logic runs
+    end-to-end through the view, per the "never mirror the logic under test" doctrine.
+    """
+
+    def _make_engine(self):
+        from unittest.mock import AsyncMock
+
+        from custom_components.climate_advisor.automation import AutomationEngine
+        from custom_components.climate_advisor.const import CONF_OVERRIDE_CONFIRM_PERIOD
+
+        hass = MagicMock()
+        hass.services = MagicMock()
+        hass.services.async_call = AsyncMock()
+        hass.async_create_task = MagicMock(side_effect=lambda coro: coro.close())
+        hass.states = MagicMock()
+        state = MagicMock()
+        state.state = "cool"
+        state.attributes = {"hvac_modes": ["off", "heat", "cool"], "supported_features": 1}
+        hass.states.get.return_value = state
+
+        config = {
+            "comfort_heat": 70,
+            "comfort_cool": 75,
+            "notify_service": "notify.notify",
+            CONF_OVERRIDE_CONFIRM_PERIOD: 0,
+        }
+        return AutomationEngine(
+            hass=hass,
+            climate_entity="climate.thermostat",
+            weather_entity="weather.forecast_home",
+            door_window_sensors=[],
+            notify_service=config["notify_service"],
+            config=config,
+        )
+
+    def _make_request(self, coordinator) -> MagicMock:
+        hass = MagicMock()
+        hass.data = {DOMAIN: {"entry1": coordinator}}
+        hass.async_create_task = MagicMock(side_effect=lambda coro: coro.close())
+        req = MagicMock()
+        req.app = {"hass": hass}
+        return req
+
+    def _post(self, view_cls, coordinator):
+        import asyncio
+
+        request = self._make_request(coordinator)
+        view = view_cls()
+        return asyncio.run(view.post(request))
+
+    def test_cancel_override_view_cancels_grace_for_thermostat_override(self):
+        from custom_components.climate_advisor.api import ClimateAdvisorCancelOverrideView
+
+        ae = self._make_engine()
+        ae.handle_manual_override()
+        assert ae._grace_active is True
+
+        coordinator = MagicMock()
+        coordinator.automation_engine = ae
+        coordinator._current_classification = None
+
+        self._post(ClimateAdvisorCancelOverrideView, coordinator)
+
+        assert ae._manual_override_active is False
+        assert ae._grace_active is False
+
+    def test_cancel_fan_override_view_cancels_grace(self):
+        """The Issue #508 regression: cancelling a FAN-only override must also cancel grace.
+
+        Before the fix, ClimateAdvisorCancelFanOverrideView.post() called only
+        clear_fan_override(), leaving _grace_active stuck True for the rest of the original
+        (potentially 8-hour, RF-remote-timer) grace duration.
+        """
+        from custom_components.climate_advisor.api import ClimateAdvisorCancelFanOverrideView
+
+        ae = self._make_engine()
+        ae.handle_fan_manual_override(fan_before="auto", fan_after="on")
+        assert ae._manual_override_active is False  # fan overrides never set this flag
+        assert ae._fan_override_active is True
+        assert ae._grace_active is True
+
+        coordinator = MagicMock()
+        coordinator.automation_engine = ae
+        coordinator._current_classification = None
+
+        response = self._post(ClimateAdvisorCancelFanOverrideView, coordinator)
+
+        assert ae._fan_override_active is False
+        assert ae._grace_active is False
+        assert response.json_data["status"] == "ok"
+        assert "cleared" in response.json_data["message"].lower()
+
+    def test_cancel_fan_override_view_noop_message_when_nothing_active(self):
+        from custom_components.climate_advisor.api import ClimateAdvisorCancelFanOverrideView
+
+        ae = self._make_engine()
+        coordinator = MagicMock()
+        coordinator.automation_engine = ae
+        coordinator._current_classification = None
+
+        response = self._post(ClimateAdvisorCancelFanOverrideView, coordinator)
+
+        assert response.json_data["status"] == "ok"
+        assert "no active fan override" in response.json_data["message"].lower()
+
+    def test_cancel_fan_override_view_schedules_reclassify(self):
+        """Root cause #2: cancelling the fan override must schedule a reclassify, not just clear flags."""
+        from unittest.mock import patch
+
+        from custom_components.climate_advisor.api import ClimateAdvisorCancelFanOverrideView
+
+        ae = self._make_engine()
+        ae.handle_fan_manual_override(fan_before="auto", fan_after="on")
+
+        coordinator = MagicMock()
+        coordinator.automation_engine = ae
+        coordinator._current_classification = None
+
+        with patch("homeassistant.helpers.event.async_call_later") as mock_call_later:
+            self._post(ClimateAdvisorCancelFanOverrideView, coordinator)
+            mock_call_later.assert_called_once()

--- a/tests/test_cancel_override.py
+++ b/tests/test_cancel_override.py
@@ -195,6 +195,105 @@ class TestCancelOverride:
         assert engine._manual_grace_cancel is None
 
 
+class TestCancelOverrideMethod:
+    """Issue #508: AutomationEngine.cancel_override() — the single canonical
+
+    "deliberate cancel" operation both dashboard "Cancel..." buttons use, replacing
+    hand-composed clear_manual_override()/_cancel_grace_timers() call pairs that had
+    drifted out of sync between the two API views.
+    """
+
+    def test_cancel_override_clears_thermostat_override_and_grace(self):
+        """Thermostat override active → cancel_override() clears everything, returns True."""
+        engine = _make_automation_engine()
+        state = MagicMock()
+        state.state = "cool"
+        engine.hass.states.get.return_value = state
+        engine.handle_manual_override()
+        assert engine._manual_override_active is True
+        assert engine._grace_active is True
+
+        result = engine.cancel_override(reason="user_cancel_override")
+
+        assert result is True
+        assert engine._manual_override_active is False
+        assert engine._fan_override_active is False
+        assert engine._grace_active is False
+
+    def test_cancel_override_clears_fan_only_override_and_grace(self):
+        """Fan-only override (never sets _manual_override_active) — the Issue #508 regression case.
+
+        Before the fix, the dashboard's "Cancel Fan Override" button called only
+        clear_fan_override(), leaving _grace_active stuck True for the rest of the original
+        grace duration (up to 8 hours for an RF-remote timer) even though the override it
+        protected was gone.
+        """
+        engine = _make_automation_engine()
+        engine.handle_fan_manual_override(fan_before="auto", fan_after="on")
+        assert engine._manual_override_active is False  # fan overrides never set this flag
+        assert engine._fan_override_active is True
+        assert engine._grace_active is True
+
+        events: list[tuple[str, dict]] = []
+        engine._emit_event_callback = lambda etype, payload: events.append((etype, payload))
+
+        result = engine.cancel_override(reason="user_cancel_fan_override")
+
+        assert result is True
+        assert engine._fan_override_active is False
+        assert engine._grace_active is False
+        assert any(etype == "override_cleared" for etype, _ in events), (
+            "cancel_override() must emit an activity-log event even for a fan-only override"
+        )
+
+    def test_cancel_override_noop_when_nothing_active(self):
+        """No override, no grace — safe no-op, returns False, no event emitted."""
+        engine = _make_automation_engine()
+        emitted = MagicMock()
+        engine._emit_event_callback = emitted
+
+        result = engine.cancel_override()
+
+        assert result is False
+        assert engine._manual_override_active is False
+        assert engine._grace_active is False
+        emitted.assert_not_called()
+
+    def test_cancel_override_triggers_fan_reconcile_and_refresh(self):
+        """cancel_override() forces the same post-processing a natural grace expiry performs.
+
+        Without this, resuming automation after a deliberate cancel depended on an incidental
+        unrelated event (e.g. a door/window debounce) firing shortly after — Root cause #2
+        of Issue #508.
+        """
+        engine = _make_automation_engine()
+        engine.handle_fan_manual_override(fan_before="auto", fan_after="on")
+
+        fan_check = MagicMock()
+        refresh = MagicMock()
+        engine._post_grace_fan_check_callback = fan_check
+        engine._request_refresh_callback = refresh
+
+        engine.cancel_override()
+
+        fan_check.assert_called_once()
+        refresh.assert_called_once()
+
+    def test_cancel_override_does_not_trigger_reconcile_on_noop(self):
+        """No wasted work / noise when there is nothing to cancel."""
+        engine = _make_automation_engine()
+        fan_check = MagicMock()
+        refresh = MagicMock()
+        engine._post_grace_fan_check_callback = fan_check
+        engine._request_refresh_callback = refresh
+
+        result = engine.cancel_override()
+
+        assert result is False
+        fan_check.assert_not_called()
+        refresh.assert_not_called()
+
+
 class TestDebugStateOverrideFields:
     """Verify get_debug_state() includes override time and grace duration."""
 

--- a/tests/test_grace_stuck.py
+++ b/tests/test_grace_stuck.py
@@ -366,3 +366,96 @@ class TestStuckGraceDetection:
 
         coord.automation_engine.clear_manual_override.assert_not_called()
         coord._emit_event.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TestOrphanedGraceDetection: coordinator._check_orphaned_grace() (Issue #508)
+#
+# Mirror shape of Issue #321's stuck-grace check, but the opposite condition:
+# grace_active=True with no override active (rather than grace_active=False with
+# an override stuck true past its own due grace_end_time). Unlike the tests above,
+# these invoke the REAL coordinator._check_orphaned_grace() method directly instead
+# of re-implementing its logic in the test — see CLAUDE.md's "never mirror the logic
+# under test" doctrine (Issue #434).
+# ---------------------------------------------------------------------------
+
+
+class TestOrphanedGraceDetection:
+    """coordinator._check_orphaned_grace() self-heals a grace period protecting nothing."""
+
+    def test_orphaned_grace_is_cancelled(self):
+        """grace_active=True with no override active — grace is force-cancelled.
+
+        Occupant impact: this is Issue #508's actual bug shape — a user cancelled a fan
+        override via the dashboard but the endpoint (before the fix) never cancelled grace.
+        This watchdog is the defense-in-depth backstop for any future path that reproduces
+        that gap.
+        """
+        coord = _make_stuck_grace_coord_stub(
+            manual_override_active=False,
+            grace_active=True,
+            grace_end_time="2026-06-12T21:53:00+00:00",
+        )
+        coord.automation_engine._fan_override_active = False
+        coord.automation_engine._cancel_grace_timers = MagicMock()
+
+        coord._check_orphaned_grace()
+
+        coord.automation_engine._cancel_grace_timers.assert_called_once()
+        coord._emit_event.assert_called_once()
+        event_name, event_data = coord._emit_event.call_args[0]
+        assert event_name == "stuck_grace_recovered"
+        assert event_data["reason"] == "grace_without_override"
+        assert event_data["grace_end_time"] == "2026-06-12T21:53:00+00:00"
+
+    def test_orphaned_grace_not_cancelled_when_manual_override_active(self):
+        """grace_active=True WITH a manual override active — must NOT fire.
+
+        A false-positive here would kill a legitimate in-progress override's grace period.
+        """
+        coord = _make_stuck_grace_coord_stub(
+            manual_override_active=True,
+            grace_active=True,
+            grace_end_time="2026-06-12T21:53:00+00:00",
+        )
+        coord.automation_engine._fan_override_active = False
+        coord.automation_engine._cancel_grace_timers = MagicMock()
+
+        coord._check_orphaned_grace()
+
+        coord.automation_engine._cancel_grace_timers.assert_not_called()
+        coord._emit_event.assert_not_called()
+
+    def test_orphaned_grace_not_cancelled_when_fan_override_active(self):
+        """grace_active=True WITH a fan override active — must NOT fire.
+
+        This is the fan-only-override shape (Root cause #1 of Issue #508): _manual_override_
+        active is False even though a real, legitimate override is in progress.
+        """
+        coord = _make_stuck_grace_coord_stub(
+            manual_override_active=False,
+            grace_active=True,
+            grace_end_time="2026-06-12T21:53:00+00:00",
+        )
+        coord.automation_engine._fan_override_active = True
+        coord.automation_engine._cancel_grace_timers = MagicMock()
+
+        coord._check_orphaned_grace()
+
+        coord.automation_engine._cancel_grace_timers.assert_not_called()
+        coord._emit_event.assert_not_called()
+
+    def test_no_orphaned_grace_when_grace_inactive(self):
+        """grace_active=False — nothing to do regardless of override state."""
+        coord = _make_stuck_grace_coord_stub(
+            manual_override_active=False,
+            grace_active=False,
+            grace_end_time=None,
+        )
+        coord.automation_engine._fan_override_active = False
+        coord.automation_engine._cancel_grace_timers = MagicMock()
+
+        coord._check_orphaned_grace()
+
+        coord.automation_engine._cancel_grace_timers.assert_not_called()
+        coord._emit_event.assert_not_called()


### PR DESCRIPTION
## Summary
- Pressing **Cancel Fan Override** on the dashboard cleared the fan-override flag but never cancelled the grace-period timer, leaving the dashboard reporting "Grace period active" for up to 8 hours (the full RF-remote-timer duration) after the override was already gone. Confirmed via `git log -p` this is an original design gap from Issue #79 (2026-03-30), not a regression — the sibling "Cancel Override" button has always cancelled grace correctly since Issue #41.
- Neither cancel view forced the fan/HVAC state to reconcile immediately; the fan-cancel view also never scheduled a full reclassification the way the thermostat-cancel view already did. Resumption depended on an incidental unrelated event firing shortly after.
- `clear_fan_override()` never emitted an activity-log event, so a fan-only cancellation was invisible in the Activity Report.
- New `AutomationEngine.cancel_override()` is the single canonical "deliberate cancel" operation (clear override + cancel grace + fan-reconcile + coordinator refresh + activity event) used by both dashboard buttons and the internal `adopted_matching_decision` path — closing the gap structurally instead of patching one call site.
- Deduped `_on_grace_expired()`'s three inline grace-flag resets into calls to the existing `_cancel_grace_timers()`.
- Added `coordinator._check_orphaned_grace()`, mirroring the existing Issue #321 stuck-grace watchdog, as defense-in-depth against any future path that clears an override without going through `cancel_override()`.
- Updated `docs/grace-periods-spec.md` and `docs/activity-report-table.md`.
- Version bumped to 0.5.28 with `RELEASE_NOTES`/`KNOWN_FIXES[508]` entries.

## Test plan
- [x] New engine-level tests for `cancel_override()` (thermostat override, fan-only override — the regression case, no-op case, fan-reconcile/refresh invocation)
- [x] New API-view tests for both cancel endpoints (regression guardrail) — verified they fail without the fix via a manual revert-test, then restored
- [x] Watchdog extension tests (positive + two negative cases) using the real `coordinator._check_orphaned_grace()` method, not a mirrored re-implementation
- [x] Renderer tests for both `stuck_grace_recovered` reason branches
- [x] Full suite: `python -m pytest tests/` — 3496 passed
- [x] `python tools/simulate.py` — 74/74 golden scenarios passed, integrity check clean
- [x] `ruff check` + `ruff format` clean