### PR TITLE
Fix #557: options sections save immediately on Submit, no separate Save step

### DIFF
--- a/custom_components/climate_advisor/config_flow.py
+++ b/custom_components/climate_advisor/config_flow.py
@@ -142,7 +142,6 @@ OPTIONS_MENU_OPTIONS = [
     "classification_thresholds",
     "ai_settings",
     "github_settings",
-    "save",
 ]
 
 TEMP_UNIT_OPTIONS = [
@@ -588,10 +587,14 @@ class ClimateAdvisorOptionsFlow(config_entries.OptionsFlow):
 
     def __init__(self) -> None:
         """Initialize the options flow."""
+        # Scratch space used only within a single section's commit — see
+        # _commit_section(). Not carried across steps: each section persists
+        # immediately on submit (Issue #557), so there is no multi-step
+        # staged-but-unsaved state to track between calls.
         self._updates: dict[str, Any] = {}
         # Keys that a step owns but that came back cleared (omitted from the
-        # submitted input). Applied as deletions in async_step_save so optional
-        # entity fields can actually be emptied (Issue #434).
+        # submitted input). Applied as deletions in _commit_section() so
+        # optional entity fields can actually be emptied (Issue #434).
         self._removed: set[str] = set()
 
     def _apply_step_input(self, user_input: dict[str, Any], clearable_keys: tuple[str, ...]) -> None:
@@ -602,7 +605,7 @@ class ClimateAdvisorOptionsFlow(config_entries.OptionsFlow):
         ``user_input`` entirely — so a plain ``self._updates.update(user_input)``
         would silently keep the old stored value (Issue #434). For each key the
         step owns: if present, it's a set/update; if absent, it's a clear, which
-        we record for removal at save time.
+        we record for removal when this section commits.
         """
         for key in clearable_keys:
             if key in user_input:
@@ -611,6 +614,33 @@ class ClimateAdvisorOptionsFlow(config_entries.OptionsFlow):
                 self._removed.add(key)
                 self._updates.pop(key, None)
         self._updates.update(user_input)
+
+    async def _commit_section(self, user_input: dict[str, Any], clearable_keys: tuple[str, ...] = ()) -> None:
+        """Persist one section's submitted values immediately and reload (Issue #557).
+
+        Previously, section steps only staged values into ``self._updates`` and
+        a separate "Save & Close" menu step was the only thing that ever wrote
+        to the config entry — so re-opening a section before hitting Save showed
+        stale data. Submit now commits directly: every section step's success
+        branch calls this instead of staging, so "Submit" always means "saved."
+        """
+        if clearable_keys:
+            self._apply_step_input(user_input, clearable_keys)
+        else:
+            self._updates.update(user_input)
+
+        data = {**self.config_entry.data, **self._updates}
+        for key in self._removed:
+            data.pop(key, None)
+
+        self.hass.config_entries.async_update_entry(self.config_entry, data=data)
+        await self.hass.config_entries.async_reload(self.config_entry.entry_id)
+        _LOGGER.info("Options section saved — reload triggered (cleared=%d)", len(self._removed))
+
+        # Everything just flushed to config_entry.data; reset scratch state so
+        # the next section's commit starts clean.
+        self._updates = {}
+        self._removed = set()
 
     # ---- Menu ----
 
@@ -634,7 +664,7 @@ class ClimateAdvisorOptionsFlow(config_entries.OptionsFlow):
             if not _NOTIFY_SERVICE_RE.match(notify_svc):
                 errors["notify_service"] = "invalid_notify_service"
             if not errors:
-                self._updates.update(user_input)
+                await self._commit_section(user_input)
                 return await self.async_step_init()
 
         return self.async_show_form(
@@ -688,7 +718,7 @@ class ClimateAdvisorOptionsFlow(config_entries.OptionsFlow):
                 for key in ("comfort_heat", "comfort_cool", "setback_heat", "setback_cool", "sleep_heat", "sleep_cool"):
                     if key in user_input:
                         user_input[key] = to_fahrenheit(user_input[key], unit)
-                self._updates.update(user_input)
+                await self._commit_section(user_input)
                 return await self.async_step_init()
 
         if is_celsius:
@@ -812,12 +842,12 @@ class ClimateAdvisorOptionsFlow(config_entries.OptionsFlow):
     ) -> config_entries.ConfigFlowResult:
         """Temperature source selection."""
         if user_input is not None:
-            self._apply_step_input(user_input, ("outdoor_temp_entity", "indoor_temp_entity"))
             _LOGGER.debug(
                 "Options — outdoor_source=%s, indoor_source=%s",
                 user_input.get("outdoor_temp_source"),
                 user_input.get("indoor_temp_source"),
             )
+            await self._commit_section(user_input, clearable_keys=("outdoor_temp_entity", "indoor_temp_entity"))
             return await self.async_step_init()
 
         current = self.config_entry.data
@@ -870,7 +900,9 @@ class ClimateAdvisorOptionsFlow(config_entries.OptionsFlow):
             ):
                 if key in user_input:
                     user_input[key] = int(user_input[key] * 60)
-            self._apply_step_input(user_input, (CONF_FAN_ENTITY, CONF_FAN_STATE_ENTITY, CONF_FAN_REMOTE_ENTITY))
+            await self._commit_section(
+                user_input, clearable_keys=(CONF_FAN_ENTITY, CONF_FAN_STATE_ENTITY, CONF_FAN_REMOTE_ENTITY)
+            )
             return await self.async_step_init()
 
         current = self.config_entry.data
@@ -994,7 +1026,9 @@ class ClimateAdvisorOptionsFlow(config_entries.OptionsFlow):
         if user_input is not None:
             if CONF_WELCOME_HOME_DEBOUNCE in user_input:
                 user_input[CONF_WELCOME_HOME_DEBOUNCE] = int(user_input[CONF_WELCOME_HOME_DEBOUNCE] * 60)
-            self._apply_step_input(user_input, (CONF_HOME_TOGGLE, CONF_VACATION_TOGGLE, CONF_GUEST_TOGGLE))
+            await self._commit_section(
+                user_input, clearable_keys=(CONF_HOME_TOGGLE, CONF_VACATION_TOGGLE, CONF_GUEST_TOGGLE)
+            )
             return await self.async_step_init()
 
         current = self.config_entry.data
@@ -1054,7 +1088,7 @@ class ClimateAdvisorOptionsFlow(config_entries.OptionsFlow):
     async def async_step_schedule(self, user_input: dict[str, Any] | None = None) -> config_entries.ConfigFlowResult:
         """Daily schedule configuration."""
         if user_input is not None:
-            self._updates.update(user_input)
+            await self._commit_section(user_input)
             return await self.async_step_init()
 
         current = self.config_entry.data
@@ -1087,7 +1121,7 @@ class ClimateAdvisorOptionsFlow(config_entries.OptionsFlow):
     ) -> config_entries.ConfigFlowResult:
         """Notification preferences — per-event push and email toggles."""
         if user_input is not None:
-            self._updates.update(user_input)
+            await self._commit_section(user_input)
             return await self.async_step_init()
 
         current = self.config_entry.data
@@ -1157,7 +1191,7 @@ class ClimateAdvisorOptionsFlow(config_entries.OptionsFlow):
             if default_p > max_p:
                 errors["default_preheat_minutes"] = "preheat_default_exceeds_max"
             if not errors:
-                self._updates.update(user_input)
+                await self._commit_section(user_input)
                 return await self.async_step_init()
 
         current = self.config_entry.data
@@ -1246,7 +1280,7 @@ class ClimateAdvisorOptionsFlow(config_entries.OptionsFlow):
                 for key in (CONF_THRESHOLD_HOT, CONF_THRESHOLD_WARM, CONF_THRESHOLD_MILD, CONF_THRESHOLD_COOL):
                     if key in user_input:
                         converted[key] = to_fahrenheit(user_input[key], unit)
-                self._updates.update(converted)
+                await self._commit_section(converted)
                 return await self.async_step_init()
 
         if is_celsius:
@@ -1384,7 +1418,7 @@ class ClimateAdvisorOptionsFlow(config_entries.OptionsFlow):
                     if key in merged:
                         merged[key] = int(merged[key])
 
-                self._updates.update(merged)
+                await self._commit_section(merged)
                 return await self.async_step_init()
 
         # Build masked key status placeholder for description
@@ -1523,7 +1557,7 @@ class ClimateAdvisorOptionsFlow(config_entries.OptionsFlow):
                 else:
                     merged.pop(CONF_GITHUB_TOKEN, None)
                 merged[CONF_GITHUB_REPO] = repo
-                self._updates.update(merged)
+                await self._commit_section(merged)
                 return await self.async_step_init()
 
         existing_token = current.get(CONF_GITHUB_TOKEN, "")
@@ -1547,20 +1581,3 @@ class ClimateAdvisorOptionsFlow(config_entries.OptionsFlow):
             errors=errors,
             description_placeholders={"token_status": token_status},
         )
-
-    # ---- Save & Close ----
-
-    async def async_step_save(self, user_input: dict[str, Any] | None = None) -> config_entries.ConfigFlowResult:
-        """Merge all updates and save."""
-        data = {**self.config_entry.data, **self._updates}
-        # Apply explicit clears (Issue #434): keys a step owned but that came back
-        # empty are removed so optional entity fields can actually be unset.
-        for key in self._removed:
-            data.pop(key, None)
-        self.hass.config_entries.async_update_entry(
-            self.config_entry,
-            data=data,
-        )
-        await self.hass.config_entries.async_reload(self.config_entry.entry_id)
-        _LOGGER.info("Options updated — reload triggered (cleared=%d)", len(self._removed))
-        return self.async_create_entry(title="", data={})

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,17 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.48"
+VERSION = "0.5.49"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.49": [
+        "Fix #557: options dialog sections now save the instant you hit Submit — no more"
+        " separate 'Save & Close' step. Previously, submitting a section (e.g. Setpoints or"
+        " Notifications) only staged the change in memory; re-opening that same section"
+        " before hitting the separate Save button showed the old value, making it look like"
+        " the change hadn't taken. Every section now writes and reloads immediately, so"
+        " what you see after Submit is always what's actually saved.",
+    ],
     "0.5.48": [
         "Fix #558: the AC no longer chases a colder-than-comfort setpoint on hot days after"
         " you return from being away — it now simply restores your normal comfort setting."
@@ -1394,6 +1402,48 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    557: {
+        "version_fixed": "0.5.49",
+        "title": (
+            "Options dialog sections appeared to silently discard changes: submitting any"
+            " one of the 11 section forms (core, setpoints, temperature sources, sensors,"
+            " occupancy, schedule, notifications, advanced, classification thresholds, AI"
+            " settings, GitHub integration) only staged the values into an in-memory"
+            " self._updates dict and routed back to the menu — none of them called"
+            " hass.config_entries.async_update_entry(). Every section's form defaults were"
+            " built from self.config_entry.data (the persisted entry), never from the staged"
+            " self._updates, so re-opening the just-edited section showed the old value"
+            " unless the user separately navigated to the menu's distinct 'Save & Close'"
+            " item, which was the only step that actually persisted and reloaded."
+        ),
+        "scope_covered": (
+            "Replaced the two-phase stage-then-save design with immediate per-section commit."
+            " Added ClimateAdvisorOptionsFlow._commit_section() — merges the section's input"
+            " (reusing _apply_step_input() for the 3 steps with clearable optional-entity"
+            " fields), calls hass.config_entries.async_update_entry() +"
+            " hass.config_entries.async_reload() immediately, logs an INFO line, then resets"
+            " scratch state. All 11 section steps' success branches now call"
+            " _commit_section() instead of staging into self._updates directly. Deleted"
+            " async_step_save() and removed 'save' from OPTIONS_MENU_OPTIONS and both"
+            " strings.json/translations/en.json menu labels — the HA frontend's built-in"
+            " dialog close control is the only way to exit the options flow now. Updated"
+            " tests/test_config_flow.py's _make_options_flow()/_run_options_flow() harness to"
+            " mirror real HA's async_update_entry() (mutating entry.data in place) and to"
+            " drive steps without a trailing save call; rewrote TestOptionsFlowMenu's"
+            " save-specific tests into per-section-commit tests including an explicit"
+            " regression guard that a single section submit persists without any further"
+            " step. TestOptionsFlowMultiStep and TestOptionsFlowClearing (Issue #434)"
+            " continued passing unchanged against the new harness, confirming multi-section"
+            " accumulation and clearable-field semantics are preserved."
+        ),
+        "scope_not_covered": (
+            "Editing multiple sections in one sitting now triggers one coordinator reload per"
+            " section submitted (was one reload total, at Save & Close) — an accepted,"
+            " bounded tradeoff for always-correct display, not a regression fix in itself."
+            " No mechanism was added to batch or debounce reloads across rapid consecutive"
+            " section edits."
+        ),
+    },
     558: {
         "version_fixed": "0.5.48",
         "title": (

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.48"
+  "version": "0.5.49"
 }

--- a/custom_components/climate_advisor/strings.json
+++ b/custom_components/climate_advisor/strings.json
@@ -146,8 +146,7 @@
           "advanced": "Learning & Behavior",
           "classification_thresholds": "Day-Type Thresholds",
           "ai_settings": "AI Settings (Claude)",
-          "github_settings": "GitHub Integration",
-          "save": "Save & Close"
+          "github_settings": "GitHub Integration"
         }
       },
       "core": {

--- a/custom_components/climate_advisor/translations/en.json
+++ b/custom_components/climate_advisor/translations/en.json
@@ -150,8 +150,7 @@
           "advanced": "Learning & Behavior",
           "classification_thresholds": "Day-Type Thresholds",
           "ai_settings": "AI Settings (Claude)",
-          "github_settings": "GitHub Integration",
-          "save": "Save & Close"
+          "github_settings": "GitHub Integration"
         }
       },
       "core": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -49,11 +49,18 @@ def _make_options_flow(entry_data: dict):
     Enabled by the ha_stubs realification of ``config_entries.OptionsFlow``
     (same pattern as SensorEntity/HomeAssistantView, Issue #452). Returns
     ``(flow, captured)`` where ``captured['data']`` is the dict persisted by
-    ``async_step_save``.
+    the most recent section commit (``_commit_section``, Issue #557 — each
+    section step persists immediately on submit; there is no longer a
+    separate save step).
 
-    DOCTRINE: options-flow tests must exercise the production step handlers and
-    save path — never re-implement the merge in the test body. A mirror of the
-    merge embeds the same logic it claims to test and cannot catch a bug in it
+    The mocked ``async_update_entry`` also mirrors real HA's behavior of
+    mutating ``entry.data`` in place, so that driving multiple section steps
+    in sequence correctly accumulates: each step's ``_commit_section`` reads
+    ``self.config_entry.data`` fresh, which must reflect prior steps' commits.
+
+    DOCTRINE: options-flow tests must exercise the production step handlers —
+    never re-implement the merge in the test body. A mirror of the merge
+    embeds the same logic it claims to test and cannot catch a bug in it
     (this is exactly how Issue #434 shipped despite green tests).
     """
     from unittest.mock import AsyncMock
@@ -66,26 +73,29 @@ def _make_options_flow(entry_data: dict):
     flow.config_entry = _make_config_entry(entry_data)
 
     captured: dict = {}
+
+    def _update_entry(entry, data):
+        captured["data"] = data
+        entry.data = data  # mirror real HA: async_update_entry mutates entry.data
+
     hass = MagicMock()
-    hass.config_entries.async_update_entry = MagicMock(
-        side_effect=lambda entry, data: captured.__setitem__("data", data)
-    )
+    hass.config_entries.async_update_entry = MagicMock(side_effect=_update_entry)
     hass.config_entries.async_reload = AsyncMock()
     flow.hass = hass
     return flow, captured
 
 
 def _run_options_flow(entry_data: dict, steps: list[tuple[str, dict]]) -> dict:
-    """Drive the REAL flow: apply each (step_method_name, user_input), then save.
+    """Drive the REAL flow: apply each (step_method_name, user_input) in sequence.
 
-    Returns the dict actually persisted by ``async_step_save``.
+    Each step commits immediately (Issue #557) — no trailing save call.
+    Returns the dict persisted by the last driven step.
     """
     flow, captured = _make_options_flow(entry_data)
 
     async def _drive() -> None:
         for method_name, user_input in steps:
             await getattr(flow, method_name)(user_input)
-        await flow.async_step_save()
 
     asyncio.run(_drive())
     return captured["data"]
@@ -1849,7 +1859,6 @@ class TestOptionsFlowMenu:
             "classification_thresholds",
             "ai_settings",
             "github_settings",
-            "save",
         ]
         assert expected == OPTIONS_MENU_OPTIONS
 
@@ -1859,14 +1868,23 @@ class TestOptionsFlowMenu:
 
         assert "notifications" in OPTIONS_MENU_OPTIONS
 
-    def test_menu_has_save(self):
-        """Save & Close must be a menu option."""
-        from custom_components.climate_advisor.config_flow import OPTIONS_MENU_OPTIONS
+    def test_menu_has_no_separate_save_step(self):
+        """Issue #557 — there is no separate "Save & Close" menu item or step.
 
-        assert "save" in OPTIONS_MENU_OPTIONS
+        Each section persists immediately on submit; a distinct save step
+        re-introduces the stage-then-save design whose stale-value bug this
+        issue fixed.
+        """
+        from custom_components.climate_advisor.config_flow import (
+            OPTIONS_MENU_OPTIONS,
+            ClimateAdvisorOptionsFlow,
+        )
 
-    def test_save_merges_updates(self):
-        """The REAL save step merges accumulated updates and preserves untouched fields."""
+        assert "save" not in OPTIONS_MENU_OPTIONS
+        assert not hasattr(ClimateAdvisorOptionsFlow, "async_step_save")
+
+    def test_section_commit_merges_updates(self):
+        """A single section's commit merges into entry data and preserves untouched fields."""
         data = _run_options_flow(
             dict(FULL_CONFIG),
             [("async_step_advanced", {"learning_enabled": False, "aggressive_savings": True})],
@@ -1875,6 +1893,19 @@ class TestOptionsFlowMenu:
         assert data["aggressive_savings"] is True
         # Untouched fields preserved
         assert data["weather_entity"] == "weather.forecast_home"
+
+    def test_section_submit_persists_without_separate_save(self):
+        """Issue #557 regression guard: submitting ONE section must itself persist and
+        reload — re-opening that section must not require a separate save step to see
+        the new value, since config_entry.data is what forms read their defaults from.
+        """
+        flow, captured = _make_options_flow(dict(FULL_CONFIG))
+
+        asyncio.run(flow.async_step_advanced({"learning_enabled": False, "aggressive_savings": True}))
+
+        assert "data" in captured, "async_update_entry must be called on section submit, not deferred"
+        assert flow.config_entry.data["learning_enabled"] is False
+        flow.hass.config_entries.async_reload.assert_called_once_with(flow.config_entry.entry_id)
 
 
 # ---------------------------------------------------------------------------
@@ -1915,7 +1946,7 @@ class TestNotificationsStep:
         assert config.get("email_briefing", True) is True
 
     def test_notifications_saves_to_updates(self):
-        """Submitted notification values persist through the REAL save step."""
+        """Submitted notification values persist immediately through the REAL step handler."""
         data = _run_options_flow(
             dict(FULL_CONFIG),
             [
@@ -1939,7 +1970,7 @@ class TestOptionsFlowMultiStep:
     """Test that the multi-step options flow merges data correctly."""
 
     def test_step_core_merges_core_settings(self):
-        """Core step collects entity and temperature settings (via the REAL handler + save)."""
+        """Core step collects entity and temperature settings and persists immediately (REAL handler)."""
         data = _run_options_flow(
             dict(FULL_CONFIG),
             [
@@ -2060,12 +2091,13 @@ class TestOptionsFlowMultiStep:
 class TestOptionsFlowClearing:
     """Issue #434 — optional entity fields must actually clear when left blank.
 
-    These tests INVOKE the real options flow (the production step handlers plus
-    async_step_save), not a re-implementation of the merge. The bug shipped
-    because the prior tests mirrored the merge in the test body and only ever
-    supplied values — never an omitted (cleared) key. A cleared optional entity
-    field is dropped from user_input by voluptuous, so the fix must record it for
-    removal at save time.
+    These tests INVOKE the real options flow (the production step handlers,
+    which persist immediately on submit as of Issue #557), not a
+    re-implementation of the merge. The bug shipped because the prior tests
+    mirrored the merge in the test body and only ever supplied values — never
+    an omitted (cleared) key. A cleared optional entity field is dropped from
+    user_input by voluptuous, so the fix must record it for removal when the
+    section commits.
     """
 
     # (owning step handler, config key) for every clearable optional-entity field.


### PR DESCRIPTION
## Summary
- Every options-flow section (core, setpoints, temperature sources, sensors, occupancy, schedule, notifications, advanced, classification thresholds, AI settings, GitHub integration) only staged submitted values in memory and routed back to the menu — none of them called `async_update_entry`. Re-opening a section before hitting the separate "Save & Close" menu item showed stale data, because forms build their defaults from the persisted entry, not the staged updates.
- Replaced the two-phase stage-then-save design with a shared `_commit_section()` helper: every section now persists (`async_update_entry`) and reloads immediately on Submit.
- Deleted `async_step_save` and removed `"save"` from the options menu (and both translation files) — the frontend's dialog close control is the only way to exit now.
- Accepted tradeoff: editing multiple sections in one sitting now triggers one reload per section instead of one reload total — bounded, expected cost for HA options flows, not a regression.

## Test plan
- [x] `pytest tests/test_config_flow.py` — 137 passed, including rewritten `TestOptionsFlowMenu`/`TestOptionsFlowMultiStep`/`TestOptionsFlowClearing` tests and a new regression guard asserting a single section submit persists without any further step
- [x] `pytest tests/test_config_flow.py -W error::pytest.PytestUnraisableExceptionWarning -W error::RuntimeWarning` — clean
- [x] `pytest tests/` full suite — 3637 passed
- [x] `ruff check` / `ruff format --check` on modified files — clean
- [x] `pytest tests/test_version_sync.py` — VERSION/manifest.json in sync (0.5.49)

Closes #557