### PR TITLE
Fix #527: Status card duplicated automation-pause narration in Next User Action and Next Automation

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -137,6 +137,19 @@ Any new automation phase or state that the occupant (or developer) would want to
 
 Typical state values a status field should express: `"scheduled (X°F @ HH:MM)"`, `"active (X°F)"`, `"suppressed — reason"`, `null` when inactive (hidden from UI).
 
+#### Status Card Ontology (CRITICAL — Issue #527)
+
+Four Status-tab cards each answer one distinct question. A card must never answer another card's question — this is how the dashboard ended up narrating "a door/window is open, automation is paused" independently in three places with three different wordings (Issue #527; the same duplication class hit `_compute_automation_status()`/`_compute_next_action()` once already, Issue #495, §9d).
+
+| Card | Question it answers | Backend owner | Must NOT contain |
+|---|---|---|---|
+| **Status** | What's happening right now, and why? | `_compute_automation_status()` | — (this is the only card where mechanism state belongs) |
+| **Next User Action** | Stop doing something, start doing something, or continue doing something — for comfort, right now | `_compute_next_action()` | Any automation mechanism word (paused, grace, override, waiting, confirming), and any "the AC/heater/automation is handling it" filler |
+| **Next Automation** | What is the automation's plan to do next (comfort-impact terms), assuming conditions hold? | `_compute_next_automation_action()`, action string only | Time-of-day phrasing; "waiting"/"paused"/"grace"/door-window "why" |
+| **Automation Time** | When will that plan step happen? | Same function, time string element | — |
+
+Before adding a branch to any of these three functions that reads an automation-mechanism flag (`is_paused_by_door`, `_grace_active`, `_override_confirm_pending`, `_manual_override_active`), ask: does this belong in Status instead? If the branch's purpose is to explain *why* the system is in a state, it belongs only in `_compute_automation_status()`. Next User Action and Next Automation must answer their own question regardless of the automation's current mechanism state — that state is simply deferred, not different.
+
 #### Chart Coverage
 
 Any automation phase that changes the thermostat setpoint (even temporarily) MUST be reflected in the chart's Target Band:

--- a/custom_components/climate_advisor/api.py
+++ b/custom_components/climate_advisor/api.py
@@ -183,6 +183,20 @@ class ClimateAdvisorStatusView(HomeAssistantView):
             and not coordinator.config.get("aggressive_savings", False)
         )
 
+        # Issue #527: pause_suppressed_classification had the identical "documented but
+        # never wired in" gap as nat_vent_active above (see KNOWN_FIXES[367] in const.py) —
+        # the frontend's Status-card line reading data.pause_suppressed_classification was
+        # unreachable dead code because this endpoint never included the key. Computed live
+        # (not from coordinator.data) for the same freshness reason as ca_target_heat/cool.
+        # The text itself now lives here (backend) instead of hardcoded in index.html, so
+        # the Status card's text has one source, like every other line on that card.
+        _pause_suppressed_classification = bool(ae.is_paused_by_door) and ae._last_classification_applied is not None
+        _pause_suppressed_classification_text = (
+            "Classification suppressed — HVAC held off until windows close"
+            if _pause_suppressed_classification
+            else None
+        )
+
         # Issue #480: gate on coordinator.last_update_success instead of silently
         # serving coordinator.data forever once updates start failing. HA's own
         # DataUpdateCoordinator retains the last successful snapshot indefinitely
@@ -228,6 +242,8 @@ class ClimateAdvisorStatusView(HomeAssistantView):
             # ambient sensor discoverable, or no press observed yet this session).
             "fan_remote_speed": data.get("fan_remote_speed"),
             "paused_by_door": ae.is_paused_by_door,
