### PR TITLE
Fix #538: Next User Action card no longer narrates automation status

### DIFF
--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,15 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.38"
+VERSION = "0.5.39"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.39": [
+        "Fix #538: the 'Next User Action' card said 'Free cooling is active.' while nat-vent"
+        " or economizer cooling was already running — just repeating what the Status card"
+        " already showed instead of telling you what to do. It now shows '-' when there's"
+        " nothing for you to do.",
+    ],
     "0.5.38": [
         "Fix #534: the Next Automation card's 'outdoor no longer helping' message could read"
         " as a claim about right now even though it was always a forecast for a specific"
@@ -1320,6 +1326,31 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    538: {
+        "version_fixed": "0.5.39",
+        "title": (
+            "Next User Action card narrated automation-mechanism state ('Free cooling is"
+            " active.') instead of answering what the occupant should do, duplicating the"
+            " Status card and violating the Issue #527 card ontology"
+        ),
+        "scope_covered": (
+            "coordinator.py: _compute_next_action() had two branches (HOT-day fallback and the"
+            " WARM/MILD/COOL cooling-needed path) that returned 'Free cooling is active.' when"
+            " ae._natural_vent_active or ae._economizer_active was already True. Both now return"
+            " '-' — there is nothing for the occupant to do while free cooling is already"
+            " handling comfort, and the Status card already surfaces the nat-vent/economizer"
+            " mechanism state. Audited the rest of _compute_next_action() for other"
+            " mechanism-flag leaks (is_paused_by_door, _grace_active, _manual_override_active,"
+            " _override_confirm_pending) — none found outside the diagnostic log line, which is"
+            " not user-facing."
+        ),
+        "scope_not_covered": (
+            "Did not re-audit _compute_automation_status() or"
+            " _compute_next_automation_action() for the same duplication class — those own"
+            " different questions in the Issue #527 card ontology and were not implicated in"
+            " this report."
+        ),
+    },
     534: {
         "version_fixed": "0.5.38",
         "title": (

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -6207,7 +6207,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             elif c.window_opportunity_evening and now >= time(ECONOMIZER_EVENING_START_HOUR, 0):
                 return _decide(f"Open windows if outdoor temp is below {format_temp(threshold, unit)}")
             if ae is not None and (ae._natural_vent_active or ae._economizer_active):
-                return _decide("Free cooling is active.")
+                return _decide("-")
             return _decide("Keep windows and blinds closed.")
         elif c.day_type == DAY_TYPE_COLD:
             if windows_physically_open:
@@ -6221,7 +6221,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
 
         if cooling_needed:
             if ae is not None and (ae._natural_vent_active or ae._economizer_active):
-                return _decide("Free cooling is active.")
+                return _decide("-")
             if windows_physically_open:
                 if outdoor_temp is not None and not direction_ok:
                     return _decide(

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.38"
+  "version": "0.5.39"
 }

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -378,11 +378,11 @@ class TestComputeNextAction:
         assert "fan" in result.lower()
 
     def test_next_action_cooling_needed_free_cooling_already_active(self):
-        """Nat-vent/economizer already active → don't suggest a duplicate action."""
+        """Nat-vent/economizer already active → nothing for the occupant to do (Issue #527 regression)."""
         c = _make_classification(day_type=DAY_TYPE_MILD, windows_recommended=False)
         ae = _make_ae_stub(_natural_vent_active=True)
         result = _compute_next_action(c, {"comfort_cool": 75}, time(14, 0), indoor_temp=78.0, outdoor_temp=70.0, ae=ae)
-        assert "free cooling is active" in result.lower()
+        assert result == "-"
 
     def test_next_action_cooling_needed_windows_open_direction_favorable(self):
         """Cooling needed, windows already open, outdoor favorable → confirm, don't repeat the ask."""
@@ -495,7 +495,7 @@ class TestComputeNextAction:
         assert "paused" not in result.lower()
 
     def test_next_action_hot_no_opportunity_free_cooling_active(self):
-        """HOT day, no scheduled opportunity, but nat-vent/economizer already active — don't contradict it."""
+        """HOT day, no scheduled opportunity, nat-vent/economizer already active — nothing to do (Issue #527)."""
         c = _make_classification(
             day_type=DAY_TYPE_HOT,
             window_opportunity_morning=False,
@@ -503,7 +503,7 @@ class TestComputeNextAction:
         )
         ae = _make_ae_stub(_economizer_active=True)
         result = _compute_next_action(c, {}, time(13, 0), ae=ae)
-        assert "free cooling is active" in result.lower()
+        assert result == "-"
 
     def test_next_action_guest_occupancy_behaves_like_home(self):
         """GUEST occupancy mode is not short-circuited — full comfort logic applies same as HOME."""


### PR DESCRIPTION
## Summary
- The "Next User Action" card showed "Free cooling is active." while nat-vent/economizer was already running — a status statement, not an action, that duplicated the Status card and violated the Issue #527 card ontology.
- `_compute_next_action()` now returns `"-"` in both branches (HOT-day fallback, WARM/MILD/COOL cooling-needed path) when free cooling is already active — nothing for the occupant to do.
- Version bumped 0.5.38 → 0.5.39 with `RELEASE_NOTES` and `KNOWN_FIXES[538]` entries per project process.

## Test plan
- [x] `tests/test_coordinator.py` — updated the two assertions that expected "Free cooling is active." to expect "-"
- [x] `python -m pytest tests/test_version_sync.py tests/test_coordinator.py tests/test_status_sensors.py` — 147 passed
- [x] `ruff check` / `ruff format` clean