### PR TITLE
Fix #530: whole-house-fan-off grace killed by orphaned-grace watchdog

### DIFF
--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -77,6 +77,7 @@ from .const import (
     TEMP_SOURCE_CLIMATE_FALLBACK,
     TEMP_SOURCE_INPUT_NUMBER,
     TEMP_SOURCE_SENSOR,
+    TIMER_BOUNDARY_SETTLE_SECONDS,
     VACATION_SETBACK_EXTRA,
 )
 from .desired_state import (
@@ -114,6 +115,19 @@ from .temperature import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+# Issue #530: the ONLY two `_start_grace_period(trigger=...)` values that mean "this grace
+# exists to protect an active manual/fan override" — read by `_start_grace_period()` to set
+# `_grace_protects_override`, which `coordinator._check_orphaned_grace()` uses to scope its
+# self-heal to grace types that can actually BE orphaned (an override was cleared without its
+# grace being cancelled alongside it). Every other grace trigger (fan-off cooldown, physical-
+# drift correction, window-close resume, nat-vent-exit resume, dashboard resume) never sets
+# `_manual_override_active`/`_fan_override_active` in the first place by design — treating
+# their absence as "orphaned" was the root cause of #530's fan-off grace being killed within
+# ~1ms of starting. A future grace-starting call site is automatically excluded here unless
+# its trigger string is deliberately added to this set — if it's meant to protect a real
+# override, add it; if not, leave it out.
+_GRACE_TRIGGERS_PROTECTING_OVERRIDE = frozenset({"fan_manual_override", "override_confirmed"})
 
 
 @dataclass(frozen=True)
@@ -501,6 +515,10 @@ class AutomationEngine:
         self._last_resume_source: str | None = None
         self._grace_end_time: str | None = None
         self._grace_duration_seconds: int = 0
+        # Issue #530: whether the CURRENTLY active grace exists to protect a real override
+        # (see _GRACE_TRIGGERS_PROTECTING_OVERRIDE) — set fresh by _start_grace_period() on
+        # every start, read by coordinator._check_orphaned_grace().
+        self._grace_protects_override: bool = False
 
         # Comfort-band event dedup (Issue #444): tracks the last-announced band so
         # overlapping triggers (startup coalesce + its own refresh, grace-expiry
@@ -548,6 +566,12 @@ class AutomationEngine:
         # "the last speed the remote reported," not an indicator of which path set it.
         self._fan_remote_speed: str | None = None
         self._fan_command_pending: bool = False  # transient: distinguishes integration vs manual changes
+        # Issue #530: when a manual grace tied to an RF-remote timer expires, the timer's
+        # physical hardware side typically finishes within seconds of CA's software clock —
+        # not always before. This deadline marks a short coalescing window during which a
+        # fan-off report is treated as the tail of that SAME timer boundary (not a fresh,
+        # unexpected event) — see on_fan_turned_off() and _on_grace_expired().
+        self._timer_boundary_settle_until: datetime | None = None
         # HVAC mode captured before whole-house fan activation (Issue #277 Fix C).
         # Restored when the whole-house fan deactivates so AC/heat resumes.
         self._pre_fan_hvac_mode: str | None = None
@@ -1014,6 +1038,48 @@ class AutomationEngine:
                 any (Issue #482) — surfaced in the Activity Report payload as diagnostic
                 provenance data.
         """
+        # Issue #530: a fan-off arriving inside the settle window of a just-expired
+        # RF-timer-linked grace is the tail of that SAME timer boundary, not a fresh
+        # event — coalesce into whatever the post-grace reconcile already decided instead
+        # of starting a brand-new fan-off grace (which the orphaned-grace watchdog cannot
+        # distinguish from a genuinely stuck one) and re-litigating the whole decision
+        # from scratch.
+        _settle_until = getattr(self, "_timer_boundary_settle_until", None)
+        if _settle_until is not None and dt_util.now() <= _settle_until:
+            self._timer_boundary_settle_until = None  # one-shot — consumed
+            _LOGGER.info(
+                "Fan turned off within the RF-timer boundary settle window (fan=%s->%s) —"
+                " treating as the same timer session ending, not a new event",
+                fan_before or "?",
+                fan_after or "?",
+            )
+            if self._emit_event_callback:
+                self._emit_event_callback(
+                    "fan_cancel",
+                    {
+                        "fan_before": fan_before,
+                        "fan_after": fan_after,
+                        "trigger": "timer_boundary_settle",
+                        "fan_device": _fan_device_label(self.config),
+                        "event_context_id": event_context_id,
+                    },
+                )
+            if self._natural_vent_active:
+                # The post-grace reconcile adopted this fan as a nat-vent session moments
+                # ago (it was still physically on when the grace's software clock
+                # expired) — let the single choke point for ending a session decide
+                # pause-vs-restore against live sensor state, instead of starting a fresh
+                # fan-off grace that only gets fought by the orphaned-grace watchdog.
+                self.hass.async_create_task(
+                    self._exit_nat_vent(reason=f"fan={fan_before or '?'}->{fan_after or '?'} (RF timer boundary)")
+                )
+            else:
+                # Reconcile didn't adopt the fan (or it was already off) — nothing further
+                # to reconcile; just make sure the flags reflect reality.
+                self._fan_active = False
+                self._fan_on_since = None
+            return
+
         _LOGGER.info(
             "Fan turned off by user: fan=%s->%s, trigger=fan_off",
             fan_before or "?",
@@ -3454,6 +3520,7 @@ class AutomationEngine:
         outdoor: float | None,
         thermostat_fan_running: bool,
         any_sensor_open: bool,
+        trigger: str = "startup",
     ) -> None:
         """Reconcile fan state on HA startup / coalesce window (Issue #327).
 
@@ -3483,6 +3550,16 @@ class AutomationEngine:
                                     fan session based on an unrelated thermostat-internal fan
                                     blip while the real WHF was off (Issue #423).
             any_sensor_open:      True when at least one door/window sensor is open.
+            trigger:               Which of the 4 call sites invoked this reconcile — used only
+                                    in log/reason strings (Issue #530). This method is called from
+                                    a genuine HA restart (``"ha_restart"``), the periodic 30-min
+                                    untracked-fan backstop (``"backstop_30min"``), a live
+                                    thermostat hvac_action transition (``"thermostat_state_change"``),
+                                    and every grace-period expiry (``"post_grace_expiry"``) — the
+                                    reason string previously hardcoded "startup reconcile" for all
+                                    four, which read as a phantom HA restart when none of the other
+                                    three triggers fired. Defaults to ``"startup"`` for any caller
+                                    that doesn't pass one explicitly.
         """
         fan_mode = self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED)
         archetype = fan_mode
@@ -3514,7 +3591,7 @@ class AutomationEngine:
             # restart could silently re-command HVAC on right after the classification block
             # above correctly paused it for an open window.
             await self._deactivate_fan(
-                reason="startup reconcile — fan confirmed off, releasing any stranded HVAC suppression",
+                reason=f"{trigger} reconcile — fan confirmed off, releasing any stranded HVAC suppression",
                 restore_hvac=not self._paused_by_door,
             )
             return
@@ -3561,7 +3638,7 @@ class AutomationEngine:
             # managed with no record of why, unlike the turn-off branch below which does
             # emit a fan_deactivated event. Record the adoption the same way.
             _adopt_reason = (
-                f"startup reconcile — fan already running, indoor {indoor:.1f}°F,"
+                f"{trigger} reconcile — fan already running, indoor {indoor:.1f}°F,"
                 f" outdoor {outdoor:.1f}°F, nat-vent conditions met — adopting as CA-owned"
             )
             self._record_action("Fan activated", _adopt_reason)
@@ -3584,7 +3661,7 @@ class AutomationEngine:
                 decision,
                 archetype,
             )
-            _turn_off_reason = "startup reconcile — fan running without CA warrant"
+            _turn_off_reason = f"{trigger} reconcile — fan running without CA warrant"
 
             # Issue #446: reconcile_fan_on_startup() is called from 4 different sites
             # (startup coalesce, 30-min backstop, thermostat state-change, post-grace-expiry)
@@ -3692,6 +3769,15 @@ class AutomationEngine:
         Args:
             source: "manual" for user-initiated overrides,
                     "automation" for Climate Advisor resumptions.
+            trigger: Distinct per-callsite label (e.g. "fan_manual_override", "fan_off",
+                "dashboard_resume") — logged/emitted for observability, and, as of Issue
+                #530, also determines whether this grace protects a real override:
+                membership in ``_GRACE_TRIGGERS_PROTECTING_OVERRIDE`` sets
+                ``self._grace_protects_override``, which ``coordinator._check_orphaned_grace()``
+                reads to decide whether an override-less grace is a bug (a real override
+                grace whose flag vanished without going through ``cancel_override()``) or
+                expected (fan-off cooldown, window-close resume, etc. never set an override
+                flag in the first place). Every callsite must pass an explicit trigger.
             duration_override: When set (seconds), bypasses the configured manual
                 grace duration and uses this value instead. Used by RF-remote timer
                 selections (Issue #486) to make the grace period last exactly as
@@ -3732,6 +3818,7 @@ class AutomationEngine:
         self._last_resume_source = source
         self._grace_duration_seconds = duration
         self._grace_end_time = grace.at.isoformat()
+        self._grace_protects_override = trigger in _GRACE_TRIGGERS_PROTECTING_OVERRIDE
 
         @callback
         def _grace_expired(_now: Any) -> None:
@@ -3760,6 +3847,19 @@ class AutomationEngine:
         Extracted from the inner callback in ``_start_grace_period`` so it can
         also be invoked from ``_reschedule_grace_timer`` after an HA restart.
         """
+        # Issue #530: snapshot whether this grace was tied to an RF-remote timer BEFORE
+        # clear_manual_override() (called in every branch below) wipes
+        # _fan_remote_timer_hours. If so, arm a short settle window: a fan-off report
+        # arriving shortly after is the tail of this SAME timer boundary — the timer's
+        # own hardware side completing a few seconds after CA's software clock — not a
+        # fresh, independent event. See on_fan_turned_off().
+        if source == "manual" and getattr(self, "_fan_remote_timer_hours", None) is not None:
+            self._timer_boundary_settle_until = dt_util.now() + timedelta(seconds=TIMER_BOUNDARY_SETTLE_SECONDS)
+            _LOGGER.debug(
+                "RF-timer-linked grace expiring — arming %ss timer-boundary settle window",
+                TIMER_BOUNDARY_SETTLE_SECONDS,
+            )
+
         # If within planned window period, sensors open is expected — just clear grace
         if self._is_within_planned_window_period():
             _LOGGER.info(
@@ -3888,6 +3988,7 @@ class AutomationEngine:
         self._grace_active = False
         self._grace_end_time = None  # Bug 2 fix (Issue #321): prevent stuck-at-0 display
         self._last_resume_source = None
+        self._grace_protects_override = False
 
     async def _re_pause_for_open_sensor(self) -> None:
         """Re-pause HVAC because a sensor is still open when grace expired."""
@@ -4755,9 +4856,27 @@ class AutomationEngine:
         None in command-only mode). The post-grace fan reconcile
         (``_on_post_grace_fan_check`` -> ``reconcile_fan_on_startup``) owns the "still running"
         case; releasing here too would race it.
+
+        Guard (Issue #530): also no-op if ``_natural_vent_active`` is still True. Physical
+        fan state alone is not sufficient — ``clear_fan_override()`` calls this method
+        whenever an override is cleared, including cases where the fan happens to be
+        physically off at that instant but CA still considers a nat-vent session live (e.g.
+        wake-up clearing a leftover fan override while nat-vent is mid-session, confirmed
+        live: ``handle_morning_wakeup()`` decided ``DEFER_NAT_VENT`` — "leaving fan alone" —
+        moments before this exact call released suppression anyway, letting the very next
+        comfort-band write arm active HVAC with windows still open). As long as
+        ``_natural_vent_active`` is True, the nat-vent session itself owns when suppression
+        ends — via ``_exit_nat_vent()`` — not this override-clear side effect.
         """
         if self._pre_fan_hvac_mode is None:
             return  # no suppression session to release
+        if self._natural_vent_active:
+            _LOGGER.debug(
+                "WHF release-and-reclassify skipped (%s) — nat-vent session still active,"
+                " _exit_nat_vent() owns suppression release",
+                reason,
+            )
+            return
         if self._get_fan_physical_state_callback and self._get_fan_physical_state_callback():
             _LOGGER.debug("WHF release-and-reclassify skipped (%s) — fan still physically on", reason)
             return
@@ -5649,6 +5768,7 @@ class AutomationEngine:
         self._grace_end_time = None
         self._grace_duration_seconds = None
         self._last_resume_source = None
+        self._grace_protects_override = False
         # Issue #327: fan override cleared on restart — no grace timer to reschedule.
         # reconcile_fan_on_startup() runs shortly after and decides adopt-on / turn-off.
         self._fan_override_active = False

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,23 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.36"
+VERSION = "0.5.37"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.37": [
+        "Fix #530: turning off the whole-house fan didn't reliably stick — a watchdog meant"
+        " to catch a completely different, rare bug was mistaking the normal 'no override in"
+        " progress' state of an ordinary fan-off for a stuck automation, and killing its"
+        " protection within about a second almost every time. Fixed at the root, so fan-off"
+        " now stays off for its full protection window like it's always been supposed to."
+        " On top of that, an overnight session started via an 8-hour RF remote timer no"
+        " longer produces a burst of contradictory decisions right when the timer runs out —"
+        " a fan-off report in the couple of minutes after that timer's own grace period ends"
+        " is now recognized as the tail of the same session instead of a brand-new event."
+        " Separately, a leftover fan override being cleared at the 6:30 AM wake-up could arm"
+        " the AC with windows still open — wake-up no longer releases whole-house-fan HVAC"
+        " suppression while a nat-vent session is still active.",
+    ],
     "0.5.36": [
         "Fix #528: on warm/mild days, the briefing's window-close and reopen times could"
         " be badly wrong — one real example told the user to close windows at 8 AM"
@@ -1297,6 +1311,76 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    530: {
+        "version_fixed": "0.5.37",
+        "title": (
+            "Whole-house-fan-off grace was killed by the Issue #508 orphaned-grace watchdog"
+            " within ~1 event-loop tick almost universally (not just the RF-timer case"
+            " originally reported); an 8h RF-timer boundary compounded this into a burst of"
+            " contradictory grace/override decisions; morning wake-up could separately arm"
+            " HVAC with windows still open"
+        ),
+        "scope_covered": (
+            "Three fixes, automation.py + coordinator.py. (1) ROOT CAUSE, general case:"
+            " coordinator._check_orphaned_grace() (Issue #508) inferred 'orphaned' purely"
+            " from _manual_override_active/_fan_override_active both being False — also the"
+            " normal, by-design shape of fan-off/physical-drift-correction/window-close-"
+            " resume/dashboard-resume/nat-vent-exit-resume grace, none of which ever touch"
+            " those flags. Fixed by making _start_grace_period(trigger=...) set a new"
+            " self._grace_protects_override = trigger in _GRACE_TRIGGERS_PROTECTING_OVERRIDE"
+            " (frozenset of exactly 'fan_manual_override'/'override_confirmed', the only two"
+            " triggers that correspond to a real override) — centralized classification via"
+            " the trigger string every callsite already passes, not a new parameter threaded"
+            " through all 7 call sites. _check_orphaned_grace() now additionally requires"
+            " _grace_protects_override; _cancel_grace_timers() resets it. This restores"
+            " Issue #359's fan-off protection for ANY whole-house-fan-off, not only the"
+            " RF-timer scenario originally reported, while leaving the original Issue #508"
+            " protection fully intact for the three genuine override-driven triggers."
+            " (2) RF-timer-specific refinement: _on_grace_expired() snapshots whether the"
+            " expiring grace was RF-timer-linked (_fan_remote_timer_hours, read before"
+            " clear_manual_override() wipes it) and, if so, arms"
+            " self._timer_boundary_settle_until for TIMER_BOUNDARY_SETTLE_SECONDS (const.py,"
+            " 120s — the real observed software/hardware gap was ~11s). on_fan_turned_off()"
+            " checks this window first: a fan-off inside it routes straight to"
+            " _exit_nat_vent() instead of starting a second, independent grace at all —"
+            " stronger than (1) alone for this specific, predictable case, since CA already"
+            " knows the timer is about to complete. (3) _release_whf_and_reclassify()"
+            " (called from clear_fan_override(), itself called by handle_morning_wakeup()"
+            " via clear_manual_override()) gained a _natural_vent_active guard: no longer"
+            " releases WHF HVAC suppression while a nat-vent session is still considered"
+            " active, even if the fan happens to be physically off at that instant — closes"
+            " an ordering bug where wake-up's own DEFER_NAT_VENT gate decision (computed"
+            " moments earlier) was silently undercut by this side effect before the"
+            " following comfort-band write ran. Also threaded a `trigger` parameter through"
+            " reconcile_fan_on_startup() (previously hardcoded 'startup reconcile' in its"
+            " reason strings for all 4 call sites — ha_restart, backstop_30min,"
+            " thermostat_state_change, post_grace_expiry — reading as a phantom HA restart"
+            " when none occurred). 13 new regression tests across"
+            " tests/test_whole_house_fan_hvac_suppression.py, tests/test_grace_stuck.py, and"
+            " tests/test_fan_command_guard.py, each verified to fail without its"
+            " corresponding fix via a stash/revert check. docs/grace-periods-spec.md updated:"
+            " Orphaned Grace Self-Heal section rewritten for the corrected scope, new"
+            " RF-Timer Boundary Settle Window section, Fan-Off Grace and Shared"
+            " Scheduled-Band Gate sections cross-referenced."
+        ),
+        "scope_not_covered": (
+            "No golden simulation scenario was added — the Tier A production harness"
+            " (tools/sim_harness/run_production.py) has no event dispatch path for the"
+            " QuietCool RF-remote entity (_async_fan_remote_changed()/"
+            " handle_fan_manual_override() with duration_override), only for the plain"
+            " fan_entity on/off transition (external_fan_state_change). Adding that dispatch"
+            " path is a harness feature, not a production fix, and was intentionally left"
+            " out of this change's scope; regression coverage is the unit tests against the"
+            " real AutomationEngine/coordinator instead. H3 from the investigation (whether"
+            " the FAN_MODE_HVAC archetype's fan-off path also gets an immediate coordinator"
+            " refresh the way the WHF fan_entity path does, per Issue #510) was checked and"
+            " disproven — that path never calls async_request_refresh() — but fix (1) above"
+            " protects that archetype's fan-off grace regardless, since it no longer depends"
+            " on refresh timing at all. The 'startup reconcile' -> trigger-labeled reason"
+            " string change is cosmetic/observability only and does not itself change any"
+            " HVAC or fan decision."
+        ),
+    },
     528: {
         "version_fixed": "0.5.36",
         "title": (
@@ -5342,6 +5426,14 @@ MAX_CONTINUOUS_RUNTIME_HOURS = 3
 # (~5-6 minutes) while staying well under the 30-minute regular classification
 # cycle, so a genuine re-announcement after a real cycle is never swallowed.
 COMFORT_BAND_EVENT_DEDUP_SECONDS = 600  # 10 minutes
+
+# Issue #530: an RF-remote-timer-linked manual grace period's software-tracked expiry and
+# the timer's own hardware-side completion are the same physical event, but don't land at
+# the exact same instant — confirmed live at an 11-second gap, with follow-on RF chatter
+# settling within 60 seconds. This window (generous vs. that observed gap) marks how long
+# after such a grace expires a fan-off report is still treated as the tail of that SAME
+# timer boundary, not a fresh, independent event requiring its own new grace period.
+TIMER_BOUNDARY_SETTLE_SECONDS = 120  # 2 minutes
 
 # Economizer (window cooling) threshold
 ECONOMIZER_TEMP_DELTA = 3  # °F — activate when outdoor temp within this delta of comfort_cool

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -1610,6 +1610,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             outdoor=outdoor,
             thermostat_fan_running=_thermostat_fan_running,
             any_sensor_open=self._any_sensor_open(),
+            trigger="ha_restart",
         )
         _LOGGER.debug("[coalesce-diag] after reconcile_fan_on_startup()")
 
@@ -1636,9 +1637,24 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         mid-cancel, or a future third endpoint that bypasses it). Runs every regular update cycle
         (~30s), so any residual inconsistency self-heals within one cycle instead of persisting
         for hours.
+
+        Scoped via ``ae._grace_protects_override`` (Issue #530): only grace periods started for
+        a real override (``_start_grace_period(trigger=...)`` with a trigger in
+        ``automation._GRACE_TRIGGERS_PROTECTING_OVERRIDE``) can be "orphaned" in the sense this
+        check means. Fan-off cooldown, physical-drift-correction, window-close-resume, and
+        nat-vent-exit-resume grace never set an override flag in the first place — checking only
+        flag-absence (pre-#530) misread every one of those as orphaned and killed them within
+        about one event-loop tick of starting, defeating Issue #359's fan-off protection almost
+        universally. This does not weaken the original Issue #508 protection: every trigger that
+        genuinely represents an override-confirmation grace is still covered.
         """
         ae = self.automation_engine
-        if not (ae._grace_active and not ae._manual_override_active and not ae._fan_override_active):
+        if not (
+            ae._grace_active
+            and getattr(ae, "_grace_protects_override", False)
+            and not ae._manual_override_active
+            and not ae._fan_override_active
+        ):
             return
         _LOGGER.error(
             "Stuck grace detected: grace_active=True but no override is active — force-cancelling grace (Issue #508)."
@@ -2198,6 +2214,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                         hvac_action_attr=_bst_hvac_action,
                     ),
                     any_sensor_open=self._any_sensor_open(),
+                    trigger="backstop_30min",
                 )
             else:
                 _LOGGER.warning(
@@ -3539,6 +3556,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                     hvac_action_attr=new_action,
                 ),
                 any_sensor_open=self._any_sensor_open(),
+                trigger="thermostat_state_change",
             )
 
         # If thermostat is now fully off, clear any stale HVAC-based fan active flag.
@@ -4263,6 +4281,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 outdoor=self._last_outdoor_temp,
                 thermostat_fan_running=archetype_fan_running,
                 any_sensor_open=self._any_sensor_open(),
+                trigger="post_grace_expiry",
             )
 
     def _fan_state_feedback_enabled(self) -> bool:

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.36"
+  "version": "0.5.37"
 }

--- a/docs/grace-periods-spec.md
+++ b/docs/grace-periods-spec.md
@@ -15,7 +15,9 @@
 | What is the override confirmation delay — how does it work and what does it gate? | A debounce window (default 600 s) between detecting a thermostat mode change and formally accepting it as a manual override. While pending, `apply_classification()` returns early, blocking all HVAC commands. If the mode self-corrects within the window (transient glitch), the event is discarded — no grace period starts. | [§ Override Confirmation Delay](#override-confirmation-delay) |
 | What are all the callsites that clear a manual override, and under what conditions? | Eight callsites: three in `_grace_expired()` branches (always clear — intended, one of them via `cancel_override()` as of Issue #508), two scheduled handlers (bedtime/wakeup — skip if override active after Issue #204 fix), the two dashboard cancel buttons (always clear, via `cancel_override()` as of Issue #508), and one occupancy handler (away/vacation — clears before setback, fix #220). Every clear is logged at INFO with a `reason=` parameter. Note (Issue #498): both scheduled handlers must snapshot `_fan_override_active` *before* calling `clear_manual_override()` — that call unconditionally clears the fan-override flag as a side effect via `clear_fan_override()`, so reading the live attribute afterward always sees it already cleared. | [§ What Clears a Manual Override](#what-clears-a-manual-override) |
 | What is the difference between `clear_manual_override()` and `cancel_override()`, and which should a new callsite use? | `clear_manual_override()` clears override flags only — used by scheduled handlers (bedtime/wakeup/occupancy) that supersede an override without touching its grace timer, by design. `cancel_override()` (Issue #508) additionally cancels grace and forces the same fan-reconcile + coordinator-refresh a natural grace expiry performs — it is the single entry point for "user/system deliberately ends this override right now" (both dashboard "Cancel..." buttons, and the `adopted_matching_decision` path). A new callsite meaning deliberate cancellation must call `cancel_override()`, not compose the primitives by hand. | [§ Deliberate Cancellation — `cancel_override()` (Issue #508)](#deliberate-cancellation-cancel_override-issue-508) |
-| What happens if grace is left active with no override behind it (e.g. a future callsite bypasses `cancel_override()`)? | `coordinator._check_orphaned_grace()` (Issue #508), run every regular update cycle (~30s), self-heals: if `_grace_active=True` and neither `_manual_override_active` nor `_fan_override_active` is set, it force-cancels grace and emits `stuck_grace_recovered` with `reason="grace_without_override"`. This is the mirror of the pre-existing Issue #321 stuck-grace check (which catches the opposite shape — an override stuck active past its own due grace-end-time); the two checks are independent and cannot both fire on the same state. | [§ Orphaned Grace Self-Heal (Issue #508)](#orphaned-grace-self-heal-issue-508) |
+| What happens if grace is left active with no override behind it (e.g. a future callsite bypasses `cancel_override()`)? | `coordinator._check_orphaned_grace()` (Issue #508), run every regular update cycle (~30s), self-heals: if `_grace_active=True`, `_grace_protects_override=True` (Issue #530 — see next row), and neither `_manual_override_active` nor `_fan_override_active` is set, it force-cancels grace and emits `stuck_grace_recovered` with `reason="grace_without_override"`. This is the mirror of the pre-existing Issue #321 stuck-grace check (which catches the opposite shape — an override stuck active past its own due grace-end-time); the two checks are independent and cannot both fire on the same state. | [§ Orphaned Grace Self-Heal (Issue #508)](#orphaned-grace-self-heal-issue-508) |
+| Can every grace type be "orphaned" in the Issue #508 sense — does the watchdog apply to fan-off/window-close/resume grace too? | No (Issue #530 fix). `_start_grace_period(trigger=...)` sets `_grace_protects_override = trigger in _GRACE_TRIGGERS_PROTECTING_OVERRIDE` (only `"fan_manual_override"` and `"override_confirmed"`) — the watchdog now only fires for grace that was genuinely started to protect a real override. Before this fix, the watchdog inferred "orphaned" purely from absent override flags, which is also the NORMAL, by-design shape of fan-off/drift-correction/window-close/dashboard-resume grace — every one of those was being killed within about one event-loop tick of starting. | [§ Orphaned Grace Self-Heal (Issue #508)](#orphaned-grace-self-heal-issue-508) |
+| A fan-off arrives seconds after an RF-remote-timer grace expires — is that a fresh event? | No (Issue #530). `_on_grace_expired()` arms `_timer_boundary_settle_until` (2 min) whenever the expiring grace's `_fan_remote_timer_hours` was set. A fan-off inside that window is treated as the tail of the SAME timer boundary — routed straight through `_exit_nat_vent()` instead of starting an independent new grace. | [§ RF-Timer Boundary Settle Window (Issue #530)](#rf-timer-boundary-settle-window-issue-530) |
 | Does PATH B (self-resolved transient) send a notification? | Yes (Issue #200). When the thermostat reverts to the expected mode within the confirmation window, a push notification is sent: "Brief thermostat adjustment detected — treated as transient. Climate Advisor continues normal operation." | [§ State Machine — PATH B](#state-machine) |
 | What happens if the user changes to a different mode while a grace period is already active? | The current override and grace timer are cleared, and a fresh 10-minute confirmation window starts for the new mode (Issue #201). The latest user action always wins. | [§ Second Override During Active Grace](#second-override-during-active-grace-issue-201) |
 | Where can the user see how much longer an active grace period will run? | The Status dashboard's next-action text (`_compute_next_automation_action()`/`_compute_next_action()` in coordinator.py) appends a formatted end-time + remaining-minutes suffix, e.g. "Grace period active (manual) — ends 7:14 AM (18 min left)", via `_format_grace_remaining()` reading `_grace_end_time` (Issue #498 — previously shown with no time at all). | [§ Timer Lifecycle](#timer-lifecycle) |
@@ -31,18 +33,20 @@
 
 **Line ranges (automation.py):**
 - `_is_within_planned_window_period()`: L706
-- `clear_manual_override()`: L764–L797
-- `cancel_override()`: L799–L831 (Issue #508 — see [§ Deliberate Cancellation](#deliberate-cancellation-cancel_override-issue-508))
-- `clear_fan_override()`: L1058
+- `clear_manual_override()`: L799
+- `cancel_override()`: L834 (Issue #508 — see [§ Deliberate Cancellation](#deliberate-cancellation-cancel_override-issue-508))
+- `on_fan_turned_off()`: L1026 (Issue #530: RF-timer boundary settle-window check at its top — see [§ RF-Timer Boundary Settle Window](#rf-timer-boundary-settle-window-issue-530))
+- `clear_fan_override()`: L1180
 - `handle_door_window_open()`: L2408
 - `handle_all_doors_windows_closed()`: L2607
 - `handle_manual_override_during_pause()`: L3532
 - `resume_from_pause()`: L3557
-- `_start_grace_period()`: L3590
-- `_on_grace_expired()`: L3658 (its three branches now call `_cancel_grace_timers()` for the grace-flag
-  reset instead of inlining it — deduped in Issue #508)
-- `_cancel_grace_timers()`: L3781
+- `_start_grace_period()`: L3766 (Issue #530: sets `_grace_protects_override` from `trigger`)
+- `_on_grace_expired()`: L3844 (its three branches now call `_cancel_grace_timers()` for the grace-flag
+  reset instead of inlining it — deduped in Issue #508; Issue #530 added the settle-window arm at its top)
+- `_cancel_grace_timers()`: L3980
 - `_re_pause_for_open_sensor()`: L3793
+- `_release_whf_and_reclassify()`: L4842 (Issue #530: `_natural_vent_active` guard added — see [§ Shared Scheduled-Band Gate](#shared-scheduled-band-gate-issue-498))
 - `restore_state()`: L5503
 - `get_serializable_state()`: L5588
 
@@ -50,11 +54,11 @@
 - `_subscribe_door_window_listeners()`: L1146
 - `_cancel_all_debounce_timers()`: L1302
 - `_any_sensor_open()`: L1350
-- `_check_orphaned_grace()`: L1521 (Issue #508 — see [§ Orphaned Grace Self-Heal](#orphaned-grace-self-heal-issue-508))
+- `_check_orphaned_grace()`: L1629 (Issue #508, scope corrected in #530 — see [§ Orphaned Grace Self-Heal](#orphaned-grace-self-heal-issue-508))
 - `_async_door_window_changed()`: L2960
 - `_async_thermostat_changed()` (pause-override detection): L3080
 
-**Note on line-number drift:** these are exact as of Issue #508 (v0.5.28) but will drift with future edits —
+**Note on line-number drift:** these are exact as of Issue #530 but will drift with future edits —
 treat them as a navigation aid, not a contract; if a line doesn't match, search for the function name.
 
 **Out of scope for this spec:**
@@ -80,7 +84,9 @@ treat them as a navigation aid, not a contract; if a line doesn't match, search 
 
 **Flags cleared:** `_fan_active = False`, `_natural_vent_active = False`. Critically, `_fan_override_active` is NOT set — this is not a manual override (the user stopped the fan, not started one against CA's intent).
 
-**End condition:** Grace timer fires → `reconcile_fan_on_startup()` is called to re-evaluate the physical fan state. If the fan is still running (edge case), the reconcile step either adopts it as nat-vent or turns it off. If the fan is off (normal case), no action is taken.
+**Never orphaned-grace-eligible (Issue #530):** because this grace type never sets an override flag by design, `_start_grace_period(trigger="fan_off")` (the default `trigger_label` in `_clear_fan_flags_and_start_grace()`) is NOT a member of `_GRACE_TRIGGERS_PROTECTING_OVERRIDE` — `_grace_protects_override` is `False`, so `coordinator._check_orphaned_grace()` never touches it. Before this fix, the watchdog could not distinguish "no override flag because nothing needs protecting" from "no override flag because something is broken," and killed essentially every fan-off grace within about one event-loop tick of starting (see [§ Orphaned Grace Self-Heal](#orphaned-grace-self-heal-issue-508)).
+
+**End condition:** Grace timer fires → `reconcile_fan_on_startup()` is called to re-evaluate the physical fan state. If the fan is still running (edge case), the reconcile step either adopts it as nat-vent or turns it off. If the fan is off (normal case), no action is taken. **Exception (Issue #530):** if the fan-off arrives inside the RF-timer boundary settle window, no fan-off grace is started at all — see [§ RF-Timer Boundary Settle Window](#rf-timer-boundary-settle-window-issue-530).
 
 #### Fan-Off Grace and Command-Only Mode (Issue #361)
 
@@ -286,26 +292,95 @@ cancellation plus reconciliation, only for callers that mean deliberate, immedia
 
 **Shape of the problem:** the opposite of the pre-existing Issue #321 stuck-grace check (below).
 Issue #321 catches `_grace_active=False` with `_grace_end_time` in the past (a timer that should
-have fired but didn't — override stuck active). This new check catches `_grace_active=True` with
+have fired but didn't — override stuck active). This check catches `_grace_active=True` with
 no override active at all — `_grace_end_time` is typically still validly in the future (the timer
 will fire correctly on its own), but nothing is being protected. Defense-in-depth for any path that
 clears an override without going through `cancel_override()` — an exception mid-cancel, or a future
 third endpoint that composes the primitives by hand again.
 
-**Implementation:** `coordinator._check_orphaned_grace()` (`coordinator.py:1521`), called once per
-regular `_async_update_data()` cycle (~30s). Condition: `ae._grace_active and not
-ae._manual_override_active and not ae._fan_override_active`. On match: logs an ERROR, calls
-`ae._cancel_grace_timers()`, and emits `"stuck_grace_recovered"` with
-`{"grace_end_time": ..., "reason": "grace_without_override"}`.
+**Corrected scope (Issue #530) — only grace that claims to protect an override can be "orphaned":**
+The original implementation inferred "orphaned" purely from `_manual_override_active`/
+`_fan_override_active` both being `False`. That is also the *normal, by-design* shape of every
+grace type that was never about an override in the first place — fan-off cooldown (Issue #359),
+physical-drift-correction, window-close resume, nat-vent-exit resume, and dashboard resume all
+start grace without ever touching either flag. The watchdog could not tell "nothing to protect
+because nothing is broken" from "nothing to protect because something clobbered the flag," and
+killed the former just as eagerly as the latter — confirmed live: a whole-house-fan session's
+fan-off grace was destroyed within roughly one event-loop tick of starting, because the same fan
+transition that started it also requested an immediate coordinator refresh (Issue #510), and that
+refresh's `_check_orphaned_grace()` call ran before anything else had a chance to protect it. This
+defeated Issue #359's fan-off protection for essentially every whole-house-fan-off, not just the
+RF-remote-timer scenario #530 was originally reported against.
+
+**Fix:** `_start_grace_period(trigger=...)` now sets `self._grace_protects_override = trigger in
+_GRACE_TRIGGERS_PROTECTING_OVERRIDE` (`automation.py`) — a 2-item frozenset containing only
+`"fan_manual_override"` and `"override_confirmed"`, the two triggers that genuinely correspond to
+a real override having just been set. This is a **centralized classification, not a parameter
+threaded through every callsite**: every `_start_grace_period()` caller already passes a distinct
+`trigger` string (pre-existing, used for logging/events), so a future 8th callsite is automatically
+excluded unless its trigger is deliberately added to the set — there is no new per-callsite
+judgment call to get wrong or forget. `_cancel_grace_timers()` resets `_grace_protects_override`
+to `False` alongside `_grace_active` so a stale `True` can never leak into whatever starts next.
+
+**Implementation:** `coordinator._check_orphaned_grace()` (`coordinator.py:1629`), called once per
+regular `_async_update_data()` cycle (~30s). Condition: `ae._grace_active and
+ae._grace_protects_override and not ae._manual_override_active and not ae._fan_override_active`.
+On match: logs an ERROR, calls `ae._cancel_grace_timers()`, and emits `"stuck_grace_recovered"`
+with `{"grace_end_time": ..., "reason": "grace_without_override"}`.
 
 **Renderer note:** `_render_stuck_grace_recovered()` (`ai_skills_activity.py`) branches on the
 `reason` field — the pre-existing Issue #321 call site never sets it and keeps its original
-`"Stuck grace recovered (expired {grace_end})"` label; this new call site renders `"Stuck grace
+`"Stuck grace recovered (expired {grace_end})"` label; this call site renders `"Stuck grace
 recovered (no override was active to protect it)"` instead, since `grace_end` is misleadingly
 labeled "expired" when it's actually still in the future.
 
 **These two watchdog checks are mutually exclusive** — one requires `_grace_active=False`, the
 other requires `_grace_active=True` — and run independently in the same update cycle.
+
+---
+
+## RF-Timer Boundary Settle Window (Issue #530)
+
+**Problem:** A manual grace tied to an RF-remote timer (`_start_grace_period(duration_override=...)`
+from `handle_fan_manual_override()`, e.g. an 8-hour QuietCool selection) tracks that timer in
+software. The physical remote/fan hardware runs the *same* timer independently and completes it on
+its own clock — confirmed live at an ~11-second gap, with follow-on RF chatter settling within
+~60 seconds total. When CA's software-side grace expires first (the common case), its normal
+expiry path (`clear_manual_override()` → `clear_fan_override()`) discards `_fan_remote_timer_hours`
+immediately — so by the time the hardware's own fan-off report arrives seconds later,
+`on_fan_turned_off()` has zero memory a timer was ever involved and treats it as a brand-new,
+unrelated event: a fresh fan-off grace starts, gets killed by the (pre-#530) orphaned-grace
+watchdog, the fan gets re-armed 5 seconds after the user/timer turned it off, and that re-arm can
+itself trigger a further RF override detection — three independent grace/override cycles from one
+physical action.
+
+**Fix — treat it as the same transition, not a new event:** `_on_grace_expired()` snapshots, before
+`clear_manual_override()` runs, whether the expiring grace's `_fan_remote_timer_hours` was set. If
+so, it arms `self._timer_boundary_settle_until = now + TIMER_BOUNDARY_SETTLE_SECONDS` (`const.py`,
+120s — generous headroom over the observed single-digit-second real gap). `on_fan_turned_off()`
+checks this window first, before anything else: if the fan-off lands inside it, the window is
+consumed (one-shot) and the event is **not** treated as fresh —
+- If `_natural_vent_active` is `True` (the post-grace reconcile had already adopted the still-running
+  fan as a nat-vent session), the fan-off is routed straight to `_exit_nat_vent()` — the single
+  choke point for ending a session, which correctly checks live sensor state (pauses if a monitored
+  sensor is still open; restores HVAC + starts an ordinary `"automation"`-sourced grace if closed).
+- Otherwise, the fan flags are simply reconciled to "off" with no new grace at all.
+
+Either way, **no second, independent fan-off grace is started** for a timer-boundary fan-off — this
+is a stronger guarantee than "the fan-off grace now survives the orphaned-grace watchdog" (the
+general fix above): it skips the redundant grace/session entirely, matching the fact that CA
+already knew this fan-off was coming.
+
+**Relationship to the Orphaned Grace Self-Heal fix above:** complementary, not overlapping. The
+watchdog fix (Issue #530, previous section) restores fan-off grace surviving its full duration for
+*any* fan-off, timer-linked or not. This settle window additionally recognizes the *specific*,
+predictable case of a timer-linked fan-off and resolves it immediately instead of even starting a
+grace — per the project's operating model, an automation outcome CA can already predict should be
+handled as a known continuation, not re-discovered from scratch by a second mechanism.
+
+**Location:** `automation.py` — `_on_grace_expired()` (arms the window),
+`on_fan_turned_off()` (consumes it), `_timer_boundary_settle_until` (instance attribute,
+reset alongside grace's other one-shot state). `const.py` — `TIMER_BOUNDARY_SETTLE_SECONDS`.
 
 ---
 
@@ -587,3 +662,18 @@ snapshot `_fan_was_overridden = self._fan_override_active` *before* calling
 `clear_manual_override()`, and use that snapshot for the deactivation decision — the same
 capture-before-clear pattern already used in `_confirm_override()` (automation.py:~3648) for
 `_manual_override_mode`/`_manual_override_source`.
+
+**A second, independent side effect of the same call (Issue #530):** the capture-before-clear fix
+above only protects the *fan-deactivation* decision inside `handle_morning_wakeup()` itself.
+`clear_manual_override()` → `clear_fan_override()` also unconditionally calls
+`_release_whf_and_reclassify()`, which releases WHF HVAC suppression (`_pre_fan_hvac_mode = None`)
+whenever the physical fan reads off — with **no awareness of `_natural_vent_active` at all**.
+Confirmed live: `handle_morning_wakeup()` correctly computed `DEFER_NAT_VENT` ("leaving fan alone")
+from the gate at the top of the handler, then two lines later `clear_manual_override()`'s side
+effect released suppression anyway (physical fan was off; `_natural_vent_active` was still `True`
+but never checked), so the `_apply_comfort_band()` write a few lines further down armed active
+HVAC mode with windows still open. Fixed by adding a `_natural_vent_active` guard to
+`_release_whf_and_reclassify()` itself (automation.py) — it now no-ops whenever a nat-vent session
+is still considered active, deferring to `_exit_nat_vent()` as the only path that ends that
+session's suppression, matching the pattern already established for the physical-fan-state guard
+immediately above it.

--- a/tests/test_fan_command_guard.py
+++ b/tests/test_fan_command_guard.py
@@ -345,6 +345,7 @@ class TestPostStartupUntrackedFanReconcile:
             outdoor=65.0,
             thermostat_fan_running=True,
             any_sensor_open=False,
+            trigger="thermostat_state_change",
         )
 
     def test_fan_action_start_ca_owned_skips_reconcile(self):
@@ -531,6 +532,7 @@ class TestReconcileSite3ArchetypeAware:
             outdoor=65.0,
             thermostat_fan_running=False,
             any_sensor_open=False,
+            trigger="thermostat_state_change",
         )
 
     def test_whf_thermostat_blip_with_whf_physically_on_does_adopt(self):
@@ -549,4 +551,5 @@ class TestReconcileSite3ArchetypeAware:
             outdoor=65.0,
             thermostat_fan_running=True,
             any_sensor_open=False,
+            trigger="thermostat_state_change",
         )

--- a/tests/test_grace_stuck.py
+++ b/tests/test_grace_stuck.py
@@ -136,6 +136,11 @@ def _make_stuck_grace_coord_stub(
     ae._manual_override_active = manual_override_active
     ae._grace_active = grace_active
     ae._grace_end_time = grace_end_time
+    # Issue #530: MagicMock attributes are truthy by default (CLAUDE.md testing doctrine) —
+    # must be set explicitly or _check_orphaned_grace()'s new _grace_protects_override gate
+    # would pass for the wrong reason. Default True here matches every pre-#530 test's intent
+    # in this file: they all model a grace that protects a real override.
+    ae._grace_protects_override = True
     ae.clear_manual_override = MagicMock()
     coord.automation_engine = ae
 
@@ -459,3 +464,102 @@ class TestOrphanedGraceDetection:
 
         coord.automation_engine._cancel_grace_timers.assert_not_called()
         coord._emit_event.assert_not_called()
+
+    def test_orphaned_grace_not_cancelled_when_grace_does_not_protect_override(self):
+        """Issue #530: grace_active=True, no override flags, BUT this grace was never
+        started to protect an override (e.g. fan-off cooldown, window-close resume) —
+        must NOT fire. Pre-#530, this exact shape (no override flag set, by design) was
+        indistinguishable from a genuinely orphaned override-grace, so a fan-off grace
+        was killed within ~1 event-loop tick of starting, defeating Issue #359's
+        fan-off protection almost universally, not just in the RF-timer scenario #530
+        was originally reported against.
+        """
+        coord = _make_stuck_grace_coord_stub(
+            manual_override_active=False,
+            grace_active=True,
+            grace_end_time="2026-06-12T21:53:00+00:00",
+        )
+        coord.automation_engine._fan_override_active = False
+        coord.automation_engine._grace_protects_override = False
+        coord.automation_engine._cancel_grace_timers = MagicMock()
+
+        coord._check_orphaned_grace()
+
+        coord.automation_engine._cancel_grace_timers.assert_not_called()
+        coord._emit_event.assert_not_called()
+
+    def test_orphaned_grace_still_cancelled_when_protects_override_and_flags_gone(self):
+        """Issue #530 regression guard: the new gate must not accidentally weaken the
+        original Issue #508 protection. A grace that WAS started to protect a real
+        override, whose override flags are now gone (the actual bug #508 exists to
+        catch), must still be force-cancelled."""
+        coord = _make_stuck_grace_coord_stub(
+            manual_override_active=False,
+            grace_active=True,
+            grace_end_time="2026-06-12T21:53:00+00:00",
+        )
+        coord.automation_engine._fan_override_active = False
+        coord.automation_engine._grace_protects_override = True
+        coord.automation_engine._cancel_grace_timers = MagicMock()
+
+        coord._check_orphaned_grace()
+
+        coord.automation_engine._cancel_grace_timers.assert_called_once()
+        coord._emit_event.assert_called_once()
+
+
+class TestGraceProtectsOverrideClassification:
+    """automation._start_grace_period() sets _grace_protects_override from `trigger`
+    membership in _GRACE_TRIGGERS_PROTECTING_OVERRIDE (Issue #530) — centralized
+    classification instead of a boolean threaded through every callsite. Exercises the
+    REAL AutomationEngine._start_grace_period(), not a re-implementation.
+    """
+
+    def _make_real_engine_for_grace_start(self):
+        ae = _make_automation_engine_stub()
+        ae._start_grace_period = types.MethodType(AutomationEngine._start_grace_period, ae)
+        ae._cancel_grace_timers = types.MethodType(AutomationEngine._cancel_grace_timers, ae)
+        ae._emit_event_callback = None
+        ae.config = {}
+        return ae
+
+    def test_fan_manual_override_trigger_protects_override(self):
+        """trigger='fan_manual_override' (a real fan-on override) -> protects_override=True."""
+        ae = self._make_real_engine_for_grace_start()
+        ae._start_grace_period("manual", trigger="fan_manual_override")
+        assert ae._grace_protects_override is True
+
+    def test_override_confirmed_trigger_protects_override(self):
+        """trigger='override_confirmed' (a real thermostat override) -> protects_override=True."""
+        ae = self._make_real_engine_for_grace_start()
+        ae._start_grace_period("manual", trigger="override_confirmed")
+        assert ae._grace_protects_override is True
+
+    def test_fan_off_trigger_does_not_protect_override(self):
+        """trigger='fan_off' (Issue #359 cooldown, no override involved) -> protects_override=False."""
+        ae = self._make_real_engine_for_grace_start()
+        ae._start_grace_period("manual", trigger="fan_off")
+        assert ae._grace_protects_override is False
+
+    def test_dashboard_resume_trigger_does_not_protect_override(self):
+        """trigger='dashboard_resume' -> protects_override=False."""
+        ae = self._make_real_engine_for_grace_start()
+        ae._start_grace_period("manual", trigger="dashboard_resume")
+        assert ae._grace_protects_override is False
+
+    def test_sensor_closed_resume_trigger_does_not_protect_override(self):
+        """trigger='sensor_closed_resume' (automation-initiated) -> protects_override=False."""
+        ae = self._make_real_engine_for_grace_start()
+        ae._start_grace_period("automation", trigger="sensor_closed_resume")
+        assert ae._grace_protects_override is False
+
+    def test_cancel_grace_timers_resets_protects_override(self):
+        """_cancel_grace_timers() must reset _grace_protects_override alongside _grace_active,
+        so a stale True doesn't leak into whatever starts next."""
+        ae = self._make_real_engine_for_grace_start()
+        ae._start_grace_period("manual", trigger="fan_manual_override")
+        assert ae._grace_protects_override is True
+
+        ae._cancel_grace_timers()
+
+        assert ae._grace_protects_override is False

--- a/tests/test_whole_house_fan_hvac_suppression.py
+++ b/tests/test_whole_house_fan_hvac_suppression.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import asyncio
 import importlib
 import sys
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # Patch dt_util.now before importing automation
@@ -975,6 +975,29 @@ class TestManualWhfOffReleasesAndReclassifies:
         assert engine._pre_fan_hvac_mode == "cool", "Must not release suppression while fan is still on"
         engine._reclassify_callback.assert_not_called()
 
+    def test_clear_fan_override_does_not_release_while_nat_vent_session_active(self):
+        """Issue #530: clearing a fan override must NOT release WHF HVAC suppression while
+        a nat-vent session is still considered active, even when the fan happens to be
+        physically off at that instant (command-only mode, no ground-truth callback).
+
+        Live incident: handle_morning_wakeup() computed DEFER_NAT_VENT ("leaving fan
+        alone") because _natural_vent_active was True, then clear_manual_override() ->
+        clear_fan_override() released suppression anyway a few lines later in the same
+        handler — letting the immediately-following comfort-band write arm active HVAC
+        with windows still open. _exit_nat_vent() is the only path that should end this
+        session's suppression.
+        """
+        engine = _make_engine(fan_mode=FAN_MODE_WHOLE_HOUSE, current_hvac_mode="off")
+        engine._pre_fan_hvac_mode = "off"
+        engine._fan_override_active = True
+        engine._natural_vent_active = True
+        engine._reclassify_callback = MagicMock()
+
+        engine.clear_fan_override()
+
+        assert engine._pre_fan_hvac_mode == "off", "Must not release suppression while nat-vent session is active"
+        engine._reclassify_callback.assert_not_called()
+
     def test_clear_fan_override_no_op_when_no_suppression_session(self):
         """clear_fan_override() with no _pre_fan_hvac_mode set (e.g. FAN_MODE_HVAC override,
         or override cleared with nothing to release) must not touch the reclassify callback."""
@@ -986,3 +1009,134 @@ class TestManualWhfOffReleasesAndReclassifies:
         engine.clear_fan_override()
 
         engine._reclassify_callback.assert_not_called()
+
+
+class TestTimerBoundarySettleWindow:
+    """Issue #530: a fan-off report arriving shortly after an RF-timer-linked grace
+    expires must be treated as the tail of that SAME timer boundary, not a fresh event.
+
+    Live incident: an 8h RF remote timer's grace expired in software at T+0; the timer's
+    own hardware side turned the physical fan off ~11s later. CA's post-grace reconcile
+    had already adopted the still-running fan as a fresh nat-vent session at T+0, so the
+    delayed fan-off (T+11s) looked like an unexpected new event: it started a second,
+    independent fan-off grace, which the Issue #508 orphaned-grace watchdog immediately
+    killed (fan-off grace deliberately carries no override flag), re-arming the fan 5s
+    later — a decision made by one automation feature immediately undone by another.
+    """
+
+    _FIXED_NOW = datetime(2026, 6, 12, 14, 0, 30)
+
+    def setup_method(self) -> None:
+        # dt_util.now() must return a real, comparable datetime — the settle-window check
+        # does `dt_util.now() <= self._timer_boundary_settle_until`, which raises against
+        # the module-default MagicMock some other tests in this file never exercise.
+        # Patched directly on automation.dt_util (not sys.modules["homeassistant.util.dt"])
+        # because `from homeassistant.util import dt as dt_util` resolves, in this stub
+        # environment, via the parent mock's auto-vivified `.dt` attribute — a distinct
+        # object per importing module, not the sys.modules entry (see ha_stubs.py's
+        # equivalent, deliberate pinning for entity_registry/device_registry, which this
+        # module was never included in).
+        automation_module = importlib.import_module("custom_components.climate_advisor.automation")
+        automation_module.dt_util.now = lambda: self._FIXED_NOW
+
+    def _arm_settle_window(self, engine, *, seconds_remaining: float = 60.0) -> None:
+        engine._timer_boundary_settle_until = self._FIXED_NOW + timedelta(seconds=seconds_remaining)
+
+    def test_fan_off_within_settle_window_and_nat_vent_active_exits_via_choke_point(self):
+        """Fan-off inside the settle window, with nat-vent already adopted, and sensors
+        closed: must route through _exit_nat_vent() (restoring HVAC + starting an
+        AUTOMATION grace) rather than starting a fresh MANUAL fan-off grace."""
+        engine = _make_engine(fan_mode=FAN_MODE_WHOLE_HOUSE, current_hvac_mode="off")
+        self._arm_settle_window(engine)
+        engine._natural_vent_active = True
+        engine._fan_active = True
+        engine._pre_fan_hvac_mode = "cool"
+        engine._sensor_check_callback = MagicMock(return_value=False)  # sensors closed
+
+        captured: list = []
+        engine.hass.async_create_task = MagicMock(side_effect=lambda c: captured.append(c))
+
+        engine.on_fan_turned_off(fan_before="on", fan_after="off")
+
+        assert engine._timer_boundary_settle_until is None, "Settle window must be consumed (one-shot)"
+        assert len(captured) == 1, "_exit_nat_vent() must be scheduled, not run inline"
+        asyncio.run(captured[0])
+
+        assert engine._natural_vent_active is False
+        assert engine._grace_active is True
+        assert engine._last_resume_source == "automation", (
+            "Sensors closed -> _exit_nat_vent() restores HVAC and starts an AUTOMATION grace,"
+            " never a fresh MANUAL fan-off grace"
+        )
+
+    def test_fan_off_within_settle_window_and_sensor_open_pauses_instead_of_reengaging(self):
+        """Fan-off inside the settle window with a monitored sensor still open: must pause
+        (not restore HVAC / re-arm the fan) — proves the coalesced exit still respects live
+        sensor state instead of blindly resuming."""
+        engine = _make_engine(fan_mode=FAN_MODE_WHOLE_HOUSE, current_hvac_mode="off")
+        self._arm_settle_window(engine)
+        engine._natural_vent_active = True
+        engine._fan_active = True
+        engine._pre_fan_hvac_mode = "cool"
+        engine._sensor_check_callback = MagicMock(return_value=True)  # sensor still open
+        engine._paused_by_door = False
+
+        captured: list = []
+        engine.hass.async_create_task = MagicMock(side_effect=lambda c: captured.append(c))
+
+        engine.on_fan_turned_off(fan_before="on", fan_after="off")
+        asyncio.run(captured[0])
+
+        assert engine._natural_vent_active is False
+        assert engine._paused_by_door is True, "Open sensor -> pause, not restore/re-engage"
+        assert engine._grace_active is False, "No grace should start while paused for an open sensor"
+
+    def test_fan_off_within_settle_window_but_not_adopted_just_clears_flags(self):
+        """If the post-grace reconcile did NOT adopt the fan as nat-vent (e.g. conditions no
+        longer favored it), a fan-off inside the settle window has nothing to reconcile —
+        flags are cleared and no new grace is started at all."""
+        engine = _make_engine(fan_mode=FAN_MODE_WHOLE_HOUSE, current_hvac_mode="off")
+        self._arm_settle_window(engine)
+        engine._natural_vent_active = False
+        engine._fan_active = False
+
+        engine.hass.async_create_task = MagicMock(side_effect=_consume_coroutine)
+
+        engine.on_fan_turned_off(fan_before="on", fan_after="off")
+
+        assert engine._timer_boundary_settle_until is None
+        assert engine._fan_active is False
+        assert engine._grace_active is False, "No fan-off grace should start for a coalesced timer-boundary event"
+        engine.hass.async_create_task.assert_not_called()
+
+    def test_fan_off_outside_settle_window_uses_normal_fresh_event_path(self):
+        """No settle window armed (the common case: a fan-off unrelated to any RF timer)
+        must behave exactly as before — starts a fresh manual fan-off grace."""
+        engine = _make_engine(fan_mode=FAN_MODE_WHOLE_HOUSE, current_hvac_mode="off")
+        assert engine._timer_boundary_settle_until is None
+        engine._natural_vent_active = True
+        engine._fan_active = True
+
+        engine.hass.async_create_task = MagicMock(side_effect=_consume_coroutine)
+
+        engine.on_fan_turned_off(fan_before="on", fan_after="off")
+
+        assert engine._grace_active is True
+        assert engine._last_resume_source == "manual", "Unrelated fan-off still starts its own fan-off grace"
+        assert engine._natural_vent_active is False
+
+    def test_fan_off_after_settle_window_expired_uses_normal_fresh_event_path(self):
+        """A settle window that has already elapsed must not coalesce a later, unrelated
+        fan-off — the one-shot window only covers events genuinely close to the timer
+        boundary."""
+        engine = _make_engine(fan_mode=FAN_MODE_WHOLE_HOUSE, current_hvac_mode="off")
+        self._arm_settle_window(engine, seconds_remaining=-5.0)  # already expired
+        engine._natural_vent_active = True
+        engine._fan_active = True
+
+        engine.hass.async_create_task = MagicMock(side_effect=_consume_coroutine)
+
+        engine.on_fan_turned_off(fan_before="on", fan_after="off")
+
+        assert engine._grace_active is True
+        assert engine._last_resume_source == "manual"


### PR DESCRIPTION
## Summary

- **Root cause fix (general, not just RF-timer):** `coordinator._check_orphaned_grace()` (Issue #508) inferred "orphaned" purely from absent `_manual_override_active`/`_fan_override_active` — also the normal, by-design shape of fan-off, physical-drift-correction, window-close-resume, dashboard-resume, and nat-vent-exit-resume grace, none of which ever set an override flag. This killed fan-off grace within ~1 event-loop tick of starting almost universally (any whole-house-fan-off), defeating Issue #359's fan-off protection well beyond the RF-timer scenario originally reported. Fixed via a centralized classification: `_start_grace_period(trigger=...)` sets `_grace_protects_override` from membership in a 2-item frozenset (`_GRACE_TRIGGERS_PROTECTING_OVERRIDE`), keyed off the `trigger` string every callsite already passes — not a new parameter threaded through all 7 call sites. The original Issue #508 protection is fully preserved for the two genuine override-driven triggers.
- **RF-timer-specific refinement:** a fan-off within 2 minutes of an RF-remote-timer grace's own expiry is now recognized as the tail of the same session (routed straight through `_exit_nat_vent()`) instead of starting an independent new grace at all.
- **Separate ordering bug:** `handle_morning_wakeup()` could arm HVAC with windows still open via a `clear_manual_override()` side effect (`_release_whf_and_reclassify()`) that released whole-house-fan suppression without checking `_natural_vent_active`. Now guarded.

Full investigation and design discussion: #530.

## Test plan

- [x] 13 new regression tests (`tests/test_grace_stuck.py`, `tests/test_whole_house_fan_hvac_suppression.py`), each individually verified to fail without its corresponding fix via a stash/revert check
- [x] Full suite: 3612 passed
- [x] `ruff check` / `ruff format` clean
- [x] `tools/validate.py` clean
- [x] All 74 golden simulation scenarios pass
- [x] `docs/grace-periods-spec.md` updated (Orphaned Grace Self-Heal rewritten, new RF-Timer Boundary Settle Window section, cross-references)
- [x] Version bumped 0.5.36 → 0.5.37, RELEASE_NOTES + KNOWN_FIXES[530] added