+            "pause_suppressed_classification": _pause_suppressed_classification,
+            "pause_suppressed_classification_text": _pause_suppressed_classification_text,
             "ca_target_heat": _ca_target_heat,
             "ca_target_cool": _ca_target_cool,
             "nat_vent_active": _nat_vent_active,

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,19 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.34"
+VERSION = "0.5.35"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.35": [
+        "Fix #527: the dashboard's Status, Next User Action, and Next Automation cards could"
+        " all say the same thing in different words whenever a door/window was open (or a"
+        " grace period or thermostat-change confirmation was active) — the Next User Action"
+        " card said 'Automation paused,' restating the Status card instead of telling you"
+        " what to actually do (like closing the window), and the Next Automation card said"
+        " 'Waiting' instead of showing the real next step (like tonight's bedtime setback)"
+        " and when it'll happen. Each card now sticks to its own job, and away/vacation mode"
+        " gets a bit of rotating personality in Next User Action instead of one flat line.",
+    ],
     "0.5.34": [
         "Fix #523: after an HA restart, if a window was already open, Climate Advisor could"
         " turn the AC on and cool against the open window instead of staying paused like it"
@@ -1277,6 +1287,51 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    527: {
+        "version_fixed": "0.5.35",
+        "title": (
+            "Status, Next User Action, and Next Automation cards independently narrated the"
+            " same automation-mechanism fact (paused by door/window, grace period, override"
+            " confirming) with three different wordings, instead of each card answering its"
+            " own question"
+        ),
+        "scope_covered": (
+            "coordinator.py: _compute_next_action() (Next User Action card) — deleted the"
+            " early-return block that read _override_confirm_pending/_manual_override_active/"
+            "_grace_active/is_paused_by_door and returned mechanism text; this had been"
+            " pre-empting the function's own real comfort guidance (window/fan direction"
+            " checks, heating/cooling-needed logic) further down, which is now always"
+            " reachable regardless of automation mechanism state. Also trimmed redundant"
+            " 'the AC/heater/automation is handling it' tails and an 'Automation active —'"
+            " lead-in that restated the Status card's job inside the comfort-guidance card,"
+            " and replaced the flat away/vacation sentences with a small date-seeded rotating"
+            " pool (_AWAY_ACTION_MESSAGES/_VACATION_ACTION_MESSAGES via _pick_daily_line())."
+            " _compute_next_automation_action() (Next Automation + Automation Time cards) —"
+            " deleted the 'Windows open as recommended' / 'Waiting — HVAC paused' / 'Grace"
+            " period active' / 'Evaluating door/window sensors' early returns so the function"
+            " always falls through to the real schedule-candidate list (briefing/wake/bedtime/"
+            "pre-cool); added INFO-level entry and outcome logging (this function previously"
+            " had none). api.py: wired pause_suppressed_classification and a new"
+            " pause_suppressed_classification_text into ClimateAdvisorStatusView — this field"
+            " existed in coordinator.get_serializable_state() (Debug tab) and was flagged as a"
+            " known gap in KNOWN_FIXES[367] but had never reached the actual Status API"
+            " response, so index.html's check of it was unreachable dead code; the text itself"
+            " also moved from a frontend-hardcoded literal to this new backend field."
+            " CLAUDE.md + docs/08-COMPUTATION-REFERENCE.md §9e: documented the four-card"
+            " ontology (Status=state+why, Next User Action=comfort action only, Next"
+            " Automation=plan only, Automation Time=when) as a guardrail against a repeat —"
+            " this is the second time this duplication class has appeared (first: #495, §9d,"
+            " which patched two functions to stay in sync rather than removing the"
+            " duplication; that patch didn't hold when a third function grew the same problem"
+            " independently)."
+        ),
+        "scope_not_covered": (
+            "No new predictive next-automation event types were added (e.g. a forecast-based"
+            " ETA for when the whole-house fan/nat-vent will start) — Next Automation still"
+            " only predicts the four pre-existing fixed-schedule events (briefing, wake,"
+            " bedtime, pre-cool). Tracked separately in issue #528."
+        ),
+    },
     523: {
         "version_fixed": "0.5.34",
         "title": (

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import functools
+import hashlib
 import logging
 import math
 from collections.abc import Callable
@@ -265,6 +266,47 @@ class _PendingFanRemoteBurst:
     timer_hours: float | None = None
     has_timer: bool = False
     was_running_before: bool | None = None
+
+
+# Next User Action flavor text for occupancy modes where there's nothing for the
+# occupant to do (Issue #527). Date-seeded rotation (see _pick_daily_line()) picks
+# one line per calendar day so the dashboard doesn't flicker between refreshes.
+_AWAY_ACTION_MESSAGES: tuple[str, ...] = (
+    "You're away. The house is holding steady.",
+    "Away mode: nothing needs you right now.",
+    "No action needed. The thermostat has it handled.",
+    "You're away — temperature's stable, no news is good news.",
+    "Nothing to do. The house is behaving.",
+    "You're away — the house says it's fine, promise.",
+    "We've got the house-sitting covered.",
+    "Away and comfortable. Go enjoy wherever you are.",
+    "Nothing to do — even the thermostat's taking it easy.",
+    "Away mode: the house is behaving better than usual.",
+)
+_VACATION_ACTION_MESSAGES: tuple[str, ...] = (
+    "Vacation mode: deep setback engaged, nothing for you to do.",
+    "On vacation. The thermostat is unbothered.",
+    "Deep setback active — the house is coasting.",
+    "Nothing needed here. Go be on vacation.",
+    "Setback engaged. This message is the only work being done.",
+    "Vacation mode — the house is on autopilot, saving you money while you're gone.",
+    "Go have fun. The thermostat's got the boring part.",
+    "On vacation — sit back, we're saving energy for you.",
+    "Deep setback engaged. The house is basically hibernating politely.",
+    "Vacation: lights out, temps relaxed, wallet happy.",
+)
+
+
+def _pick_daily_line(pool: tuple[str, ...], salt: str) -> str:
+    """Deterministically pick one line from ``pool`` per calendar day.
+
+    Stable across repeated calls within the same day (no flicker on the ~30-min
+    update cycle); changes the next day. ``salt`` distinguishes independent pools
+    (e.g. "away" vs "vacation") so they don't rotate in lockstep.
+    """
+    today = dt_util.now().date().isoformat()
+    index = int(hashlib.sha256(f"{today}:{salt}".encode()).hexdigest(), 16) % len(pool)
+    return pool[index]
 
 
 class ClimateAdvisorCoordinator(DataUpdateCoordinator):
@@ -6069,46 +6111,30 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             (_LOGGER.warning if warn else _LOGGER.info)("Next-action: %s (%s)", msg, ctx_str)
             return msg
 
+        def _close_windows_msg(od: float, id_: float) -> str:
+            return f"Close windows — outdoor's not helping now ({format_temp(od, unit)} vs {format_temp(id_, unit)})."
+
+        def _windows_helping_msg(od: float, id_: float) -> str:
+            return f"Windows open — outdoor's helping ({format_temp(od, unit)} vs {format_temp(id_, unit)})."
+
         if not c:
             return _decide("Waiting for forecast data...")
 
+        # Occupancy guards (Issue #527): these answer "what should I do" with "nothing —
+        # you're not here," which is legitimate comfort-relevant guidance, not automation
+        # mechanism narration, so they stay ahead of the comfort-guidance branches below.
         if self._occupancy_mode == OCCUPANCY_VACATION:
-            return _decide("On vacation — deep energy-saving setback active.")
+            return _decide(_pick_daily_line(_VACATION_ACTION_MESSAGES, "vacation"))
         if self._occupancy_mode == OCCUPANCY_AWAY:
-            return _decide("You're away — automation managing temperature.")
+            return _decide(_pick_daily_line(_AWAY_ACTION_MESSAGES, "away"))
 
-        # Automation-state guards checked early/globally: if the system isn't in its
-        # normal control loop right now, that fact is more relevant to the occupant
-        # than a scheduled reminder that ignores it (see plan's "Guard ordering"
-        # decision, Issue #428).
-        if ae is not None:
-            # Issue #495: _override_confirm_pending (the 10-min setpoint-override confirm
-            # window) and _grace_active (the fan-override grace) are independent tracks that
-            # can legitimately overlap — a manual WHF-on starts its grace immediately while a
-            # concurrent setpoint override is still only pending confirmation. Without this
-            # branch, a pending-confirm setpoint override with no fan override active fell
-            # through silently to no guard at all, and one WITH a concurrent fan-override
-            # grace fell through to the grace_active branch below, which then described the
-            # fan's grace as if it were the (still-unconfirmed) setpoint override's own —
-            # narrating two different overrides as one. This mirrors
-            # _compute_automation_status()'s "override pending (confirming...)" check
-            # (checked ahead of its own grace_active check there too) so the two dashboard
-            # status lines agree instead of contradicting each other.
-            if ae._override_confirm_pending:
-                if ae._grace_active:
-                    return _decide(
-                        "Confirming your thermostat change; whole-house fan override also active.",
-                        fan_override_active=ae._fan_override_active,
-                    )
-                return _decide("Confirming your thermostat change before automation resumes.")
-            if ae._manual_override_active:
-                return _decide("Manual override active — automation is standing by.")
-            if ae._grace_active:
-                return _decide(
-                    f"Grace period active — automation will resume shortly.{self._format_grace_remaining(ae)}"
-                )
-            if ae.is_paused_by_door:
-                return _decide("Automation paused — a door or window is open.")
+        # Issue #527: automation-mechanism state (override/grace/pause) used to be
+        # narrated here directly, pre-empting the comfort guidance below and duplicating
+        # what the Status card already says (_compute_automation_status()). That guard
+        # block was removed — this card answers "what should I do for comfort," which is
+        # true independent of whether the automation itself is currently paused/grace/
+        # confirming. See docs/08-COMPUTATION-REFERENCE.md §9d for the prior (Issue #495)
+        # instance of this exact duplication class, and CLAUDE.md's card-ontology table.
 
         now = dt_util.now().time()
         direction_ok = free_cooling_direction_ok(outdoor_temp, indoor_temp)
@@ -6122,30 +6148,28 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 if windows_physically_open:
                     if outdoor_temp is not None and indoor_temp is not None and not direction_ok:
                         return _decide(
-                            f"Windows are open, but outdoor ({format_temp(outdoor_temp, unit)}) isn't cooler"
-                            f" than indoor ({format_temp(indoor_temp, unit)}) — consider closing them so the"
-                            f" AC/fan can help.",
+                            _close_windows_msg(outdoor_temp, indoor_temp),
                             warn=True,
                             outdoor=outdoor_temp,
                             indoor=indoor_temp,
                         )
-                    return _decide("Windows are open — you're all set.")
+                    return _decide("Windows open — you're all set.")
                 if outdoor_temp is not None and indoor_temp is not None:
                     if direction_ok:
                         return _decide(
-                            f"Open windows to cool down — outdoor ({format_temp(outdoor_temp, unit)}) is"
-                            f" now cooler than indoor ({format_temp(indoor_temp, unit)}).",
+                            f"Open windows — outdoor's cooler now ({format_temp(outdoor_temp, unit)} vs"
+                            f" {format_temp(indoor_temp, unit)}).",
                             outdoor=outdoor_temp,
                             indoor=indoor_temp,
                         )
                     return _decide(
-                        f"Outdoor ({format_temp(outdoor_temp, unit)}) isn't cooler than indoor"
-                        f" ({format_temp(indoor_temp, unit)}) yet — keep windows closed for now.",
+                        f"Keep windows closed for now — outdoor ({format_temp(outdoor_temp, unit)}) isn't"
+                        f" cooler than indoor ({format_temp(indoor_temp, unit)}) yet.",
                         warn=True,
                         outdoor=outdoor_temp,
                         indoor=indoor_temp,
                     )
-                return _decide("Open windows to cool down — outdoor air may be cooler now.")
+                return _decide("Open windows — outdoor air may be cooler now.")
 
         if c.day_type == DAY_TYPE_HOT:
             threshold = comfort_cool + ECONOMIZER_TEMP_DELTA
@@ -6155,12 +6179,12 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             elif c.window_opportunity_evening and now >= time(ECONOMIZER_EVENING_START_HOUR, 0):
                 return _decide(f"Open windows if outdoor temp is below {format_temp(threshold, unit)}")
             if ae is not None and (ae._natural_vent_active or ae._economizer_active):
-                return _decide("AC and free cooling are both working on it.")
-            return _decide("Keep windows and blinds closed. AC is handling it.")
+                return _decide("Free cooling is active.")
+            return _decide("Keep windows and blinds closed.")
         elif c.day_type == DAY_TYPE_COLD:
             if windows_physically_open:
-                return _decide("Keep doors closed — help the heater out.")
-            return _decide("Doors are closed — heater is handling it.")
+                return _decide("Close doors to help the heater.")
+            return _decide("Keep doors closed.")
 
         # WARM/MILD/COOL fallback: symmetric cooling-direction and heating-direction
         # checks, both gated on live outdoor-vs-indoor direction (Issue #428).
@@ -6169,35 +6193,34 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
 
         if cooling_needed:
             if ae is not None and (ae._natural_vent_active or ae._economizer_active):
-                return _decide("Free cooling is already active.")
+                return _decide("Free cooling is active.")
             if windows_physically_open:
                 if outdoor_temp is not None and not direction_ok:
                     return _decide(
-                        f"Windows are open, but outdoor ({format_temp(outdoor_temp, unit)}) isn't cooler"
-                        f" than indoor ({format_temp(indoor_temp, unit)}) — consider closing them so the"
-                        f" AC/fan can help.",
+                        _close_windows_msg(outdoor_temp, indoor_temp),
                         warn=True,
                         outdoor=outdoor_temp,
                         indoor=indoor_temp,
                     )
-                return _decide("Windows are open and outdoor air is helping.")
+                if outdoor_temp is not None:
+                    return _decide(_windows_helping_msg(outdoor_temp, indoor_temp))
+                return _decide("Windows open — you're all set.")
             if outdoor_temp is None:
                 return _decide(
-                    f"Indoor is {format_temp(indoor_temp, unit)} — outdoor reading unavailable,"
-                    f" automation is handling it conservatively.",
+                    f"Indoor is {format_temp(indoor_temp, unit)} — no outdoor reading available.",
                     indoor=indoor_temp,
                 )
             if direction_ok:
                 fan_clause = " or turn on the fan" if fan_enabled else ""
                 return _decide(
-                    f"Indoor temp is {format_temp(indoor_temp, unit)} — open windows{fan_clause} to cool"
-                    f" down; outdoor ({format_temp(outdoor_temp, unit)}) is cooler now.",
+                    f"Open windows{fan_clause} — outdoor's cooler now ({format_temp(outdoor_temp, unit)} vs"
+                    f" {format_temp(indoor_temp, unit)}).",
                     outdoor=outdoor_temp,
                     indoor=indoor_temp,
                 )
             return _decide(
-                f"Indoor is {format_temp(indoor_temp, unit)} — outdoor ({format_temp(outdoor_temp, unit)})"
-                f" isn't cooler, so windows/fan won't help right now. Automation is handling it.",
+                f"Outdoor ({format_temp(outdoor_temp, unit)}) isn't cooler than indoor"
+                f" ({format_temp(indoor_temp, unit)}) yet — windows/fan won't help.",
                 warn=True,
                 outdoor=outdoor_temp,
                 indoor=indoor_temp,
@@ -6205,21 +6228,20 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
 
         if heating_needed:
             if windows_physically_open:
-                return _decide("Windows are open — close them to help the heater.")
+                return _decide("Close windows to enable the heater.")
             if outdoor_temp is not None and outdoor_temp > indoor_temp:
                 return _decide(
-                    f"Indoor is {format_temp(indoor_temp, unit)} — outdoor ({format_temp(outdoor_temp, unit)})"
-                    f" is warmer; opening windows briefly could help warm the home.",
+                    f"Open windows briefly — outdoor's warmer ({format_temp(outdoor_temp, unit)} vs"
+                    f" {format_temp(indoor_temp, unit)}).",
                     outdoor=outdoor_temp,
                     indoor=indoor_temp,
                 )
             return _decide(
-                f"Indoor is {format_temp(indoor_temp, unit)} — keep windows and doors closed to hold heat."
-                f" Automation is handling it.",
+                f"Keep windows and doors closed to hold heat (indoor {format_temp(indoor_temp, unit)}).",
                 indoor=indoor_temp,
             )
 
-        return _decide("Automation active — no changes planned right now.")
+        return _decide("Comfortable — no action needed.")
 
     def _emit_event(self, event_type: str, data: dict) -> None:
         """Append a timestamped event to the in-memory event log ring buffer (Issue #76)."""
@@ -6808,28 +6830,26 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         now = dt_util.now()
         today = now.date()
 
-        # Check if windows are open during planned window period
-        if self.automation_engine._is_within_planned_window_period() and self._any_sensor_open():
-            return ("Windows open as recommended", "")
-
-        # Check if automation is paused
-        if self.automation_engine.is_paused_by_door:
-            return ("Waiting — HVAC paused (door/window open)", "")
-
-        if self.automation_engine._grace_active:
-            source = self.automation_engine._last_resume_source or "automation"
-            return (f"Grace period active ({source}){self._format_grace_remaining(self.automation_engine)}", "")
-
-        # If a contact sensor debounce is pending, that is the soonest upcoming action
-        if self._door_open_timers and self._door_open_timer_expiry:
-            try:
-                earliest_iso = min(self._door_open_timer_expiry.values())
-                expiry_dt = dt_util.parse_datetime(earliest_iso)
-                if expiry_dt and expiry_dt > now:
-                    time_str = dt_util.as_local(expiry_dt).strftime("%I:%M:%S %p").lstrip("0")
-                    return ("Evaluating door/window sensors", time_str)
-            except (ValueError, AttributeError, TypeError):
-                pass
+        # Issue #527: this function used to short-circuit here whenever automation was
+        # paused by an open door/window, in a debounce window, or in a grace period,
+        # returning mechanism text ("Waiting — HVAC paused...", "Grace period active...")
+        # instead of the real next plan step. That duplicated what the Status card
+        # already says (_compute_automation_status()) and hid the actual answer to "what
+        # will the automation do next" — which is unaffected by those mechanism states;
+        # it's simply deferred until they clear. Always fall through to the real
+        # schedule-candidate list below. See docs/08-COMPUTATION-REFERENCE.md §9d and
+        # CLAUDE.md's card-ontology table.
+        ae = self.automation_engine
+        _LOGGER.info(
+            "Next-automation evaluation: day_type=%s hvac_mode=%s paused_by_door=%s grace_active=%s"
+            " debounce_pending=%s startup_coalesce_active=%s",
+            c.day_type,
+            c.hvac_mode,
+            ae.is_paused_by_door,
+            ae._grace_active,
+            bool(self._door_open_timers),
+            self._startup_coalesce_active,
+        )
 
         # Build list of upcoming scheduled events as (datetime, description).
         # Using full datetimes (not time objects) so cross-midnight events like
@@ -6885,11 +6905,13 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             candidates.append((self._pre_cool_trigger_dt, pc_desc))
 
         if not candidates:
+            _LOGGER.info("Next-automation: No more actions today")
             return ("No more actions today", "")
 
         candidates.sort(key=lambda e: e[0])
         next_dt, next_desc = candidates[0]
         time_str = dt_util.as_local(next_dt).strftime("%I:%M %p").lstrip("0")
+        _LOGGER.info("Next-automation: %s at %s", next_desc, time_str)
         return (next_desc, time_str)
 
     @property

--- a/custom_components/climate_advisor/frontend/index.html
+++ b/custom_components/climate_advisor/frontend/index.html
@@ -951,7 +951,7 @@
           <div class="label">Status</div>
           <div class="value">${data.automation_status || 'unknown'}</div>
           ${data.coordinator_healthy === false ? `<div class="value" style="color:var(--danger, #f44336)">⚠ Climate Advisor unavailable since ${data.stale_since ? new Date(data.stale_since).toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'}) : 'unknown'} — ${escapeHtml(data.last_error || 'unknown error')}</div>` : ''}
-          ${data.pause_suppressed_classification ? `<div class="value">Classification suppressed — HVAC held off until windows close</div>` : ''}
+          ${data.pause_suppressed_classification_text ? `<div class="value">${escapeHtml(data.pause_suppressed_classification_text)}</div>` : ''}
           ${data.nat_vent_active && data.nat_vent_off_threshold != null && data.nat_vent_on_threshold != null ? `
           <div class="value" style="font-size:0.8rem;opacity:0.85">
             ${escapeHtml(data.nat_vent_ac_assist ? 'AC assist' : 'savings mode')} · cycling ${Math.round(data.nat_vent_off_threshold)}${unitSym}–${Math.round(data.nat_vent_on_threshold)}${unitSym}

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.34"
+  "version": "0.5.35"
 }

--- a/docs/08-COMPUTATION-REFERENCE.md
+++ b/docs/08-COMPUTATION-REFERENCE.md
@@ -1770,6 +1770,51 @@ this only makes what's already true readable on the dashboard.
 defaults `_override_confirm_pending`/`_fan_override_active` to `False`, per the MagicMock-truthy
 pitfall this project has hit before — see CLAUDE.md's async-mock testing rules).
 
+**Superseded by Issue #527** — the branch-syncing fix above kept two functions manually in
+agreement about mechanism state, but it didn't hold: a third function
+(`_compute_next_automation_action()`) independently grew the same class of duplication, and
+`_compute_next_action()`'s own mechanism-flag branches went on to shadow its real comfort
+guidance. §9e documents the resolution: mechanism state (paused/grace/override/confirming) was
+removed from `_compute_next_action()` and `_compute_next_automation_action()` entirely, not kept
+in sync — it now lives only in `_compute_automation_status()`. The four-card ontology table this
+established is also in `CLAUDE.md` under "Status Card Ontology."
+
+### 9e. Status Card Ontology — Removing Mechanism Narration from Next User Action / Next Automation (Issue #527)
+
+Three coordinator functions feed the Status tab: `_compute_automation_status()` (Status card),
+`_compute_next_action()` (Next User Action card), and `_compute_next_automation_action()` (Next
+Automation + Automation Time cards). Each answers a different question, but `_compute_next_action()`
+and `_compute_next_automation_action()` had each accumulated early-return branches that read
+automation-mechanism flags (`is_paused_by_door`, `_grace_active`, `_override_confirm_pending`,
+`_manual_override_active`) and returned mechanism text — duplicating `_compute_automation_status()`
+and, in `_compute_next_action()`'s case, pre-empting its own real comfort guidance lower in the
+function (unreachable whenever any of those flags was set).
+
+**Fix:** those branches were deleted outright, not synced. `_compute_next_action()` now always
+falls through to comfort-based guidance (window/fan direction checks, heating/cooling-needed
+logic) regardless of pause/grace/override state — the guidance is correct independent of whether
+the automation itself is currently paused. `_compute_next_automation_action()` now always falls
+through to the real schedule-candidate list (briefing/wake/bedtime/pre-cool) for the same reason:
+the plan is simply deferred until the mechanism state clears, not different.
+
+Wording was also tightened to drop redundant "the AC/heater/automation is handling it" tails and
+a stray "Automation active —" lead-in in the in-band fallback — these restated the Status card's
+job (confirming the automation is active) inside a card whose job is comfort guidance. Away/vacation
+occupancy messages became a small date-seeded rotating pool (`_AWAY_ACTION_MESSAGES`/
+`_VACATION_ACTION_MESSAGES`, `_pick_daily_line()`) instead of one fixed sentence.
+
+Also fixed in the same issue: `pause_suppressed_classification` (and a new
+`pause_suppressed_classification_text`) were wired into `ClimateAdvisorStatusView` in `api.py` for
+the first time — the field existed in `get_serializable_state()` (the Debug tab) and was
+documented as a known gap in `KNOWN_FIXES[367]`, but had never been added to the actual Status API
+response, so the frontend's `pause_suppressed_classification` check in `index.html` was
+unreachable dead code (identical shape to the `nat_vent_active` gap fixed in the same PR as #367).
+
+**Test coverage:** `tests/test_coordinator.py::TestComputeNextAction` (paused/grace/override tests
+renamed `test_next_action_*_does_not_preempt_schedule`, asserting the real guidance now surfaces
+and the mechanism word does NOT appear), `tests/test_status_sensors.py::TestComputeNextAutomationAction`
+(`test_paused_by_door_still_shows_real_next_step`, `test_grace_period_active_still_shows_real_next_step`).
+
 ---
 
 ## 10. Door/Window HVAC Pause

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -150,20 +150,41 @@ class TestComputeNextAction:
         assert result == "Waiting for forecast data..."
 
     def test_next_action_vacation_occupancy_short_circuits(self):
-        """VACATION occupancy → status message, bypassing all thermal/window logic."""
+        """VACATION occupancy → rotating flavor message, bypassing all thermal/window logic (Issue #527).
+
+        Asserts pool membership (not a literal "vacation" substring) since the pool
+        deliberately mixes deadpan/playful lines that don't all repeat the mode name —
+        the invariant under test is that occupancy mode short-circuits to the curated
+        pool and never leaks the 78/80 temps into the message.
+        """
+        mod = importlib.import_module("custom_components.climate_advisor.coordinator")
         c = _make_classification(day_type=DAY_TYPE_MILD)
         result = _compute_next_action(
             c, {}, time(8, 0), indoor_temp=78.0, outdoor_temp=80.0, occupancy_mode=OCCUPANCY_VACATION
         )
-        assert "vacation" in result.lower()
+        assert result in mod._VACATION_ACTION_MESSAGES
+        assert "78" not in result
+        assert "80" not in result
 
     def test_next_action_away_occupancy_short_circuits(self):
-        """AWAY occupancy → status message, bypassing all thermal/window logic."""
+        """AWAY occupancy → rotating flavor message, bypassing all thermal/window logic (Issue #527)."""
+        mod = importlib.import_module("custom_components.climate_advisor.coordinator")
         c = _make_classification(day_type=DAY_TYPE_MILD)
         result = _compute_next_action(
             c, {}, time(8, 0), indoor_temp=78.0, outdoor_temp=80.0, occupancy_mode=OCCUPANCY_AWAY
         )
-        assert "away" in result.lower()
+        assert result in mod._AWAY_ACTION_MESSAGES
+        assert "78" not in result
+        assert "80" not in result
+
+    def test_next_action_away_vacation_rotate_daily_stable_within_day(self):
+        """Date-seeded rotation: same line across repeated calls same day, pool membership guaranteed."""
+        mod = importlib.import_module("custom_components.climate_advisor.coordinator")
+        c = _make_classification(day_type=DAY_TYPE_MILD)
+        first = _compute_next_action(c, {}, time(8, 0), occupancy_mode=OCCUPANCY_AWAY)
+        second = _compute_next_action(c, {}, time(20, 0), occupancy_mode=OCCUPANCY_AWAY)
+        assert first == second
+        assert first in mod._AWAY_ACTION_MESSAGES
 
     def test_next_action_hot_morning_shows_threshold(self):
         """HOT day, morning opportunity, before 9 AM → threshold and cutoff time shown."""
@@ -235,7 +256,6 @@ class TestComputeNextAction:
         )
         result = _compute_next_action(c, {}, time(13, 0))
         assert "Keep windows and blinds closed" in result
-        assert "AC is handling it" in result
 
     def test_next_action_hot_uses_custom_comfort_cool(self):
         """HOT day morning opportunity respects a non-default comfort_cool setting."""
@@ -249,22 +269,22 @@ class TestComputeNextAction:
         assert "75" in result
 
     def test_next_action_cold_day_doors_open(self):
-        """COLD day, doors physically open → keep-doors-closed message."""
+        """COLD day, doors physically open → close-doors message."""
         c = _make_classification(day_type=DAY_TYPE_COLD)
         result = _compute_next_action(c, {}, time(12, 0), windows_physically_open=True)
-        assert "Keep doors closed" in result
+        assert "Close doors" in result
 
     def test_next_action_cold_day_doors_already_closed(self):
-        """COLD day, doors already physically closed → confirms heater is handling it, no redundant ask."""
+        """COLD day, doors already physically closed → confirms nothing to change, no redundant ask."""
         c = _make_classification(day_type=DAY_TYPE_COLD)
         result = _compute_next_action(c, {}, time(12, 0), windows_physically_open=False)
-        assert "Doors are closed" in result
+        assert "Keep doors closed" in result
 
     def test_next_action_mild_day(self):
         """Mild day (not hot/cold) → no action needed message."""
         c = _make_classification(day_type="mild")
         result = _compute_next_action(c, {}, time(12, 0))
-        assert "Automation active" in result
+        assert "Comfortable" in result
 
     def test_next_action_warm_day_after_close_before_evening(self):
         """WARM day after 10 AM close, before 5 PM — mid-day gap, no window guidance."""
@@ -275,7 +295,7 @@ class TestComputeNextAction:
             window_close_time=time(WARM_WINDOW_CLOSE_HOUR, 0),
         )
         result = _compute_next_action(c, {}, time(13, 0))
-        assert "Automation active" in result
+        assert "Comfortable" in result
 
     def test_next_action_warm_day_after_close_at_evening_start(self):
         """WARM day after 10 AM close, at exactly 5 PM — evening ventilation suggested."""
@@ -306,7 +326,7 @@ class TestComputeNextAction:
         assert "78" in result
         assert "70" in result
         assert "open windows" in result.lower()
-        assert "Automation active" not in result
+        assert "Comfortable" not in result
 
     def test_next_action_indoor_above_comfort_outdoor_hotter_suppresses_bug(self):
         """Regression test for Issue #428 — indoor 75/outdoor 80 must NOT suggest opening windows."""
@@ -329,7 +349,7 @@ class TestComputeNextAction:
         """Outdoor reading unavailable → conservative message, never a guessed suggestion."""
         c = _make_classification(day_type=DAY_TYPE_MILD, windows_recommended=False)
         result = _compute_next_action(c, {"comfort_cool": 75}, time(14, 0), indoor_temp=78.0, outdoor_temp=None)
-        assert "unavailable" in result.lower()
+        assert "no outdoor reading" in result.lower()
         assert "open windows" not in result.lower()
 
     def test_next_action_indoor_above_comfort_fan_disabled_no_fan_mention(self):
@@ -362,7 +382,7 @@ class TestComputeNextAction:
         c = _make_classification(day_type=DAY_TYPE_MILD, windows_recommended=False)
         ae = _make_ae_stub(_natural_vent_active=True)
         result = _compute_next_action(c, {"comfort_cool": 75}, time(14, 0), indoor_temp=78.0, outdoor_temp=70.0, ae=ae)
-        assert "already active" in result.lower()
+        assert "free cooling is active" in result.lower()
 
     def test_next_action_cooling_needed_windows_open_direction_favorable(self):
         """Cooling needed, windows already open, outdoor favorable → confirm, don't repeat the ask."""
@@ -375,7 +395,7 @@ class TestComputeNextAction:
             outdoor_temp=70.0,
             windows_physically_open=True,
         )
-        assert "windows are open" in result.lower()
+        assert "windows open" in result.lower()
         assert "helping" in result.lower()
 
     def test_next_action_cooling_needed_windows_open_direction_unfavorable(self):
@@ -389,7 +409,7 @@ class TestComputeNextAction:
             outdoor_temp=80.0,
             windows_physically_open=True,
         )
-        assert "closing them" in result.lower()
+        assert "close windows" in result.lower()
 
     def test_next_action_heating_needed_outdoor_warmer_suggests_windows(self):
         """Heating needed (indoor below comfort_heat), outdoor warmer → new heating-direction mirror."""
@@ -402,7 +422,7 @@ class TestComputeNextAction:
             outdoor_temp=72.0,
         )
         assert "warmer" in result.lower()
-        assert "opening windows" in result.lower()
+        assert "open windows" in result.lower()
 
     def test_next_action_heating_needed_outdoor_not_warmer_keep_closed(self):
         """Heating needed, outdoor not warmer than indoor → keep closed, hold heat."""
@@ -427,10 +447,16 @@ class TestComputeNextAction:
             outdoor_temp=72.0,
             windows_physically_open=True,
         )
-        assert "close them" in result.lower()
+        assert "close windows" in result.lower()
 
-    def test_next_action_manual_override_active_preempts_schedule(self):
-        """Manual override active → surfaced before any scheduled window message (guard-ordering decision)."""
+    def test_next_action_manual_override_active_does_not_preempt_schedule(self):
+        """Manual override active → still shows real comfort guidance (Issue #527).
+
+        Prior behavior (pre-#527) short-circuited to "Manual override active — automation
+        is standing by," duplicating what the Status card already says and hiding the
+        actual comfort guidance. Next User Action must never narrate automation mechanism
+        state — see the card-ontology table in CLAUDE.md.
+        """
         c = _make_classification(
             day_type=DAY_TYPE_WARM,
             windows_recommended=True,
@@ -438,10 +464,11 @@ class TestComputeNextAction:
         )
         ae = _make_ae_stub(_manual_override_active=True)
         result = _compute_next_action(c, {}, time(7, 0), ae=ae)
-        assert "manual override" in result.lower()
+        assert "09:00 AM" in result
+        assert "manual override" not in result.lower()
 
-    def test_next_action_grace_active_preempts_schedule(self):
-        """Grace period active → surfaced before any scheduled window message."""
+    def test_next_action_grace_active_does_not_preempt_schedule(self):
+        """Grace period active → still shows real comfort guidance, not mechanism state (Issue #527)."""
         c = _make_classification(
             day_type=DAY_TYPE_WARM,
             windows_recommended=True,
@@ -449,10 +476,14 @@ class TestComputeNextAction:
         )
         ae = _make_ae_stub(_grace_active=True)
         result = _compute_next_action(c, {}, time(7, 0), ae=ae)
-        assert "grace period" in result.lower()
+        assert "09:00 AM" in result
+        assert "grace period" not in result.lower()
 
-    def test_next_action_paused_by_door_preempts_schedule(self):
-        """Paused by an open door → surfaced before any scheduled window message."""
+    def test_next_action_paused_by_door_does_not_preempt_schedule(self):
+        """Paused by an open door → still shows real comfort guidance, not mechanism state (Issue #527).
+
+        The Status card is the only place "paused" belongs (_compute_automation_status()).
+        """
         c = _make_classification(
             day_type=DAY_TYPE_WARM,
             windows_recommended=True,
@@ -460,7 +491,8 @@ class TestComputeNextAction:
         )
         ae = _make_ae_stub(is_paused_by_door=True)
         result = _compute_next_action(c, {}, time(7, 0), ae=ae)
-        assert "paused" in result.lower()
+        assert "09:00 AM" in result
+        assert "paused" not in result.lower()
 
     def test_next_action_hot_no_opportunity_free_cooling_active(self):
         """HOT day, no scheduled opportunity, but nat-vent/economizer already active — don't contradict it."""
@@ -471,7 +503,7 @@ class TestComputeNextAction:
         )
         ae = _make_ae_stub(_economizer_active=True)
         result = _compute_next_action(c, {}, time(13, 0), ae=ae)
-        assert "both working on it" in result.lower()
+        assert "free cooling is active" in result.lower()
 
     def test_next_action_guest_occupancy_behaves_like_home(self):
         """GUEST occupancy mode is not short-circuited — full comfort logic applies same as HOME."""
@@ -491,19 +523,19 @@ class TestComputeNextAction:
         c = _make_classification(day_type=DAY_TYPE_MILD, windows_recommended=False)
         result = _compute_next_action(c, {"comfort_cool": 75}, time(14, 0), indoor_temp=78.0, outdoor_temp=70.0)
         assert "78" in result
-        assert "Automation active" not in result
+        assert "Comfortable" not in result
 
     def test_next_action_indoor_at_comfort_boundary_no_guidance(self):
         """Indoor temp exactly at comfort_cool boundary (not above) → no alert."""
         c = _make_classification(day_type=DAY_TYPE_MILD, windows_recommended=False)
         result = _compute_next_action(c, {"comfort_cool": 75}, time(14, 0), indoor_temp=75.0)
-        assert "Automation active" in result
+        assert "Comfortable" in result
 
     def test_next_action_indoor_none_falls_back_to_no_action(self):
         """When indoor_temp is None — no comfort alert, falls back to default."""
         c = _make_classification(day_type=DAY_TYPE_MILD, windows_recommended=False)
         result = _compute_next_action(c, {"comfort_cool": 75}, time(14, 0), indoor_temp=None)
-        assert "Automation active" in result
+        assert "Comfortable" in result
 
     def test_next_action_warm_day_midday_indoor_above_comfort(self):
         """WARM day mid-day with indoor above comfort, outdoor cooler — comfort guidance wins over 'no action'."""
@@ -515,7 +547,7 @@ class TestComputeNextAction:
         )
         result = _compute_next_action(c, {"comfort_cool": 75}, time(13, 0), indoor_temp=79.0, outdoor_temp=72.0)
         assert "79" in result
-        assert "Automation active" not in result
+        assert "Comfortable" not in result
 
     def test_next_action_hot_day_indoor_above_comfort_still_shows_ac_message(self):
         """HOT day: HOT branch always returns before indoor check — AC message wins."""
@@ -526,7 +558,6 @@ class TestComputeNextAction:
         )
         result = _compute_next_action(c, {"comfort_cool": 75}, time(14, 0), indoor_temp=80.0)
         assert "Keep windows and blinds closed" in result
-        assert "AC is handling it" in result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_occupancy.py
+++ b/tests/test_occupancy.py
@@ -592,20 +592,30 @@ class TestNextActionWithOccupancy:
     """Test _compute_next_action reflects occupancy mode."""
 
     def test_vacation_shows_vacation_message(self):
-        """When on vacation, next action mentions vacation."""
+        """When on vacation, next action is one of the curated vacation-flavor lines (Issue #527).
+
+        Pool membership (not a literal "vacation" substring) since the pool deliberately
+        mixes deadpan/playful lines that don't all repeat the mode name.
+        """
+        import importlib
+
+        mod = importlib.import_module("custom_components.climate_advisor.coordinator")
         coord = _make_coordinator()
         coord._occupancy_mode = OCCUPANCY_VACATION
         c = _make_classification()
         action = coord._compute_next_action(c)
-        assert "vacation" in action.lower()
+        assert action in mod._VACATION_ACTION_MESSAGES
 
     def test_away_shows_away_message(self):
-        """When away, next action mentions away."""
+        """When away, next action is one of the curated away-flavor lines (Issue #527)."""
+        import importlib
+
+        mod = importlib.import_module("custom_components.climate_advisor.coordinator")
         coord = _make_coordinator()
         coord._occupancy_mode = OCCUPANCY_AWAY
         c = _make_classification()
         action = coord._compute_next_action(c)
-        assert "away" in action.lower()
+        assert action in mod._AWAY_ACTION_MESSAGES
 
     def test_home_shows_normal_action(self):
         """When home, next action is the normal day-type action."""

--- a/tests/test_status_sensors.py
+++ b/tests/test_status_sensors.py
@@ -213,21 +213,26 @@ class TestComputeNextAutomationAction:
         assert action == "Waiting for classification..."
         assert t == ""
 
-    def test_paused_by_door_returns_waiting_message(self):
-        """When paused_by_door → returns paused message regardless of schedule."""
+    def test_paused_by_door_still_shows_real_next_step(self):
+        """When paused_by_door → still shows the real next scheduled step, not mechanism text (Issue #527).
+
+        The Status card is the only place "paused" belongs (_compute_automation_status()).
+        Next Automation answers "what's the plan," which holds regardless of the pause —
+        it's simply deferred until the pause clears.
+        """
         ae = _make_automation_engine(is_paused_by_door=True)
         c = _make_classification(hvac_mode="cool")
         action, t = _compute_next_automation_action(c, ae, {}, time(8, 0))
-        assert "paused" in action.lower()
-        assert "door" in action.lower()
+        assert "paused" not in action.lower()
+        assert "Bedtime" in action
 
-    def test_grace_period_active_returns_grace_message(self):
-        """When grace period active → returns grace message."""
+    def test_grace_period_active_still_shows_real_next_step(self):
+        """When grace period active → still shows the real next scheduled step, not mechanism text (Issue #527)."""
         ae = _make_automation_engine(grace_active=True, last_resume_source="manual")
         c = _make_classification(hvac_mode="cool")
         action, t = _compute_next_automation_action(c, ae, {}, time(8, 0))
-        assert "grace period" in action.lower()
-        assert "manual" in action.lower()
+        assert "grace period" not in action.lower()
+        assert "Bedtime" in action
 
     def test_before_briefing_time_returns_briefing_event(self):
         """Time before briefing_time → first event is 'Send daily briefing'."""


### PR DESCRIPTION
## Summary
- Status, Next User Action, and Next Automation independently narrated the same automation-mechanism fact (paused by door/window, grace period, override confirming) with three different wordings. Each card now answers only its own question — see the four-card ontology table added to `CLAUDE.md` and `docs/08-COMPUTATION-REFERENCE.md` §9e.
- `_compute_next_action()`: removed the mechanism-flag early-return block that was pre-empting its own real comfort guidance; trimmed redundant "AC/heater/automation is handling it" filler and an "Automation active —" lead-in; away/vacation now pick from a small date-seeded rotating pool instead of one flat sentence.
- `_compute_next_automation_action()`: removed the "Windows open as recommended" / "Waiting — HVAC paused" / "Grace period active" / "Evaluating door/window sensors" early returns so it always shows the real next scheduled step and time; added INFO-level entry/outcome logging (previously had none).
- `api.py`: wired `pause_suppressed_classification` + new `pause_suppressed_classification_text` into the actual Status API response — this field existed only in the Debug tab's `get_serializable_state()` and was documented as a known gap (`KNOWN_FIXES[367]`); the frontend's check of it was unreachable dead code until now.
- No HVAC/automation decision logic changed — display text and one API field only.
- Deferred to #528 (tracking issue): predictive threshold-crossing next-automation events (e.g. WHF/nat-vent forecast ETA).

## Test plan
- [x] `pytest tests/` — 3577 passed
- [x] `ruff check` / `ruff format` — clean
- [x] `python tools/simulate.py` — 74/74 golden scenarios pass
- [x] `pytest tests/test_version_sync.py` — version bump verified (0.5.34 → 0.5.35)