### PR TITLE
Feat #540: nat-vent soft-start at outdoor/indoor parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,7 @@ See [Issue #11](https://github.com/gunkl/ClimateAdvisor/issues/11) for full trac
 - [x] Warm/mild-day window-close and reopen times fixed (a data-alignment bug could tell users to close windows hours too early); Next Automation card now predicts WHF/nat-vent start, warm-day window/AC events, and hot-day window-cooling opportunities using the same logic the automation itself uses (#528)
 - [x] Whole-house-fan-off grace period reliably sticks for its full protection window — a watchdog meant for a rare stuck-automation case was misfiring on ordinary fan-off almost every time; 8-hour RF remote timer sessions no longer produce a burst of contradictory decisions when the timer runs out (#530)
 - [x] Next Automation's "outdoor no longer helping" message now states when that's expected to happen instead of reading like a claim about right now; mild-day briefings use the same forecast-based window-close time warm days already got instead of a fixed 5:00 PM (#534)
+- [x] Whole-house fan can now soft-start for air movement and attic/thermal-mass purge as soon as outdoor reaches parity with indoor in the evening, once the day is confirmed past its peak — instead of waiting for outdoor to be measurably cooler; on by default, disable in settings for the old strict-delta behavior (#540)
 
 ### Phase 4: Seasonal & Cost Intelligence (v0.5+) — Future
 - [ ] Seasonal performance baselines (after 1 year of data)

--- a/custom_components/climate_advisor/ai_skills_activity.py
+++ b/custom_components/climate_advisor/ai_skills_activity.py
@@ -676,6 +676,21 @@ def _render_nat_vent_predicted_floor_exit(p: dict, unit: str) -> tuple[str, str]
     return label, ", ".join(parts)
 
 
+def _render_nat_vent_soft_start_entered(p: dict, unit: str) -> tuple[str, str]:
+    outdoor = p.get("outdoor")
+    indoor = p.get("indoor")
+    label = "Nat-vent soft-start -- purge/comfort at parity"
+    if outdoor is not None and indoor is not None:
+        with contextlib.suppress(TypeError, ValueError):
+            label = (
+                f"Nat-vent soft-start -- outdoor {format_temp(float(outdoor), unit)}"
+                f" <= indoor {format_temp(float(indoor), unit)}, past today's peak"
+            )
+    peak = p.get("outdoor_today_peak")
+    detail = f"today's peak: {format_temp(float(peak), unit)}" if peak is not None else ""
+    return label, detail
+
+
 def _render_nat_vent_ceiling_escalation(p: dict, unit: str) -> tuple[str, str]:
     indoor = p.get("indoor")
     cool = p.get("comfort_cool")
@@ -947,6 +962,7 @@ EVENT_RENDERERS: dict[str, Callable[[dict, str], tuple[str, str]]] = {
     "nat_vent_reconcile_exit": _render_nat_vent_reconcile_exit,
     "nat_vent_comfort_floor_exit": _render_nat_vent_comfort_floor_exit,
     "nat_vent_away_ceiling_exit": _render_nat_vent_away_ceiling_exit,
+    "nat_vent_soft_start_entered": _render_nat_vent_soft_start_entered,
     "nat_vent_predicted_floor_exit": _render_nat_vent_predicted_floor_exit,
     "nat_vent_ceiling_escalation": _render_nat_vent_ceiling_escalation,
     "nat_vent_ac_assist_armed": _render_nat_vent_ac_assist_armed,

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -36,6 +36,7 @@ from .const import (
     CONF_MANUAL_GRACE_PERIOD,
     CONF_NAT_VENT_HYSTERESIS_F,
     CONF_NAT_VENT_REACTIVATION_LOCKOUT_S,
+    CONF_NAT_VENT_SOFT_START_ENABLED,
     CONF_NATURAL_VENT_DELTA,
     CONF_OVERRIDE_CONFIRM_PERIOD,
     CONF_SENSOR_DEBOUNCE,
@@ -48,6 +49,7 @@ from .const import (
     DEFAULT_COMFORT_HEAT,
     DEFAULT_FAN_MIN_RUNTIME_PER_HOUR,
     DEFAULT_MANUAL_GRACE_SECONDS,
+    DEFAULT_NAT_VENT_SOFT_START_ENABLED,
     DEFAULT_NATURAL_VENT_DELTA,
     DEFAULT_OVERRIDE_CONFIRM_SECONDS,
     DEFAULT_SENSOR_DEBOUNCE_SECONDS,
@@ -73,6 +75,7 @@ from .const import (
     OCCUPANCY_HOME,
     OCCUPANCY_VACATION,
     OVERRIDE_ADOPT_SETPOINT_TOLERANCE_F,
+    PEAK_DECLINE_MARGIN_F,
     REVISIT_DELAY_SECONDS,
     TEMP_SOURCE_CLIMATE_FALLBACK,
     TEMP_SOURCE_INPUT_NUMBER,
@@ -102,7 +105,12 @@ from .fan_thermostat_decision import (
     decide_fan_thermostat_check,
     resolve_hard_exit_floor,
 )
-from .nat_vent_gate import NatVentGateInputs, decide_nat_vent_gate
+from .nat_vent_gate import (
+    NatVentGateInputs,
+    NatVentSoftStartGateInputs,
+    decide_nat_vent_gate,
+    decide_nat_vent_soft_start_gate,
+)
 from .nat_vent_reactivation_lockout import is_reactivation_locked_out
 from .setpoint_verify_decision import SetpointVerifyOutcome, decide_setpoint_verify
 from .temperature import (
@@ -607,6 +615,21 @@ class AutomationEngine:
         # Timestamp of last outdoor-warm exit (outdoor ≥ indoor → pause).
         # Used for hysteresis lockout. Not serialized — resets on HA restart (acceptable for 5-min window).
         self._nat_vent_outdoor_exit_time: datetime | None = None
+
+        # Nat-vent soft-start sub-mode (Issue #540, scoped from #533): qualifies WHY an
+        # active nat-vent session was entered — True when entered via the parity/
+        # past-peak soft-start gate rather than the full bulk-cooling gate. Coexists with
+        # _natural_vent_active the same way _grace_protects_override coexists with
+        # _grace_active: same top-level state, a distinct qualifying sub-flag. Cleared
+        # alongside every _natural_vent_active = False assignment (see _exit_nat_vent()
+        # and its documented bypass sites).
+        self._nat_vent_soft_start: bool = False
+        # Today's observed outdoor peak-so-far and sample count, mirrored from the
+        # coordinator's _outdoor_temp_history (single source of truth — see
+        # coordinator._apply_outdoor_temp()). Not serialized — rebuilt from the
+        # coordinator's own persisted/restored history within one update cycle.
+        self._outdoor_temp_today_peak: float | None = None
+        self._outdoor_temp_today_sample_count: int = 0
 
         # Override confirmation period (Issue #76) — pending window before override is formally accepted
         self._override_confirm_pending: bool = False
@@ -1161,6 +1184,7 @@ class AutomationEngine:
         self._fan_on_since = None
         if not preserve_nat_vent_session:
             self._natural_vent_active = False
+            self._nat_vent_soft_start = False
 
         _LOGGER.info(
             "Fan flags cleared (%s): _fan_active/_fan_on_since cleared, _natural_vent_active %s;"
@@ -1959,6 +1983,7 @@ class AutomationEngine:
                                     )
                                 )
                                 self._natural_vent_active = False
+                                self._nat_vent_soft_start = False
                                 if self._emit_event_callback:
                                     self._emit_event_callback(
                                         "nat_vent_ceiling_escalation",
@@ -2931,7 +2956,71 @@ class AutomationEngine:
                                 "trigger": "open_door_reeval",
                             },
                         )
+                elif self._nat_vent_may_soft_start(
+                    outdoor=outdoor,
+                    indoor=_indoor,
+                    comfort_heat=_comfort_heat,
+                    comfort_cool=comfort_cool,
+                    full_gate_active=False,
+                ):
+                    # Issue #540: WHF purge/comfort soft-start — outdoor has reached parity
+                    # with indoor and today is confirmed past its peak and declining, but the
+                    # full bulk-cooling gate (outdoor meaningfully below indoor) hasn't
+                    # cleared yet. Reuses the same fan-activation/HVAC-band machinery as full
+                    # nat-vent; only the qualifier flag and log/event text differ.
+                    _LOGGER.info(
+                        "Nat-vent soft-start entered: outdoor %.1f°F <= indoor %.1f°F,"
+                        " past today's peak %.1f°F by >= %.1f°F, indoor > comfort_heat %.1f°F",
+                        outdoor,
+                        _indoor,
+                        self._outdoor_temp_today_peak or 0.0,
+                        PEAK_DECLINE_MARGIN_F,
+                        _comfort_heat,
+                    )
+                    await self._activate_fan(
+                        reason=(
+                            f"nat-vent soft-start: outdoor {outdoor:.1f}°F at/below indoor {_indoor:.1f}°F"
+                            " parity, past today's peak and declining — purge/comfort air movement"
+                        )
+                    )
+                    self._natural_vent_active = True
+                    self._nat_vent_soft_start = True
+                    await self._apply_nat_vent_hvac_state()
+                    if self._emit_event_callback:
+                        self._emit_event_callback(
+                            "nat_vent_soft_start_entered",
+                            {
+                                "outdoor": outdoor,
+                                "indoor": _indoor,
+                                "outdoor_today_peak": self._outdoor_temp_today_peak,
+                            },
+                        )
                 return
+
+            # Issue #540: soft-start → full nat-vent upgrade. Once an active soft-start
+            # session's outdoor/indoor delta independently clears the full bulk-cooling
+            # gate, drop the qualifier — the session itself (fan, HVAC suppression, exit
+            # hierarchy) is already running unchanged; only the status label changes.
+            if self._natural_vent_active and self._nat_vent_soft_start:
+                _indoor_upg = self._get_indoor_temp_f()
+                _comfort_heat_upg = self._nat_vent_reactivation_floor()
+                _hysteresis_upg = float(self.config.get(CONF_NAT_VENT_HYSTERESIS_F, NAT_VENT_HYSTERESIS_F))
+                if self._nat_vent_may_reactivate(
+                    outdoor=outdoor,
+                    indoor=_indoor_upg,
+                    comfort_heat=_comfort_heat_upg,
+                    comfort_cool=comfort_cool,
+                    nat_vent_delta=nat_vent_delta,
+                    hysteresis=_hysteresis_upg,
+                ):
+                    self._nat_vent_soft_start = False
+                    _LOGGER.info(
+                        "Nat-vent soft-start upgraded to full free-cooling: outdoor %.1f°F"
+                        " < indoor %.1f°F − %.1f°F hysteresis",
+                        outdoor if outdoor is not None else 0.0,
+                        _indoor_upg if _indoor_upg is not None else 0.0,
+                        _hysteresis_upg,
+                    )
 
             # Issue #99: Comfort-floor exit — check BEFORE outdoor warmth to avoid conflicting
             # transitions. If indoor drops to comfort_heat, stop fan and restore heat.
@@ -3017,6 +3106,7 @@ class AutomationEngine:
                         comfort_cool,
                     )
                     self._natural_vent_active = False
+                    self._nat_vent_soft_start = False
                     await self._deactivate_fan(reason="nat-vent ceiling exit (away mode)")
                     # Do NOT pause — just let away setback handle HVAC
                     if self._emit_event_callback:
@@ -3187,6 +3277,45 @@ class AutomationEngine:
                         hysteresis,
                         threshold,
                     )
+                    await self._apply_nat_vent_hvac_state()
+                elif self._nat_vent_may_soft_start(
+                    outdoor=outdoor,
+                    indoor=indoor,
+                    comfort_heat=comfort_heat,
+                    comfort_cool=comfort_cool,
+                    full_gate_active=False,
+                ):
+                    # Issue #540: same soft-start sub-mode as the idle-open reactivation
+                    # path above, for the paused-by-door reactivation site. Still subject
+                    # to this block's outdoor-warm-exit lockout (checked above) — soft-start
+                    # doesn't bypass it, it only relaxes the outdoor/indoor delta itself.
+                    await self._activate_fan(
+                        reason=(
+                            f"nat-vent soft-start while paused: outdoor {outdoor:.1f}°F at/below"
+                            f" indoor {indoor:.1f}°F parity, past today's peak and declining"
+                        )
+                    )
+                    self._natural_vent_active = True
+                    self._nat_vent_soft_start = True
+                    self._paused_by_door = False
+                    self._paused_with_hvac_already_off = False
+                    _LOGGER.info(
+                        "Nat-vent soft-start activated while paused: outdoor %.1f°F <= indoor %.1f°F,"
+                        " past today's peak %.1f°F by >= %.1f°F",
+                        outdoor,
+                        indoor,
+                        self._outdoor_temp_today_peak or 0.0,
+                        PEAK_DECLINE_MARGIN_F,
+                    )
+                    if self._emit_event_callback:
+                        self._emit_event_callback(
+                            "nat_vent_soft_start_entered",
+                            {
+                                "outdoor": outdoor,
+                                "indoor": indoor,
+                                "outdoor_today_peak": self._outdoor_temp_today_peak,
+                            },
+                        )
                     await self._apply_nat_vent_hvac_state()
                 else:
                     _LOGGER.debug(
@@ -3511,6 +3640,7 @@ class AutomationEngine:
         )
         if self._natural_vent_active:
             self._natural_vent_active = False
+            self._nat_vent_soft_start = False
         await self._deactivate_fan(reason=f"fan thermostat check — {stop_reason}")
 
     async def reconcile_fan_on_startup(
@@ -3575,6 +3705,7 @@ class AutomationEngine:
             self._fan_active = False
             self._fan_on_since = None
             self._natural_vent_active = False
+            self._nat_vent_soft_start = False
             decision = "no-fan"
             _LOGGER.info(
                 "Fan reconcile: thermostat_fan_running=%s nat_vent_eligible=%s decision=%s archetype=%s",
@@ -4307,6 +4438,7 @@ class AutomationEngine:
             if _gate != ScheduledBandGate.DEFER_NAT_VENT and self._fan_active and not _fan_was_overridden:
                 await self._deactivate_fan(reason="bedtime — no classification")
                 self._natural_vent_active = False
+                self._nat_vent_soft_start = False
             if self._economizer_active:
                 await self._deactivate_economizer(outdoor_temp=0)
             return
@@ -4333,6 +4465,7 @@ class AutomationEngine:
             if self._fan_active and not _fan_was_overridden:
                 await self._deactivate_fan(reason="bedtime — nat-vent not active")
                 self._natural_vent_active = False
+                self._nat_vent_soft_start = False
         if self._economizer_active:
             await self._deactivate_economizer(outdoor_temp=0)
 
@@ -4672,6 +4805,7 @@ class AutomationEngine:
                 refactor (Issue #411 blast-radius finding).
         """
         self._natural_vent_active = False
+        self._nat_vent_soft_start = False
         if set_outdoor_exit_time:
             self._nat_vent_outdoor_exit_time = dt_util.now()
         sensor_open = bool(self._sensor_check_callback and self._sensor_check_callback())
@@ -4779,6 +4913,51 @@ class AutomationEngine:
             aggressive_savings=bool(self.config.get("aggressive_savings", False)),
         )
         return decide_nat_vent_gate(inputs)
+
+    def _nat_vent_may_soft_start(
+        self,
+        *,
+        outdoor: float | None,
+        indoor: float | None,
+        comfort_heat: float,
+        comfort_cool: float,
+        full_gate_active: bool,
+    ) -> bool:
+        """Shared soft-start sub-gate for nat-vent (Issue #540, scoped from #533).
+
+        Distinct from ``_nat_vent_may_reactivate()``/``decide_nat_vent_gate()`` — allows
+        WHF purge/comfort activation at outdoor/indoor parity once today's outdoor temp
+        is confirmed past its peak and declining, without waiting for the full
+        bulk-cooling gate's hysteresis-cleared delta. Opt-out via
+        ``CONF_NAT_VENT_SOFT_START_ENABLED`` (default on — no humidity/dew-point sensor
+        guards this today, so disable it if you only want the fan to run once outdoor is
+        measurably cooler than indoor). See ``nat_vent_gate.NatVentSoftStartGateInputs``
+        for full field rationale.
+
+        Args:
+            outdoor: Current outdoor temperature (°F), or None if unavailable.
+            indoor: Current indoor temperature (°F), or None if unavailable.
+            comfort_heat: Comfort floor (°F) — already sleep-window-resolved by the
+                caller, same as ``_nat_vent_may_reactivate()``'s ``comfort_heat`` arg.
+            comfort_cool: Comfort ceiling (°F).
+            full_gate_active: The caller's own ``_nat_vent_may_reactivate(...)`` result
+                for the same inputs — soft-start stands down once the full gate would
+                already apply, so the two gates never compete for the same activation.
+        """
+        if not self.config.get(CONF_NAT_VENT_SOFT_START_ENABLED, DEFAULT_NAT_VENT_SOFT_START_ENABLED):
+            return False
+        inputs = NatVentSoftStartGateInputs(
+            outdoor=outdoor,
+            indoor=indoor,
+            comfort_heat=comfort_heat,
+            comfort_cool=comfort_cool,
+            fan_mode=self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED),
+            outdoor_today_peak=self._outdoor_temp_today_peak,
+            outdoor_sample_count=self._outdoor_temp_today_sample_count,
+            peak_decline_margin=PEAK_DECLINE_MARGIN_F,
+            full_gate_active=full_gate_active,
+        )
+        return decide_nat_vent_soft_start_gate(inputs)
 
     def _ceiling_threshold(self, comfort_cool: float | None) -> float | None:
         """Ceiling above which the compressor should take over from fan-assisted cooling.

--- a/custom_components/climate_advisor/config_flow.py
+++ b/custom_components/climate_advisor/config_flow.py
@@ -49,6 +49,7 @@ from .const import (
     CONF_HOME_TOGGLE_INVERT,
     CONF_MANUAL_GRACE_NOTIFY,
     CONF_MANUAL_GRACE_PERIOD,
+    CONF_NAT_VENT_SOFT_START_ENABLED,
     CONF_OVERRIDE_CONFIRM_PERIOD,
     CONF_PUSH_BRIEFING,
     CONF_PUSH_DOOR_WINDOW_PAUSE,
@@ -82,6 +83,7 @@ from .const import (
     DEFAULT_FAN_MIN_RUNTIME_PER_HOUR,
     DEFAULT_FAN_MODE,
     DEFAULT_MANUAL_GRACE_SECONDS,
+    DEFAULT_NAT_VENT_SOFT_START_ENABLED,
     DEFAULT_OVERRIDE_CONFIRM_SECONDS,
     DEFAULT_SENSOR_DEBOUNCE_SECONDS,
     DEFAULT_SETBACK_COOL,
@@ -977,6 +979,10 @@ class ClimateAdvisorOptionsFlow(config_entries.OptionsFlow):
                     ): selector.NumberSelector(
                         selector.NumberSelectorConfig(min=0, max=60, step=1, unit_of_measurement="min", mode="box")
                     ),
+                    vol.Optional(
+                        CONF_NAT_VENT_SOFT_START_ENABLED,
+                        default=current.get(CONF_NAT_VENT_SOFT_START_ENABLED, DEFAULT_NAT_VENT_SOFT_START_ENABLED),
+                    ): selector.BooleanSelector(),
                 }
             ),
         )

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,17 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.39"
+VERSION = "0.5.40"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.40": [
+        "Feat #540: new 'Nat-Vent Soft-Start (Purge Mode)' setting, on by default. The"
+        " whole-house fan can now start moving air and purging attic/thermal-mass heat as soon"
+        " as outdoor temperature reaches parity with indoor in the evening, once the day is"
+        " confirmed past its peak — instead of waiting for outdoor to be measurably cooler."
+        " Disable it in settings if you prefer the old strict-delta-only behavior. See the"
+        " Status card for a distinct 'soft-start (purge)' label while it's active.",
+    ],
     "0.5.39": [
         "Fix #538: the 'Next User Action' card said 'Free cooling is active.' while nat-vent"
         " or economizer cooling was already running — just repeating what the Status card"
@@ -1326,6 +1334,47 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    540: {
+        "version_fixed": "0.5.40",
+        "title": (
+            "Whole-house fan sat idle for up to ~30 minutes after outdoor temperature reached"
+            " parity with indoor in the evening — every existing nat-vent activation path"
+            " required outdoor to be measurably below indoor, so air-movement/purge benefit at"
+            " parity was structurally unreachable, not just delayed"
+        ),
+        "scope_covered": (
+            "New opt-out (default on) 'soft-start' sub-mode: nat_vent_gate.py gains"
+            " NatVentSoftStartGateInputs + decide_nat_vent_soft_start_gate(), a sibling to the"
+            " existing full gate, not a modification of it. Gated on: WHF fan archetype only"
+            " (whole_house_fan/both), door/window open, indoor above comfort_heat and"
+            " comfort_cool, today's outdoor temp confirmed past its peak and declining (derived"
+            " from coordinator._outdoor_temp_history, with a >=3-sample minimum guard against a"
+            " thin post-restart buffer), outdoor <= indoor (parity, not the full gate's"
+            " hysteresis-cleared delta), and only when the full bulk-cooling gate hasn't already"
+            " cleared (the two gates never compete for the same activation). automation.py: new"
+            " _nat_vent_soft_start qualifier flag alongside _natural_vent_active (same pattern as"
+            " _grace_protects_override/_grace_active) — cleared at every"
+            " _natural_vent_active=False site, wired into both reactivation call sites"
+            " (idle-open/comfort-ceiling-during-grace and paused-by-door), with an upgrade check"
+            " that clears the qualifier once the full gate independently clears. Reuses the"
+            " existing exit hierarchy unchanged. Status card shows 'nat-vent — soft-start"
+            " (purge)' distinctly (no new card); nat_vent_soft_start_entered event rendered in"
+            " the Activity Report."
+        ),
+        "scope_not_covered": (
+            "Does not add a humidity/dew-point guard (Issue #533 Related Condition (E)) — no"
+            " such sensor exists in the integration today; parity-triggered activation inherits"
+            " the same unaddressed risk the original issue flagged, and defaulting this on"
+            " (rather than opt-in as #533 recommended) means every WHF install is exposed to"
+            " that gap unless the user explicitly disables the setting. Does not extend soft-start"
+            " to HVAC-only fan archetypes or decouple it into a general comfort-fan mode (Issue"
+            " #533 Related Condition (C)) — that is a larger philosophical scope change needing"
+            " explicit owner sign-off, deliberately not folded in here. reconcile_fan_on_startup()"
+            " always adopts a found-running fan as full nat-vent, never as soft-start — a cosmetic"
+            " status-label gap only, self-corrects via the upgrade check on the next cycle if the"
+            " full gate is already satisfied, otherwise persists until conditions change."
+        ),
+    },
     538: {
         "version_fixed": "0.5.39",
         "title": (
@@ -5618,6 +5667,18 @@ NAT_VENT_REACTIVATION_LOCKOUT_S = 300
 CONF_NAT_VENT_HYSTERESIS_F = "nat_vent_hysteresis_f"
 CONF_NAT_VENT_REACTIVATION_LOCKOUT_S = "nat_vent_reactivation_lockout_s"
 
+# Nat-vent soft-start sub-mode (Issue #540, scoped from #533): WHF-purge/comfort activation
+# at outdoor/indoor parity once today's outdoor temp is confirmed past its peak and
+# declining. Opt-out (default on) — users who want the old strict-delta-only behavior can
+# disable it. No humidity/dew-point guard exists today; the comfort benefit itself is
+# still subjective, but the project has chosen to default this on rather than opt-in.
+CONF_NAT_VENT_SOFT_START_ENABLED = "nat_vent_soft_start_enabled"
+DEFAULT_NAT_VENT_SOFT_START_ENABLED = True
+
+# Degrees below today's observed outdoor peak required before soft-start considers the
+# day "declining" — mirrors NAT_VENT_HYSTERESIS_F's role as a noise-margin buffer.
+PEAK_DECLINE_MARGIN_F = 1.0
+
 # Minimum viable nat vent window — skip activation (or exit proactively) if thermal
 # model predicts indoor will hit comfort_heat floor within this many hours.
 MIN_VIABLE_NAT_VENT_HOURS = 1.0
@@ -5868,6 +5929,18 @@ CONFIG_METADATA = {
             "Controls how fans assist ventilation. 'Whole house fan' controls a dedicated entity."
             " 'HVAC fan' uses the thermostat fan mode."
             " Fan activates during economizer maintain phase."
+        ),
+        "category": "fan",
+    },
+    "nat_vent_soft_start_enabled": {
+        "label": "Nat-Vent Soft-Start (Purge Mode)",
+        "description": (
+            "When enabled, the whole-house fan may start at outdoor/indoor temperature parity"
+            " (not waiting for outdoor to be measurably cooler) once today's outdoor temperature"
+            " is confirmed past its peak and declining — for air movement and attic/thermal-mass"
+            " purge, not bulk cooling. On by default; disable if you only want the fan to run"
+            " once outdoor is measurably cooler than indoor. No humidity/dew-point sensor guards"
+            " this today."
         ),
         "category": "fan",
     },

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -899,6 +899,14 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         temp_hist = state.get("temp_history", {})
         self._outdoor_temp_history = [(ts, t) for ts, t in temp_hist.get("outdoor", [])]
         self._indoor_temp_history = [(ts, t) for ts, t in temp_hist.get("indoor", [])]
+        # Issue #540: mirror the restored buffer's peak/count immediately, so soft-start's
+        # minimum-sample guard doesn't see an artificially thin buffer for up to 30 min
+        # after a same-day restart (this restore path only runs when the persisted date
+        # matches today's local date — see the state_date == today_str gate above).
+        if self._outdoor_temp_history:
+            _restored_outdoor_temps = [t for _, t in self._outdoor_temp_history]
+            self.automation_engine._outdoor_temp_today_peak = max(_restored_outdoor_temps)
+            self.automation_engine._outdoor_temp_today_sample_count = len(_restored_outdoor_temps)
 
         # Today's record
         record_data = state.get("today_record")
@@ -1514,6 +1522,13 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         self._apply_outdoor_windows_gate()
         if record_history:
             self._outdoor_temp_history.append((dt_util.now().isoformat(), value))
+            # Issue #540: nat-vent soft-start needs "today's observed peak so far" to
+            # detect a past-peak/declining trend. Computed here (single source of truth,
+            # same buffer used for forecast high/low correction below) and plumbed to the
+            # automation engine the same way _hourly_forecast_temps already is.
+            observed_temps = [t for _, t in self._outdoor_temp_history]
+            self.automation_engine._outdoor_temp_today_peak = max(observed_temps)
+            self.automation_engine._outdoor_temp_today_sample_count = len(observed_temps)
         if getattr(self, "data", None):
             self.data[ATTR_OUTDOOR_TEMP] = value
             self.async_update_listeners()
@@ -3121,6 +3136,11 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         self._outdoor_temp_history.clear()
         self._indoor_temp_history.clear()
         self._hourly_forecast_temps.clear()
+        # Issue #540: reset the soft-start peak-tracking mirror alongside the buffer it's
+        # derived from, so a stale "yesterday's peak" can't leak into the new day before
+        # the first post-midnight sample arrives.
+        self.automation_engine._outdoor_temp_today_peak = None
+        self.automation_engine._outdoor_temp_today_sample_count = 0
         # Issue #511: refetch immediately rather than waiting for the next 30-min
         # cycle — otherwise outdoor-temp interpolation has nothing to interpolate
         # against for up to ~30 min after every midnight reset, degrading nightly
@@ -6549,6 +6569,11 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             # here can silently drift from the live band across a sleep-window boundary
             # (e.g. cached "71°F" vs. live "64°F–66°F"). The live band is the only place
             # this temperature is shown now; don't reintroduce it here.
+            # Issue #540: soft-start is a distinct sub-mode (purge/comfort at parity, not
+            # bulk free-cooling) — surfaced here per the Status Card Ontology, since this
+            # is the one card where mechanism state belongs.
+            if self.automation_engine._nat_vent_soft_start:
+                return "nat-vent — soft-start (purge)"
             return "nat-vent"
         if self.automation_engine.is_paused_by_door:
             if self._occupancy_mode == OCCUPANCY_AWAY:
@@ -7552,6 +7577,8 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             ),
             # Bug 3 (Issue #321): nat-vent cycling visibility in debug pane
             "nat_vent_active": ae._natural_vent_active,
+            # Issue #540: soft-start qualifier — only meaningful when nat_vent_active is True.
+            "nat_vent_soft_start": ae._nat_vent_soft_start,
             # Issue #338: AC assist status — true when nat-vent is active with FAN_MODE_HVAC
             # and aggressive_savings is off (full comfort band armed, compressor may assist).
             # FAN_MODE_BOTH excluded: _activate_fan() suppresses HVAC for BOTH (same as WHOLE_HOUSE).

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.39"
+  "version": "0.5.40"
 }

--- a/custom_components/climate_advisor/nat_vent_gate.py
+++ b/custom_components/climate_advisor/nat_vent_gate.py
@@ -107,3 +107,78 @@ def decide_nat_vent_gate(inputs: NatVentGateInputs) -> bool:
         and inputs.outdoor < threshold
         and ceiling_ok
     )
+
+
+# Minimum number of same-day outdoor-temp samples required before trusting
+# "today's peak" (Issue #540). Below this, _outdoor_temp_history may be thin
+# after a restart that crossed local midnight (see coordinator.py's
+# async_restore_state day-boundary gate) — failing closed avoids a false
+# "already past peak" read from 0-1 samples.
+_MIN_PEAK_SAMPLE_COUNT = 3
+
+
+@dataclass(frozen=True)
+class NatVentSoftStartGateInputs:
+    """Inputs for the nat-vent soft-start sub-gate (Issue #540, scoped from #533).
+
+    Distinct from, and does not modify, ``NatVentGateInputs``/``decide_nat_vent_gate()``.
+    Soft-start is a separate WHF-purge/comfort entry path that fires only in the gap
+    before the full bulk-cooling gate would already apply.
+
+    Field-by-field correspondence to the real code:
+      outdoor, indoor          -> same live reads as NatVentGateInputs
+      comfort_heat             -> already sleep-resolved by the caller (mirrors
+                                   NatVentGateInputs.comfort_heat_raw/sleep_heat resolution)
+      comfort_cool             -> raw config comfort_cool
+      fan_mode                 -> config CONF_FAN_MODE; soft-start is WHF-only
+                                   (whole_house_fan/both) — the attic-purge claim doesn't
+                                   apply to HVAC-only fan archetypes
+      outdoor_today_peak       -> max of coordinator._outdoor_temp_history for today,
+                                   plumbed to the caller via
+                                   automation_engine._outdoor_temp_today_peak
+      outdoor_sample_count     -> len(coordinator._outdoor_temp_history) for today, plumbed
+                                   via automation_engine._outdoor_temp_today_sample_count
+      peak_decline_margin      -> PEAK_DECLINE_MARGIN_F (const.py), degrees below today's
+                                   observed peak required before calling it "declining"
+      full_gate_active         -> the caller's own decide_nat_vent_gate(...) result for the
+                                   same inputs — soft-start stands down once the full gate
+                                   would already apply, so the two gates never compete for
+                                   the same activation
+    """
+
+    outdoor: float | None
+    indoor: float | None
+    comfort_heat: float
+    comfort_cool: float
+    fan_mode: str
+    outdoor_today_peak: float | None
+    outdoor_sample_count: int
+    peak_decline_margin: float
+    full_gate_active: bool
+
+
+def decide_nat_vent_soft_start_gate(inputs: NatVentSoftStartGateInputs) -> bool:
+    """Should nat-vent soft-start (purge/comfort sub-mode) activate right now?
+
+    Unlike ``decide_nat_vent_gate()``, this does not require outdoor to be below
+    indoor by any margin — only that outdoor has reached parity (``<=``) with
+    indoor, and that today's outdoor temperature is confirmed past its peak and
+    declining. See Issue #540 (scoped from #533's soft-start hypothesis).
+    """
+    if inputs.outdoor is None or inputs.indoor is None:
+        return False
+    if inputs.full_gate_active:
+        return False
+    if inputs.fan_mode not in (FAN_MODE_WHOLE_HOUSE, FAN_MODE_BOTH):
+        return False
+    if inputs.outdoor_sample_count < _MIN_PEAK_SAMPLE_COUNT or inputs.outdoor_today_peak is None:
+        return False
+
+    past_peak = inputs.outdoor < inputs.outdoor_today_peak - inputs.peak_decline_margin
+
+    return (
+        past_peak
+        and inputs.indoor > inputs.comfort_heat
+        and inputs.indoor > inputs.comfort_cool
+        and inputs.outdoor <= inputs.indoor
+    )

--- a/docs/08-COMPUTATION-REFERENCE.md
+++ b/docs/08-COMPUTATION-REFERENCE.md
@@ -2269,6 +2269,69 @@ If outdoor were 76°F instead, the ceiling check would fail (`76 ≥ 75`) and na
 
 Default value: `NAT_VENT_DELTA_DEFAULT = 3°F` (see §15 Defaults Reference).
 
+### Soft-Start Sub-Mode (Issue #540, scoped from #533)
+
+**Occupant impact:** without soft-start, the whole-house fan sits idle for the entire
+approach-to-parity window in the evening — even once the home has clearly passed its
+daily peak and outdoor air is falling toward indoor — because every other activation
+path requires outdoor to be *measurably* cooler than indoor (see Activation Conditions
+and Re-activation from Pause above). Soft-start closes that gap: it lets the WHF start
+at outdoor/indoor **parity** for air-movement comfort and attic/thermal-mass purge,
+distinct from bulk free-cooling.
+
+**Opt-out, on by default** (`nat_vent_soft_start_enabled` config key). Issue #533
+recommended opt-in given the comfort benefit is subjective and unverified by any
+humidity/dew-point sensor (none exists in the integration today — tracked as an explicit
+gap, not solved here); the project chose to default this on instead, so every WHF install
+gets the benefit unless the user explicitly disables it in settings.
+
+**Gate** (`decide_nat_vent_soft_start_gate()` in `nat_vent_gate.py`), all of the
+following must hold:
+
+| Condition | Rationale |
+|---|---|
+| `fan_mode in (whole_house_fan, both)` | The attic-purge claim is WHF-specific; HVAC-only fan archetypes don't qualify for v1 (a general comfort-fan mode is a separate, larger decision — see Related Condition (C) in Issue #533) |
+| At least one door/window sensor open | Same physical prerequisite as the full gate |
+| `indoor > comfort_heat` | Same floor guard as the full gate |
+| `indoor > comfort_cool` | Still warm enough that purge/air-movement has value |
+| `outdoor_sample_count >= 3` AND `outdoor < today's observed peak − PEAK_DECLINE_MARGIN_F (1.0°F)` | "Past peak and declining" — built from `coordinator._outdoor_temp_history` (already sampled every 30 min for forecast high/low correction), not a new sensor. The minimum-sample guard fails closed after a restart that crosses local midnight, when the history buffer is briefly thin (see Timezone/Day-Boundary note below) — it doesn't risk a false "already past peak" read from 0-2 samples |
+| `outdoor <= indoor` | Parity, not the full gate's `outdoor < indoor − hysteresis` — this is the core relaxation |
+| `not decide_nat_vent_gate(...)` for the same inputs | Soft-start only fires in the gap *before* the full bulk-cooling gate would already apply — the two gates never compete for the same activation |
+
+**Qualifier flag, not a second session:** soft-start sets `_nat_vent_soft_start = True`
+alongside `_natural_vent_active = True` — it is a qualifying sub-flag on the *same*
+session (mirroring how `_grace_protects_override` coexists with `_grace_active`), not a
+parallel state machine. It reuses the existing fan-activation machinery, HVAC-band
+arming, and — critically — the existing Exit Hierarchy above completely unchanged: an
+outdoor-rise exit, comfort-floor exit, ceiling exit, etc. all end a soft-start session
+exactly the same way they end a full one, clearing both flags together.
+
+**Upgrade path:** every cycle a soft-start session is active, the engine re-checks
+whether the full bulk-cooling gate (`decide_nat_vent_gate()`) now independently holds. If
+it does, `_nat_vent_soft_start` clears (logged as an upgrade) — the fan keeps running
+uninterrupted; only the status label changes from soft-start to full nat-vent. There is
+no downgrade path (full → soft-start): once the full gate has been satisfied, exiting and
+re-entering soft-start on a later temperature dip is intentionally out of scope for v1.
+
+**Status/logging:** surfaced via the existing Status card (`_compute_automation_status()`
+returns `"nat-vent — soft-start (purge)"` instead of `"nat-vent"` — no new card, per the
+Status Card Ontology in the root `CLAUDE.md`). Entry is logged at INFO and emits
+`nat_vent_soft_start_entered` (rendered in the Activity Report via
+`ai_skills_activity.py`'s `EVENT_RENDERERS`).
+
+**Timezone/day-boundary note:** `coordinator._outdoor_temp_history` is written and
+cleared entirely in HA local time (`dt_util.now()`, `async_track_time_change` at
+23:59:00 local) and restored on restart only when the persisted date matches today's
+local calendar date — consistent with the Issue #190 local-date convention used
+elsewhere in `coordinator.py`. The one edge case is an overnight outage that crosses
+local midnight: the buffer starts thin until the next 30-min cycle, which is exactly
+what the `outdoor_sample_count >= 3` guard protects against.
+
+**Test coverage:** `tests/test_nat_vent_gate.py::TestDecideNatVentSoftStartGate` (pure
+gate logic); `tests/test_nat_vent_soft_start.py` (engine-level entry, precedence over the
+full gate, HVAC-only fan exclusion, thin-buffer fail-safe, upgrade, and exit-hierarchy
+reuse).
+
 ### Fan Cycling Within an Active Session (Issues #321, #374)
 
 Once `_natural_vent_active = True`, the fan does not simply stay on until the session ends. Instead, the engine targets a context-dependent temperature and cycles the fan on and off using a hysteresis band to prevent rapid toggling. The target and thresholds differ between the daytime and sleep windows.

--- a/tests/test_config_metadata.py
+++ b/tests/test_config_metadata.py
@@ -36,6 +36,7 @@ EXPECTED_KEYS = {
     "fan_state_feedback",
     "fan_remote_entity",
     "fan_min_runtime_per_hour",
+    "nat_vent_soft_start_enabled",
     "wake_time",
     "sleep_time",
     "sleep_heat",

--- a/tests/test_nat_vent_dashboard_target.py
+++ b/tests/test_nat_vent_dashboard_target.py
@@ -55,6 +55,7 @@ def _make_nat_vent_coord_stub(*, config: dict) -> object:
 
     ae = MagicMock()
     ae._natural_vent_active = True
+    ae._nat_vent_soft_start = False
     ae._fan_active = True
     ae._fan_override_active = False
     ae._manual_override_active = False

--- a/tests/test_nat_vent_gate.py
+++ b/tests/test_nat_vent_gate.py
@@ -13,9 +13,11 @@ from custom_components.climate_advisor.nat_vent_gate import (
     FAN_MODE_HVAC,
     FAN_MODE_WHOLE_HOUSE,
     NatVentGateInputs,
+    NatVentSoftStartGateInputs,
     _resolve_ceiling_threshold,
     _resolve_comfort_heat,
     decide_nat_vent_gate,
+    decide_nat_vent_soft_start_gate,
 )
 
 _BASE = {
@@ -120,3 +122,89 @@ class TestResolveCeilingThreshold:
 
     def test_aggressive_savings_adds_margin(self):
         assert _resolve_ceiling_threshold(_inputs(fan_mode=FAN_MODE_HVAC, aggressive_savings=True)) == 78.0
+
+
+_SOFT_START_BASE = {
+    "outdoor": 75.0,
+    "indoor": 76.0,
+    "comfort_heat": 70.0,
+    "comfort_cool": 74.0,
+    "fan_mode": FAN_MODE_WHOLE_HOUSE,
+    "outdoor_today_peak": 90.0,
+    "outdoor_sample_count": 5,
+    "peak_decline_margin": 1.0,
+    "full_gate_active": False,
+}
+
+
+def _soft_start_inputs(**overrides) -> NatVentSoftStartGateInputs:
+    return NatVentSoftStartGateInputs(**{**_SOFT_START_BASE, **overrides})
+
+
+class TestDecideNatVentSoftStartGate:
+    """Issue #540 (scoped from #533): WHF purge/comfort soft-start at outdoor/indoor
+    parity once today is confirmed past its peak and declining."""
+
+    def test_activates_when_all_conditions_met(self):
+        assert decide_nat_vent_soft_start_gate(_soft_start_inputs()) is True
+
+    def test_none_outdoor_blocks(self):
+        assert decide_nat_vent_soft_start_gate(_soft_start_inputs(outdoor=None)) is False
+
+    def test_none_indoor_blocks(self):
+        assert decide_nat_vent_soft_start_gate(_soft_start_inputs(indoor=None)) is False
+
+    def test_full_gate_already_active_stands_down(self):
+        """Soft-start never competes with the full bulk-cooling gate for the same activation."""
+        assert decide_nat_vent_soft_start_gate(_soft_start_inputs(full_gate_active=True)) is False
+
+    def test_hvac_only_fan_mode_blocks(self):
+        """Soft-start is a WHF-purge claim — HVAC-only fan archetype does not qualify."""
+        assert decide_nat_vent_soft_start_gate(_soft_start_inputs(fan_mode=FAN_MODE_HVAC)) is False
+
+    def test_disabled_fan_mode_blocks(self):
+        assert decide_nat_vent_soft_start_gate(_soft_start_inputs(fan_mode=FAN_MODE_DISABLED)) is False
+
+    def test_both_fan_mode_qualifies(self):
+        assert decide_nat_vent_soft_start_gate(_soft_start_inputs(fan_mode=FAN_MODE_BOTH)) is True
+
+    def test_parity_boundary_equal_temps_activates(self):
+        """Core ask: outdoor <= indoor, not the full gate's strict outdoor < indoor."""
+        assert decide_nat_vent_soft_start_gate(_soft_start_inputs(outdoor=76.0, indoor=76.0)) is True
+
+    def test_parity_boundary_outdoor_above_indoor_blocks(self):
+        assert decide_nat_vent_soft_start_gate(_soft_start_inputs(outdoor=76.1, indoor=76.0)) is False
+
+    def test_floor_boundary_indoor_at_comfort_heat_blocks(self):
+        assert decide_nat_vent_soft_start_gate(_soft_start_inputs(indoor=70.0, outdoor=68.0)) is False
+
+    def test_floor_boundary_indoor_at_comfort_cool_blocks(self):
+        """Strict '>' on comfort_cool too — indoor must be above, not just above comfort_heat."""
+        assert decide_nat_vent_soft_start_gate(_soft_start_inputs(indoor=74.0, outdoor=70.0)) is False
+
+    def test_past_peak_margin_boundary_exactly_at_margin_blocks(self):
+        """Strict '<' — outdoor exactly (peak - margin) is not yet 'declining'."""
+        assert (
+            decide_nat_vent_soft_start_gate(
+                _soft_start_inputs(outdoor_today_peak=90.0, peak_decline_margin=1.0, outdoor=89.0, indoor=89.5)
+            )
+            is False
+        )
+
+    def test_past_peak_margin_boundary_just_past_activates(self):
+        assert (
+            decide_nat_vent_soft_start_gate(
+                _soft_start_inputs(outdoor_today_peak=90.0, peak_decline_margin=1.0, outdoor=88.9, indoor=89.5)
+            )
+            is True
+        )
+
+    def test_thin_sample_buffer_fails_safe(self):
+        """Issue #540 timezone/restart sanity check: a thin post-restart buffer must not
+        produce a false 'already past peak' read."""
+        assert decide_nat_vent_soft_start_gate(_soft_start_inputs(outdoor_sample_count=0)) is False
+        assert decide_nat_vent_soft_start_gate(_soft_start_inputs(outdoor_sample_count=2)) is False
+        assert decide_nat_vent_soft_start_gate(_soft_start_inputs(outdoor_sample_count=3)) is True
+
+    def test_none_peak_blocks(self):
+        assert decide_nat_vent_soft_start_gate(_soft_start_inputs(outdoor_today_peak=None)) is False

--- a/tests/test_nat_vent_soft_start.py
+++ b/tests/test_nat_vent_soft_start.py
@@ -1,0 +1,245 @@
+"""Tests for Issue #540 (scoped from #533): nat-vent soft-start at outdoor/indoor parity.
+
+Covers the automation-engine-level wiring around ``decide_nat_vent_soft_start_gate()``
+(unit-tested directly in test_nat_vent_gate.py::TestDecideNatVentSoftStartGate):
+  - Entry via the paused-by-door reactivation site, on by default (opt-out)
+  - Full gate takes precedence over soft-start when both would qualify
+  - HVAC-only fan archetype does not qualify
+  - Thin sample-count buffer fails safe (restart/timezone edge case)
+  - Upgrade from soft-start to full nat-vent as outdoor keeps falling
+  - Existing exit hierarchy (outdoor-rise exit) clears the soft-start qualifier too
+
+Mirrors the fixture pattern from test_nat_vent_activation.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.climate_advisor.automation import AutomationEngine
+from custom_components.climate_advisor.const import (
+    CONF_FAN_MODE,
+    CONF_NAT_VENT_SOFT_START_ENABLED,
+    FAN_MODE_HVAC,
+    FAN_MODE_WHOLE_HOUSE,
+)
+
+sys.modules["homeassistant.util.dt"].now = lambda: datetime(2026, 7, 29, 18, 0, 0)
+
+import custom_components.climate_advisor.automation as _automation_mod  # noqa: E402
+
+
+def _real_parse_datetime(dt_str: str):
+    try:
+        return datetime.fromisoformat(dt_str)
+    except Exception:
+        return None
+
+
+_automation_mod.dt_util.parse_datetime = _real_parse_datetime
+
+
+def _make_engine(
+    comfort_heat: float = 70.0,
+    comfort_cool: float = 74.0,
+    nat_vent_delta: float = 3.0,
+    indoor_f: float | None = None,
+    soft_start_enabled: bool = True,
+    fan_mode: str = FAN_MODE_WHOLE_HOUSE,
+) -> AutomationEngine:
+    """Create an AutomationEngine with mocked HA dependencies, soft-start opt-in set."""
+    hass = MagicMock()
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+
+    def _consume_coroutine(coro):
+        coro.close()
+
+    hass.async_create_task = MagicMock(side_effect=_consume_coroutine)
+
+    climate_state = MagicMock()
+    climate_state.state = "cool"
+    climate_state.attributes = {}
+    if indoor_f is not None:
+        climate_state.attributes = {"current_temperature": indoor_f}
+
+    hass.states = MagicMock()
+    hass.states.get = MagicMock(return_value=climate_state)
+
+    config = {
+        "comfort_heat": comfort_heat,
+        "comfort_cool": comfort_cool,
+        "setback_heat": 60,
+        "setback_cool": 80,
+        "natural_vent_delta": nat_vent_delta,
+        "notify_service": "notify.notify",
+        CONF_FAN_MODE: fan_mode,
+        CONF_NAT_VENT_SOFT_START_ENABLED: soft_start_enabled,
+    }
+
+    engine = AutomationEngine(
+        hass=hass,
+        climate_entity="climate.thermostat",
+        weather_entity="weather.forecast_home",
+        door_window_sensors=["binary_sensor.front_door"],
+        notify_service="notify.notify",
+        config=config,
+    )
+    return engine
+
+
+def _arm_paused_reactivation(
+    engine: AutomationEngine,
+    *,
+    outdoor: float,
+    outdoor_today_peak: float = 90.0,
+    outdoor_sample_count: int = 5,
+) -> None:
+    """Set up engine state so check_natural_vent_conditions() reaches the
+    paused-by-door reactivation branch with no lockout in effect."""
+    engine._paused_by_door = True
+    engine._natural_vent_active = False
+    engine._nat_vent_soft_start = False
+    engine._last_outdoor_temp = outdoor
+    engine._nat_vent_outdoor_exit_time = None
+    engine._outdoor_temp_today_peak = outdoor_today_peak
+    engine._outdoor_temp_today_sample_count = outdoor_sample_count
+
+
+class TestSoftStartEntry:
+    """Parity-only entry when the full bulk-cooling gate hasn't cleared yet."""
+
+    def test_activates_soft_start_at_parity_past_peak(self):
+        # comfort_cool=74, indoor=76 (> comfort_heat and > comfort_cool); outdoor=75.5
+        # (<= indoor, so parity holds; full gate needs outdoor < indoor - 1.0 = 75.0, which
+        # 75.5 does NOT satisfy — full gate stays False, soft-start should take over).
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=74.0, indoor_f=76.0)
+        _arm_paused_reactivation(engine, outdoor=75.5, outdoor_today_peak=90.0)
+
+        asyncio.run(engine.check_natural_vent_conditions())
+
+        assert engine._natural_vent_active is True
+        assert engine._nat_vent_soft_start is True
+
+    def test_config_key_absent_falls_back_to_on_by_default(self):
+        """DEFAULT_NAT_VENT_SOFT_START_ENABLED is True — an install that predates this
+        config key (key absent entirely, not just unset) must still get soft-start."""
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=74.0, indoor_f=76.0)
+        del engine.config[CONF_NAT_VENT_SOFT_START_ENABLED]
+        _arm_paused_reactivation(engine, outdoor=75.5, outdoor_today_peak=90.0)
+
+        asyncio.run(engine.check_natural_vent_conditions())
+
+        assert engine._natural_vent_active is True
+        assert engine._nat_vent_soft_start is True
+
+    def test_user_disabled_config_stays_paused(self):
+        """Opt-out setting (default on, per DEFAULT_NAT_VENT_SOFT_START_ENABLED) — a user who
+        explicitly disables it gets the old strict-delta-only behavior."""
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=74.0, indoor_f=76.0, soft_start_enabled=False)
+        _arm_paused_reactivation(engine, outdoor=75.5, outdoor_today_peak=90.0)
+
+        asyncio.run(engine.check_natural_vent_conditions())
+
+        assert engine._natural_vent_active is False
+        assert engine._nat_vent_soft_start is False
+
+    def test_full_gate_takes_precedence_over_soft_start(self):
+        """When outdoor already clears the full hysteresis gate, the full gate wins —
+        the two gates never compete for the same activation."""
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=76.0, indoor_f=76.0)
+        # outdoor 74.9 < indoor(76) - hysteresis(1.0) = 75.0 → full gate satisfied
+        _arm_paused_reactivation(engine, outdoor=74.9, outdoor_today_peak=90.0)
+
+        asyncio.run(engine.check_natural_vent_conditions())
+
+        assert engine._natural_vent_active is True
+        assert engine._nat_vent_soft_start is False
+
+    def test_hvac_only_fan_archetype_does_not_qualify(self):
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=74.0, indoor_f=76.0, fan_mode=FAN_MODE_HVAC)
+        _arm_paused_reactivation(engine, outdoor=75.5, outdoor_today_peak=90.0)
+
+        asyncio.run(engine.check_natural_vent_conditions())
+
+        assert engine._natural_vent_active is False
+        assert engine._nat_vent_soft_start is False
+
+    def test_thin_sample_buffer_fails_safe(self):
+        """Issue #540 timezone/restart edge case: a thin post-restart buffer must not
+        produce a false 'already past peak' read."""
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=74.0, indoor_f=76.0)
+        _arm_paused_reactivation(engine, outdoor=75.5, outdoor_today_peak=90.0, outdoor_sample_count=1)
+
+        asyncio.run(engine.check_natural_vent_conditions())
+
+        assert engine._natural_vent_active is False
+        assert engine._nat_vent_soft_start is False
+
+    def test_not_yet_past_peak_stays_paused(self):
+        """outdoor within the peak-decline margin of today's peak — not yet 'declining'."""
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=74.0, indoor_f=76.0)
+        # peak=76.0, margin=1.0 -> needs outdoor < 75.0; 75.5 doesn't qualify as past-peak here
+        _arm_paused_reactivation(engine, outdoor=75.5, outdoor_today_peak=76.0)
+
+        asyncio.run(engine.check_natural_vent_conditions())
+
+        assert engine._natural_vent_active is False
+        assert engine._nat_vent_soft_start is False
+
+
+class TestSoftStartUpgrade:
+    """An active soft-start session upgrades to full nat-vent once outdoor falls far
+    enough below indoor to independently satisfy the full bulk-cooling gate."""
+
+    def test_upgrades_when_full_gate_clears(self):
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=76.0, indoor_f=76.0)
+        engine._natural_vent_active = True
+        engine._nat_vent_soft_start = True
+        engine._paused_by_door = False
+        # outdoor now well below indoor - hysteresis(1.0) -> full gate clears
+        engine._last_outdoor_temp = 70.0
+        engine._outdoor_temp_today_peak = 90.0
+        engine._outdoor_temp_today_sample_count = 5
+
+        asyncio.run(engine.check_natural_vent_conditions())
+
+        assert engine._natural_vent_active is True
+        assert engine._nat_vent_soft_start is False
+
+    def test_stays_soft_start_while_full_gate_not_yet_cleared(self):
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=76.0, indoor_f=76.0)
+        engine._natural_vent_active = True
+        engine._nat_vent_soft_start = True
+        engine._paused_by_door = False
+        # outdoor still within the hysteresis gap -> full gate not yet satisfied
+        engine._last_outdoor_temp = 75.5
+        engine._outdoor_temp_today_peak = 90.0
+        engine._outdoor_temp_today_sample_count = 5
+
+        asyncio.run(engine.check_natural_vent_conditions())
+
+        assert engine._natural_vent_active is True
+        assert engine._nat_vent_soft_start is True
+
+
+class TestSoftStartExitHierarchy:
+    """A soft-start session reuses the existing exit hierarchy unchanged — outdoor-rise
+    exit must clear the soft-start qualifier along with _natural_vent_active."""
+
+    def test_outdoor_rise_exit_clears_soft_start_flag(self):
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=76.0, indoor_f=76.0)
+        engine._natural_vent_active = True
+        engine._nat_vent_soft_start = True
+        engine._paused_by_door = False
+        engine._paused_with_hvac_already_off = False
+        # outdoor now above indoor -> Priority-3 outdoor-rise exit fires
+        engine._last_outdoor_temp = 77.0
+
+        asyncio.run(engine.check_natural_vent_conditions())
+
+        assert engine._natural_vent_active is False
+        assert engine._nat_vent_soft_start is False


