### PR TITLE
Fix #555: shorten TLDR table to fit HA's 255-char sensor state limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.5.41] — 2026-08-02
+
+- Fix #555: Daily Briefing sensor no longer drops to "unknown" on days with a lot to say (away/vacation occupancy + dual window opportunities) — the TLDR summary is now shortened to reliably fit HA's 255-char sensor state limit, with a truncation safety net and full text still available in the sensor's attributes as a backstop.
+
 ## [0.4.60] — 2026-07-03
 
 - Fix #402: whole-house-fan nat-vent could silently stop controlling the home for hours overnight instead of cycling through the sleep window. Two causes: (1) `fan_thermostat_check()` — the tick-level safety check that runs far more often than the 30-minute classification cycle — still used the flat daytime `comfort_heat` floor even during the sleep window, so it always ended the nat-vent session prematurely before the correct sleep-window cycling (fixed in #374) ever got a chance to run. (2) Once that premature exit fired, `apply_classification()` legitimately arms `cool` mode as a compressor backstop — but that permanently blocked the fan's own re-activation check, which required the thermostat's armed mode to be literally "off" even though the compressor was never actually running. Both fixed: the tick-level floor check is now sleep-aware, and re-activation now checks whether the compressor is actively calling instead of the armed mode string.

--- a/custom_components/climate_advisor/briefing.py
+++ b/custom_components/climate_advisor/briefing.py
@@ -310,9 +310,9 @@ def _generate_tldr_table(
     setback_cool = config.get("setback_cool", DEFAULT_SETBACK_COOL)
     if occupancy_mode in ("away", "vacation"):
         if c.hvac_mode == "cool":
-            hvac_val = f"Cool at {format_temp(setback_cool, temp_unit)} (setback — {occupancy_mode})"
+            hvac_val = f"Cool at {format_temp(setback_cool, temp_unit)}"
         elif c.hvac_mode == "heat":
-            hvac_val = f"Heat at {format_temp(setback_heat, temp_unit)} (setback — {occupancy_mode})"
+            hvac_val = f"Heat at {format_temp(setback_heat, temp_unit)}"
         else:
             hvac_val = f"Off — {occupancy_mode}"
     elif c.hvac_mode == "cool":
@@ -369,23 +369,22 @@ def _generate_tldr_table(
     trend_desc = _trend_description(c, temp_unit=temp_unit)
     tomorrow_val = f"{trend_desc} ({format_temp(c.tomorrow_high, temp_unit)})"
 
-    label_w = 17
     rows = [
-        f"  {'Day Type:':<{label_w}} {day_type_val}",
-        f"  {'HVAC Mode:':<{label_w}} {hvac_val}",
+        f"  Day Type: {day_type_val}",
+        f"  HVAC Mode: {hvac_val}",
     ]
     # Issue #85: show occupancy status when not home
     if occupancy_mode == "away":
-        rows.append(f"  {'Occupancy:':<{label_w}} Away — setback active")
+        rows.append("  Occupancy: Away — setback active")
     elif occupancy_mode == "vacation":
-        rows.append(f"  {'Occupancy:':<{label_w}} Vacation — deep setback active")
+        rows.append("  Occupancy: Vacation — deep setback active")
     elif occupancy_mode == "guest":
-        rows.append(f"  {'Occupancy:':<{label_w}} Guest — comfort maintained")
+        rows.append("  Occupancy: Guest — comfort maintained")
     rows.extend(
         [
-            f"  {'Windows:':<{label_w}} {windows_val}",
-            f"  {'Bedtime Setback:':<{label_w}} {bedtime_val}",
-            f"  {'Tomorrow:':<{label_w}} {tomorrow_val}",
+            f"  Windows: {windows_val}",
+            f"  Bedtime Setback: {bedtime_val}",
+            f"  Tomorrow: {tomorrow_val}",
         ]
     )
     return rows

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,16 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.40"
+VERSION = "0.5.41"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.41": [
+        "Fix #555: Daily Briefing sensor no longer drops to 'unknown' on days with a lot"
+        " to say (away/vacation occupancy + dual window opportunities) — the TLDR summary"
+        " is now shortened to reliably fit HA's 255-char sensor state limit, with a"
+        " truncation safety net and full text still available in the sensor's attributes"
+        " as a backstop.",
+    ],
     "0.5.40": [
         "Feat #540: new 'Nat-Vent Soft-Start (Purge Mode)' setting, on by default. The"
         " whole-house fan can now start moving air and purging attic/thermal-mass heat as soon"
@@ -1334,6 +1341,39 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    555: {
+        "version_fixed": "0.5.41",
+        "title": (
+            "sensor.climate_advisor_daily_briefing exceeded HA's 255-char sensor state limit"
+            " on days with a lot to report (away/vacation occupancy + dual morning/evening"
+            " window-opportunity rows), causing HA to reject the state and fall the sensor"
+            " back to 'unknown' — the primary UI surface went blank on exactly the days with"
+            " the most to say"
+        ),
+        "scope_covered": (
+            "_generate_tldr_table() in briefing.py shortened: dropped fixed 17-char label"
+            " alignment padding (pure whitespace overhead, not reliably rendered as aligned"
+            " columns in either UI surface), and removed the redundant '(setback — away/"
+            " vacation)' phrase from the HVAC Mode row since the Occupancy row directly below"
+            " it already states the same fact. Brings the documented worst case from ~260-265"
+            " chars to a comfortable margin under 250. Added a shared"
+            " ClimateAdvisorBaseSensor._capped_state() truncation safety net (used by both"
+            " ClimateAdvisorBriefingSensor and, refactored behavior-preserving,"
+            " ClimateAdvisorLastActionReasonSensor) so a future regression degrades gracefully"
+            " instead of dropping to 'unknown'. Added TestTldrTableLength regression test"
+            " covering the away/vacation + dual-window worst case, and"
+            " tests/test_briefing_sensor.py covering the sensor's truncation/fallback logic"
+            " directly."
+        ),
+        "scope_not_covered": (
+            "The full multi-section briefing (ATTR_BRIEFING, non-tldr_only verbosity) already"
+            " had its own truncate-on-fallback handling and is unchanged. Conversational body"
+            " sections (_hot_day_plan() etc.) are unchanged. Column alignment is lost in the"
+            " full-briefing text display — not reliably rendered as aligned columns in either"
+            " UI surface today (dashboard and notify-service bodies are both proportional-"
+            " font), so not treated as a regression. Table label wording is unchanged."
+        ),
+    },
     540: {
         "version_fixed": "0.5.40",
         "title": (

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.40"
+  "version": "0.5.41"
 }

--- a/custom_components/climate_advisor/sensor.py
+++ b/custom_components/climate_advisor/sensor.py
@@ -93,6 +93,7 @@ class ClimateAdvisorBaseSensor(CoordinatorEntity, SensorEntity):
     """Base class for Climate Advisor sensors."""
 
     _empty_data_warned: bool = False
+    _truncation_warned: bool = False
 
     def __init__(
         self,
@@ -121,6 +122,25 @@ class ClimateAdvisorBaseSensor(CoordinatorEntity, SensorEntity):
             )
             self._empty_data_warned = True
         return None
+
+    def _capped_state(self, text: str, *, limit: int = 250, level: int = logging.DEBUG) -> str:
+        """Truncate text to HA's 255-char sensor state limit, logging once if triggered.
+
+        This is a safety net, not the primary fix (Issue #555) — callers should shrink
+        their source data so this rarely/never actually triggers.
+        """
+        if len(text) <= limit:
+            return text
+        if not self._truncation_warned:
+            _LOGGER.log(
+                level,
+                "%s state truncated — %d chars exceeds %d-char limit",
+                self._attr_name,
+                len(text),
+                limit,
+            )
+            self._truncation_warned = True
+        return text[: limit - 3] + "..."
 
 
 class ClimateAdvisorDayTypeSensor(ClimateAdvisorBaseSensor):
@@ -201,17 +221,16 @@ class ClimateAdvisorBriefingSensor(ClimateAdvisorBaseSensor):
         if not self.coordinator.data:
             return ""
         short = self.coordinator.data.get(ATTR_BRIEFING_SHORT, "")
-        if short:
-            return short
-        # Fallback: truncate full briefing if short version not yet available
-        full = self.coordinator.data.get(ATTR_BRIEFING, "")
-        return full[:247] + "..." if len(full) > 250 else full
+        text = short or self.coordinator.data.get(ATTR_BRIEFING, "")
+        return self._capped_state(text, level=logging.WARNING)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        """Store the full briefing text as an attribute."""
+        """Store the full briefing text and untruncated TLDR as attributes."""
+        data = self.coordinator.data or {}
         return {
-            "full_briefing": self.coordinator.data.get(ATTR_BRIEFING, "") if self.coordinator.data else "",
+            "full_briefing": data.get(ATTR_BRIEFING, ""),
+            "tldr": data.get(ATTR_BRIEFING_SHORT, ""),
         }
 
 
@@ -301,8 +320,6 @@ class ClimateAdvisorLastActionTimeSensor(ClimateAdvisorBaseSensor):
 class ClimateAdvisorLastActionReasonSensor(ClimateAdvisorBaseSensor):
     """Sensor showing the reason for the last HVAC action."""
 
-    _truncation_warned: bool = False
-
     def __init__(self, coordinator, entry):
         super().__init__(coordinator, entry, ATTR_LAST_ACTION_REASON, "Last Action Reason", "mdi:text-box-outline")
 
@@ -312,15 +329,7 @@ class ClimateAdvisorLastActionReasonSensor(ClimateAdvisorBaseSensor):
         full = self.coordinator.data.get(ATTR_LAST_ACTION_REASON, "") if self.coordinator.data else ""
         if not full:
             return None
-        if len(full) > 250:
-            if not self._truncation_warned:
-                _LOGGER.debug(
-                    "Last action reason truncated — %d chars exceeds limit",
-                    len(full),
-                )
-                self._truncation_warned = True
-            return full[:247] + "..."
-        return full
+        return self._capped_state(full)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/docs/02-ARCHITECTURE-REFERENCE.md
+++ b/docs/02-ARCHITECTURE-REFERENCE.md
@@ -155,7 +155,7 @@ Both are rendered in the dashboard as a stepped purple/magenta line: solid past,
 | `sensor.climate_advisor_day_type` | hot/warm/mild/cool/cold | trend_direction, trend_magnitude |
 | `sensor.climate_advisor_trend` | warming/cooling/stable | (dynamic icon) |
 | `sensor.climate_advisor_next_action` | Human-readable next action | — |
-| `sensor.climate_advisor_daily_briefing` | Truncated briefing (255 char) | full_briefing (complete text) |
+| `sensor.climate_advisor_daily_briefing` | TLDR summary, capped at 250 chars (HA's hard limit is 255 — Issue #555) | full_briefing (complete text), tldr (untruncated TLDR) |
 | `sensor.climate_advisor_comfort_score` | 0–100% | `pending_suggestions`, `comfort_violations_minutes_today`, `comfort_range_low`, `comfort_range_high` |
 | `sensor.climate_advisor_status` | active/inactive | — |
 | `sensor.climate_advisor_occupancy_mode` | home/away/vacation/guest | occupancy_entity_states (raw toggle states) |

--- a/docs/04-BRIEFING-EXAMPLES.md
+++ b/docs/04-BRIEFING-EXAMPLES.md
@@ -16,7 +16,7 @@ These are example briefings for each day type, showing the tone, structure, and 
 ## Structure (every briefing)
 
 1. Structured header with today/tomorrow temps, day type, and trend (scannable at a glance)
-2. TLDR summary table — plain-text aligned key/value rows (Day Type, HVAC Mode, Windows, Bedtime Setback, Tomorrow) for quick scanning in push notifications and email
+2. TLDR summary table — plain-text key/value rows (Day Type, HVAC Mode, Windows, Bedtime Setback, Tomorrow), single-space gap not column-aligned (Issue #555 — fixed-width padding was pure overhead toward HA's 255-char sensor state limit and wasn't reliably rendered as aligned columns in either UI surface anyway) for quick scanning in push notifications and email
 3. Conversational body — flowing prose paragraphs covering the day plan, what the system will do, and what the user can do to help
 3. "If you head out" paragraph — occupancy setback behavior
 4. "Fresh air" paragraph — affirms the user's right to open a window anytime, explains what the system will do in response using the actual configured debounce duration, describes the impact on the day's climate strategy, and suggests how to minimize that impact. Varies by HVAC mode.
@@ -38,11 +38,11 @@ Today: High 68°F / Low 48°F
 Tomorrow: High 78°F / Low 58°F
 Day Type: Mild | Trend: Significantly warmer tomorrow (+10°F)
 
-  Day Type:        Mild (68°F)
-  HVAC Mode:       Heat at 70°F
-  Windows:         Open 10 AM – 5 PM
+  Day Type: Mild (68°F)
+  HVAC Mode: Heat at 70°F
+  Windows: Open 10 AM – 5 PM
   Bedtime Setback: 66°F at 10:30 PM
-  Tomorrow:        Significantly warmer tomorrow (+10°F) (78°F)
+  Tomorrow: Significantly warmer tomorrow (+10°F) (78°F)
 
 This is the good stuff — a day where the house practically takes care of itself. I ran the heater to 70°F before sunrise, and now it's off for the day. The weather does the rest.
 
@@ -77,11 +77,11 @@ Today: High 80°F / Low 60°F
 Tomorrow: High 82°F / Low 62°F
 Day Type: Warm | Trend: Stable
 
-  Day Type:        Warm (80°F)
-  HVAC Mode:       Off — windows day
-  Windows:         Open 6 AM – 10 AM
+  Day Type: Warm (80°F)
+  HVAC Mode: Off — windows day
+  Windows: Open 6 AM – 10 AM
   Bedtime Setback: No setback
-  Tomorrow:        Stable (82°F)
+  Tomorrow: Stable (82°F)
 
 Open windows around 6:00 AM to catch the cool morning air. Close up at 10:00 AM — after that the outdoor air will be warmer than inside.
 
@@ -114,11 +114,11 @@ Today: High 95°F / Low 72°F
 Tomorrow: High 92°F / Low 70°F
 Day Type: Hot | Trend: Stable
 
-  Day Type:        Hot (95°F)
-  HVAC Mode:       Cool at 75°F
-  Windows:         Closed all day
+  Day Type: Hot (95°F)
+  HVAC Mode: Cool at 75°F
+  Windows: Closed all day
   Bedtime Setback: 78°F at 10:30 PM
-  Tomorrow:        Stable (92°F)
+  Tomorrow: Stable (92°F)
 
 I got a head start on the heat this morning. The AC pre-cooled the house to 73°F while the outdoor air was still cool — that banking strategy saves a lot of energy over the course of the day.
 
@@ -147,11 +147,11 @@ Today: High 55°F / Low 35°F
 Tomorrow: High 50°F / Low 30°F
 Day Type: Cool | Trend: Cooling trend (-5°F)
 
-  Day Type:        Cool (55°F)
-  HVAC Mode:       Heat at 70°F
-  Windows:         Closed all day
+  Day Type: Cool (55°F)
+  HVAC Mode: Heat at 70°F
+  Windows: Closed all day
   Bedtime Setback: 66°F at 10:30 PM
-  Tomorrow:        Cooling trend (-5°F) (50°F)
+  Tomorrow: Cooling trend (-5°F) (50°F)
 
 It's a heater day. I'll keep the house at 70°F through the morning — it's too cool outside for windows today, so we're staying sealed up.
 
@@ -180,11 +180,11 @@ Today: High 38°F / Low 22°F
 Tomorrow: High 28°F / Low 12°F
 Day Type: Cold | Trend: Significant cold front coming (-10°F)
 
-  Day Type:        Cold (38°F)
-  HVAC Mode:       Heat at 70°F
-  Windows:         Closed all day
+  Day Type: Cold (38°F)
+  HVAC Mode: Heat at 70°F
+  Windows: Closed all day
   Bedtime Setback: 66°F at 10:30 PM
-  Tomorrow:        Significant cold front coming (-10°F) (28°F)
+  Tomorrow: Significant cold front coming (-10°F) (28°F)
 
 It's going to be cold out there. The heater runs all day at 70°F, and you can help it out — keep doors and windows closed, minimize how long you hold exterior doors open, and close curtains on the north side. If you have south-facing windows, open those curtains to grab some free solar heat.
 

--- a/docs/08-COMPUTATION-REFERENCE.md
+++ b/docs/08-COMPUTATION-REFERENCE.md
@@ -153,7 +153,7 @@ Default values used in examples: `comfort_heat = 70`, `comfort_cool = 75`, `setb
 - Guest mode calls `handle_occupancy_home()` directly — no separate handler.
 - Morning wakeup is skipped when occupancy is `away` or `vacation` (Issue #85).
 - Bedtime setback is skipped when occupancy is `vacation` (vacation setback is deeper).
-- The daily briefing TLDR table shows setback temps and an occupancy status row when not home.
+- The daily briefing TLDR table shows setback temps and an occupancy status row when not home. The HVAC Mode row's setback temp no longer repeats "(setback — away/vacation)" — the Occupancy row directly below it already states that fact (Issue #555 dedup, needed to fit HA's 255-char sensor state limit).
 
 ### 5a. Adaptive Bedtime Setback (`compute_bedtime_setback()`)
 

--- a/docs/09-DEBUGGING-GUIDE.md
+++ b/docs/09-DEBUGGING-GUIDE.md
@@ -31,7 +31,7 @@ Climate Advisor exposes several sensor entities in Home Assistant. These persist
 | Last Action Time | `sensor.climate_advisor_last_action_time` | ISO timestamp | — | When last action occurred |
 | Contact Sensors | `sensor.climate_advisor_contact_status` | "all closed" / sensor names | `sensors`, `paused_by_door`, `open_count` | Door/window state and pause status |
 | Fan Status | `sensor.climate_advisor_fan_status` | active / inactive / override — on / override — off / disabled | `fan_runtime_minutes`, `fan_override_since`, `fan_running` | Fan automation state |
-| Daily Briefing | `sensor.climate_advisor_daily_briefing` | TLDR summary | `full_briefing` | Today's plan |
+| Daily Briefing | `sensor.climate_advisor_daily_briefing` | TLDR summary, truncated (250 chars) only if it exceeds HA's 255-char limit (Issue #555) | `full_briefing`, `tldr` (untruncated) | Today's plan |
 | Occupancy Mode | `sensor.climate_advisor_occupancy_mode` | home / away / guest / vacation | — | Current occupancy |
 | Comfort Score | `sensor.climate_advisor_comfort_score` | 0-100% | `pending_suggestions` | Compliance tracking |
 | AI Status | `sensor.climate_advisor_ai_status` | active / inactive / error / disabled / circuit_open | `last_request_time`, `error_count`, `total_requests`, `model_in_use`, `circuit_breaker`, `monthly_cost_estimate`, `auto_requests_today`, `manual_requests_today` | AI integration health and usage |

--- a/docs/briefing-spec.md
+++ b/docs/briefing-spec.md
@@ -27,6 +27,7 @@ learning suggestions, and any required human actions.
 | How does the grace period state appear in briefing output? | [§ Grace Period Injection](#grace-period-injection) |
 | How does the header table stay consistent with the conversational body? | [§ Single Source of Truth for Warm-Day Timing (Issue #518)](#single-source-of-truth-for-warm-day-timing-issue-518) |
 | What does each day-type briefing look like? | [Briefing Examples](04-BRIEFING-EXAMPLES.md) |
+| Why does the TLDR table stay under HA's 255-char sensor state limit? | [§ TLDR Table Length Budget (Issue #555)](#tldr-table-length-budget-issue-555) |
 
 ## Date Computation
 
@@ -131,6 +132,36 @@ reopen) are derived from `predicted_indoor_future`/`predicted_outdoor_future` ti
 which are already local-time-aware by the time they reach `briefing.py` (produced upstream by
 `coordinator.py`'s forecast pipeline) — `briefing.py` only calls `.strftime(_FMT_HOUR)` on
 them, performing no timezone conversion itself.
+
+## TLDR Table Length Budget (Issue #555)
+
+`ClimateAdvisorBriefingSensor.native_value` (`sensor.py`) returns `ATTR_BRIEFING_SHORT` —
+the TLDR table produced by `_generate_tldr_table()` — as the sensor's `state`. HA rejects
+any sensor `state` string over 255 chars outright and falls the entity back to `unknown`.
+Before Issue #555, no length guard existed on this path (only on the full-briefing
+fallback, which is unreachable once the TLDR is populated), so away/vacation days with
+dual morning+evening window-opportunity rows and a large warming trend could exceed 255
+chars and silently blank the primary UI surface.
+
+Two changes keep this from recurring:
+
+1. **Content is shortened, not just truncated.** `_generate_tldr_table()` uses a single
+   fixed-width gap (`"  Label: value"`) instead of column-padding every label to a
+   constant width — that padding was pure whitespace overhead and wasn't reliably
+   rendered as aligned columns in either UI surface (dashboard/notify-service bodies are
+   both proportional-font, not monospace). The HVAC Mode row also no longer repeats
+   `"(setback — away/vacation)"` when the Occupancy row directly below it already states
+   the same fact. This keeps the documented worst case comfortably under 250 chars.
+2. **Truncation remains a safety net**, not the primary fix: `ClimateAdvisorBaseSensor._capped_state()`
+   (`sensor.py`) caps any sensor state at 250 chars (`text[:247] + "..."`), logging a
+   one-time `WARNING` if it ever actually fires, so a future regression degrades to a
+   truncated-but-valid state instead of `unknown`. The untruncated TLDR is always
+   available via the `tldr` attribute (and the full multi-section briefing via
+   `full_briefing`).
+
+`tests/test_briefing.py::TestTldrTableLength` asserts the away/vacation + dual-window
+worst case stays ≤ 250 chars across all occupancy modes — this is the regression guard;
+the sensor-level cap should rarely/never actually trigger in practice.
 
 ## Stale/Missing Data Handling
 

--- a/tests/test_briefing.py
+++ b/tests/test_briefing.py
@@ -1303,6 +1303,47 @@ class TestTldrLength:
         assert len(result) < len(normal), "tldr_only should be shorter than normal"
 
 
+class TestTldrTableLength:
+    """Issue #555: TLDR table must stay well under HA's 255-char sensor state limit.
+
+    TestTldrLength above covers the simple per-day-type case, but the real regression
+    only showed up when occupancy (away/vacation) and dual morning+evening window
+    opportunity rows stack together with a large warming trend — this is the documented
+    worst case (a real-world instance measured 261 chars before this fix).
+    """
+
+    @pytest.mark.parametrize("occupancy_mode", ["home", "away", "vacation", "guest"])
+    def test_worst_case_tldr_fits_sensor_state_limit(self, occupancy_mode):
+        """HOT day + low temps <= WINDOW_OPPORTUNITY_MAX_LOW_F (classifier.py) auto-trigger
+        both morning and evening window-opportunity rows, combined with the longest trend
+        text and (for away/vacation) the occupancy row — the documented worst case."""
+        c = _make_classification(
+            "hot",
+            today_high=95,
+            today_low=72,
+            tomorrow_high=110,
+            tomorrow_low=72,
+            trend_direction="warming",
+            trend_magnitude=15,
+        )
+        result = generate_briefing(
+            classification=c,
+            comfort_heat=COMFORT_HEAT,
+            comfort_cool=COMFORT_COOL,
+            setback_heat=SETBACK_HEAT,
+            setback_cool=SETBACK_COOL,
+            wake_time=DEFAULT_WAKE,
+            sleep_time=DEFAULT_SLEEP,
+            occupancy_mode=occupancy_mode,
+            verbosity="tldr_only",
+        )
+        assert len(result) <= 250, (
+            f"TLDR table is {len(result)} chars — exceeds the 250-char safety margin "
+            f"under HA's 255-char sensor state limit (Issue #555). Shorten "
+            f"_generate_tldr_table() output before merging."
+        )
+
+
 # ---------------------------------------------------------------------------
 # No markdown in briefing output (Issue #21)
 # ---------------------------------------------------------------------------

--- a/tests/test_briefing_sensor.py
+++ b/tests/test_briefing_sensor.py
@@ -1,0 +1,88 @@
+"""Tests for ClimateAdvisorBriefingSensor (Issue #555).
+
+Issue #555: the sensor's native_value returned the TLDR text unconditionally with no
+length guard, so HA rejected states over 255 chars and forced the sensor to `unknown`
+on the exact days (away/vacation occupancy, dual window-opportunity) that had the most
+to say. briefing.py now shrinks the TLDR content so this should rarely trigger, but the
+truncation safety net (ClimateAdvisorBaseSensor._capped_state) must still behave
+correctly when it does.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+from custom_components.climate_advisor.const import ATTR_BRIEFING, ATTR_BRIEFING_SHORT
+from custom_components.climate_advisor.sensor import ClimateAdvisorBriefingSensor
+
+
+def _briefing_sensor(data: dict | None) -> ClimateAdvisorBriefingSensor:
+    """Build a real ClimateAdvisorBriefingSensor over `data`."""
+    coord = MagicMock()
+    coord.data = data
+    entry = MagicMock()
+    entry.entry_id = "test_entry"
+    return ClimateAdvisorBriefingSensor(coord, entry)
+
+
+class TestBriefingSensorNativeValue:
+    def test_short_tldr_returned_unchanged(self, caplog):
+        """TLDR under the limit is returned as-is, no truncation, no warning."""
+        text = "  Day Type: Hot (88°F)\n  HVAC Mode: Cool at 75°F"
+        sensor = _briefing_sensor({ATTR_BRIEFING_SHORT: text, ATTR_BRIEFING: text})
+        with caplog.at_level(logging.WARNING):
+            value = sensor.native_value
+        assert value == text
+        assert not any("truncated" in r.message for r in caplog.records)
+
+    def test_long_tldr_truncated_with_warning(self, caplog):
+        """TLDR over 250 chars is capped to 247 chars + '...', WARNING logged once."""
+        long_text = "X" * 300
+        sensor = _briefing_sensor({ATTR_BRIEFING_SHORT: long_text, ATTR_BRIEFING: long_text})
+        with caplog.at_level(logging.WARNING):
+            value1 = sensor.native_value
+            value2 = sensor.native_value
+        assert value1 == long_text[:247] + "..."
+        assert len(value1) <= 255
+        assert value2 == value1
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING and "truncated" in r.message]
+        assert len(warnings) == 1
+
+    def test_falls_back_to_full_briefing_when_short_empty(self):
+        """No TLDR yet — falls back to (possibly truncated) full briefing text."""
+        full = "Full briefing text"
+        sensor = _briefing_sensor({ATTR_BRIEFING_SHORT: "", ATTR_BRIEFING: full})
+        assert sensor.native_value == full
+
+    def test_falls_back_and_truncates_long_full_briefing(self):
+        """No TLDR yet, and the full briefing itself exceeds the limit."""
+        full = "Y" * 300
+        sensor = _briefing_sensor({ATTR_BRIEFING_SHORT: "", ATTR_BRIEFING: full})
+        assert sensor.native_value == full[:247] + "..."
+
+    def test_empty_coordinator_data_returns_empty_string(self):
+        """No coordinator data at all — existing empty-string behavior preserved."""
+        sensor = _briefing_sensor(None)
+        assert sensor.native_value == ""
+
+
+class TestBriefingSensorAttributes:
+    def test_attributes_expose_full_briefing_and_tldr(self):
+        sensor = _briefing_sensor({ATTR_BRIEFING: "full text", ATTR_BRIEFING_SHORT: "short text"})
+        attrs = sensor.extra_state_attributes
+        assert attrs["full_briefing"] == "full text"
+        assert attrs["tldr"] == "short text"
+
+    def test_tldr_attribute_holds_untruncated_text_even_when_state_truncates(self):
+        """The attribute must retain the full TLDR even when native_value truncates it."""
+        long_text = "Z" * 300
+        sensor = _briefing_sensor({ATTR_BRIEFING_SHORT: long_text, ATTR_BRIEFING: "full"})
+        assert sensor.native_value == long_text[:247] + "..."
+        assert sensor.extra_state_attributes["tldr"] == long_text
+
+    def test_attributes_empty_when_no_coordinator_data(self):
+        sensor = _briefing_sensor(None)
+        attrs = sensor.extra_state_attributes
+        assert attrs["full_briefing"] == ""
+        assert attrs["tldr"] == ""


### PR DESCRIPTION
## Summary
- `sensor.climate_advisor_daily_briefing` was dropping to `unknown` on days with a lot to report (away/vacation occupancy + dual morning/evening window-opportunity days), because `_generate_tldr_table()` had no length guard and HA rejects sensor states over 255 chars.
- Shrinks the TLDR table content itself (drops fixed-width label alignment padding — pure whitespace overhead that wasn't rendered as aligned columns in either UI surface anyway — and removes the redundant "(setback — away/vacation)" phrase from the HVAC Mode row since the Occupancy row directly below it already states that fact).
- Adds a shared `ClimateAdvisorBaseSensor._capped_state()` truncation safety net used by both the briefing sensor (new) and the last-action-reason sensor (refactored, behavior-identical), so a future regression degrades gracefully instead of going to `unknown`.
- Docs updated: `docs/briefing-spec.md` (new §), `08-COMPUTATION-REFERENCE.md`, `09-DEBUGGING-GUIDE.md`, `02-ARCHITECTURE-REFERENCE.md`, `04-BRIEFING-EXAMPLES.md` (example blocks updated to the new non-padded format).
- Version bumped 0.5.40 → 0.5.41, `RELEASE_NOTES`/`KNOWN_FIXES`/`CHANGELOG.md` updated.

Closes #555.

## Test plan
- [x] `tests/test_briefing.py::TestTldrTableLength` — new regression test covering the away/vacation + dual-window-opportunity worst case across all occupancy modes, asserts ≤ 250 chars
- [x] `tests/test_briefing_sensor.py` — new file, 8 tests covering truncation/fallback/attribute behavior of `ClimateAdvisorBriefingSensor`
- [x] Full suite: `pytest tests/` — 3651 passed
- [x] `ruff check` / `ruff format --check` — clean
- [x] `tools/validate.py` — passed
- [x] `tests/test_version_sync.py` — passed