### PR TITLE
Fix #528: warm/mild-day briefing timing bug + predictive Next Automation events

### DIFF
--- a/custom_components/climate_advisor/briefing.py
+++ b/custom_components/climate_advisor/briefing.py
@@ -34,7 +34,7 @@ from .const import (
     FAN_MODE_DISABLED,
     OCCUPANCY_SETBACK_MINUTES,
 )
-from .temperature import FAHRENHEIT, format_temp, format_temp_delta
+from .temperature import FAHRENHEIT, find_temperature_crossing, format_temp, format_temp_delta
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -510,41 +510,38 @@ def _derive_warm_day_events(
     if not predicted_indoor or not predicted_outdoor:
         return result
 
-    # Build aligned (ts, indoor_temp, outdoor_temp) triples by matching timestamps
-    pairs = []
-    for i_entry, o_entry in zip(predicted_indoor, predicted_outdoor, strict=False):
-        i_temp = i_entry.get("temp")
-        o_temp = o_entry.get("temp")
-        ts_str = i_entry.get("ts")
-        if i_temp is None or o_temp is None or ts_str is None:
+    # Issue #528: each crossing is found via find_temperature_crossing(), which aligns
+    # the two curves by matching ISO timestamp — not list position — so a mismatch in
+    # how/when the two curves were built (different "now" filter boundaries, one cached
+    # from an earlier cycle vs. the other rebuilt fresh) can no longer silently shift
+    # the pairing the way the previous zip()-by-index implementation did. See
+    # docs/08-COMPUTATION-REFERENCE.md's warm-day-events note for the production
+    # incident this replaced.
+    result["any_nat_vent_window"] = (
+        find_temperature_crossing(predicted_indoor, predicted_outdoor, lambda _ts, o, i: o < i) is not None
+    )
+
+    result["nat_vent_cutoff"] = find_temperature_crossing(
+        predicted_indoor, predicted_outdoor, lambda _ts, o, i: _nat_vent_cutoff_reached(o, i)
+    )
+
+    # ceiling_breach_time only reads the indoor curve — no pairing needed.
+    for entry in predicted_indoor:
+        ts_str = entry.get("ts")
+        i_temp = entry.get("temp")
+        if ts_str is None or i_temp is None:
             continue
         try:
             ts = datetime.fromisoformat(ts_str)
         except (ValueError, TypeError):
             continue
-        pairs.append((ts, float(i_temp), float(o_temp)))
-
-    if not pairs:
-        return result
-
-    # Any nat-vent window (outdoor < indoor at any point)
-    result["any_nat_vent_window"] = any(o < i for _, i, o in pairs)
-
-    # nat_vent_cutoff: first entry where outdoor >= indoor - 1 F
-    for ts, i_temp, o_temp in pairs:
-        if _nat_vent_cutoff_reached(o_temp, i_temp):
-            result["nat_vent_cutoff"] = ts
-            break
-
-    # ceiling_breach_time: first entry where indoor > comfort_cool
-    for ts, i_temp, _o_temp in pairs:
-        if i_temp > comfort_cool:
+        if float(i_temp) > comfort_cool:
             result["ceiling_breach_time"] = ts
             break
 
     # precool_start_time = ceiling_breach_time - lead_time
     if result["ceiling_breach_time"] is not None:
-        t_in_now = pairs[0][1] if pairs else comfort_cool - 2.0
+        t_in_now = predicted_indoor[0].get("temp", comfort_cool - 2.0)
         if k_active_cool is not None and abs(k_active_cool) > 0:
             lead_min = ((comfort_cool - t_in_now) / abs(k_active_cool)) * 60 * 1.3
         else:
@@ -554,19 +551,18 @@ def _derive_warm_day_events(
 
     # nat_vent_recovers / recovery_time: outdoor drops back below indoor AFTER the cutoff
     if result["nat_vent_cutoff"] is not None:
-        cutoff_ts = result["nat_vent_cutoff"]
-        for ts, i_temp, o_temp in pairs:
-            if ts > cutoff_ts and o_temp < i_temp:
-                result["nat_vent_recovers"] = True
-                result["recovery_time"] = ts
-                break
+        result["recovery_time"] = find_temperature_crossing(
+            predicted_indoor, predicted_outdoor, lambda _ts, o, i: o < i, after=result["nat_vent_cutoff"]
+        )
+        result["nat_vent_recovers"] = result["recovery_time"] is not None
 
     _LOGGER.debug(
-        "WarmDayEvents: nat_vent_cutoff=%s, ceiling_breach=%s, precool_start=%s, recovers=%s",
+        "WarmDayEvents: nat_vent_cutoff=%s, ceiling_breach=%s, precool_start=%s, recovers=%s, recovery_time=%s",
         result["nat_vent_cutoff"],
         result["ceiling_breach_time"],
         result["precool_start_time"],
         result["nat_vent_recovers"],
+        result["recovery_time"],
     )
 
     return result

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,19 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.35"
+VERSION = "0.5.36"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.36": [
+        "Fix #528: on warm/mild days, the briefing's window-close and reopen times could"
+        " be badly wrong — one real example told the user to close windows at 8 AM"
+        " (outdoor was still cooler for hours after that) and reopen at 2 PM, before the"
+        " day's actual heat peak, both computed from a data-alignment bug that's now fixed."
+        " Feat #528: the Next Automation card can now predict the whole-house fan/nat-vent"
+        " starting (using the same real activation logic the automation itself uses), the"
+        " warm-day window-close/AC-on/reopen events, and hot-day morning/evening window-"
+        " cooling opportunities — previously only the daily briefing knew about any of this.",
+    ],
     "0.5.35": [
         "Fix #527: the dashboard's Status, Next User Action, and Next Automation cards could"
         " all say the same thing in different words whenever a door/window was open (or a"
@@ -1287,6 +1297,48 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    528: {
+        "version_fixed": "0.5.36",
+        "title": (
+            "Warm/mild-day briefing window-close and reopen times could be implausibly"
+            " wrong (e.g. reopen shown hours before the day's actual heat peak); Next"
+            " Automation card had no predictive events at all — only fixed-schedule ones"
+        ),
+        "scope_covered": (
+            "temperature.py: new find_temperature_crossing(indoor_curve, outdoor_curve,"
+            " comparator, after=None) — aligns two {ts,temp} forecast curves by matching"
+            " ISO timestamp (not list position) before evaluating comparator(ts, outdoor,"
+            " indoor); returns the first matching timestamp or None. briefing.py:"
+            " _derive_warm_day_events() nat_vent_cutoff/recovery_time (and transitively"
+            " any_nat_vent_window) now go through this function instead of a zip()-by-index"
+            " pairing that silently mispaired the two curves whenever they were built with"
+            " different 'now' filter boundaries or at different times (indoor cached from"
+            " the last 30-min cycle, outdoor rebuilt fresh per briefing) — confirmed live via"
+            " production logs and a git-blame trace to the original #518 commit (introduced"
+            " whole-cloth, never modified since — an original design gap, not a regression)."
+            " Added recovery_time to the existing WarmDayEvents debug log line (previously"
+            " the one field in that dict not logged). coordinator.py:"
+            " _compute_next_automation_action() gained three new candidate types: (1)"
+            " nat-vent/WHF start prediction via decide_nat_vent_gate()/NatVentGateInputs"
+            " (nat_vent_gate.py) — the real, already-production-validated activation gate,"
+            " not compute_nat_vent_cycling_band() (that function describes the fan's cycling"
+            " band once already active, a materially different formula with no ceiling-"
+            " margin/fan-mode awareness) — gated on a door/window already open or grace,"
+            " matching check_natural_vent_conditions()'s own precondition; (2) the same"
+            " WARM/MILD warm-day events above, surfaced as 'Close windows'/'AC turns on'/"
+            "'Reopen windows' candidates; (3) HOT-day window_opportunity_morning/evening"
+            " (classifier.py, already-computed static fields) surfaced as fixed-schedule"
+            " candidates for the first time. docs/08-COMPUTATION-REFERENCE.md: §7 WARM row"
+            " now discloses the same ODE-override caveat the MILD row already had; new §9f."
+        ),
+        "scope_not_covered": (
+            "No sanity/plausibility bound was added inside find_temperature_crossing() or"
+            " _derive_warm_day_events() itself — a genuinely malformed forecast curve could"
+            " still produce an implausible crossing; the fix addresses the confirmed root"
+            " cause (index-based pairing) rather than adding a second, independent"
+            " correctness check on top of it."
+        ),
+    },
     527: {
         "version_fixed": "0.5.35",
         "title": (

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -43,7 +43,7 @@ from .automation import (
     compute_pre_cool_target,
     select_comfort_band,
 )
-from .briefing import generate_briefing
+from .briefing import _derive_warm_day_events, generate_briefing
 from .chart_log import ChartStateLog
 from .classifier import DayClassification, ForecastSnapshot, classify_day
 from .const import (
@@ -95,6 +95,7 @@ from .const import (
     CONF_HOME_TOGGLE_INVERT,
     CONF_MANUAL_GRACE_PERIOD,
     CONF_NAT_VENT_HYSTERESIS_F,
+    CONF_NATURAL_VENT_DELTA,
     CONF_SENSOR_DEBOUNCE,
     CONF_SENSOR_POLARITY_INVERTED,
     CONF_SLEEP_HEAT,
@@ -226,8 +227,16 @@ from .const import (
 )
 from .fan_status import is_ca_fan_running, parse_remote_speed_event, parse_remote_timer_event
 from .learning import DailyRecord, LearningEngine, compute_k_passive_blocks
+from .nat_vent_gate import NatVentGateInputs, decide_nat_vent_gate
 from .state import StatePersistence
-from .temperature import convert_delta, format_temp, free_cooling_direction_ok, from_fahrenheit, to_fahrenheit
+from .temperature import (
+    convert_delta,
+    find_temperature_crossing,
+    format_temp,
+    free_cooling_direction_ok,
+    from_fahrenheit,
+    to_fahrenheit,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -6903,6 +6912,97 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             unit = self.config.get("temp_unit", "fahrenheit")
             pc_desc = f"Pre-cool ceiling ({format_temp(self._pre_cool_target, unit)})"
             candidates.append((self._pre_cool_trigger_dt, pc_desc))
+
+        # HOT-day window-cooling opportunities (Issue #528) — static, classifier-computed
+        # hours, no forecast-scan needed. Wording deliberately avoids implying the
+        # automation opens the window itself — these are forecasted conditions the
+        # occupant can act on, not an automation-executed setpoint change.
+        if c.window_opportunity_morning and c.window_opportunity_morning_start:
+            mo_dt = _to_dt(c.window_opportunity_morning_start)
+            if mo_dt > now:
+                candidates.append((mo_dt, "Morning window cooling opportunity"))
+
+        if c.window_opportunity_evening and c.window_opportunity_evening_start:
+            ev_dt = _to_dt(c.window_opportunity_evening_start)
+            if ev_dt > now:
+                candidates.append((ev_dt, "Evening window cooling opportunity"))
+
+        # Issue #528: self._last_predicted_indoor is always set in __init__() in
+        # production, but several test files build a coordinator via object.__new__()
+        # without running __init__() — getattr() keeps those minimal stubs working
+        # rather than requiring every one of them to know about this new attribute.
+        _predicted_indoor = getattr(self, "_last_predicted_indoor", None)
+
+        # WARM/MILD-day forecast-derived events (Issue #528) — the same nat_vent_cutoff/
+        # ceiling_breach_time/precool_start_time/recovery_time already computed for the
+        # briefing (now timestamp-correct, see _derive_warm_day_events()), surfaced here
+        # for the first time so the dashboard doesn't have to wait for the next briefing
+        # to show them.
+        if c.windows_recommended and _predicted_indoor:
+            _outdoor_curve = _build_future_forecast_outdoor(self._hourly_forecast_temps, c)
+            _warm_events = _derive_warm_day_events(
+                predicted_indoor=_predicted_indoor,
+                predicted_outdoor=_outdoor_curve,
+                comfort_cool=float(self.config.get("comfort_cool", DEFAULT_COMFORT_COOL)),
+            )
+            if _warm_events["nat_vent_cutoff"] and _warm_events["nat_vent_cutoff"] > now:
+                candidates.append((_warm_events["nat_vent_cutoff"], "Close windows — outdoor no longer helping"))
+            if _warm_events["ceiling_breach_time"] and _warm_events["ceiling_breach_time"] > now:
+                candidates.append((_warm_events["ceiling_breach_time"], "AC turns on to hold the ceiling"))
+            if _warm_events["recovery_time"] and _warm_events["recovery_time"] > now:
+                candidates.append((_warm_events["recovery_time"], "Reopen windows — outdoor helping again"))
+
+        # Nat-vent/WHF start prediction (Issue #528). Uses the real activation gate
+        # (decide_nat_vent_gate(), the same pure function automation.py's
+        # check_natural_vent_conditions() calls) — not compute_nat_vent_cycling_band(),
+        # which describes the fan's cycling band once ALREADY active, a different
+        # threshold entirely (see docs/08-COMPUTATION-REFERENCE.md's #528 note).
+        # Gated on a door/window already being open (or grace), mirroring
+        # check_natural_vent_conditions()'s own precondition — nat-vent cannot start
+        # with everything closed, so this never promises a time that depends on the
+        # occupant opening a window first.
+        if (
+            self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED) != FAN_MODE_DISABLED
+            and not ae._natural_vent_active
+            and (ae.is_paused_by_door or self._any_sensor_open())
+            and _predicted_indoor
+        ):
+            _comfort_heat_raw = float(self.config.get("comfort_heat", DEFAULT_COMFORT_HEAT))
+            # "sleep_heat" literal, not the CONF_SLEEP_HEAT constant: the bedtime block
+            # above does a local `from .const import ... CONF_SLEEP_HEAT` inside an
+            # `if c.hvac_mode in ("heat", "cool")` branch, which makes CONF_SLEEP_HEAT a
+            # local name for this ENTIRE function regardless of whether that branch
+            # actually runs — referencing the module-level import here raises
+            # UnboundLocalError whenever hvac_mode is "off"/"auto". Same value either way.
+            _sleep_heat = float(self.config.get("sleep_heat", _comfort_heat_raw))
+            _comfort_cool = float(self.config.get("comfort_cool", DEFAULT_COMFORT_COOL))
+            _nat_vent_delta = float(self.config.get(CONF_NATURAL_VENT_DELTA, DEFAULT_NATURAL_VENT_DELTA))
+            _hysteresis = float(self.config.get(CONF_NAT_VENT_HYSTERESIS_F, NAT_VENT_HYSTERESIS_F))
+            _fan_mode_val = self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED)
+            _aggressive_savings = bool(self.config.get("aggressive_savings", False))
+
+            def _nat_vent_gate_comparator(ts: datetime, outdoor: float, indoor: float) -> bool:
+                return decide_nat_vent_gate(
+                    NatVentGateInputs(
+                        outdoor=outdoor,
+                        indoor=indoor,
+                        comfort_heat_raw=_comfort_heat_raw,
+                        sleep_heat=_sleep_heat,
+                        in_sleep_window=_in_sleep_window(ts, self.config),
+                        comfort_cool=_comfort_cool,
+                        nat_vent_delta=_nat_vent_delta,
+                        hysteresis=_hysteresis,
+                        fan_mode=_fan_mode_val,
+                        aggressive_savings=_aggressive_savings,
+                    )
+                )
+
+            _nat_vent_outdoor_curve = _build_future_forecast_outdoor(self._hourly_forecast_temps, c)
+            _nat_vent_dt = find_temperature_crossing(
+                _predicted_indoor, _nat_vent_outdoor_curve, _nat_vent_gate_comparator, after=now
+            )
+            if _nat_vent_dt:
+                candidates.append((_nat_vent_dt, "Natural ventilation"))
 
         if not candidates:
             _LOGGER.info("Next-automation: No more actions today")

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.35"
+  "version": "0.5.36"
 }

--- a/custom_components/climate_advisor/temperature.py
+++ b/custom_components/climate_advisor/temperature.py
@@ -6,6 +6,9 @@ This module provides the only conversion boundary used throughout the integratio
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from datetime import datetime
+
 FAHRENHEIT = "fahrenheit"
 CELSIUS = "celsius"
 
@@ -75,6 +78,65 @@ def free_cooling_direction_ok(outdoor_temp: float | None, indoor_temp: float | N
     Unknown readings default to True (caller decides whether to act on an unknown).
     """
     return indoor_temp is None or outdoor_temp is None or outdoor_temp < indoor_temp
+
+
+def find_temperature_crossing(
+    indoor_curve: list[dict] | None,
+    outdoor_curve: list[dict] | None,
+    comparator: Callable[[datetime, float, float], bool],
+    after: datetime | None = None,
+) -> datetime | None:
+    """Find the first timestamp where comparator(ts, outdoor_temp, indoor_temp) is True.
+
+    Each curve is a list of {"ts": ISO-8601 string, "temp": float} entries (the shape
+    both _build_predicted_indoor_future() and _build_future_forecast_outdoor() in
+    coordinator.py already produce). Aligns the two curves by matching ISO timestamps
+    — not list position — so an hour present in only one curve is skipped rather than
+    silently mismatched against a neighboring hour from the other curve. Curves may
+    differ in length, start time, or filtering boundary; alignment is by timestamp
+    value only (Issue #528 — replaces the zip()-by-index pairing that produced
+    implausible warm-day window-close/reopen times whenever the two curves drifted).
+
+    `ts` is passed to the comparator, not just the two temperatures, because some
+    crossing conditions depend on time-of-day (e.g. a sleep-window-aware gate) and
+    not on temperature alone.
+
+    `after`, if given, restricts the scan to timestamps strictly after it — lets a
+    "first crossing following an earlier crossing" scan reuse this same function.
+
+    Returns None if either curve is empty/None or no crossing is found.
+    """
+    if not indoor_curve or not outdoor_curve:
+        return None
+
+    outdoor_by_ts: dict[datetime, float] = {}
+    for entry in outdoor_curve:
+        ts_str = entry.get("ts")
+        temp = entry.get("temp")
+        if ts_str is None or temp is None:
+            continue
+        try:
+            outdoor_by_ts[datetime.fromisoformat(ts_str)] = float(temp)
+        except (ValueError, TypeError):
+            continue
+
+    for entry in indoor_curve:
+        ts_str = entry.get("ts")
+        indoor_temp = entry.get("temp")
+        if ts_str is None or indoor_temp is None:
+            continue
+        try:
+            ts = datetime.fromisoformat(ts_str)
+        except (ValueError, TypeError):
+            continue
+        if after is not None and ts <= after:
+            continue
+        outdoor_temp = outdoor_by_ts.get(ts)
+        if outdoor_temp is None:
+            continue
+        if comparator(ts, outdoor_temp, float(indoor_temp)):
+            return ts
+    return None
 
 
 def convert_delta(value_fahrenheit: float, unit: str) -> float:

--- a/docs/08-COMPUTATION-REFERENCE.md
+++ b/docs/08-COMPUTATION-REFERENCE.md
@@ -1130,12 +1130,12 @@ Window advice is set by the classifier at classification time, based on `day_typ
 |---|---|---|---|---|
 | `hot` | Not a traditional recommendation — window *opportunities* only | 6:00 AM | 9:00 AM | Morning opportunity: `today_low <= 80` |
 | `hot` | Evening opportunity | 5:00 PM | Midnight (00:00) | Evening opportunity: `tomorrow_low <= 80` |
-| `warm` | Yes (if condition met) | 6:00 AM | 10:00 AM | `today_low <= comfort_cool - ECONOMIZER_TEMP_DELTA` = `today_low <= 72°F` (defaults) |
+| `warm` | Yes (if condition met) | 6:00 AM | 10:00 AM (`WARM_WINDOW_CLOSE_HOUR`) or `nat_vent_cutoff` when ODE available | `today_low <= comfort_cool - ECONOMIZER_TEMP_DELTA` = `today_low <= 72°F` (defaults) |
 | `mild` | Always yes | 10:00 AM (`MILD_WINDOW_OPEN_HOUR`) | 5:00 PM (`MILD_WINDOW_CLOSE_HOUR`) or `nat_vent_cutoff` when ODE available | No condition — always recommended |
 | `cool` | No | — | — | — |
 | `cold` | No | — | — | — |
 
-**Warm-day window condition formula:** `today_low <= DEFAULT_COMFORT_COOL - ECONOMIZER_TEMP_DELTA` = `75 - 3 = 72°F` at defaults. Constant: `WARM_WINDOW_OPEN_HOUR = 6`, `WARM_WINDOW_CLOSE_HOUR = 10`.
+**Warm-day window condition formula:** `today_low <= DEFAULT_COMFORT_COOL - ECONOMIZER_TEMP_DELTA` = `75 - 3 = 72°F` at defaults. Constant: `WARM_WINDOW_OPEN_HOUR = 6`, `WARM_WINDOW_CLOSE_HOUR = 10`. **Like MILD (below), the static `WARM_WINDOW_CLOSE_HOUR` is only a fallback** — `briefing.py`'s `_derive_warm_day_events()` (§9e, Issue #528) overrides it with the ODE-derived `nat_vent_cutoff` whenever a forecast curve is available, exactly the same cascade §6d documents for MILD days. This table previously omitted that caveat for WARM specifically, which read as a contradiction between a correct-but-dynamic production briefing and this static reference.
 
 **MILD-day window times (v0.3.46+):** Open time is always `MILD_WINDOW_OPEN_HOUR = 10` (10:00 AM). Close time uses `nat_vent_cutoff` when the ODE is calibrated, otherwise falls back to `MILD_WINDOW_CLOSE_HOUR = 17` (5:00 PM). See [§6d. MILD Day Dynamic Window Close Time](#6d-mild-day-dynamic-window-close-time-fix-c-issue-147).
 
@@ -1814,6 +1814,69 @@ unreachable dead code (identical shape to the `nat_vent_active` gap fixed in the
 renamed `test_next_action_*_does_not_preempt_schedule`, asserting the real guidance now surfaces
 and the mechanism word does NOT appear), `tests/test_status_sensors.py::TestComputeNextAutomationAction`
 (`test_paused_by_door_still_shows_real_next_step`, `test_grace_period_active_still_shows_real_next_step`).
+
+### 9f. Timestamp-Correct Forecast-Curve Crossing Scan, and Predictive Next Automation Candidates (Issue #528)
+
+**Bug:** `briefing.py`'s `_derive_warm_day_events()` — the function that derives WARM/MILD-day
+window-close and reopen times shown in the daily briefing (§7) — paired the predicted-indoor and
+predicted-outdoor forecast curves by **list index** (`zip(predicted_indoor, predicted_outdoor)`)
+rather than by matching ISO timestamp. The two curves are built with different "now" filter
+operators and, in production, at different times (indoor is cached from the last 30-min coordinator
+cycle; outdoor is rebuilt fresh on every briefing send) — any drift between the two silently shifted
+the pairing without either timestamp ever being cross-checked. This shipped whole-cloth with Issue
+#518 (which fixed the two briefing surfaces *agreeing* with each other, not the derived values
+themselves being correct) and had zero test coverage, since every existing test built both curves
+starting at the same hour with the same length — i.e., perfectly aligned by construction. Live
+production logs confirmed a real occurrence: a Warm 79°F day's briefing said "Close up at 8:00 AM"
+and "Reopen windows around 2:00 PM," neither plausible relative to the same computation's own
+5:30 PM `ceiling_breach_time`.
+
+**Fix:** `find_temperature_crossing(indoor_curve, outdoor_curve, comparator, after=None)` in
+`temperature.py` — aligns the two curves by building a `{ts: temp}` lookup from one and walking the
+other, so an hour present in only one curve is skipped rather than mismatched against a neighboring
+hour from the other. `comparator(ts, outdoor_temp, indoor_temp)` receives the timestamp (not just
+the two temperatures) so time-of-day-aware conditions (e.g. a sleep-window-gated threshold) can be
+expressed without a second scanning loop. `_derive_warm_day_events()`'s `nat_vent_cutoff` and
+`recovery_time` (and, transitively, `any_nat_vent_window`) now go through this function instead of
+the manual zip; `ceiling_breach_time` was never pairing-dependent (indoor-only) and is unchanged.
+`recovery_time` was also added to the function's `_LOGGER.debug("WarmDayEvents: ...")` line — it was
+the one field in that dict not logged, which is why this took live-log correlation across the other
+three fields to catch instead of a direct log grep.
+
+**Feature, built on the same primitive:** `_compute_next_automation_action()` gained three new
+candidate types, none of which existed before this issue:
+- **Nat-vent/WHF start prediction** — scans `self._last_predicted_indoor` against a freshly-built
+  outdoor forecast curve (`_build_future_forecast_outdoor()`) using `decide_nat_vent_gate()` from
+  `nat_vent_gate.py` as the comparator — the same pure, already-production-validated activation gate
+  `automation.py`'s `check_natural_vent_conditions()` calls (differentially tested against
+  `_nat_vent_may_reactivate()`). **Not** `compute_nat_vent_cycling_band()` — that function
+  describes the fan's on/off cycling midpoint *while a session is already active* (its own docstring
+  says so explicitly, and `nat_vent_temperature_check()` early-returns when inactive) — a materially
+  different formula (no ceiling-margin/fan-mode/aggressive-savings awareness) that would have
+  silently repeated this section's own bug class had it been used as the activation threshold. Gated
+  on `ae.is_paused_by_door or self._any_sensor_open()`, mirroring `check_natural_vent_conditions()`'s
+  own precondition — nat-vent cannot start with everything closed, so the candidate never promises a
+  time contingent on the occupant opening a window first.
+- **WARM/MILD warm-day-event candidates** — the same `nat_vent_cutoff`/`ceiling_breach_time`/
+  `recovery_time` computed above (now timestamp-correct) are surfaced as "Close windows — outdoor no
+  longer helping" / "AC turns on to hold the ceiling" / "Reopen windows — outdoor helping again," gated
+  on `c.windows_recommended` and a forecast curve being available. Previously computed only for the
+  briefing; now also visible on the dashboard ahead of the next briefing send.
+- **HOT-day window-cooling opportunities** — `classifier.py`'s existing static
+  `window_opportunity_morning`/`_evening` fields (already computed, previously only used for the
+  Next User Action card) surfaced as "Morning/Evening window cooling opportunity" candidates —
+  fixed-hour, no forecast scan needed, same pattern as the pre-existing briefing/wake/bedtime
+  candidates. Deliberately worded to avoid implying the automation opens the window itself — these
+  are forecasted conditions the occupant can act on, not an automation-executed setpoint change,
+  unlike every other candidate in this function.
+
+**Test coverage:** `tests/test_temperature.py::TestFindTemperatureCrossing` (alignment, `after`
+boundary, comparator receiving `ts`); `tests/test_briefing.py::TestDeriveWarmDayEvents`
+(`test_misaligned_curves_pair_by_timestamp_not_index`, `test_misaligned_curves_recovery_time_after_true_cutoff`
+— both fail against the pre-fix zip-based implementation, confirmed by reverting locally before
+merge); `tests/test_status_sensors.py::TestHotDayWindowOpportunityCandidates`,
+`TestNatVentStartCandidate` (including `test_uses_real_gate_ceiling_margin_not_naive_midpoint`,
+proving the real gate's formula is used, not the cycling-band midpoint), `TestWarmDayForecastEventCandidates`.
 
 ---
 

--- a/tests/test_briefing.py
+++ b/tests/test_briefing.py
@@ -1532,6 +1532,48 @@ class TestDeriveWarmDayEvents:
         # fallback = 120 min -> precool = breach - 2h
         assert abs((breach - precool).total_seconds() - 7200) < 60  # within 1 min
 
+    def test_misaligned_curves_pair_by_timestamp_not_index(self):
+        """Issue #528 regression: indoor/outdoor curves that start at different hours
+        (the real production shape — indoor cached from an earlier cycle, outdoor
+        rebuilt fresh) must be paired by matching ISO timestamp, not list position.
+
+        Indoor covers hours 8-11 UTC; outdoor covers hours 10-13 UTC (only 10 and 11
+        overlap). The old zip()-by-index implementation would pair indoor[0] (hour 8,
+        72F) against outdoor[0] (hour 10, 73F) — two hours apart — and (wrongly)
+        report a cutoff at hour 8, since 73 >= 72-1. The timestamp-correct
+        implementation has no outdoor entry for hour 8 at all, so it must skip
+        straight to the real overlap and report the cutoff at hour 10, where
+        outdoor(73) >= indoor(74)-1=73.
+        """
+        indoor = _make_indoor_curve([72.0, 73.0, 74.0, 75.0], start_hour_utc=8)
+        outdoor = _make_outdoor_curve([73.0, 76.0, 78.0, 80.0], start_hour_utc=10)
+        events = _derive_warm_day_events(
+            predicted_indoor=indoor,
+            predicted_outdoor=outdoor,
+            comfort_cool=100.0,  # keep ceiling_breach out of the way for this test
+        )
+        assert events["nat_vent_cutoff"] is not None
+        assert events["nat_vent_cutoff"].hour == 10
+        # The old buggy behavior would have reported hour 8 here.
+        assert events["nat_vent_cutoff"].hour != 8
+
+    def test_misaligned_curves_recovery_time_after_true_cutoff(self):
+        """Same misalignment shape, extended to prove recovery_time also uses the
+        timestamp-correct cutoff as its `after` boundary, not an index-drifted one."""
+        indoor = _make_indoor_curve([72.0, 73.0, 74.0, 75.0, 74.0, 70.0], start_hour_utc=8)
+        outdoor = _make_outdoor_curve([73.0, 76.0, 71.0, 68.0], start_hour_utc=10)
+        events = _derive_warm_day_events(
+            predicted_indoor=indoor,
+            predicted_outdoor=outdoor,
+            comfort_cool=100.0,
+        )
+        assert events["nat_vent_cutoff"] is not None
+        assert events["nat_vent_cutoff"].hour == 10
+        assert events["nat_vent_recovers"] is True
+        assert events["recovery_time"] is not None
+        assert events["recovery_time"] > events["nat_vent_cutoff"]
+        assert events["recovery_time"].hour == 12
+
 
 class TestWarmDayBriefWithPrediction:
     """Enriched warm-day brief includes action/consequence language."""

--- a/tests/test_status_sensors.py
+++ b/tests/test_status_sensors.py
@@ -9,7 +9,7 @@ Tests for:
 from __future__ import annotations
 
 import sys
-from datetime import date, time
+from datetime import date, datetime, time, timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -334,6 +334,192 @@ class TestComputeNextAutomationAction:
         }
         action, t = _compute_next_automation_action(c, ae, config, time(20, 0))
         assert action == "Bedtime check"
+
+
+# ---------------------------------------------------------------------------
+# Tests: Issue #528 forecast-derived Next Automation candidates
+# ---------------------------------------------------------------------------
+
+
+def _curve(temps: list[float], start_hour: int, ts_key: str = "ts", temp_key: str = "temp") -> list[dict]:
+    """Build a naive-datetime curve matching the (ts_key, temp_key) shape a given
+    consumer expects — {"ts","temp"} for predicted-indoor curves, {"datetime","temperature"}
+    for raw self._hourly_forecast_temps entries."""
+    base = datetime(2026, 7, 10, start_hour, 0, 0)
+    return [{ts_key: (base + timedelta(hours=i)).isoformat(), temp_key: t} for i, t in enumerate(temps)]
+
+
+def _compute_next_automation_action_with_forecast(
+    c,
+    automation_engine,
+    config: dict,
+    now_time: time,
+    predicted_indoor: list[dict] | None,
+    hourly_forecast_temps: list[dict] | None,
+):
+    """Like _compute_next_automation_action(), but also wires forecast-curve state
+    (self._last_predicted_indoor / self._hourly_forecast_temps) needed by the
+    Issue #528 candidates — not part of the base wrapper since most existing tests
+    don't need it."""
+    from custom_components.climate_advisor import coordinator as _coord_mod
+
+    coord = _make_real_coordinator(True, automation_engine)
+    coord.config = config
+    coord._last_predicted_indoor = predicted_indoor
+    coord._hourly_forecast_temps = hourly_forecast_temps or []
+
+    now_dt = datetime.combine(date(2026, 7, 10), now_time)
+    with (
+        patch.object(_coord_mod.dt_util, "now", return_value=now_dt),
+        patch.object(_coord_mod.dt_util, "as_local", side_effect=lambda x: x),
+    ):
+        return coord._compute_next_automation_action(c)
+
+
+class TestHotDayWindowOpportunityCandidates:
+    """HOT-day window-cooling opportunity candidates (Issue #528)."""
+
+    def test_morning_opportunity_present_before_start(self):
+        ae = _make_automation_engine()
+        c = _make_classification(
+            day_type="hot",
+            window_opportunity_morning=True,
+            window_opportunity_morning_start=time(6, 0),
+        )
+        # briefing_time defaults to 06:00:00 too — push it out of the way so this test
+        # isolates the window-opportunity candidate instead of a same-time tiebreak.
+        action, t = _compute_next_automation_action(c, ae, {"briefing_time": "23:00:00"}, time(5, 0))
+        assert action == "Morning window cooling opportunity"
+        assert t == "6:00 AM"
+
+    def test_morning_opportunity_absent_once_past(self):
+        ae = _make_automation_engine()
+        c = _make_classification(
+            day_type="hot",
+            window_opportunity_morning=True,
+            window_opportunity_morning_start=time(6, 0),
+        )
+        action, _t = _compute_next_automation_action(c, ae, {}, time(7, 0))
+        assert action != "Morning window cooling opportunity"
+
+    def test_morning_opportunity_absent_when_flag_false(self):
+        ae = _make_automation_engine()
+        c = _make_classification(day_type="hot", window_opportunity_morning=False)
+        action, _t = _compute_next_automation_action(c, ae, {}, time(5, 0))
+        assert action != "Morning window cooling opportunity"
+
+    def test_evening_opportunity_present_before_start(self):
+        ae = _make_automation_engine()
+        c = _make_classification(
+            day_type="hot",
+            window_opportunity_evening=True,
+            window_opportunity_evening_start=time(17, 0),
+        )
+        action, t = _compute_next_automation_action(c, ae, {}, time(16, 0))
+        assert action == "Evening window cooling opportunity"
+        assert t == "5:00 PM"
+
+
+class TestNatVentStartCandidate:
+    """Nat-vent/WHF start prediction candidate (Issue #528)."""
+
+    def test_predicted_when_gate_crosses_and_window_open(self):
+        """Uses the real decide_nat_vent_gate() semantics, not the cycling-band formula."""
+        ae = _make_automation_engine(is_paused_by_door=True)
+        ae._natural_vent_active = False
+        c = _make_classification(day_type="warm", hvac_mode="off")
+        config = {"fan_mode": "whole_house_fan"}
+        indoor = _curve([80.0, 80.0, 80.0, 80.0], start_hour=13)
+        outdoor = _curve([85.0, 82.0, 70.0, 65.0], start_hour=13, ts_key="datetime", temp_key="temperature")
+        action, t = _compute_next_automation_action_with_forecast(c, ae, config, time(12, 0), indoor, outdoor)
+        assert action == "Natural ventilation"
+        assert t == "3:00 PM"  # hour 15: outdoor 70 < indoor 80 - 1 = 79, indoor > comfort_heat, outdoor < 77
+
+    def test_absent_when_nothing_open(self):
+        """Nat-vent cannot start with everything closed — no candidate, even if the
+        temperature gate alone would pass."""
+        ae = _make_automation_engine(is_paused_by_door=False)
+        ae._natural_vent_active = False
+        c = _make_classification(day_type="warm", hvac_mode="off")
+        config = {"fan_mode": "whole_house_fan"}
+        indoor = _curve([80.0, 80.0, 80.0, 80.0], start_hour=13)
+        outdoor = _curve([85.0, 82.0, 70.0, 65.0], start_hour=13, ts_key="datetime", temp_key="temperature")
+        action, _t = _compute_next_automation_action_with_forecast(c, ae, config, time(12, 0), indoor, outdoor)
+        assert action != "Natural ventilation"
+
+    def test_absent_when_fan_disabled(self):
+        ae = _make_automation_engine(is_paused_by_door=True)
+        ae._natural_vent_active = False
+        c = _make_classification(day_type="warm", hvac_mode="off")
+        config = {"fan_mode": "disabled"}
+        indoor = _curve([80.0, 80.0, 80.0, 80.0], start_hour=13)
+        outdoor = _curve([85.0, 82.0, 70.0, 65.0], start_hour=13, ts_key="datetime", temp_key="temperature")
+        action, _t = _compute_next_automation_action_with_forecast(c, ae, config, time(12, 0), indoor, outdoor)
+        assert action != "Natural ventilation"
+
+    def test_uses_real_gate_ceiling_margin_not_naive_midpoint(self):
+        """Proves the candidate is sourced from decide_nat_vent_gate() — which has a
+        fan-mode/aggressive-savings-aware ceiling check — not the cycling-band midpoint
+        formula, which has no such concept at all. With fan_mode=hvac_fan and
+        aggressive_savings=True, the real gate's ceiling_threshold is comfort_cool(74) + 2 = 76;
+        indoor held at 80 (above that ceiling) must block the candidate even though the
+        temperature-only condition (outdoor dropping well below indoor) is satisfied —
+        a naive midpoint-only formula would have no ceiling check to block on.
+        """
+        ae = _make_automation_engine(is_paused_by_door=True)
+        ae._natural_vent_active = False
+        c = _make_classification(day_type="warm", hvac_mode="off")
+        config = {"fan_mode": "hvac_fan", "aggressive_savings": True}
+        indoor = _curve([80.0, 80.0, 80.0, 80.0], start_hour=13)
+        outdoor = _curve([85.0, 82.0, 70.0, 65.0], start_hour=13, ts_key="datetime", temp_key="temperature")
+        action, _t = _compute_next_automation_action_with_forecast(c, ae, config, time(12, 0), indoor, outdoor)
+        assert action != "Natural ventilation"
+
+    def test_absent_when_already_active(self):
+        ae = _make_automation_engine(is_paused_by_door=True)
+        ae._natural_vent_active = True
+        c = _make_classification(day_type="warm", hvac_mode="off")
+        config = {"fan_mode": "whole_house_fan"}
+        indoor = _curve([80.0, 80.0, 80.0, 80.0], start_hour=13)
+        outdoor = _curve([85.0, 82.0, 70.0, 65.0], start_hour=13, ts_key="datetime", temp_key="temperature")
+        action, _t = _compute_next_automation_action_with_forecast(c, ae, config, time(12, 0), indoor, outdoor)
+        assert action != "Natural ventilation"
+
+
+class TestWarmDayForecastEventCandidates:
+    """WARM/MILD-day forecast-derived events surfaced as Next Automation candidates (Issue #528)."""
+
+    def test_ceiling_breach_candidate_present(self):
+        ae = _make_automation_engine()
+        ae._natural_vent_active = False
+        c = _make_classification(day_type="warm", hvac_mode="off", windows_recommended=True)
+        config = {"comfort_cool": 75.0}
+        indoor = _curve([70.0, 72.0, 76.0, 78.0], start_hour=13)
+        outdoor = _curve([65.0, 66.0, 67.0, 68.0], start_hour=13, ts_key="datetime", temp_key="temperature")
+        action, t = _compute_next_automation_action_with_forecast(c, ae, config, time(12, 0), indoor, outdoor)
+        assert action == "AC turns on to hold the ceiling"
+        assert t == "3:00 PM"  # hour 15: indoor 76 > comfort_cool 75
+
+    def test_close_windows_candidate_present(self):
+        ae = _make_automation_engine()
+        ae._natural_vent_active = False
+        c = _make_classification(day_type="warm", hvac_mode="off", windows_recommended=True)
+        config = {"comfort_cool": 100.0}  # keep ceiling breach out of the way
+        indoor = _curve([70.0, 71.0, 72.0, 73.0], start_hour=13)
+        outdoor = _curve([60.0, 62.0, 71.5, 74.0], start_hour=13, ts_key="datetime", temp_key="temperature")
+        action, t = _compute_next_automation_action_with_forecast(c, ae, config, time(12, 0), indoor, outdoor)
+        assert action == "Close windows — outdoor no longer helping"
+        assert t == "3:00 PM"  # hour 15: outdoor 71.5 >= indoor 72 - 1
+
+    def test_absent_when_windows_not_recommended(self):
+        ae = _make_automation_engine()
+        ae._natural_vent_active = False
+        c = _make_classification(day_type="mild", hvac_mode="off", windows_recommended=False)
+        config = {"comfort_cool": 75.0}
+        indoor = _curve([70.0, 72.0, 76.0, 78.0], start_hour=13)
+        outdoor = _curve([65.0, 66.0, 67.0, 68.0], start_hour=13, ts_key="datetime", temp_key="temperature")
+        action, _t = _compute_next_automation_action_with_forecast(c, ae, config, time(12, 0), indoor, outdoor)
+        assert action != "AC turns on to hold the ceiling"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_temperature.py
+++ b/tests/test_temperature.py
@@ -2,18 +2,26 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
+
 import pytest
 
 from custom_components.climate_advisor.temperature import (
     CELSIUS,
     FAHRENHEIT,
     UNIT_SYMBOL,
+    find_temperature_crossing,
     format_temp,
     format_temp_delta,
     free_cooling_direction_ok,
     from_fahrenheit,
     to_fahrenheit,
 )
+
+
+def _curve(temps: list[float], start_hour: int = 8) -> list[dict]:
+    base = datetime(2026, 7, 27, start_hour, 0, 0, tzinfo=UTC)
+    return [{"ts": (base + timedelta(hours=i)).isoformat(), "temp": t} for i, t in enumerate(temps)]
 
 
 class TestToFahrenheit:
@@ -185,3 +193,56 @@ class TestFreeCoolingDirectionOk:
 
     def test_indoor_none_defaults_to_ok(self):
         assert free_cooling_direction_ok(outdoor_temp=70.0, indoor_temp=None) is True
+
+
+class TestFindTemperatureCrossing:
+    """Tests for find_temperature_crossing() (Issue #528)."""
+
+    def test_finds_first_crossing_on_aligned_curves(self):
+        indoor = _curve([72.0, 73.0, 74.0, 75.0], start_hour=8)
+        outdoor = _curve([65.0, 68.0, 73.0, 76.0], start_hour=8)
+        result = find_temperature_crossing(indoor, outdoor, lambda _ts, o, i: o >= i - 1.0)
+        assert result is not None
+        assert result.hour == 10
+
+    def test_returns_none_when_no_crossing(self):
+        indoor = _curve([72.0, 73.0, 74.0], start_hour=8)
+        outdoor = _curve([50.0, 51.0, 52.0], start_hour=8)
+        assert find_temperature_crossing(indoor, outdoor, lambda _ts, o, i: o >= i) is None
+
+    def test_returns_none_for_empty_or_none_curves(self):
+        curve = _curve([72.0], start_hour=8)
+        assert find_temperature_crossing(None, curve, lambda _ts, o, i: True) is None
+        assert find_temperature_crossing(curve, None, lambda _ts, o, i: True) is None
+        assert find_temperature_crossing([], [], lambda _ts, o, i: True) is None
+
+    def test_misaligned_curves_align_by_timestamp_not_index(self):
+        """The core Issue #528 regression: curves starting at different hours must be
+        paired by matching ISO timestamp, never by list position."""
+        indoor = _curve([72.0, 73.0, 74.0, 75.0], start_hour=8)
+        outdoor = _curve([73.0, 76.0, 78.0, 80.0], start_hour=10)  # only hours 10-11 overlap
+        result = find_temperature_crossing(indoor, outdoor, lambda _ts, o, i: o >= i - 1.0)
+        assert result is not None
+        assert result.hour == 10  # not 8 — hour 8 has no matching outdoor entry at all
+
+    def test_hour_present_in_only_one_curve_is_skipped(self):
+        indoor = _curve([72.0, 999.0], start_hour=8)  # hour 9 would trivially "cross" if matched wrongly
+        outdoor = _curve([65.0], start_hour=8)  # only hour 8 present
+        result = find_temperature_crossing(indoor, outdoor, lambda _ts, o, i: o >= i - 1.0)
+        assert result is None  # hour 8: 65 >= 72-1=71 is False; hour 9 has no outdoor match to test against
+
+    def test_after_parameter_restricts_scan_to_later_timestamps(self):
+        indoor = _curve([72.0, 73.0, 74.0, 75.0], start_hour=8)
+        outdoor = _curve([73.0, 76.0, 78.0, 80.0], start_hour=8)  # crosses at hour 8 already
+        cutoff = datetime(2026, 7, 27, 8, 0, 0, tzinfo=UTC)
+        result = find_temperature_crossing(indoor, outdoor, lambda _ts, o, i: o >= i - 1.0, after=cutoff)
+        assert result is not None
+        assert result.hour == 9  # hour 8 excluded by `after`, even though it also crosses
+
+    def test_comparator_receives_timestamp(self):
+        """Comparator must see `ts`, not just the two temperatures, for time-of-day-aware gates."""
+        indoor = _curve([72.0, 72.0], start_hour=8)
+        outdoor = _curve([72.0, 72.0], start_hour=8)
+        result = find_temperature_crossing(indoor, outdoor, lambda ts, _o, _i: ts.hour == 9)
+        assert result is not None
+        assert result.hour == 9


### PR DESCRIPTION
## Summary
- **Root-cause fix**: `_derive_warm_day_events()` in `briefing.py` paired predicted-indoor/predicted-outdoor forecast curves by `zip()` list index instead of matching ISO timestamp — silently mispairing them whenever the two curves were built with different "now" filter boundaries or at different times (indoor cached from the last 30-min cycle, outdoor rebuilt fresh per briefing). Confirmed live via production logs: a Warm 79°F day's briefing said "Close up at 8:00 AM" and "Reopen windows around 2:00 PM," neither plausible against the same computation's own 5:30 PM ceiling-breach time. Introduced whole-cloth in #518, never modified since — an original design gap, not a regression.
- New `find_temperature_crossing(indoor_curve, outdoor_curve, comparator, after=None)` in `temperature.py` aligns curves by timestamp lookup instead of index. `briefing.py` now uses it; `recovery_time` was also added to the existing debug log line (previously the one field not logged).
- **New feature, built on the same primitive** — `_compute_next_automation_action()` (Next Automation / Automation Time cards) gained three candidate types that didn't exist before:
  - Whole-house-fan/nat-vent start prediction, using the real `decide_nat_vent_gate()` activation gate (`nat_vent_gate.py`) — **not** `compute_nat_vent_cycling_band()`, which only describes the fan's cycling band once already active (a materially different formula). Gated on a door/window already open, matching the real automation's own precondition.
  - The same warm-day window-close / AC-on / reopen events, now timestamp-correct, surfaced on the dashboard instead of only the daily briefing.
  - HOT-day morning/evening window-cooling opportunities (already-computed static classifier fields), surfaced for the first time.
- Docs: `docs/08-COMPUTATION-REFERENCE.md` §7 WARM row now discloses the same ODE-override caveat the MILD row already had; new §9f.
- No automation/HVAC decision logic changed — display/prediction only.

## Test plan
- [x] `pytest tests/` — 3598 passed
- [x] New regression tests (`test_misaligned_curves_pair_by_timestamp_not_index`, `test_misaligned_curves_recovery_time_after_true_cutoff`) confirmed to **fail** against the pre-fix zip-based implementation, then pass against the fix
- [x] New test proving the nat-vent candidate uses `decide_nat_vent_gate()` semantics (ceiling-margin/fan-mode aware), not a naive cycling-band midpoint
- [x] `ruff check` / `ruff format` — clean
- [x] `python tools/simulate.py` — 74/74 golden scenarios pass
- [x] `pytest tests/test_version_sync.py` — version bump verified (0.5.35 → 0.5.36)