### PR DESCRIPTION
## Summary
- New opt-out (on by default) nat-vent sub-mode: the whole-house fan can start for air-movement comfort and attic/thermal-mass purge as soon as outdoor reaches parity with indoor in the evening, once the day is confirmed past its peak and declining — instead of waiting for the full bulk-cooling gate's outdoor-below-indoor delta to clear.
- Scoped from the design-space investigation in #533; deliberately excludes the larger, owner-sign-off-required options from that issue (general comfort-fan mode for HVAC-only archetypes, k_solar-gated purge, humidity/dew-point guard — no such sensor exists today).
- `nat_vent_gate.py` gets a new sibling gate (`decide_nat_vent_soft_start_gate()`), not a modification of the existing one; the two gates never compete for the same activation. `automation.py` adds a `_nat_vent_soft_start` qualifier flag (same pattern as `_grace_protects_override`) that reuses the existing exit hierarchy, fan machinery, and HVAC-band arming unchanged, and upgrades to full nat-vent once the bulk gate independently clears.
- Status card shows a distinct `"nat-vent — soft-start (purge)"` label (no new card); new `nat_vent_soft_start_entered` event is rendered in the Activity Report.

Refs #533. Closes #540.

## Test plan
- [x] `tests/test_nat_vent_gate.py::TestDecideNatVentSoftStartGate` — 16 pure gate unit tests
- [x] `tests/test_nat_vent_soft_start.py` — 10 engine-level tests: entry, config opt-out, config-absent fallback, full-gate precedence, HVAC-only-fan exclusion, thin-sample-buffer fail-safe, not-yet-past-peak, upgrade to full nat-vent, exit-hierarchy reuse
- [x] Full suite: 3639 passed, 0 failed, clean under `-W error::RuntimeWarning`
- [x] `ruff check` / `ruff format` clean
- [x] `docs/08-COMPUTATION-REFERENCE.md` §17 updated with the new sub-mode
- [x] `README.md` roadmap synced
- [x] Version bumped to 0.5.40 (`const.py` + `manifest.json`), `RELEASE_NOTES`/`KNOWN_FIXES` entries added