### PR TITLE
Fix #534: Next Automation card wording clarity + mild-day dynamic close time

### DIFF
--- a/custom_components/climate_advisor/briefing.py
+++ b/custom_components/climate_advisor/briefing.py
@@ -121,6 +121,23 @@ def generate_briefing(
         if c.day_type == DAY_TYPE_WARM and predicted_indoor_future and predicted_outdoor_future
         else None
     )
+    # Issue #534: MILD-day window close time was documented (docs/08-COMPUTATION-REFERENCE.md
+    # §6d) as ODE-dynamic but never actually wired up — _mild_day_plan() always used the static
+    # classifier hour. The dead `_derive_natural_vent_events()` helper was built for a
+    # list[float] hour-indexed curve shape that _build_predicted_indoor_future() has never
+    # actually produced (it returns list[{"ts", "temp"}], same as the warm-day curves) — so
+    # reuse _derive_warm_day_events() here instead, the same call already validated accurate
+    # for warm days, rather than wiring up a function whose expected input shape doesn't match
+    # what production provides.
+    mild_events = (
+        _derive_warm_day_events(
+            predicted_indoor=predicted_indoor_future,
+            predicted_outdoor=predicted_outdoor_future,
+            comfort_cool=comfort_cool,
+        )
+        if c.day_type == DAY_TYPE_MILD and predicted_indoor_future and predicted_outdoor_future
+        else None
+    )
 
     tldr_lines = _generate_tldr_table(
         c,
@@ -130,6 +147,7 @@ def generate_briefing(
         bedtime_setback_cool=bedtime_setback_cool,
         occupancy_mode=occupancy_mode,
         warm_events=warm_events,
+        mild_events=mild_events,
     )
 
     if verbosity == "tldr_only":
@@ -168,7 +186,9 @@ def generate_briefing(
             )
         )
     elif c.day_type == DAY_TYPE_MILD:
-        lines.extend(_mild_day_plan(c, comfort_heat, wake_time, sleep_time, temp_unit=temp_unit))
+        lines.extend(
+            _mild_day_plan(c, comfort_heat, wake_time, sleep_time, temp_unit=temp_unit, mild_events=mild_events)
+        )
     elif c.day_type == DAY_TYPE_COOL:
         lines.extend(
             _cool_day_plan(
@@ -258,6 +278,7 @@ def _generate_tldr_table(
     bedtime_setback_cool: float | None = None,
     occupancy_mode: str = "home",
     warm_events: dict | None = None,
+    mild_events: dict | None = None,
 ) -> list[str]:
     """Generate a plain-text aligned TLDR summary table.
 
@@ -271,6 +292,8 @@ def _generate_tldr_table(
         warm_events: Result of _derive_warm_day_events(), pre-computed once in
             generate_briefing() (Issue #518) so the header's window-close time always
             agrees with the conversational body — never re-derive it independently here.
+        mild_events: Same, for MILD days (Issue #534) — only one of warm_events/mild_events
+            is ever populated for a given classification's day_type.
 
     Returns:
         List of lines forming a plain-text aligned table.
@@ -303,12 +326,13 @@ def _generate_tldr_table(
     threshold = comfort_cool + ECONOMIZER_TEMP_DELTA
     if c.windows_recommended and c.window_open_time and c.window_close_time:
         open_t = c.window_open_time.strftime(_FMT_HOUR)
-        # Prefer the same ODE-derived cutoff the conversational body uses (Issue #518) \u2014
-        # falls back to the classifier's static hour only when no forecast curve exists.
-        warm_cutoff = warm_events.get("nat_vent_cutoff") if warm_events else None
-        close_t = (
-            warm_cutoff.strftime(_FMT_HOUR) if warm_cutoff is not None else c.window_close_time.strftime(_FMT_HOUR)
-        )
+        # Prefer the same ODE-derived cutoff the conversational body uses (Issue #518, extended
+        # to MILD days in #534) \u2014 falls back to the classifier's static hour only when no
+        # forecast curve exists. warm_events/mild_events are mutually exclusive (populated only
+        # for their matching day_type).
+        _events = warm_events or mild_events
+        _cutoff = _events.get("nat_vent_cutoff") if _events else None
+        close_t = _cutoff.strftime(_FMT_HOUR) if _cutoff is not None else c.window_close_time.strftime(_FMT_HOUR)
         windows_val = f"Open {open_t} \u2013 {close_t}"
     elif c.window_opportunity_morning and c.window_opportunity_evening:
         m_start = c.window_opportunity_morning_start.strftime(_FMT_HOUR).lstrip("0")
@@ -728,7 +752,9 @@ def _warm_day_plan(
     return lines
 
 
-def _mild_day_plan(c, comfort_heat, wake_time, sleep_time, temp_unit: str = FAHRENHEIT) -> list[str]:
+def _mild_day_plan(
+    c, comfort_heat, wake_time, sleep_time, temp_unit: str = FAHRENHEIT, mild_events: dict | None = None
+) -> list[str]:
     """Conversational plan for mild days (60-74\u00b0F)."""
     lines = [
         f"A day where the house practically takes care of itself. I warmed to"
@@ -744,8 +770,14 @@ def _mild_day_plan(c, comfort_heat, wake_time, sleep_time, temp_unit: str = FAHR
             f" cross-breeze that freshens the air and warms the house for free."
         )
 
-    if c.window_close_time:
-        close_t = c.window_close_time.strftime(_FMT_HOUR)
+    # Issue #534: prefer the ODE-derived cutoff when available (same forecast already validated
+    # accurate for warm days), matching docs/08-COMPUTATION-REFERENCE.md \u00a76d \u2014 falls back to the
+    # classifier's static hour only when no forecast curve exists (fresh install, uncalibrated
+    # model), same fallback pattern _generate_tldr_table() already uses for warm days.
+    _mild_cutoff = mild_events.get("nat_vent_cutoff") if mild_events else None
+    _close_time = _mild_cutoff if _mild_cutoff is not None else c.window_close_time
+    if _close_time:
+        close_t = _close_time.strftime(_FMT_HOUR)
         lines.append("")
         lines.append(
             f"Close up by {close_t} to trap the warmth. If it dips below"

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,18 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.37"
+VERSION = "0.5.38"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.38": [
+        "Fix #534: the Next Automation card's 'outdoor no longer helping' message could read"
+        " as a claim about right now even though it was always a forecast for a specific"
+        " future time — the action text now says when that's expected to happen (e.g."
+        " 'Outdoor will stop helping around 9:00 AM — close windows') instead of only showing"
+        " the time in a separate card. Also: mild-day briefings now use the same"
+        " weather-forecast-based window close time warm days already got, instead of always"
+        " showing a fixed 5:00 PM regardless of actual conditions.",
+    ],
     "0.5.37": [
         "Fix #530: turning off the whole-house fan didn't reliably stick — a watchdog meant"
         " to catch a completely different, rare bug was mistaking the normal 'no override in"
@@ -1311,6 +1320,48 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    534: {
+        "version_fixed": "0.5.38",
+        "title": (
+            "Next Automation card's 'outdoor no longer helping' text could be misread as a"
+            " present-tense claim even though it was always an accurate forecast for a"
+            " separately-displayed future time; mild-day briefings never used the"
+            " weather-forecast-based window close time warm days already had"
+        ),
+        "scope_covered": (
+            "Investigated as a possible live nat-vent control defect (reported symptom: nat-vent"
+            " session inactive for ~2.5 hours overnight while conditions looked favorable)."
+            " Extending the log window through the predicted cutoff time and viewing the"
+            " reporter's screenshot directly confirmed the forecast (9:00 AM) was accurate"
+            " (outdoor actually caught up to indoor ~9:10-9:23 AM) and nat-vent reactivated on"
+            " its own the moment indoor cleared the comfort floor, exactly as designed — no"
+            " control-path defect. coordinator.py: _compute_next_automation_action() now folds"
+            " the predicted time into the candidate action string itself (e.g. 'Outdoor will"
+            " stop helping around 9:00 AM — close windows') instead of relying on the separate"
+            " Automation Time card alone, removing the present-tense misread. briefing.py:"
+            " generate_briefing() now computes mild_events via _derive_warm_day_events() for"
+            " MILD days (mirroring the existing warm-day pattern) and threads it into both"
+            " _generate_tldr_table() and _mild_day_plan(), so mild-day close times use the ODE"
+            " forecast when available, falling back to the static classifier hour otherwise —"
+            " closing a gap where docs/08-COMPUTATION-REFERENCE.md §6d already claimed this"
+            " behavior existed but it never had been wired up."
+        ),
+        "scope_not_covered": (
+            "_derive_warm_day_events()'s nat_vent_cutoff prediction (outdoor >= indoor - 1°F)"
+            " still has no comfort-floor term, unlike the real activation gate"
+            " decide_nat_vent_gate() in nat_vent_gate.py. In this incident the outdoor-crossing"
+            " prediction was the correct binding constraint anyway, so this did not cause the"
+            " reported symptom, but it could produce a wrong prediction in a scenario where the"
+            " floor would bind first. No incident has confirmed this firing — tracked as a"
+            " separate defensive-hardening follow-up (Issue #535) rather than bundled into this"
+            " fix."
+            " _derive_natural_vent_events() (the MILD-day hour-indexed sibling of the warm-day"
+            " function) remains dead code — it was never wired up (the fix above uses"
+            " _derive_warm_day_events() instead, since it matches the actual curve shape"
+            " _build_predicted_indoor_future() produces; _derive_natural_vent_events()'s"
+            " documented list[float] hour-indexed input shape does not)."
+        ),
+    },
     530: {
         "version_fixed": "0.5.37",
         "title": (

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -6965,7 +6965,16 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 comfort_cool=float(self.config.get("comfort_cool", DEFAULT_COMFORT_COOL)),
             )
             if _warm_events["nat_vent_cutoff"] and _warm_events["nat_vent_cutoff"] > now:
-                candidates.append((_warm_events["nat_vent_cutoff"], "Close windows — outdoor no longer helping"))
+                # Issue #534: this is a forecast for a future time, not a claim about current
+                # conditions — the qualifying time otherwise lives only in the separate
+                # "Automation Time" card, and a user comparing this text to *current* conditions
+                # (which can look nothing like it, hours ahead of the actual crossing) reads it as
+                # a present-tense contradiction. Folding the time into the action text itself
+                # removes the ambiguity without changing when this candidate fires.
+                _cutoff_t = _warm_events["nat_vent_cutoff"].strftime("%I:%M %p").lstrip("0")
+                candidates.append(
+                    (_warm_events["nat_vent_cutoff"], f"Outdoor will stop helping around {_cutoff_t} — close windows")
+                )
             if _warm_events["ceiling_breach_time"] and _warm_events["ceiling_breach_time"] > now:
                 candidates.append((_warm_events["ceiling_breach_time"], "AC turns on to hold the ceiling"))
             if _warm_events["recovery_time"] and _warm_events["recovery_time"] > now:

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.37"
+  "version": "0.5.38"
 }

--- a/docs/08-COMPUTATION-REFERENCE.md
+++ b/docs/08-COMPUTATION-REFERENCE.md
@@ -974,11 +974,23 @@ self.window_close_time = time(MILD_WINDOW_CLOSE_HOUR, 0)
 
 **`briefing.py` applies ODE timing when available:**
 
-The `_derive_warm_day_events()` function (which computes `nat_vent_cutoff` and `ceiling_breach_time` from the predicted indoor and outdoor curves) is extracted into a shared helper `_derive_natural_vent_events(predicted_indoor_future, predicted_outdoor_future, comfort_cool, k_active_cool)`. This helper is called from the MILD day briefing path as well as the warm day path.
+**Correction (Issue #534, 2026-07-28):** this section previously described a shared helper,
+`_derive_natural_vent_events(predicted_indoor_future, predicted_outdoor_future, comfort_cool,
+k_active_cool)`, as wired into the MILD day briefing path. That was aspirational, not actual —
+the function existed and was unit-tested but had zero production call sites, and `_mild_day_plan()`
+used the static `c.window_close_time` unconditionally. It has now been wired up, but via
+`_derive_warm_day_events()` directly (the same function warm days use), not
+`_derive_natural_vent_events()` — that helper's documented input shape (`list[float]`,
+hour-indexed) does not match what `_build_predicted_indoor_future()` actually produces
+(`list[{"ts", "temp"}]`, the same shape warm-day curves use), so it remains unused/dead code.
+`generate_briefing()` computes `mild_events` for MILD days the same way it already computes
+`warm_events` for warm days (identical call shape), and passes it to both `_generate_tldr_table()`
+(header row) and `_mild_day_plan()` (conversational body).
 
-When the ODE is available (thermal model calibrated, physics gate eligible):
-- MILD day window close time = `nat_vent_cutoff` (the hour when outdoor temp ≥ indoor − 1°F)
-- Fallback when ODE unavailable = `time(MILD_WINDOW_CLOSE_HOUR, 0)` (5pm)
+When a predicted indoor/outdoor forecast curve is available (thermal model calibrated):
+- MILD day window close time = `nat_vent_cutoff` (the timestamp outdoor temp ≥ indoor − 1°F)
+- Fallback when no forecast curve is available = `time(MILD_WINDOW_CLOSE_HOUR, 0)` (5pm), unchanged
+  from before this fix
 
 #### Impact Cascade from Solar Phase Offset Correction
 

--- a/tests/test_briefing.py
+++ b/tests/test_briefing.py
@@ -335,6 +335,23 @@ class TestMildDayBriefing:
             or "takes care of itself" in low
         )
 
+    def test_uses_ode_close_time_when_forecast_available(self):
+        """Issue #534: MILD-day close time uses the ODE-derived cutoff when a forecast curve
+        is available, instead of always falling back to the static classifier hour (5 PM)."""
+        c = _make_classification("mild", today_high=68, today_low=48)
+        # Outdoor crosses indoor at hour 13 UTC (index 3) — well before the static 5 PM fallback.
+        indoor = _make_indoor_curve([65.0, 66.0, 67.0, 68.0], start_hour_utc=10)
+        outdoor = _make_outdoor_curve([55.0, 58.0, 62.0, 67.5], start_hour_utc=10)
+        result = _generate(c, predicted_indoor_future=indoor, predicted_outdoor_future=outdoor)
+        assert "1:00 PM" in result
+        assert "5:00 PM" not in result
+
+    def test_falls_back_to_static_close_time_without_forecast(self):
+        """No forecast curve (fresh install / uncalibrated model) — unchanged static fallback."""
+        c = _make_classification("mild", today_high=68, today_low=48)
+        result = _generate(c)
+        assert "5" in result or "17" in result
+
 
 class TestCoolDayBriefing:
     """Cool day briefings should mention heating and keeping sealed."""

--- a/tests/test_status_sensors.py
+++ b/tests/test_status_sensors.py
@@ -508,7 +508,7 @@ class TestWarmDayForecastEventCandidates:
         indoor = _curve([70.0, 71.0, 72.0, 73.0], start_hour=13)
         outdoor = _curve([60.0, 62.0, 71.5, 74.0], start_hour=13, ts_key="datetime", temp_key="temperature")
         action, t = _compute_next_automation_action_with_forecast(c, ae, config, time(12, 0), indoor, outdoor)
-        assert action == "Close windows — outdoor no longer helping"
+        assert action == "Outdoor will stop helping around 3:00 PM — close windows"
         assert t == "3:00 PM"  # hour 15: outdoor 71.5 >= indoor 72 - 1
 
     def test_absent_when_windows_not_recommended(self):


### PR DESCRIPTION
## Summary
- Investigated #534's report of a misleading "outdoor no longer helping" message as a possible live nat-vent control defect. Extending the log window through the predicted 9:00 AM cutoff and viewing the reporter's screenshot confirmed the forecast was accurate (outdoor actually caught up to indoor ~9:10-9:23 AM) and nat-vent reactivated on its own once indoor cleared the comfort floor, exactly as designed — **no control-path defect found**.
- The real issue: the action text carried no indication it was a future forecast, reading as a present-tense claim next to current conditions. Fixed by folding the predicted time into the action string itself.
- While investigating, found `_mild_day_plan()` always used the static classifier close hour even though the docs claimed it was ODE-dynamic like warm days — it never had been wired up. Fixed by reusing the already-validated `_derive_warm_day_events()` pattern for mild days too.
- A related but unconfirmed latent gap (`_derive_warm_day_events()`'s cutoff prediction has no comfort-floor term) is filed separately as #535, not bundled into this fix, since no incident confirmed it firing.

## Test plan
- [x] `ruff check` / `ruff format` clean
- [x] `tools/validate.py` clean
- [x] New tests added, confirmed to fail without the fix and pass with it (stash/revert check)
- [x] Full suite: 3614 passed
- [x] `docs/08-COMPUTATION-REFERENCE.md` §6d corrected to match actual behavior
- [x] `VERSION`/`manifest.json` bumped to 0.5.38, `RELEASE_NOTES`/`KNOWN_FIXES[534]` added