### PR TITLE
Fix #518: warm-day briefing text could contradict itself

### DIFF
--- a/custom_components/climate_advisor/ai_skills_context.py
+++ b/custom_components/climate_advisor/ai_skills_context.py
@@ -119,6 +119,7 @@ FOCUS_TAG_MAP: dict[str, frozenset[str]] = {
     "override": frozenset({"learning", "events", "system"}),
     "config": frozenset({"config", "system"}),
     "window": frozenset({"learning", "events", "system"}),
+    "briefing": frozenset({"briefing", "system"}),
 }
 
 # ---------------------------------------------------------------------------
@@ -439,6 +440,24 @@ async def build_current_state_context(hass: Any, coordinator: Any, **kwargs: Any
     except Exception:
         _LOGGER.warning("investigator: failed to read coordinator.data — skipping current state")
         return "=== CURRENT STATE ===\n  unavailable\n"
+
+
+async def build_last_briefing_context(hass: Any, coordinator: Any, **kwargs: Any) -> str:
+    """Build LAST BRIEFING section — the most recently rendered briefing text (Issue #518).
+
+    Lets the investigator review the user-facing briefing itself for internal
+    contradictions (e.g. header/body disagreeing on a time, or a sentence that
+    doesn't match the day's actual hvac_mode) rather than only inspecting the
+    structured coordinator state that produced it.
+    """
+    try:
+        text = getattr(coordinator, "_last_briefing", "") or ""
+        if not text:
+            return "=== LAST BRIEFING ===\n  not yet generated today\n"
+        return "\n".join(["=== LAST BRIEFING ===", text, ""])
+    except Exception:
+        _LOGGER.warning("investigator: failed to read coordinator._last_briefing — skipping")
+        return "=== LAST BRIEFING ===\n  unavailable\n"
 
 
 async def build_hvac_entity_context(hass: Any, coordinator: Any, **kwargs: Any) -> str:
@@ -1065,6 +1084,14 @@ _PROVIDER_REGISTRY.register(
         tags=frozenset({"hvac"}),
         priority=0,
         builder=build_hvac_entity_context,
+    )
+)
+_PROVIDER_REGISTRY.register(
+    ContextProvider(
+        name="last_briefing",
+        tags=frozenset({"system", "briefing"}),
+        priority=1,
+        builder=build_last_briefing_context,
     )
 )
 _PROVIDER_REGISTRY.register(

--- a/custom_components/climate_advisor/briefing.py
+++ b/custom_components/climate_advisor/briefing.py
@@ -109,6 +109,19 @@ def generate_briefing(
         "sleep_time": sleep_time,
         "wake_time": wake_time,
     }
+    # Single source of truth for warm-day window/AC timing (Issue #518): derive once here
+    # and hand the same result to both the header table and the conversational body, so
+    # they can never disagree about when windows close or whether AC is expected.
+    warm_events = (
+        _derive_warm_day_events(
+            predicted_indoor=predicted_indoor_future,
+            predicted_outdoor=predicted_outdoor_future,
+            comfort_cool=comfort_cool,
+        )
+        if c.day_type == DAY_TYPE_WARM and predicted_indoor_future and predicted_outdoor_future
+        else None
+    )
+
     tldr_lines = _generate_tldr_table(
         c,
         config,
@@ -116,6 +129,7 @@ def generate_briefing(
         bedtime_setback_heat=bedtime_setback_heat,
         bedtime_setback_cool=bedtime_setback_cool,
         occupancy_mode=occupancy_mode,
+        warm_events=warm_events,
     )
 
     if verbosity == "tldr_only":
@@ -149,8 +163,7 @@ def generate_briefing(
                 sleep_time,
                 fan_mode=fan_mode,
                 temp_unit=temp_unit,
-                predicted_indoor_future=predicted_indoor_future,
-                predicted_outdoor_future=predicted_outdoor_future,
+                warm_events=warm_events,
                 pre_cool_target=bedtime_setback_cool,
             )
         )
@@ -244,6 +257,7 @@ def _generate_tldr_table(
     bedtime_setback_heat: float | None = None,
     bedtime_setback_cool: float | None = None,
     occupancy_mode: str = "home",
+    warm_events: dict | None = None,
 ) -> list[str]:
     """Generate a plain-text aligned TLDR summary table.
 
@@ -254,6 +268,9 @@ def _generate_tldr_table(
         temp_unit: Display unit — "fahrenheit" or "celsius".
         bedtime_setback_heat: Adaptive bedtime heat setback temperature, if learned.
         bedtime_setback_cool: Adaptive bedtime cool setback temperature, if learned.
+        warm_events: Result of _derive_warm_day_events(), pre-computed once in
+            generate_briefing() (Issue #518) so the header's window-close time always
+            agrees with the conversational body — never re-derive it independently here.
 
     Returns:
         List of lines forming a plain-text aligned table.
@@ -286,7 +303,12 @@ def _generate_tldr_table(
     threshold = comfort_cool + ECONOMIZER_TEMP_DELTA
     if c.windows_recommended and c.window_open_time and c.window_close_time:
         open_t = c.window_open_time.strftime(_FMT_HOUR)
-        close_t = c.window_close_time.strftime(_FMT_HOUR)
+        # Prefer the same ODE-derived cutoff the conversational body uses (Issue #518) \u2014
+        # falls back to the classifier's static hour only when no forecast curve exists.
+        warm_cutoff = warm_events.get("nat_vent_cutoff") if warm_events else None
+        close_t = (
+            warm_cutoff.strftime(_FMT_HOUR) if warm_cutoff is not None else c.window_close_time.strftime(_FMT_HOUR)
+        )
         windows_val = f"Open {open_t} \u2013 {close_t}"
     elif c.window_opportunity_morning and c.window_opportunity_evening:
         m_start = c.window_opportunity_morning_start.strftime(_FMT_HOUR).lstrip("0")
@@ -474,6 +496,7 @@ def _derive_warm_day_events(
       precool_start_time: datetime | None — ceiling_breach_time minus computed lead
       any_nat_vent_window: bool — True if outdoor < indoor at any point
       nat_vent_recovers: bool — True if outdoor drops back below indoor after cutoff
+      recovery_time: datetime | None — first timestamp after cutoff where outdoor < indoor again
     """
     result: dict = {
         "nat_vent_cutoff": None,
@@ -481,6 +504,7 @@ def _derive_warm_day_events(
         "precool_start_time": None,
         "any_nat_vent_window": False,
         "nat_vent_recovers": False,
+        "recovery_time": None,
     }
 
     if not predicted_indoor or not predicted_outdoor:
@@ -528,12 +552,13 @@ def _derive_warm_day_events(
         lead_min = max(30.0, min(240.0, lead_min))
         result["precool_start_time"] = result["ceiling_breach_time"] - timedelta(minutes=lead_min)
 
-    # nat_vent_recovers: outdoor drops back below indoor AFTER the cutoff
+    # nat_vent_recovers / recovery_time: outdoor drops back below indoor AFTER the cutoff
     if result["nat_vent_cutoff"] is not None:
         cutoff_ts = result["nat_vent_cutoff"]
         for ts, i_temp, o_temp in pairs:
             if ts > cutoff_ts and o_temp < i_temp:
                 result["nat_vent_recovers"] = True
+                result["recovery_time"] = ts
                 break
 
     _LOGGER.debug(
@@ -610,23 +635,25 @@ def _warm_day_plan(
     predicted_indoor_future: list[dict] | None = None,
     predicted_outdoor_future: list[dict] | None = None,
     pre_cool_target: float | None = None,
+    warm_events: dict | None = None,
 ) -> list[str]:
-    """Conversational plan for warm days (75-85\u00b0F)."""
+    """Conversational plan for warm days (75-85\u00b0F).
+
+    Issue #518: window/AC timing is derived once in generate_briefing() and passed
+    in as `warm_events` so this never disagrees with the header table. Falls back to
+    deriving it locally only when called directly with raw prediction curves (tests).
+    """
     lines = []
 
-    # Derive ODE timing events if prediction data is available
-    _events = (
-        _derive_warm_day_events(
+    _events = warm_events
+    if _events is None and predicted_indoor_future and predicted_outdoor_future:
+        _events = _derive_warm_day_events(
             predicted_indoor=predicted_indoor_future,
             predicted_outdoor=predicted_outdoor_future,
             comfort_cool=comfort_cool,
         )
-        if predicted_indoor_future and predicted_outdoor_future
-        else None
-    )
     _nat_vent_cutoff = _events["nat_vent_cutoff"] if _events else None
     _ceiling_breach = _events["ceiling_breach_time"] if _events else None
-    _precool_start = _events["precool_start_time"] if _events else None
     _nat_vent_recovers = _events["nat_vent_recovers"] if _events else False
 
     if c.windows_recommended and c.window_open_time:
@@ -636,7 +663,7 @@ def _warm_day_plan(
             lines.append(
                 f"Open windows around {open_t} to catch the cool morning air."
                 f" Close up at {close_t} \u2014 after that the outdoor air will be"
-                f" warmer than inside. I'll take over with AC as needed."
+                f" warmer than inside."
             )
         else:
             lines.append(
@@ -644,28 +671,28 @@ def _warm_day_plan(
                 f" \u2014 cross-ventilation keeps things comfortable without the AC."
             )
     else:
-        lines.append("HVAC is off this morning \u2014 no action needed.")
+        lines.append("HVAC is off this morning.")
 
     if fan_mode != FAN_MODE_DISABLED:
         lines.append("I'll use the fan to boost cross-ventilation when windows are open.")
 
     lines.append("")
 
+    # Issue #518: this used to independently promise "I'll run the AC starting around
+    # X \u2014 no action needed from you", ignoring window state entirely \u2014 contradicting
+    # the real automation guard (automation.py apply_classification()'s DEFER_PAUSED
+    # branch actually suppresses AC the whole time a window is open) and duplicating
+    # _fresh_air_section()'s already-correct, debounce-aware version of this same fact.
+    # This section now only states the forecast and ties the AC to windows being
+    # closed; _fresh_air_section owns the debounce/pause mechanics, so it's said once.
     if _ceiling_breach is not None:
         breach_t = _ceiling_breach.strftime(_FMT_HOUR)
-        if _precool_start is not None:
-            precool_t = _precool_start.strftime(_FMT_HOUR)
-            lines.append(
-                f"Indoor temps are forecast to reach"
-                f" {format_temp(comfort_cool, temp_unit)} around {breach_t}."
-                f" I'll run the AC starting around {precool_t} \u2014 no action needed from you."
-            )
-        else:
-            lines.append(
-                f"Indoor temps are forecast to reach"
-                f" {format_temp(comfort_cool, temp_unit)} around {breach_t}."
-                f" I'll run the AC as needed to keep things comfortable."
-            )
+        lines.append(
+            f"Indoor temps are forecast to reach"
+            f" {format_temp(comfort_cool, temp_unit)} around {breach_t}."
+            f" Once windows are closed, the AC will step in automatically if it's"
+            f" needed to hold that ceiling."
+        )
     elif c.window_close_time:
         close_t = c.window_close_time.strftime(_FMT_HOUR)
         lines.append(
@@ -688,23 +715,19 @@ def _warm_day_plan(
         )
 
     if _nat_vent_recovers and _events is not None:
-        # Find recovery time from the curves
-        _recovery_ts = None
-        cutoff = _events["nat_vent_cutoff"]
-        if cutoff is not None and predicted_indoor_future and predicted_outdoor_future:
-            for i_e, o_e in zip(predicted_indoor_future, predicted_outdoor_future, strict=False):
-                try:
-                    ts = datetime.fromisoformat(i_e["ts"])
-                except (KeyError, ValueError, TypeError):
-                    continue
-                if ts > cutoff and o_e.get("temp", 99) < i_e.get("temp", 0):
-                    _recovery_ts = ts
-                    break
+        _recovery_ts = _events["recovery_time"]
         if _recovery_ts is not None:
             rec_t = _recovery_ts.strftime(_FMT_HOUR)
-            lines.append(
-                f"Reopen windows around {rec_t} when the evening air cools back down \u2014 I'll turn off the AC."
-            )
+            # Issue #518: only claim "I'll turn off the AC" when the AC could
+            # plausibly have engaged first (breach predicted before recovery) \u2014
+            # otherwise this contradicted itself by canceling an action that was
+            # never actually started.
+            if _ceiling_breach is not None and _ceiling_breach < _recovery_ts:
+                lines.append(
+                    f"Reopen windows around {rec_t} when the evening air cools back down \u2014 I'll turn off the AC."
+                )
+            else:
+                lines.append(f"Reopen windows around {rec_t} when the evening air cools back down.")
 
     return lines
 
@@ -992,6 +1015,6 @@ def _tonight_preview(
             f"Tomorrow looks pretty similar to today \u2014 {format_temp(c.tomorrow_high, temp_unit)}"
             f" for a high. Nothing special planned overnight.",
         ]
-    if adaptive_thermal_active:
+    if adaptive_thermal_active and c.hvac_mode in ("heat", "cool"):
         lines.append("Bedtime setback and pre-heat timing are tuned to your home's actual heating performance.")
     return lines

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,20 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.31"
+VERSION = "0.5.32"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.32": [
+        "Fix #518: the warm/windows-day briefing could contradict itself — the header's"
+        " window-close time didn't match the body's, an AC-start message ignored whether"
+        " windows were actually open (and contradicted a correct warning elsewhere in the"
+        " same briefing), a 'reopen windows' message could cancel an AC run that never"
+        " started, and a bedtime-setback note could appear even when the header said 'No"
+        " setback'. All four are now derived from a single computation so the header and"
+        " body always agree, and the AC-safety-net wording is stated once, tied to windows"
+        " being closed. Also dropped redundant 'no action needed' phrasing from the"
+        " briefing and dashboard status text.",
+    ],
     "0.5.31": [
         "Feat #519: Climate Advisor now detects and respects QuietCool remote speed changes"
         " (low/medium/high), not just timer presses. If you adjust speed while the fan was"
@@ -1250,6 +1261,46 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    518: {
+        "version_fixed": "0.5.32",
+        "title": "Warm/windows-day briefing text could contradict itself in several places",
+        "scope_covered": (
+            "briefing.py: header window-close time (_generate_tldr_table) and the"
+            " conversational body's window-close time (_warm_day_plan via"
+            " _derive_warm_day_events) were computed from two independent sources — a"
+            " classifier constant vs. a live ODE-forecast crossover — and could disagree;"
+            " now computed once in generate_briefing() and passed to both as `warm_events`."
+            " The AC-safety-net sentence in _warm_day_plan used to independently promise a"
+            " fixed clock time with no awareness of door/window state, contradicting the"
+            " real automation guard (automation.py apply_classification()'s DEFER_PAUSED"
+            " branch, which suppresses AC the whole time a window is open) and duplicating"
+            " _fresh_air_section()'s already-correct, debounce-aware version of the same"
+            " fact — removed the duplicate, kept one window-state-conditioned statement."
+            " The 'reopen windows... I'll turn off the AC' sentence now only claims the"
+            " AC-off action when the predicted ceiling breach occurred before the recovery"
+            " time (_derive_warm_day_events now also returns `recovery_time`). The"
+            " adaptive-thermal-timing footer in _tonight_preview() used to fire whenever"
+            " `adaptive_thermal_active` was true regardless of tonight's actual hvac_mode —"
+            " now also requires `hvac_mode in ('heat', 'cool')`, so it can't contradict a"
+            " header that says 'No setback'. Dropped 'no action needed' phrasing from"
+            " briefing.py and reworded coordinator.py's dashboard status fallback string."
+            " Added tools/briefing_review.py — a deterministic day_type x hvac_mode x"
+            " setback-active scenario matrix with coherence assertions for this bug class."
+            " Added an 8th investigator context block (LAST BRIEFING, ai_skills_context.py)"
+            " so the AI investigator can review the rendered briefing text itself. Authored"
+            " docs/briefing-spec.md's previously-stub sections and reconciled"
+            " docs/04-BRIEFING-EXAMPLES.md's warm-day example with 08-COMPUTATION-REFERENCE.md,"
+            " and corrected every other example's stale 5-minute debounce reference to the"
+            " actual 10-minute default (constant changed in Issue #504)."
+        ),
+        "scope_not_covered": (
+            "The issue's broader 'no action needed'-family audit was scoped to the literal"
+            " phrase; near-variant phrasing that explains an actual consequence (e.g."
+            " leaving_home_section's 'nothing really changes today') was left as-is since"
+            " it's informative, not boilerplate. learning.py:1862 (narrative help text, not"
+            " a per-cycle status line) was not changed."
+        ),
+    },
     519: {
         "version_fixed": "0.5.31",
         "title": ("Climate Advisor now detects and respects QuietCool remote speed changes, not just timer presses"),

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -6240,7 +6240,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 indoor=indoor_temp,
             )
 
-        return _decide("No action needed right now. Automation is handling it.")
+        return _decide("Automation active — no changes planned right now.")
 
     def _emit_event(self, event_type: str, data: dict) -> None:
         """Append a timestamped event to the in-memory event log ring buffer (Issue #76)."""

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.31"
+  "version": "0.5.32"
 }

--- a/docs/04-BRIEFING-EXAMPLES.md
+++ b/docs/04-BRIEFING-EXAMPLES.md
@@ -54,7 +54,7 @@ Close up the windows by 5:00 PM to trap the warmth before the sun drops. The hou
 
 If you head out, nothing really changes today — the HVAC is off. If it was running as a safety net, it'll set back on its own.
 
-If you want to open a window for some fresh air, go for it — the HVAC is off today so there's no energy impact at all. Enjoy the breeze. If the system does need to kick on as a safety net later and a window is still open, I'll give it 5 minutes and then pause until you close up.
+If you want to open a window for some fresh air, go for it — the HVAC is off today so there's no energy impact at all. Enjoy the breeze. If the system does need to kick on as a safety net later and a window is still open, I'll give it 10 minutes and then pause until you close up.
 
 Looking ahead — tomorrow's warmer at 78°F, so I'm going to set back a bit more aggressively tonight. Less heating needed means energy saved while you sleep.
 ```
@@ -63,7 +63,11 @@ Looking ahead — tomorrow's warmer at 78°F, so I'm going to set back a bit mor
 
 ## Example: Warm Day
 
-**Conditions:** Today high 80°F, low 60°F, tomorrow high 82°F
+**Conditions:** Today high 80°F, low 60°F, tomorrow high 82°F. Window times below are the
+static `WARM_WINDOW_OPEN_HOUR`/`WARM_WINDOW_CLOSE_HOUR` constants (6 AM–10 AM, see
+[§7. Window Recommendations](08-COMPUTATION-REFERENCE.md#7-window-recommendations)); when
+ODE forecast data is available, the close time instead comes from `nat_vent_cutoff`
+(Issue #518) — the header and body always show the same value, whichever source is used.
 
 ```
 🏠 Your Home Climate Plan for Today
@@ -75,20 +79,26 @@ Day Type: Warm | Trend: Stable
 
   Day Type:        Warm (80°F)
   HVAC Mode:       Off — windows day
-  Windows:         Open 8 AM – 6 PM
+  Windows:         Open 6 AM – 10 AM
   Bedtime Setback: No setback
   Tomorrow:        Stable (82°F)
 
-The HVAC is off this morning — the house held its temperature nicely overnight. Around 8:00 AM, it'll be a great time to open some windows. Opening on opposite sides gives you a nice cross-breeze that keeps things comfortable without the AC.
+Open windows around 6:00 AM to catch the cool morning air. Close up at 10:00 AM — after that the outdoor air will be warmer than inside.
 
-You'll want to close things up by 6:00 PM though — I'll be ready to kick on the AC if temps push above 75°F, and it works much better with the house sealed up.
+Indoor temps are forecast to reach 75°F around 2:30 PM. Once windows are closed, the AC will step in automatically if it's needed to hold that ceiling.
 
 If you head out, nothing really changes today — the HVAC is off. If it was running as a safety net, it'll set back on its own.
 
-If you want to open a window for some fresh air, go for it — the HVAC is off today so there's no energy impact at all. Enjoy the breeze. If the system does need to kick on as a safety net later and a window is still open, I'll give it 5 minutes and then pause until you close up.
+If you want to open a window for some fresh air, go for it — the HVAC is off today so there's no energy impact at all. Enjoy the breeze. If the system does need to kick on as a safety net later and a window is still open, I'll give it 10 minutes and then pause until you close up.
 
 Tomorrow looks pretty similar to today — 82°F for a high. Nothing special planned overnight.
 ```
+
+Note: the AC-as-backup fact is stated exactly once — the forecast/ceiling sentence ties it
+to windows being closed, and the fresh-air paragraph owns the window-open debounce/pause
+guard (matching the real `automation.py` `apply_classification()` `DEFER_PAUSED` behavior).
+Earlier versions of this example independently promised a specific AC start clock-time with
+no window-state awareness — that was the root cause of Issue #518 and has been corrected.
 
 ---
 
@@ -118,7 +128,7 @@ If outdoor temps drop below 75°F after sunset, I'll send you a heads-up that it
 
 If you head out, no worries. After about 15 minutes I'll let the house drift up to 80°F to save energy. When you're back, I'll pull it right back down — give it 20 to 30 minutes to feel normal again.
 
-If you want to crack a window for some fresh air, no problem — it's your house. I'll keep the AC running for a bit in case it's just a quick thing, but if it stays open past 5 minutes I'll shut the AC off so you're not cooling the outdoors. Once you close up, I'll fire the AC back up right away. Just know that on a day like today it may take a bit longer to pull back down to 75°F, so if you want to minimize the impact, shorter is better — and try to keep other windows and doors shut while you've got one open.
+If you want to crack a window for some fresh air, no problem — it's your house. I'll keep the AC running for a bit in case it's just a quick thing, but if it stays open past 10 minutes I'll shut the AC off so you're not cooling the outdoors. Once you close up, I'll fire the AC back up right away. Just know that on a day like today it may take a bit longer to pull back down to 75°F, so if you want to minimize the impact, shorter is better — and try to keep other windows and doors shut while you've got one open.
 
 Tomorrow looks pretty similar to today — 92°F for a high. Nothing special planned overnight.
 ```
@@ -151,7 +161,7 @@ After 3pm I'll bring it back to 70°F as the sun drops. At bedtime, I'll set thi
 
 If you head out, I'll drop to 60°F after about 15 minutes. When you get back, I'll warm things right up — should take 20 to 30 minutes depending on how long you were gone.
 
-If you want to open a window for some fresh air, no problem — go for it. I'll keep the heat running for a bit in case you're just airing things out, but if it stays open past 5 minutes I'll turn the heat off so we're not heating the neighborhood. Once you close up, the heat kicks right back on. It'll take a little extra energy to warm back up, so if you want to minimize the impact, a quick burst of fresh air works great — and closing doors to the room with the open window helps keep the rest of the house comfortable while you do it.
+If you want to open a window for some fresh air, no problem — go for it. I'll keep the heat running for a bit in case you're just airing things out, but if it stays open past 10 minutes I'll turn the heat off so we're not heating the neighborhood. Once you close up, the heat kicks right back on. It'll take a little extra energy to warm back up, so if you want to minimize the impact, a quick burst of fresh air works great — and closing doors to the room with the open window helps keep the rest of the house comfortable while you do it.
 
 Looking ahead — tomorrow's cooler at 50°F, so I'll bank some extra warmth this evening and go easy on the overnight setback. If the house feels a touch warmer than usual before bed, that's intentional.
 ```
@@ -184,7 +194,7 @@ Tonight I'm using a conservative setback — 67°F instead of the usual 60°F. W
 
 If you head out, I'll drop to 60°F after about 15 minutes. When you get back, I'll warm things right up — should take 20 to 30 minutes depending on how long you were gone.
 
-If you want to open a window for some fresh air, no problem — go for it. I'll keep the heat running for a bit in case you're just airing things out, but if it stays open past 5 minutes I'll turn the heat off so we're not heating the neighborhood. Once you close up, the heat kicks right back on. It'll take a little extra energy to warm back up, so if you want to minimize the impact, a quick burst of fresh air works great — and closing doors to the room with the open window helps keep the rest of the house comfortable while you do it.
+If you want to open a window for some fresh air, no problem — go for it. I'll keep the heat running for a bit in case you're just airing things out, but if it stays open past 10 minutes I'll turn the heat off so we're not heating the neighborhood. Once you close up, the heat kicks right back on. It'll take a little extra energy to warm back up, so if you want to minimize the impact, a quick burst of fresh air works great — and closing doors to the room with the open window helps keep the rest of the house comfortable while you do it.
 
 Looking ahead — tomorrow's cooler at 28°F, so I'll bank some extra warmth this evening and go easy on the overnight setback. If the house feels a touch warmer than usual before bed, that's intentional.
 ```

--- a/docs/ai-skills-spec.md
+++ b/docs/ai-skills-spec.md
@@ -349,12 +349,20 @@ This is the only skill in the registry that uses per-skill config overrides.
 
 `async_build_investigator_context(hass, coordinator, **kwargs) → str`
 
-Assembles seven numbered context blocks. Each block is wrapped in its own `try/except`. If a block fails, its section is replaced with `"  unavailable"` and assembly continues — a failure in one block never aborts the others.
+Assembles context blocks via a `ContextProviderRegistry` (`ai_skills_context.py`), sorted by
+`priority` and optionally filtered by a `focus` keyword (`ContextProviderRegistry.select()`).
+Each block is wrapped in its own `try/except`. If a block fails, its section is replaced with
+`"  unavailable"` and assembly continues — a failure in one block never aborts the others. The
+table below lists the blocks as of Issue #518; the registry has grown since the original
+"seven blocks" description (it now also includes `known_fixes`, `version`, and `github`
+providers) — treat the registration list in `ai_skills_context.py` (search `_PROVIDER_REGISTRY.register`)
+as authoritative if this table and the code ever disagree.
 
 | Block # | Section label | Data source |
 |---|---|---|
 | 1 | `CURRENT STATE` | `coordinator.data` + fresh HVAC runtime |
 | 2 | `HVAC ENTITY` | `hass.states.get(climate_entity_id)` — `hvac_mode` and `current_temperature` |
+| 2b | `LAST BRIEFING` | `coordinator._last_briefing` — the most recently rendered daily briefing text, verbatim (added Issue #518, so the investigator can review the user-facing briefing itself for internal contradictions, not just the structured state that produced it) |
 | 3 | `LEARNING — COMPLIANCE SUMMARY` | `learning.get_compliance_summary()` |
 | 3 | `LEARNING — THERMAL MODEL` | `learning.get_thermal_model()` |
 | 3 | `LEARNING — WEATHER BIAS` | `learning.get_weather_bias()` |

--- a/docs/briefing-spec.md
+++ b/docs/briefing-spec.md
@@ -4,7 +4,7 @@
 
 ## Status
 
-_Tier 3 Territory Spec — stub. Sections marked (TBD) need authoring._
+_Tier 3 Territory Spec — authored as part of Issue #518's Documentation Convergence pass._
 
 ## Scope
 
@@ -20,11 +20,12 @@ learning suggestions, and any required human actions.
 | Question | Location |
 |---|---|
 | How are "today" and "tomorrow" dates defined? | [§ Date Computation](#date-computation) |
-| What data does the briefing consume from the coordinator? | _(TBD)_ |
-| What timezone are timestamps displayed in? | _(TBD)_ |
-| How are learning suggestions ranked and filtered? | _(TBD)_ |
-| What happens when forecast data is unavailable? | _(TBD)_ |
-| How does the grace period state appear in briefing output? | _(TBD)_ |
+| What data does the briefing consume from the coordinator? | [§ Input Schema](#input-schema) |
+| What timezone are timestamps displayed in? | [§ Timezone Display](#timezone-display) |
+| How are learning suggestions ranked and filtered? | [§ Learning Suggestion Filtering](#learning-suggestion-filtering) |
+| What happens when forecast data is unavailable? | [§ Stale/Missing Data Handling](#stalemissing-data-handling) |
+| How does the grace period state appear in briefing output? | [§ Grace Period Injection](#grace-period-injection) |
+| How does the header table stay consistent with the conversational body? | [§ Single Source of Truth for Warm-Day Timing (Issue #518)](#single-source-of-truth-for-warm-day-timing-issue-518) |
 | What does each day-type briefing look like? | [Briefing Examples](04-BRIEFING-EXAMPLES.md) |
 
 ## Date Computation
@@ -47,10 +48,98 @@ classification has fired.
 `data` dict). It does not perform its own forecast date matching. See
 [Forecast Pipeline Spec](forecast-pipeline-spec.md) for how these values are derived.
 
-## Known Gaps (for Scribe)
+## Input Schema
 
-- Input/output schema not yet documented
-- Grace period injection logic not specified
-- Learning suggestion ranking order not specified
-- Timezone display format for timestamps not specified
-- Error handling when coordinator data is stale or unavailable not specified
+`ClimateAdvisorCoordinator._build_briefing_text()` (`coordinator.py`) assembles every argument
+`generate_briefing()` (`briefing.py`) takes and returns `(briefing_full, briefing_short)` —
+the second call passes `verbosity="tldr_only"`. Nothing else calls `generate_briefing()`
+directly. Key inputs, all read from `coordinator.config` / `coordinator.data` at call time
+(never fetched fresh by `briefing.py` itself — it has no HA dependency, see module docstring):
+
+| Argument | Source |
+|---|---|
+| `classification` | `DayClassification` from `classify_day()`, cached as `self._current_classification` |
+| `comfort_heat`/`comfort_cool`/`setback_heat`/`setback_cool` | `self.config` |
+| `wake_time`/`sleep_time` | `self.config["wake_time"/"sleep_time"]`, parsed via `_parse_time()` |
+| `learning_suggestions` | `self.learning.generate_suggestions()` |
+| `debounce_seconds`/`manual_grace_seconds`/`automation_grace_seconds` | `self.config`, falling back to `DEFAULT_*` constants |
+| `grace_active`/`grace_source` | `self.automation_engine._grace_active` / `._last_resume_source` |
+| `bedtime_setback_heat`/`bedtime_setback_cool` | `compute_bedtime_setback()` (`automation.py`), only computed for the matching `hvac_mode` |
+| `adaptive_thermal_active` | `thermal_model.get("confidence", "none") != "none"` from `self.learning.get_thermal_model()` |
+| `predicted_indoor_future`/`predicted_outdoor_future` | `self._last_predicted_indoor` / `_build_future_forecast_outdoor()` |
+| `occupancy_mode` | `self._occupancy_mode` |
+
+`generate_briefing()` is pure logic with no I/O — it never re-derives anything from `hass`,
+so any staleness in the values above (e.g. a classification computed hours ago) is a
+coordinator-layer concern, not a briefing-layer one.
+
+## Single Source of Truth for Warm-Day Timing (Issue #518)
+
+Before Issue #518, the header TLDR table (`_generate_tldr_table()`) read `c.window_close_time`
+(the classifier's static `WARM_WINDOW_CLOSE_HOUR` constant) while the conversational body
+(`_warm_day_plan()`, via `_derive_warm_day_events()`) independently derived a close time from
+the live ODE-predicted indoor/outdoor curves (`nat_vent_cutoff`) — the two could disagree, and
+the body's separate AC-start sentence could also contradict the header's `HVAC Mode: Off` by
+promising a fixed AC clock-time with no awareness of window state. Fixed by computing
+`_derive_warm_day_events()` **once** in `generate_briefing()` and passing the same `warm_events`
+dict into both `_generate_tldr_table()` and `_warm_day_plan()` — the header now prefers
+`warm_events["nat_vent_cutoff"]` when available, falling back to the classifier constant only
+when no forecast curve exists. The AC-safety-net fact is now stated exactly once (in the
+forecast-peak sentence, conditioned on windows being closed) rather than duplicated by a second,
+window-unaware sentence — see [§6e in 08-COMPUTATION-REFERENCE.md](08-COMPUTATION-REFERENCE.md)
+for the real automation-layer guard (`apply_classification()`'s `DEFER_PAUSED` branch) this
+wording now matches. The "reopen windows... I'll turn off the AC" sentence only claims the
+AC-off action when `ceiling_breach_time < recovery_time` (i.e. the AC could plausibly have
+engaged first) — otherwise it states the reopen without an AC claim.
+
+## Coherence Validation (Issue #518)
+
+`tools/briefing_review.py` renders `generate_briefing()` across a `day_type` x `hvac_mode` x
+setback-active scenario matrix and runs deterministic assertions: header/body window-close
+times must agree, the AC-safety-net sentence must never promise a fixed clock time or use
+"no action needed" boilerplate, the adaptive-setback footer must never appear when the header
+says "No setback", and "I'll turn off the AC" must never appear without a preceding
+forecast/ceiling-breach sentence. Run it with `python tools/briefing_review.py -v` to see the
+full rendered text for every scenario. This is fully deterministic — no LLM is in the runtime
+path (see the module docstring in `briefing.py`). When authoring a *new* scenario for the
+matrix, review the rendered text with an agent for user-outcome soundness before adding it —
+that review is a development-time step, not something the script does automatically.
+
+## Grace Period Injection
+
+`_grace_period_section()` returns an empty list (nothing rendered) unless `grace_active=True`
+**and** `grace_source` is set. `grace_source == "manual"` renders the "hands-off window" framing
+(`manual_grace_seconds`); anything else renders the "settling period" framing
+(`automation_grace_seconds`). The literal phrase "grace period" is never used in body text
+(voice-rule: no jargon) — only "hands-off window" / "settling period".
+
+## Learning Suggestion Filtering
+
+`Learning.generate_suggestions()` (`learning.py`) requires at least `MIN_DATA_POINTS_FOR_SUGGESTION`
+records; below that it returns `[]` unconditionally. Suggestions are built pattern-by-pattern
+(insertion order = the order patterns are checked in the function — there is no explicit score
+or ranking pass) and filtered against two suppression sets: `dismissed_suggestions` (persisted
+state) and suggestions in `settings_history` within the last 30 days that were either accepted
+or marked `verdict == "incorrect"` in feedback. `briefing.py` renders whatever list it's given
+with no further filtering or reordering of its own.
+
+## Timezone Display
+
+"Today"/"tomorrow" dates (see § Date Computation above) use `dt_util.now().date()` — HA's
+configured local timezone. Body-text clock times (window open/close, AC-forecast peak,
+reopen) are derived from `predicted_indoor_future`/`predicted_outdoor_future` timestamps,
+which are already local-time-aware by the time they reach `briefing.py` (produced upstream by
+`coordinator.py`'s forecast pipeline) — `briefing.py` only calls `.strftime(_FMT_HOUR)` on
+them, performing no timezone conversion itself.
+
+## Stale/Missing Data Handling
+
+`_async_send_briefing()` (`coordinator.py`) returns early without generating a briefing if
+`await self._get_forecast()` returns falsy — no partial/stale briefing is ever sent when the
+day's forecast is unavailable. Within `generate_briefing()` itself, every optional input
+degrades gracefully rather than raising: missing `predicted_indoor_future`/`predicted_outdoor_future`
+falls back to the classifier's static window/close-time constants (see § Single Source of Truth
+above); `bedtime_setback_heat`/`bedtime_setback_cool` of `None` falls back to
+`comfort_{heat,cool} ± DEFAULT_SETBACK_DEPTH_F`; `learning_suggestions=None` simply omits that
+section. There is no explicit "data is stale" messaging in the briefing itself — staleness is
+prevented upstream by the coordinator's early-return, not communicated to the user.

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -264,7 +264,7 @@ class TestComputeNextAction:
         """Mild day (not hot/cold) → no action needed message."""
         c = _make_classification(day_type="mild")
         result = _compute_next_action(c, {}, time(12, 0))
-        assert "No action needed" in result
+        assert "Automation active" in result
 
     def test_next_action_warm_day_after_close_before_evening(self):
         """WARM day after 10 AM close, before 5 PM — mid-day gap, no window guidance."""
@@ -275,7 +275,7 @@ class TestComputeNextAction:
             window_close_time=time(WARM_WINDOW_CLOSE_HOUR, 0),
         )
         result = _compute_next_action(c, {}, time(13, 0))
-        assert "No action needed" in result
+        assert "Automation active" in result
 
     def test_next_action_warm_day_after_close_at_evening_start(self):
         """WARM day after 10 AM close, at exactly 5 PM — evening ventilation suggested."""
@@ -306,7 +306,7 @@ class TestComputeNextAction:
         assert "78" in result
         assert "70" in result
         assert "open windows" in result.lower()
-        assert "No action needed" not in result
+        assert "Automation active" not in result
 
     def test_next_action_indoor_above_comfort_outdoor_hotter_suppresses_bug(self):
         """Regression test for Issue #428 — indoor 75/outdoor 80 must NOT suggest opening windows."""
@@ -491,19 +491,19 @@ class TestComputeNextAction:
         c = _make_classification(day_type=DAY_TYPE_MILD, windows_recommended=False)
         result = _compute_next_action(c, {"comfort_cool": 75}, time(14, 0), indoor_temp=78.0, outdoor_temp=70.0)
         assert "78" in result
-        assert "No action needed" not in result
+        assert "Automation active" not in result
 
     def test_next_action_indoor_at_comfort_boundary_no_guidance(self):
         """Indoor temp exactly at comfort_cool boundary (not above) → no alert."""
         c = _make_classification(day_type=DAY_TYPE_MILD, windows_recommended=False)
         result = _compute_next_action(c, {"comfort_cool": 75}, time(14, 0), indoor_temp=75.0)
-        assert "No action needed" in result
+        assert "Automation active" in result
 
     def test_next_action_indoor_none_falls_back_to_no_action(self):
         """When indoor_temp is None — no comfort alert, falls back to default."""
         c = _make_classification(day_type=DAY_TYPE_MILD, windows_recommended=False)
         result = _compute_next_action(c, {"comfort_cool": 75}, time(14, 0), indoor_temp=None)
-        assert "No action needed" in result
+        assert "Automation active" in result
 
     def test_next_action_warm_day_midday_indoor_above_comfort(self):
         """WARM day mid-day with indoor above comfort, outdoor cooler — comfort guidance wins over 'no action'."""
@@ -515,7 +515,7 @@ class TestComputeNextAction:
         )
         result = _compute_next_action(c, {"comfort_cool": 75}, time(13, 0), indoor_temp=79.0, outdoor_temp=72.0)
         assert "79" in result
-        assert "No action needed" not in result
+        assert "Automation active" not in result
 
     def test_next_action_hot_day_indoor_above_comfort_still_shows_ac_message(self):
         """HOT day: HOT branch always returns before indoor check — AC message wins."""

--- a/tools/briefing_review.py
+++ b/tools/briefing_review.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Briefing coherence checker (Issue #518).
+
+Renders generate_briefing() across a matrix of day_type x hvac_mode x
+setback-active combinations and runs deterministic coherence assertions —
+no contradicting window/AC times, no AC promise that ignores window state,
+no unconditional setback footer, no "no action needed" boilerplate.
+
+This is the mechanical half of the issue's requested validation loop: it
+runs in CI/dev like any other check, with fully deterministic pass/fail
+(the shipped briefing has no LLM in its runtime path — see briefing.py's
+module docstring). When AUTHORING a new scenario, the recommended workflow
+is to also have an agent review the rendered text for user-outcome
+soundness before promoting it (see docs/briefing-spec.md); that review is
+a development-time step, not something this script performs automatically.
+
+Usage:
+  python tools/briefing_review.py          # run the full scenario matrix
+  python tools/briefing_review.py -v       # also print each rendered briefing
+"""
+
+import argparse
+import sys
+from datetime import UTC, datetime, time, timedelta
+from pathlib import Path
+
+_repo_root = str(Path(__file__).resolve().parent.parent)
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+
+from tools.sim_harness.ha_stubs import install_ha_stubs  # noqa: E402
+
+install_ha_stubs()
+
+from custom_components.climate_advisor.briefing import generate_briefing  # noqa: E402
+from custom_components.climate_advisor.classifier import DayClassification  # noqa: E402
+
+COMFORT_HEAT = 68.0
+COMFORT_COOL = 75.0
+SETBACK_HEAT = 60.0
+SETBACK_COOL = 80.0
+WAKE_TIME = time(6, 30)
+SLEEP_TIME = time(22, 30)
+
+
+def _curve(temps: list[float], start_hour_utc: int = 13) -> list[dict]:
+    base = datetime(2026, 7, 25, start_hour_utc, 0, 0, tzinfo=UTC)
+    return [{"ts": (base + timedelta(hours=i)).isoformat(), "temp": t} for i, t in enumerate(temps)]
+
+
+def _make_classification(day_type: str, today_high: float, today_low: float) -> DayClassification:
+    return DayClassification(
+        day_type=day_type,
+        trend_direction="stable",
+        trend_magnitude=1.0,
+        today_high=today_high,
+        today_low=today_low,
+        tomorrow_high=today_high,
+        tomorrow_low=today_low,
+    )
+
+
+def _check_no_contradicting_window_times(name: str, text: str) -> list[str]:
+    """Header 'Windows: Open X - Y' close time must match the body's 'Close up at Y'."""
+    problems = []
+    header_line = next((line for line in text.splitlines() if "Windows:" in line), None)
+    if header_line and "–" in header_line and "Close up at" in text:
+        header_close = header_line.split("–")[-1].strip()
+        body_close = None
+        for line in text.splitlines():
+            if "Close up at" in line:
+                body_close = line.split("Close up at", 1)[1].split("—")[0].strip()
+                break
+        if body_close and header_close != body_close:
+            problems.append(f"[{name}] header close time '{header_close}' != body close time '{body_close}'")
+    return problems
+
+
+def _check_no_orphaned_ac_promise(name: str, text: str) -> list[str]:
+    """AC-safety-net language must not claim a fixed start time or ignore window state."""
+    problems = []
+    if "I'll run the AC starting around" in text:
+        problems.append(f"[{name}] AC sentence promises a fixed clock time (window-state unaware)")
+    if "no action needed" in text.lower():
+        problems.append(f"[{name}] contains flagged boilerplate phrase 'no action needed'")
+    return problems
+
+
+def _check_footer_matches_header(name: str, text: str) -> list[str]:
+    """The adaptive-setback footer must not appear when the header says 'No setback'."""
+    problems = []
+    has_no_setback_header = any("Bedtime Setback:" in line and "No setback" in line for line in text.splitlines())
+    has_footer = "tuned to your home's actual heating performance" in text
+    if has_no_setback_header and has_footer:
+        problems.append(f"[{name}] footer claims tuned setback timing but header says 'No setback'")
+    return problems
+
+
+def _check_no_dangling_ac_off_claim(name: str, text: str) -> list[str]:
+    """'I'll turn off the AC' must not appear without an earlier AC-forecast/ceiling sentence."""
+    problems = []
+    if "I'll turn off the AC" in text and "forecast to reach" not in text:
+        problems.append(f"[{name}] claims 'I'll turn off the AC' with no preceding forecast/ceiling-breach sentence")
+    return problems
+
+
+CHECKS = [
+    _check_no_contradicting_window_times,
+    _check_no_orphaned_ac_promise,
+    _check_footer_matches_header,
+    _check_no_dangling_ac_off_claim,
+]
+
+
+def _scenario_matrix() -> list[tuple[str, dict]]:
+    """day_type x hvac_mode x setback-active combinations relevant to Issue #518."""
+    scenarios = []
+
+    # Issue #518's reported case: warm/windows day, ceiling breach + recovery predicted,
+    # adaptive thermal model confident (so the footer-suppression fix is exercised).
+    c = _make_classification("warm", today_high=81, today_low=60)
+    indoor = _curve([68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 78, 77, 76])
+    outdoor = _curve([60, 63, 66, 69, 72, 75, 78, 80, 82, 83, 82, 79, 76, 73])
+    scenarios.append(
+        (
+            "warm_windows_day_breach_and_recovery",
+            dict(
+                classification=c,
+                predicted_indoor_future=indoor,
+                predicted_outdoor_future=outdoor,
+                adaptive_thermal_active=True,
+            ),
+        )
+    )
+
+    # Warm day, no ODE data at all — pure fallback path (classifier constants only).
+    scenarios.append(
+        (
+            "warm_windows_day_no_forecast_data",
+            dict(classification=_make_classification("warm", today_high=80, today_low=60)),
+        )
+    )
+
+    # Warm day, ceiling breach predicted but no recovery before end of curve.
+    c2 = _make_classification("warm", today_high=84, today_low=64)
+    indoor2 = _curve([70, 72, 74, 76, 78])
+    outdoor2 = _curve([65, 70, 76, 82, 86])
+    scenarios.append(
+        (
+            "warm_windows_day_breach_no_recovery",
+            dict(classification=c2, predicted_indoor_future=indoor2, predicted_outdoor_future=outdoor2),
+        )
+    )
+
+    # Cold day, heat mode, adaptive setback active — footer SHOULD appear (control case).
+    scenarios.append(
+        (
+            "cold_heat_day_adaptive_setback_active",
+            dict(
+                classification=_make_classification("cold", today_high=38, today_low=22),
+                adaptive_thermal_active=True,
+            ),
+        )
+    )
+
+    # Hot day, cool mode — unrelated to warm-day timing bug, included for matrix coverage.
+    scenarios.append(
+        (
+            "hot_cool_day",
+            dict(classification=_make_classification("hot", today_high=95, today_low=72)),
+        )
+    )
+
+    # Mild day, HVAC off, no setback — mirrors the warm/off footer-suppression case.
+    scenarios.append(
+        (
+            "mild_off_day_adaptive_model_present",
+            dict(
+                classification=_make_classification("mild", today_high=68, today_low=48),
+                adaptive_thermal_active=True,
+            ),
+        )
+    )
+
+    return scenarios
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-v", "--verbose", action="store_true", help="print each rendered briefing")
+    args = parser.parse_args()
+
+    all_problems: list[str] = []
+    for name, kwargs in _scenario_matrix():
+        text = generate_briefing(
+            comfort_heat=COMFORT_HEAT,
+            comfort_cool=COMFORT_COOL,
+            setback_heat=SETBACK_HEAT,
+            setback_cool=SETBACK_COOL,
+            wake_time=WAKE_TIME,
+            sleep_time=SLEEP_TIME,
+            **kwargs,
+        )
+        if args.verbose:
+            print(f"\n{'=' * 60}\n{name}\n{'=' * 60}")
+            print(text.encode("ascii", "replace").decode("ascii"))
+
+        for check in CHECKS:
+            all_problems.extend(check(name, text))
+
+    print(f"\n{len(_scenario_matrix())} scenarios checked, {len(all_problems)} coherence problems found.")
+    for problem in all_problems:
+        print(f"  FAIL: {problem}")
+
+    return 1 if all_problems else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Header window-close time and the conversational body's close time were computed independently (classifier constant vs. live ODE forecast) and could disagree; now derived once (`warm_events`) and shared by both.
- The AC-safety-net sentence ignored door/window state and duplicated a correct, debounce-aware sentence elsewhere in the same briefing — merged into one, window-state-conditioned statement, dropping the "no action needed" boilerplate the issue called out.
- "Reopen windows... I'll turn off the AC" could cancel an AC run that never started — now gated on the predicted ceiling breach actually preceding the recovery time.
- The bedtime-setback footer could appear even when the header said "No setback" — now also requires `hvac_mode in ("heat", "cool")`.
- Added `tools/briefing_review.py`, a deterministic day_type x hvac_mode x setback-active coherence checker for this bug class.
- Gave the AI investigator an 8th context block (`LAST BRIEFING`) so it can review the rendered briefing text itself.
- Authored `docs/briefing-spec.md`'s previously-stub sections and reconciled `docs/04-BRIEFING-EXAMPLES.md` (warm-day window times, stale 5-minute debounce references) against the real constants.

Closes #518.

## Test plan
- [x] `pytest tests/` — 3562 passed
- [x] `python tools/simulate.py` — 74/74 golden scenarios passed
- [x] `python tools/briefing_review.py` — 0 coherence problems across 6 scenarios
- [x] `ruff check`/`ruff format` clean
- [x] `test_version_sync.py` passes (0.5.32)
- [x] Manually rendered the issue's exact pasted scenario and confirmed header/body agreement, conditional AC wording, no orphaned AC-off claim, no contradictory footer