### PR TITLE
Fix #561: WHF no longer activates with all windows closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.5.50] — 2026-08-03
+
+- Fix #561: the whole-house fan could turn itself on with every door and window closed, briefly switching the thermostat off for no reason — and the log misleadingly claimed "whole-house fan manually turned on" even though nobody touched it. The fan-cycling logic now re-checks that a monitored sensor is actually open before ever turning the fan back on, instead of trusting an internal flag that could go stale for hours. Also fixed the underlying causes: a self-healing check that could keep a ventilation "session" alive after windows closed, and a rare timing gap that could start two duplicate internal timers, both of which could leave the system briefly confused about whether it or the user caused a fan change.
+
 ## [0.5.47] — 2026-08-02
 
 - Fix #555: Daily Briefing sensor no longer drops to "unknown" on days with a lot to say (away/vacation occupancy + dual window opportunities) — the TLDR summary is now shortened to reliably fit HA's 255-char sensor state limit, with a truncation safety net and full text still available in the sensor's attributes as a backstop.

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -635,13 +635,26 @@ class AutomationEngine:
         # context propagation through third-party fan/switch integrations (especially
         # one-way RF transmitter entities) is not guaranteed reliable, so this is treated
         # as a corroborating signal, not a replacement for the existing checks.
-        self._fan_command_context_id: str | None = None
+        # Issue #561: bounded recency list, not a single last-write-wins id — see
+        # _record_fan_command_context()'s docstring for why a scalar isn't safe.
+        self._recent_fan_command_context_ids: list[tuple[str, datetime]] = []
         self._last_commanded_hvac_mode: str | None = None  # expected-state tracking: last mode automation commanded
         self._last_commanded_hvac_time: datetime | None = None  # expected-state tracking: when it was commanded
 
         # Natural ventilation mode (Issue #73)
         self._natural_vent_active: bool = False
         self._last_outdoor_temp: float | None = None
+        # Reentrancy guard for reconcile_fan_on_startup() (Issue #561): that method is
+        # called from 4 independent sites (startup coalesce, 30-min untracked-fan backstop,
+        # thermostat state-change, post-grace-expiry) with no coordination between them.
+        # Two overlapping calls previously each independently "adopted" the same physically-
+        # running fan and each started their own self-rescheduling backstop timer
+        # (_start_fan_thermo_backstop() only tracks the single most-recent one via
+        # self._fan_thermo_cancel), leaving the earlier one permanently uncancellable and
+        # ticking forever in parallel. A plain bool (not the shared self._decision_lock,
+        # which is not reentrant and some call sites may already hold) is enough: a second
+        # concurrent call simply skips this tick rather than blocking.
+        self._reconcile_fan_in_progress: bool = False
         # Timestamp of last outdoor-warm exit (outdoor ≥ indoor → pause).
         # Used for hysteresis lockout. Not serialized — resets on HA restart (acceptable for 5-min window).
         self._nat_vent_outdoor_exit_time: datetime | None = None
@@ -676,6 +689,15 @@ class AutomationEngine:
         # _activate_fan, cancelled in _deactivate_fan + cleanup. Ensures fan_thermostat_check
         # fires even when temperature sensors update slowly.
         self._fan_thermo_cancel: Any | None = None
+        # Generation counter (Issue #561, defense-in-depth): self._fan_thermo_cancel can only
+        # ever hold one live cancel handle, so if two chains are ever started concurrently
+        # (e.g. a future reentrancy gap elsewhere), whichever started first becomes
+        # permanently uncancellable the moment the second starts, and both tick forever in
+        # parallel. Each _start_fan_thermo_backstop() call bumps this counter and stamps its
+        # own tick with the value at schedule time; a tick whose stamped generation no longer
+        # matches the current counter belongs to a superseded chain and self-terminates
+        # instead of rescheduling, so at most one chain survives past its next tick.
+        self._fan_thermo_generation: int = 0
 
         # Event log callback — set by coordinator after construction
         self._emit_event_callback: Any | None = None
@@ -2882,11 +2904,7 @@ class AutomationEngine:
                 _debounce_pending = bool(
                     self._sensor_debounce_pending_callback and self._sensor_debounce_pending_callback()
                 )
-                _idle_open = (
-                    bool(self._sensor_check_callback and self._sensor_check_callback())
-                    and _hvac_off_244
-                    and not _debounce_pending
-                )
+                _idle_open = self._any_monitored_sensor_open() and _hvac_off_244 and not _debounce_pending
                 if not ((self._grace_active and _indoor is not None and _indoor > _cool) or _idle_open):
                     return
 
@@ -3318,19 +3336,51 @@ class AutomationEngine:
                         _ceiling_ok,
                     )
 
-    async def nat_vent_temperature_check(self, current_temp: float) -> None:
+    async def nat_vent_temperature_check(self, current_temp: float, *, outdoor: float | None) -> None:
         """Thermostat-style cycling: keep indoor near the comfort midpoint during a nat-vent session.
 
         Called on every thermostat temperature tick via coordinator._async_thermostat_changed.
-        Also called as a 30-minute backstop from check_natural_vent_conditions().
+        Also called as a 5-minute backstop from _thermo_backstop_task().
 
         When indoor drops to (midpoint - hysteresis) the fan turns off temporarily — the
         nat-vent SESSION stays active (_natural_vent_active=True) and HVAC suppression is
         maintained (restore_hvac=False). When indoor warms back to (midpoint + hysteresis)
         the fan re-engages, subject to the outdoor-warm guard.
+
+        Args:
+            current_temp: Current indoor temperature in °F.
+            outdoor: Current outdoor temperature in °F, sourced fresh by the caller (Issue
+                #561) — mirrors fan_thermostat_check()'s existing convention rather than
+                reading self._last_outdoor_temp internally. That cached attribute is only
+                refreshed by coordinator._apply_outdoor_temp(), and this cycling check is
+                the one place that previously read it directly instead of receiving a
+                caller-sourced value, letting it silently go stale for hours (Issue #561
+                root cause A) while every other nat-vent gate in this module reads a live
+                value from its own caller.
         """
         async with self._decision_pass("nat_vent_temperature_check"):
             if not self._natural_vent_active:
+                return
+
+            # Issue #561: a WHF session can be left believing it's still open (e.g. by
+            # _reconcile_fan_physical_drift()'s preserve-session path, or by the
+            # duplicate-timer-chain defect fixed alongside this) well after the monitored
+            # sensors actually closed. Nothing about "cycle the fan back on" is safe to do
+            # with every window/door closed — running a whole-house exhaust fan against a
+            # sealed building has no cooling benefit and can depressurize the home. Scoped
+            # to FAN_MODE_WHOLE_HOUSE/FAN_MODE_BOTH only: FAN_MODE_HVAC's fan-only mode has
+            # no separate physical-exterior-airflow requirement (it's the thermostat's own
+            # blower, not an exhaust fan) and its reactivation paths are intentionally
+            # allowed to re-engage without an open sensor (Issue #134's grace/ceiling path).
+            _fan_mode_nvtc = self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED)
+            if _fan_mode_nvtc in (FAN_MODE_WHOLE_HOUSE, FAN_MODE_BOTH) and not self._any_monitored_sensor_open():
+                _LOGGER.warning(
+                    "Nat-vent session force-closed: _natural_vent_active was True but no"
+                    " monitored sensor is open — ending session instead of cycling fan",
+                )
+                await self._exit_nat_vent(
+                    reason="nat-vent session force-closed: session flag was stale, sensors are closed"
+                )
                 return
 
             comfort_heat = float(self.config.get("comfort_heat", DEFAULT_COMFORT_HEAT))
@@ -3421,7 +3471,6 @@ class AutomationEngine:
                 return
 
             if not self._fan_active and current_temp >= on_threshold:
-                outdoor = self._last_outdoor_temp
                 if outdoor is not None and outdoor >= current_temp:
                     _LOGGER.info(
                         "Nat-vent cycling: indoor %.1f°F ≥ on_threshold %.1f°F"
@@ -3679,6 +3728,39 @@ class AutomationEngine:
                                     three triggers fired. Defaults to ``"startup"`` for any caller
                                     that doesn't pass one explicitly.
         """
+        # Issue #561: reentrancy guard — this method is called from 4 independent sites
+        # with no coordination between them. Two overlapping calls previously each
+        # independently reached the "adopt-on" branch below and each started their own
+        # self-rescheduling backstop timer, leaving one permanently uncancellable and
+        # ticking forever in parallel with the other (root cause of the WHF activating
+        # while all windows were closed, hours after the legitimate session had ended).
+        # A concurrent call simply skips this tick — the caller that lost the race gets
+        # another chance on its own next trigger.
+        if self._reconcile_fan_in_progress:
+            _LOGGER.debug("reconcile_fan_on_startup: skipping — already in progress (trigger=%s)", trigger)
+            return
+        self._reconcile_fan_in_progress = True
+        try:
+            await self._reconcile_fan_on_startup_locked(
+                indoor=indoor,
+                outdoor=outdoor,
+                thermostat_fan_running=thermostat_fan_running,
+                any_sensor_open=any_sensor_open,
+                trigger=trigger,
+            )
+        finally:
+            self._reconcile_fan_in_progress = False
+
+    async def _reconcile_fan_on_startup_locked(
+        self,
+        *,
+        indoor: float | None,
+        outdoor: float | None,
+        thermostat_fan_running: bool,
+        any_sensor_open: bool,
+        trigger: str,
+    ) -> None:
+        """Body of reconcile_fan_on_startup(), run under its reentrancy guard (Issue #561)."""
         fan_mode = self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED)
         archetype = fan_mode
 
@@ -3994,7 +4076,7 @@ class AutomationEngine:
             return
 
         # If any contact sensor is still open, re-pause instead of clearing
-        if self._sensor_check_callback and self._sensor_check_callback():
+        if self._any_monitored_sensor_open():
             _LOGGER.info(
                 "%s grace expired but sensor(s) still open — re-pausing HVAC",
                 source,
@@ -4778,6 +4860,19 @@ class AutomationEngine:
             reason=f"morning wake-up — comfort band [{_wakeup_band.floor:.0f}/{_wakeup_band.ceiling:.0f}]",
         )
 
+    def _any_monitored_sensor_open(self) -> bool:
+        """Return True if any monitored door/window sensor is currently open.
+
+        Single choke point for this check (Issue #561) — previously re-derived inline at
+        each call site (``_sensor_check_callback and _sensor_check_callback()``). Callers
+        that need to know whether a nat-vent session is still legitimately justified by an
+        open sensor, rather than only by the ``_natural_vent_active``/``_fan_active`` flags,
+        should read this directly instead of trusting those flags as a proxy — flags can
+        outlive the sensor state that justified them (see ``nat_vent_temperature_check()``'s
+        reactivation branch and ``_reconcile_fan_physical_drift()``'s preserve-session branch).
+        """
+        return bool(self._sensor_check_callback and self._sensor_check_callback())
+
     async def _exit_nat_vent(self, *, reason: str, set_outdoor_exit_time: bool = False) -> None:
         """Single choke point for ending a nat-vent session (Issue #411).
 
@@ -4800,7 +4895,7 @@ class AutomationEngine:
         self._nat_vent_soft_start = False
         if set_outdoor_exit_time:
             self._nat_vent_outdoor_exit_time = dt_util.now()
-        sensor_open = bool(self._sensor_check_callback and self._sensor_check_callback())
+        sensor_open = self._any_monitored_sensor_open()
         # emit_event=False on both branches: every call site already emits its own more
         # specific exit event (nat_vent_predicted_floor_exit, nat_vent_comfort_floor_exit,
         # nat_vent_outdoor_rise_exit, etc.) before calling this method. Letting
@@ -5215,9 +5310,9 @@ class AutomationEngine:
         """Issue a fan/switch service call carrying a fresh HA Context (Issue #482).
 
         HA attaches the originating service call's ``Context`` to the resulting
-        state-changed ``Event``. Stamping and recording our own context here lets
+        state-changed ``Event``. Recording our own context here lets
         ``coordinator._async_fan_entity_changed()`` check ``event.context`` against
-        ``self._fan_command_context_id`` as an additional CA-attribution signal,
+        recently-issued CA command contexts as an additional CA-attribution signal,
         alongside the existing ``_fan_command_pending``/timing-heuristic guards.
 
         Scope note: context propagation through third-party fan/switch integrations
@@ -5227,8 +5322,40 @@ class AutomationEngine:
         additive/corroborating rather than a replacement for the existing checks.
         """
         cmd_context = Context()
-        self._fan_command_context_id = cmd_context.id
+        self._record_fan_command_context(cmd_context.id)
         await self.hass.services.async_call(domain, service, {"entity_id": entity_id}, context=cmd_context)
+
+    def _record_fan_command_context(self, context_id: str) -> None:
+        """Record a just-issued CA fan-command context id (Issue #561).
+
+        Replaces a single last-write-wins ``_fan_command_context_id`` attribute, which
+        could be overwritten by a second overlapping fan command before the first
+        command's resulting state-changed event was evaluated against it — causing CA's
+        own action to be misattributed as a manual override (the "whole-house fan
+        manually turned on" message this issue's report disputed). Keeping a short-lived
+        set instead means either command's context can still be matched, regardless of
+        which one the coordinator's state-change listener happens to see first.
+        """
+        now = dt_util.now()
+        cutoff = now - timedelta(seconds=30)
+        self._recent_fan_command_context_ids = [
+            (cid, ts) for cid, ts in self._recent_fan_command_context_ids if ts >= cutoff
+        ]
+        self._recent_fan_command_context_ids.append((context_id, now))
+
+    def fan_command_context_matches(self, event_context_id: str | None, event_context_parent_id: str | None) -> bool:
+        """Return True if either id matches a CA fan command issued in the last 30s (Issue #561).
+
+        Checked by ``coordinator._async_fan_entity_changed()`` in place of the old
+        single-id equality check.
+        """
+        if event_context_id is None and event_context_parent_id is None:
+            return False
+        cutoff = dt_util.now() - timedelta(seconds=30)
+        return any(
+            ts >= cutoff and cid in (event_context_id, event_context_parent_id)
+            for cid, ts in self._recent_fan_command_context_ids
+        )
 
     async def _activate_fan(self, *, reason: str, emit_event: bool = True) -> None:
         """Activate fan based on configured fan_mode.
@@ -5362,9 +5489,22 @@ class AutomationEngine:
             self._fan_thermo_cancel()
             self._fan_thermo_cancel = None
 
+        # Issue #561: stamp this chain with the current generation before scheduling —
+        # see self._fan_thermo_generation's declaration for why.
+        self._fan_thermo_generation += 1
+        _my_generation = self._fan_thermo_generation
+
         @callback
         def _thermo_tick(_now: Any) -> None:
             self._fan_thermo_cancel = None
+            if _my_generation != self._fan_thermo_generation:
+                _LOGGER.debug(
+                    "Fan thermo backstop tick (generation %d) superseded by generation %d —"
+                    " a newer chain already started; this stale chain self-terminates",
+                    _my_generation,
+                    self._fan_thermo_generation,
+                )
+                return
             self.hass.async_create_task(self._thermo_backstop_task())
 
         self._fan_thermo_cancel = async_call_later(self.hass, 5 * 60, _thermo_tick)
@@ -5388,7 +5528,7 @@ class AutomationEngine:
         # genuine new temperature-changed event arrived. Piggyback the existing 5-minute
         # timer to also re-evaluate cycling while nat-vent is active.
         if self._natural_vent_active and indoor is not None:
-            await self.nat_vent_temperature_check(indoor)
+            await self.nat_vent_temperature_check(indoor, outdoor=outdoor)
         # Re-arm only if the fan is still active after the check. Architecture-reset
         # Step 2: the decision now lives in desired_state.decide_fan_thermo_backstop() —
         # this method still owns actually calling _start_fan_thermo_backstop() to
@@ -5505,17 +5645,39 @@ class AutomationEngine:
                     "fan_device": _fan_device_label(self.config),
                 },
             )
+        # Issue #561: preserving the nat-vent session across this correction (so
+        # nat_vent_temperature_check() can immediately re-fire below) is only correct if
+        # the session is still legitimately justified by an open sensor. Without this
+        # check, a session whose windows already closed while the physical-drift-confirm
+        # was pending (2 backstop ticks = ~10 min) would be preserved indefinitely — with
+        # no further log line — until temperature happened to cross a cycling threshold
+        # again, at which point the fan would reactivate against a sealed house. If the
+        # session is no longer justified, end it for real (preserve=False) and release any
+        # WHF HVAC suppression it was holding, mirroring on_fan_turned_off()'s genuine
+        # fan-off sequence.
+        _was_nat_vent_active = self._natural_vent_active
+        _preserve_session = _was_nat_vent_active and self._any_monitored_sensor_open()
+        if _was_nat_vent_active and not _preserve_session:
+            _LOGGER.warning(
+                "Nat-vent session force-closed during physical-drift correction — no"
+                " monitored sensor is open, so the session cannot legitimately still be"
+                " open (Issue #561)"
+            )
         self._clear_fan_flags_and_start_grace(
             reason="physical-state drift confirmed over 2 backstop ticks",
             trigger_label="physical_drift_correction",
-            preserve_nat_vent_session=True,
+            preserve_nat_vent_session=_preserve_session,
             source="automation",
         )
+        if _was_nat_vent_active and not _preserve_session:
+            self._release_whf_and_reclassify(
+                reason="physical-drift correction found the nat-vent session's sensors closed"
+            )
         # Issue #449: the control entity's own HA-reported state can silently stay
         # stuck "on" (a one-way transmitter has no feedback of its own) even though
         # ground truth has just confirmed the fan is physically off — reconcile it now
         # so the very next reactivation attempt (nat_vent_temperature_check()'s
-        # immediate same-tick re-fire, since preserve_nat_vent_session=True above)
+        # immediate same-tick re-fire, when the session was preserved above)
         # starts from a control entity that genuinely reads "off".
         #
         # Issue #482: this off-command must set the same _fan_command_pending/

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,21 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.49"
+VERSION = "0.5.50"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.50": [
+        "Fix #561: the whole-house fan could turn itself on with every door and window"
+        " closed, briefly switching the thermostat off for no reason — and the log"
+        " misleadingly claimed 'whole-house fan manually turned on' even though nobody"
+        " touched it. The fan-cycling logic now re-checks that a monitored sensor is"
+        " actually open before ever turning the fan back on, instead of trusting an"
+        " internal flag that could go stale for hours. Also fixed the underlying causes:"
+        " a self-healing check that could keep a ventilation 'session' alive after"
+        " windows closed, and a rare timing gap that could start two duplicate internal"
+        " timers, both of which could leave the system briefly confused about whether"
+        " it or the user caused a fan change.",
+    ],
     "0.5.49": [
         "Fix #557: options dialog sections now save the instant you hit Submit — no more"
         " separate 'Save & Close' step. Previously, submitting a section (e.g. Setpoints or"
@@ -1402,6 +1414,79 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # "[NOT COVERED] — potential gap" instead of "could not verify."
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    561: {
+        "version_fixed": "0.5.50",
+        "title": (
+            "Whole-house fan (WHF) activated by automation with every monitored door/window"
+            " sensor closed, running the exhaust fan against a sealed house for ~45 seconds"
+            " with no cooling benefit while HVAC was silently suppressed. The log's own"
+            " 'whole-house fan manually turned on' message wrongly implied the user did it."
+            " Root-caused to three stacked defects: (A) nat_vent_temperature_check()'s"
+            " on-threshold reactivation branch had no contact-sensor check at all and read a"
+            " cached self._last_outdoor_temp instead of a caller-sourced live value; (B)"
+            " _reconcile_fan_physical_drift()'s CORRECT outcome preserved _natural_vent_active"
+            " unconditionally (Issue #423's preserve_nat_vent_session=True), so a session could"
+            " survive for hours after windows genuinely closed, with no log line, waiting for"
+            " temperature to cross a cycling threshold; (C) reconcile_fan_on_startup() had no"
+            " mutual exclusion across its 4 call sites, so two concurrent 'adopt-on' calls each"
+            " independently started their own self-rescheduling 5-min backstop timer"
+            " (_start_fan_thermo_backstop() only tracks one live handle via"
+            " self._fan_thermo_cancel), leaving one permanently uncancellable; (D) the resulting"
+            " duplicate _activate_fan() calls raced the single last-write-wins"
+            " _fan_command_context_id, so the coordinator's own state-change listener"
+            " misattributed CA's own command as a manual override."
+        ),
+        "scope_covered": (
+            "Added AutomationEngine._any_monitored_sensor_open() as the single choke point for"
+            " 'is a monitored sensor currently open', replacing 3 duplicated inline checks"
+            " (_exit_nat_vent, the idle-open reactivation gate, resume_from_pause) and adding a"
+            " 4th call site. nat_vent_temperature_check()'s on-threshold branch now force-closes"
+            " the session (via the existing _exit_nat_vent() choke point, with a WARNING log)"
+            " instead of cycling the fan on when FAN_MODE_WHOLE_HOUSE/FAN_MODE_BOTH and no"
+            " sensor is open — scoped away from FAN_MODE_HVAC, whose fan-only mode has no"
+            " physical-exterior-airflow requirement and is unaffected. nat_vent_temperature_check()"
+            " now takes outdoor as a required keyword-only parameter (mirroring"
+            " fan_thermostat_check()'s existing convention) instead of reading"
+            " self._last_outdoor_temp internally; both callers"
+            " (coordinator._async_thermostat_changed, automation._thermo_backstop_task) and the"
+            " sim harness (tools/sim_harness/run_production.py) updated accordingly."
+            " _reconcile_fan_physical_drift()'s CORRECT branch now only passes"
+            " preserve_nat_vent_session=True when _any_monitored_sensor_open() confirms the"
+            " session is still legitimate; otherwise it force-ends the session (with a WARNING"
+            " log) and releases any WHF HVAC suppression via _release_whf_and_reclassify(),"
+            " mirroring on_fan_turned_off()'s genuine fan-off sequence. reconcile_fan_on_startup()"
+            " gained a self._reconcile_fan_in_progress reentrancy guard (a concurrent call skips"
+            " its tick rather than double-processing) via a private"
+            " _reconcile_fan_on_startup_locked() body, plus a self._fan_thermo_generation counter"
+            " on _start_fan_thermo_backstop()/its tick callback as defense-in-depth (a superseded"
+            " chain self-terminates on its next tick instead of ticking forever in parallel)."
+            " Replaced the single last-write-wins self._fan_command_context_id with a 30-second"
+            " recency list (self._recent_fan_command_context_ids,"
+            " _record_fan_command_context(), fan_command_context_matches()), so an overlapping"
+            " second command can no longer erase the first's provenance before its resulting"
+            " state-changed event is evaluated; coordinator._async_fan_entity_changed() updated"
+            " to call the new matcher instead of comparing a single id. Added dedicated unit"
+            " tests for all four fixes (sensor-gate force-close, HVAC-mode exemption, drift-"
+            " correction session-closure, reentrancy-guard skip/completion/exception-safety,"
+            " generation-counter supersession, overlapping-context matching, stale-context"
+            " expiry) in tests/test_nat_vent_activation.py and tests/test_fan_control.py."
+        ),
+        "scope_not_covered": (
+            "No golden simulation scenario was added — the exact stale-flag-with-closed-sensors"
+            " condition arises from an internal timing race (concurrent reconcile calls plus a"
+            " multi-hour drift-correction window) that the synchronous event-replay harness"
+            " cannot deterministically reproduce without inventing a synthetic engine-state-"
+            "injection event type, which would violate the harness's 'never invent a decision"
+            " type/state the engine does not emit' principle. Coverage instead relies on unit"
+            " tests exercising the exact production functions directly, matching how Issue #423's"
+            " analogous internal drift-reconciliation mechanism was tested. The exact tick at"
+            " which _natural_vent_active last went stale in the reported incident's live logs"
+            " was not pinpointed with certainty — static log/code analysis established the"
+            " mechanism and ruled out version skew, a second engine instance, and every other"
+            " known reactivation code path, but confirming the precise trigger would require"
+            " live id(self)/state-dump instrumentation this fix did not add."
+        ),
+    },
     557: {
         "version_fixed": "0.5.49",
         "title": (

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -3309,7 +3309,9 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             and _new_temp_attr != _old_temp_attr
             and self.automation_engine._natural_vent_active
         ):
-            await self.automation_engine.nat_vent_temperature_check(float(_new_temp_attr))
+            await self.automation_engine.nat_vent_temperature_check(
+                float(_new_temp_attr), outdoor=self._last_outdoor_temp
+            )
 
         # Issue #327: Thermostatic fan re-evaluation on every indoor temp tick.
         # Fires whenever the thermostat reports a new current_temperature and a CA fan is running
@@ -3899,13 +3901,21 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
 
         # Issue #482: HA attaches the originating service call's Context to every
         # state-changed Event. When CA itself issued the fan command (via
-        # automation.py's _call_fan_service_with_context), it stamps
-        # automation_engine._fan_command_context_id with that Context's id. If this
-        # event's own context.id (or its parent_id, for cases where the target
-        # integration wraps CA's context in a child context) matches, that is an
-        # authoritative "CA caused this" signal — logged here on EVERY change
-        # (matched or not) so a future investigation has direct evidence instead of
-        # needing cross-source timestamp archaeology (the gap this issue closes).
+        # automation.py's _call_fan_service_with_context), it records that Context's id.
+        # If this event's own context.id (or its parent_id, for cases where the target
+        # integration wraps CA's context in a child context) matches a recently-issued
+        # CA command, that is an authoritative "CA caused this" signal — logged here on
+        # EVERY change (matched or not) so a future investigation has direct evidence
+        # instead of needing cross-source timestamp archaeology (the gap this issue
+        # closes).
+        #
+        # Issue #561: matches against a short-lived set of recently-issued command
+        # contexts (automation_engine.fan_command_context_matches()) rather than a
+        # single last-write-wins id — two fan commands issued in close succession (e.g.
+        # a duplicate reactivation attempt from a since-fixed reentrancy gap) could
+        # otherwise have the second command's context overwrite the first's before this
+        # listener evaluated the first command's resulting event, misattributing CA's
+        # own action to the user.
         #
         # This is treated as an ADDITIONAL/corroborating signal alongside the
         # existing _fan_command_pending/timing checks below, not a replacement for
@@ -3917,20 +3927,21 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         event_context = getattr(event, "context", None)
         event_context_id = getattr(event_context, "id", None) if event_context is not None else None
         event_context_parent_id = getattr(event_context, "parent_id", None) if event_context is not None else None
-        cmd_context_id = self.automation_engine._fan_command_context_id
-        context_confirms_ca = bool(
-            event_context_id is not None
-            and cmd_context_id is not None
-            and (event_context_id == cmd_context_id or event_context_parent_id == cmd_context_id)
+        # Issue #561: matches against a short-lived set of recently-issued CA command
+        # contexts rather than a single last-write-wins id — a second overlapping fan
+        # command could otherwise overwrite the first's id before this listener saw the
+        # first command's resulting event, causing CA's own action to be misattributed
+        # as a manual override.
+        context_confirms_ca = self.automation_engine.fan_command_context_matches(
+            event_context_id, event_context_parent_id
         )
         _LOGGER.debug(
             "fan_entity state change provenance: %s -> %s event_context_id=%s"
-            " event_context_parent_id=%s last_ca_command_context_id=%s context_confirms_ca=%s",
+            " event_context_parent_id=%s context_confirms_ca=%s",
             old_state.state,
             new_state.state,
             event_context_id,
             event_context_parent_id,
-            cmd_context_id,
             context_confirms_ca,
         )
 

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.49"
+  "version": "0.5.50"
 }

--- a/docs/08-COMPUTATION-REFERENCE.md
+++ b/docs/08-COMPUTATION-REFERENCE.md
@@ -1560,6 +1560,38 @@ Fan reconcile: thermostat fan_mode=<x> hvac_action=<y> nat_vent_eligible=<bool> 
 
 This is the primary grep target for post-deploy validation: `python tools/ha_logs.py --filter "Fan reconcile"`. It confirms that the new behavior ran and what decision was made for the current physical state.
 
+**Reentrancy guard (Issue #561):** `reconcile_fan_on_startup()` is called from 4 independent
+sites (startup coalesce, the 30-min untracked-fan backstop, a live thermostat state-change, and
+every grace-period expiry) with no coordination between them. Two overlapping calls previously
+could each independently reach the `adopt-on` branch and each call
+`_start_fan_thermo_backstop()` — which only tracks a single live timer handle via
+`self._fan_thermo_cancel`, so whichever chain started first became permanently uncancellable
+the moment the second started, leaving two self-rescheduling 5-minute backstop chains ticking
+in parallel indefinitely (the root cause of Issue #561's reported incident: one of those
+duplicate chains kept re-evaluating nat-vent cycling long after the legitimate session should
+have ended). `self._reconcile_fan_in_progress` (a plain bool, not the shared
+`self._decision_lock` — some of the 4 call sites may already hold that lock) now guards the
+method's body (moved into `_reconcile_fan_on_startup_locked()`): a concurrent call simply skips
+its tick and logs at DEBUG, rather than double-processing. As defense-in-depth,
+`_start_fan_thermo_backstop()`/its tick callback also carry a `self._fan_thermo_generation`
+counter — a tick whose stamped generation no longer matches the current counter belongs to a
+superseded chain and self-terminates instead of rescheduling, so even if a duplicate chain were
+ever started by some other future gap, only the most-recently-started one survives past its
+next tick.
+
+**Command-provenance recency set (Issue #561, hardens Issue #482):** the duplicate-chain defect
+above produced two overlapping `_activate_fan()` calls, and `_call_fan_service_with_context()`'s
+provenance mechanism (Issue #482) previously recorded only the single most-recently-issued
+command context in `self._fan_command_context_id` — a second overlapping command could
+overwrite the first's id before `coordinator._async_fan_entity_changed()` evaluated the first
+command's resulting state-changed event against it, causing CA's own action to be misattributed
+as a manual override (the "whole-house fan manually turned on" message reported in Issue #561).
+`self._recent_fan_command_context_ids` is now a 30-second recency list instead of a scalar,
+written by `_record_fan_command_context()` and checked via
+`fan_command_context_matches(event_context_id, event_context_parent_id)` — either of two
+overlapping commands' contexts can still be matched, regardless of which one the coordinator's
+listener happens to see first.
+
 **Listener registration observability:** at coordinator setup, one INFO line is emitted:
 
 ```
@@ -1611,7 +1643,7 @@ Fixing the ground-truth signal (§B above) prevents the *reconcile* mechanism fr
 
 - No-ops immediately for `FAN_MODE_HVAC` (no separate physical entity to drift from) and for command-only mode (`_get_fan_physical_state()` returns `None` — no ground truth to compare against).
 - For `FAN_MODE_WHOLE_HOUSE`/`FAN_MODE_BOTH` with feedback enabled: compares `_fan_active` against the real physical state. Skips if a CA fan command was issued in the last 30 seconds (`_is_recent_fan_command()`, the same echo/lag guard `_async_fan_entity_changed()` already uses). Requires the disagreement to persist across **2 consecutive ticks** (~10 minutes) before correcting, so a single transient sensor flap doesn't trigger a correct-then-immediately-re-adopt cycle.
-- On confirmed drift, clears `_fan_active`/`_fan_on_since` via `_clear_fan_flags_and_start_grace(preserve_nat_vent_session=True)` — a helper shared with (and extracted from) `on_fan_turned_off()`. Critically, the nat-vent session (`_natural_vent_active`) is **preserved**, unlike a genuine user fan-off (`on_fan_turned_off()` calls the same helper with `preserve_nat_vent_session=False`, ending the session — a real user decision). Preserving the session lets the immediately-following `nat_vent_temperature_check()` call in the same `_thermo_backstop_task()` tick re-fire `_activate_fan()` — the real HA service call — if conditions still warrant it, closing the loop end-to-end within the same tick the drift is confirmed.
+- On confirmed drift, clears `_fan_active`/`_fan_on_since` via `_clear_fan_flags_and_start_grace(preserve_nat_vent_session=...)` — a helper shared with (and extracted from) `on_fan_turned_off()`. The nat-vent session (`_natural_vent_active`) is **preserved only if `_any_monitored_sensor_open()` confirms a sensor is still open** (Issue #561) — before this check existed, the session was preserved unconditionally, which could leave `_natural_vent_active=True` for hours after windows genuinely closed (no log line exists for "session preserved, no action taken" while indoor sits between the cycling thresholds), until temperature happened to cross `on_threshold` again and reactivated the fan against a sealed house — the root cause of Issue #561's reported incident. When the session is force-closed here, `_release_whf_and_reclassify()` is also called (mirroring `on_fan_turned_off()`'s genuine fan-off sequence) so any WHF HVAC suppression doesn't strand. When a sensor genuinely is still open, preserving the session lets the immediately-following `nat_vent_temperature_check()` call in the same `_thermo_backstop_task()` tick re-fire `_activate_fan()` — the real HA service call — if conditions still warrant it, closing the loop end-to-end within the same tick the drift is confirmed.
 - Uses a distinct event `trigger` (`"physical_drift_correction"`, not `"fan_off"`) so Activity Report consumers can tell a self-correction apart from a genuine user action.
 
 **Observability:** `INFO` on the first (unconfirmed) drift tick, `WARNING` with `"self-correcting stale flag (Issue #423)"` on the confirmed (second) tick — the grep target for post-deploy validation. Since Issue #510 (§F below), `"active (unconfirmed)"` itself now also settles to `"inactive"` on the *display* side once the transient post-command window passes, independent of whether this 5-minute backstop has ticked yet — the two mechanisms are complementary, not redundant: this backstop corrects `_fan_active` (the automation-decision flag); §F corrects only what's *displayed* while `_fan_active` is still catching up.
@@ -2363,6 +2395,24 @@ Once `_natural_vent_active = True`, the fan does not simply stay on until the se
 **Fan cycles on again (indoor ≥ on_threshold):**
 - Fan reactivates if `outdoor_temp < indoor_temp` (directional check still applies).
 - The on_threshold guard prevents re-activation the moment the fan turns off (1°F dead band).
+- **Sensor re-validation gate (Issue #561, `FAN_MODE_WHOLE_HOUSE`/`FAN_MODE_BOTH` only):** before
+  reactivating, `nat_vent_temperature_check()` now calls
+  `AutomationEngine._any_monitored_sensor_open()` — the single choke point for "is a monitored
+  door/window sensor currently open" (also used by `_exit_nat_vent()`, the idle-open reactivation
+  gate, and `resume_from_pause()`). If no sensor is open, the session is force-closed via
+  `_exit_nat_vent()` (with a WARNING log) instead of cycling the fan on. `_natural_vent_active` is
+  otherwise trusted as a proxy for "windows are open," and this closes the gap where that proxy
+  could go stale — e.g. `_reconcile_fan_physical_drift()`'s `CORRECT` outcome preserving the
+  session (see §E below) after windows had already closed. Not applied to `FAN_MODE_HVAC`: its
+  fan-only mode has no separate physical-exterior-airflow requirement (it's the thermostat's own
+  blower, not an exhaust fan), and its Issue #134 reactivation path is intentionally allowed to
+  re-engage without an open sensor.
+- **Outdoor-freshness contract (Issue #561):** `nat_vent_temperature_check()` takes `outdoor` as a
+  required keyword-only parameter (mirroring `fan_thermostat_check()`'s existing convention)
+  instead of reading `self._last_outdoor_temp` internally. Both real callers
+  (`coordinator._async_thermostat_changed`, `automation._thermo_backstop_task`) source it fresh at
+  the call site — this was previously the one nat-vent gate in this module that read the cached
+  attribute directly rather than receiving a caller-sourced value.
 
 **Hard exit (session ends) — takes priority over cycling:**
 The exit hierarchy (§17 Exit Hierarchy above) is evaluated before the cycling logic. Priority 2 fires first if indoor drops to the applicable floor, ending the session (`_natural_vent_active = False`) and restoring heat mode. Fan cycling cannot keep the session alive past the hard-exit floor.

--- a/tests/test_fan_cancel.py
+++ b/tests/test_fan_cancel.py
@@ -60,7 +60,8 @@ def _make_mock_engine() -> MagicMock:
     ae._override_confirm_pending = False
     ae._last_commanded_hvac_mode = None
     ae._fan_command_time = None
-    ae._fan_command_context_id = None  # Issue #482: event.context provenance
+    ae._recent_fan_command_context_ids = []  # Issue #482/#561: event.context provenance
+    ae.fan_command_context_matches = MagicMock(return_value=False)
     ae.on_fan_turned_off = MagicMock()
     ae.handle_fan_manual_override = MagicMock()
     ae.reconcile_fan_on_startup = AsyncMock()
@@ -478,7 +479,7 @@ class TestFanEntityContextProvenance:
         ae = coord.automation_engine
         ae._fan_active = True  # CA believes fan is on
         ae._fan_command_pending = False  # already cleared — context is the ONLY signal here
-        ae._fan_command_context_id = "ctx-ca-issued-123"
+        ae.fan_command_context_matches = MagicMock(return_value=True)
 
         coord._is_recent_fan_command = MagicMock(return_value=False)
 
@@ -502,7 +503,7 @@ class TestFanEntityContextProvenance:
         ae = coord.automation_engine
         ae._fan_active = True
         ae._fan_command_pending = False
-        ae._fan_command_context_id = "ctx-ca-issued-456"
+        ae.fan_command_context_matches = MagicMock(return_value=True)
 
         coord._is_recent_fan_command = MagicMock(return_value=False)
 
@@ -529,7 +530,7 @@ class TestFanEntityContextProvenance:
         ae = coord.automation_engine
         ae._fan_active = False  # CA believes fan is off
         ae._fan_command_pending = False
-        ae._fan_command_context_id = "ctx-ca-issued-999"  # CA's last command, unrelated
+        ae.fan_command_context_matches = MagicMock(return_value=False)  # unrelated to CA's last command
 
         coord._is_recent_fan_command = MagicMock(return_value=False)
 
@@ -553,7 +554,7 @@ class TestFanEntityContextProvenance:
         ae = coord.automation_engine
         ae._fan_active = False
         ae._fan_command_pending = False
-        ae._fan_command_context_id = None  # CA has never issued a command yet
+        ae.fan_command_context_matches = MagicMock(return_value=False)  # CA has never issued a command yet
 
         coord._is_recent_fan_command = MagicMock(return_value=False)
 
@@ -579,7 +580,7 @@ class TestFanEntityContextProvenance:
         ae = coord.automation_engine
         ae._fan_active = True
         ae._fan_command_pending = False  # simulates the bookkeeping race from Part 1's investigation
-        ae._fan_command_context_id = "ctx-race-survivor"
+        ae.fan_command_context_matches = MagicMock(return_value=True)
 
         coord._is_recent_fan_command = MagicMock(return_value=False)
 

--- a/tests/test_fan_command_guard.py
+++ b/tests/test_fan_command_guard.py
@@ -126,6 +126,8 @@ def _make_coord(*, fan_command_time=None):
     ae._fan_command_time = fan_command_time
     ae._hvac_command_time = None
     ae._temp_command_time = None
+    ae._recent_fan_command_context_ids = []  # Issue #482/#561: event.context provenance
+    ae.fan_command_context_matches = MagicMock(return_value=False)
     ae.handle_manual_override_during_pause = AsyncMock()
     ae.handle_manual_override = MagicMock()
     ae.handle_fan_manual_override = MagicMock()

--- a/tests/test_fan_control.py
+++ b/tests/test_fan_control.py
@@ -18,8 +18,9 @@ Tests cover:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import sys
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # Patch dt_util.now to return a real datetime (needed for isoformat() calls)
@@ -1908,7 +1909,7 @@ class TestThermoBackstopTask:
 
         asyncio.run(engine._thermo_backstop_task())
 
-        engine.nat_vent_temperature_check.assert_awaited_once_with(69.0)
+        engine.nat_vent_temperature_check.assert_awaited_once_with(69.0, outdoor=65.0)
 
     def test_backstop_skips_nat_vent_check_when_not_active(self):
         """REGRESSION GUARD: when nat-vent is not active (e.g. a plain HVAC-fan-only
@@ -1956,11 +1957,15 @@ class TestThermoBackstopTask:
 class TestReconcileFanPhysicalDrift:
     """_reconcile_fan_physical_drift() — self-corrects a stale _fan_active (Issue #423)."""
 
-    def _engine(self, fan_mode=FAN_MODE_WHOLE_HOUSE, physical_state=False, recent_command=False):
+    def _engine(self, fan_mode=FAN_MODE_WHOLE_HOUSE, physical_state=False, recent_command=False, sensor_open=True):
         engine = _make_automation_engine({CONF_FAN_MODE: fan_mode})
         engine._get_fan_physical_state_callback = MagicMock(return_value=physical_state)
         engine._is_recent_fan_command_callback = MagicMock(return_value=recent_command)
         engine._clear_fan_flags_and_start_grace = MagicMock()
+        # Issue #561: default represents a legitimate open-window session experiencing a
+        # physical-state hiccup (the scenario this whole class is about) — sensor_open=False
+        # is exercised by its own dedicated test below.
+        engine._sensor_check_callback = MagicMock(return_value=sensor_open)
         return engine
 
     def test_noop_when_fan_not_active(self):
@@ -2027,9 +2032,11 @@ class TestReconcileFanPhysicalDrift:
 
     def test_second_consecutive_drift_tick_corrects(self):
         """Second consecutive tick of disagreement (5 min later) confirms drift and
-        self-corrects — preserving the nat-vent session so cycling-on can re-fire."""
+        self-corrects — preserving the nat-vent session (sensors still open) so
+        cycling-on can re-fire."""
         engine = self._engine(physical_state=False)
         engine._fan_active = True
+        engine._natural_vent_active = True
 
         engine._reconcile_fan_physical_drift()
         engine._reconcile_fan_physical_drift()
@@ -2041,6 +2048,26 @@ class TestReconcileFanPhysicalDrift:
             source="automation",
         )
         assert engine._fan_drift_tick_count == 0
+
+    def test_drift_correction_does_not_preserve_session_when_sensors_closed(self):
+        """Issue #561: if the monitored sensors are already closed by the time drift is
+        confirmed, the session must NOT be preserved — otherwise _natural_vent_active
+        stays True indefinitely with no further log line, until temperature happens to
+        cross a cycling threshold again and reactivates the fan against a sealed house
+        (the exact mechanism behind the reported incident)."""
+        engine = self._engine(physical_state=False, sensor_open=False)
+        engine._fan_active = True
+        engine._natural_vent_active = True
+
+        engine._reconcile_fan_physical_drift()
+        engine._reconcile_fan_physical_drift()
+
+        engine._clear_fan_flags_and_start_grace.assert_called_once_with(
+            reason="physical-state drift confirmed over 2 backstop ticks",
+            trigger_label="physical_drift_correction",
+            preserve_nat_vent_session=False,
+            source="automation",
+        )
 
     def test_correction_emits_fan_cancel_with_drift_trigger(self):
         """The correction emits a fan_cancel event with a distinct trigger so Activity
@@ -2124,6 +2151,10 @@ class TestReconcileFanDriftIntegration:
         engine._last_outdoor_temp = 59.0  # well below indoor -- favorable
         engine._start_fan_thermo_backstop = MagicMock()
         engine.fan_thermostat_check = AsyncMock()
+        # Issue #561: windows are genuinely open in this scenario — this test is about a
+        # pure physical-state drift on an otherwise-legitimate session, not a stale session
+        # with closed windows (that case is covered separately).
+        engine._sensor_check_callback = MagicMock(return_value=True)
 
         engine._fan_active = True
         engine._natural_vent_active = True
@@ -2443,6 +2474,134 @@ class TestReconcileFanOnStartup:
         assert any("suppressed" in r.message.lower() for r in caplog.records), (
             "Expected an INFO log line reporting the suppressed correction"
         )
+
+
+class TestReconcileFanOnStartupReentrancyGuard:
+    """Issue #561: reconcile_fan_on_startup() is called from 4 independent sites with no
+    coordination between them. Two overlapping calls previously each independently reached
+    the "adopt-on" branch and each started their own self-rescheduling backstop timer,
+    leaving one permanently uncancellable and ticking forever in parallel with the other —
+    the root cause of the WHF activating while all windows were closed, hours after the
+    legitimate session had ended.
+    """
+
+    def _engine(self, fan_mode=FAN_MODE_WHOLE_HOUSE):
+        engine = _make_automation_engine({CONF_FAN_MODE: fan_mode})
+        engine._deactivate_fan = AsyncMock()
+        return engine
+
+    def test_concurrent_call_is_skipped_not_processed(self):
+        """A second call arriving while the first is still marked in-progress must be
+        skipped entirely — not run the decision logic a second time."""
+        engine = self._engine()
+        engine._reconcile_fan_in_progress = True  # simulates an in-flight call
+
+        asyncio.run(
+            engine.reconcile_fan_on_startup(
+                indoor=75.0, outdoor=60.0, thermostat_fan_running=True, any_sensor_open=True
+            )
+        )
+
+        # No decision was made: neither the "adopt-on" nor "turn-off"/"no-fan" side effects
+        # ran (_start_fan_thermo_backstop untouched, no fan-flag mutation, no deactivate call).
+        assert engine._fan_active is False
+        assert engine._natural_vent_active is False
+        engine._deactivate_fan.assert_not_awaited()
+
+    def test_flag_cleared_after_completion_so_the_next_call_can_proceed(self):
+        """The reentrancy flag must not get stuck True after a call completes — otherwise
+        every future reconcile would be silently skipped forever."""
+        engine = self._engine()
+
+        asyncio.run(
+            engine.reconcile_fan_on_startup(
+                indoor=75.0, outdoor=60.0, thermostat_fan_running=False, any_sensor_open=True
+            )
+        )
+
+        assert engine._reconcile_fan_in_progress is False
+
+    def test_flag_cleared_even_if_the_body_raises(self):
+        """The reentrancy flag must be released via try/finally — a mid-call exception
+        must not permanently wedge every future reconcile call into skipping."""
+        engine = self._engine()
+        engine._deactivate_fan = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with contextlib.suppress(RuntimeError):
+            asyncio.run(
+                engine.reconcile_fan_on_startup(
+                    indoor=75.0, outdoor=60.0, thermostat_fan_running=False, any_sensor_open=True
+                )
+            )
+
+        assert engine._reconcile_fan_in_progress is False
+
+    def test_two_sequential_calls_both_adopt_independently(self):
+        """REGRESSION GUARD: the guard must only block genuinely *concurrent* calls —
+        two calls that run one after another (the normal case for the 4 real call sites
+        firing at different times) must both still be processed normally."""
+        engine = self._engine()
+        engine._start_fan_thermo_backstop = MagicMock()
+
+        asyncio.run(
+            engine.reconcile_fan_on_startup(
+                indoor=75.0, outdoor=60.0, thermostat_fan_running=True, any_sensor_open=True
+            )
+        )
+        assert engine._natural_vent_active is True
+
+        engine._natural_vent_active = False
+        asyncio.run(
+            engine.reconcile_fan_on_startup(
+                indoor=75.0, outdoor=60.0, thermostat_fan_running=True, any_sensor_open=True
+            )
+        )
+        assert engine._natural_vent_active is True, "a second, sequential call must still be processed"
+
+
+class TestFanThermoBackstopGenerationGuard:
+    """Issue #561 defense-in-depth: self._fan_thermo_cancel can only ever hold one live
+    cancel handle, so if two backstop timer chains are ever started concurrently, the
+    earlier one becomes permanently uncancellable and both tick forever in parallel. The
+    generation counter ensures a superseded chain self-terminates on its next tick instead.
+    """
+
+    def test_generation_increments_on_every_start(self):
+        """Every call to _start_fan_thermo_backstop() must stamp a new, strictly
+        increasing generation — the mechanism the tick callback checks against."""
+        engine = _make_automation_engine({CONF_FAN_MODE: FAN_MODE_WHOLE_HOUSE})
+
+        engine._start_fan_thermo_backstop()
+        first = engine._fan_thermo_generation
+        engine._start_fan_thermo_backstop()
+        second = engine._fan_thermo_generation
+
+        assert second > first
+
+    def test_stale_tick_after_new_chain_started_is_a_noop(self):
+        """Directly exercises the tick callback's own generation check: manually stamping
+        an older generation onto the engine and then invoking the callback captured by
+        async_call_later must not create a new backstop task."""
+        engine = _make_automation_engine({CONF_FAN_MODE: FAN_MODE_WHOLE_HOUSE})
+        engine.hass.async_create_task = MagicMock()
+
+        captured_ticks = []
+        with patch(
+            "custom_components.climate_advisor.automation.async_call_later",
+            side_effect=lambda hass, delay, cb: captured_ticks.append(cb) or MagicMock(),
+        ):
+            engine._start_fan_thermo_backstop()  # generation 1 tick captured
+
+        # A second, newer chain starts (e.g. from a since-fixed reentrancy gap elsewhere)
+        # before the first chain's tick ever fires.
+        with patch("custom_components.climate_advisor.automation.async_call_later"):
+            engine._start_fan_thermo_backstop()  # generation 2
+
+        # Now the stale generation-1 tick fires late.
+        stale_tick = captured_ticks[0]
+        stale_tick(None)
+
+        engine.hass.async_create_task.assert_not_called()
 
 
 class TestFanEventEmission:
@@ -3002,7 +3161,10 @@ class TestCommandWhfControlEntity:
         must force off->wait->on, not a single (silently-dropped) turn_on."""
         engine = self._engine(control_state="on", ground_truth=False)
 
-        with patch("custom_components.climate_advisor.automation.asyncio.sleep", new=AsyncMock()) as mock_sleep:
+        with (
+            patch("custom_components.climate_advisor.automation.asyncio.sleep", new=AsyncMock()) as mock_sleep,
+            patch("custom_components.climate_advisor.automation.dt_util.now", return_value=datetime(2026, 1, 1)),
+        ):
             commanded = asyncio.run(engine._command_whf_control_entity(True, reason="test"))
 
         assert commanded is True
@@ -3026,7 +3188,10 @@ class TestCommandWhfControlEntity:
         running — must force on->wait->off."""
         engine = self._engine(control_state="off", ground_truth=True)
 
-        with patch("custom_components.climate_advisor.automation.asyncio.sleep", new=AsyncMock()) as mock_sleep:
+        with (
+            patch("custom_components.climate_advisor.automation.asyncio.sleep", new=AsyncMock()) as mock_sleep,
+            patch("custom_components.climate_advisor.automation.dt_util.now", return_value=datetime(2026, 1, 1)),
+        ):
             commanded = asyncio.run(engine._command_whf_control_entity(False, reason="test"))
 
         assert commanded is True
@@ -3073,7 +3238,10 @@ class TestCommandWhfControlEntityWiring:
         engine.hass.states.get = MagicMock(return_value=state_mock)
         engine._get_fan_physical_state_callback = MagicMock(return_value=False)
 
-        with patch("custom_components.climate_advisor.automation.asyncio.sleep", new=AsyncMock()):
+        with (
+            patch("custom_components.climate_advisor.automation.asyncio.sleep", new=AsyncMock()),
+            patch("custom_components.climate_advisor.automation.dt_util.now", return_value=datetime(2026, 1, 1)),
+        ):
             asyncio.run(engine._activate_fan(reason="test"))
 
         calls = [c for c in engine.hass.services.async_call.call_args_list if c.args[0] == "fan"]
@@ -3089,7 +3257,10 @@ class TestCommandWhfControlEntityWiring:
         engine.hass.states.get = MagicMock(return_value=state_mock)
         engine._get_fan_physical_state_callback = MagicMock(return_value=True)
 
-        with patch("custom_components.climate_advisor.automation.asyncio.sleep", new=AsyncMock()):
+        with (
+            patch("custom_components.climate_advisor.automation.asyncio.sleep", new=AsyncMock()),
+            patch("custom_components.climate_advisor.automation.dt_util.now", return_value=datetime(2026, 1, 1)),
+        ):
             asyncio.run(engine._deactivate_fan(reason="test"))
 
         calls = [c for c in engine.hass.services.async_call.call_args_list if c.args[0] == "fan"]
@@ -3208,22 +3379,22 @@ class TestReconcileFanDriftBookkeeping:
     def test_fan_command_context_id_stamped_for_reconcile_off_command(self):
         """Issue #482 Part 2: the reconcile off-command routes through
         _call_fan_service_with_context (the same funnel _activate_fan/_deactivate_fan
-        use), so it also stamps _fan_command_context_id — giving the resulting
+        use), so it also records a command context — giving the resulting
         state-changed event a real HA Context to be attributed against."""
         engine, scheduled = self._engine_with_confirmed_drift()
 
         for coro in scheduled:
             asyncio.run(coro)
 
-        assert engine._fan_command_context_id is not None, (
-            "Drift-reconciliation off-command must stamp _fan_command_context_id "
+        assert engine._recent_fan_command_context_ids, (
+            "Drift-reconciliation off-command must record a fan command context "
             "via _call_fan_service_with_context, same as every other WHF command site"
         )
 
 
 class TestCallFanServiceWithContext:
     """Issue #482 Part 2 — every outgoing WHF fan/switch service call carries a
-    fresh HA Context, and _fan_command_context_id records its id so
+    fresh HA Context, and a short-lived recency set (Issue #561) records its id so
     coordinator._async_fan_entity_changed() can check event.context against it."""
 
     def test_context_kwarg_passed_to_service_call(self):
@@ -3238,16 +3409,17 @@ class TestCallFanServiceWithContext:
         assert call.kwargs.get("context") is not None
 
     def test_fan_command_context_id_recorded(self):
-        """_fan_command_context_id must be updated to the issued Context's id, so the
-        provenance check in coordinator.py has something real to compare against."""
+        """The issued Context's id must be recorded, so the provenance check in
+        coordinator.py has something real to compare against."""
         engine = _make_automation_engine({CONF_FAN_MODE: FAN_MODE_WHOLE_HOUSE, CONF_FAN_ENTITY: "fan.whf"})
-        assert engine._fan_command_context_id is None
+        assert engine._recent_fan_command_context_ids == []
 
-        asyncio.run(engine._call_fan_service_with_context("fan", "turn_on", "fan.whf"))
+        with patch("custom_components.climate_advisor.automation.dt_util.now", return_value=datetime(2026, 1, 1)):
+            asyncio.run(engine._call_fan_service_with_context("fan", "turn_on", "fan.whf"))
 
-        call = engine.hass.services.async_call.call_args_list[0]
-        issued_context = call.kwargs["context"]
-        assert engine._fan_command_context_id == issued_context.id
+            call = engine.hass.services.async_call.call_args_list[0]
+            issued_context = call.kwargs["context"]
+            assert engine.fan_command_context_matches(issued_context.id, None)
 
     def test_each_call_gets_a_distinct_context(self):
         """Two separate commands must not share a context id — otherwise a stale
@@ -3255,12 +3427,50 @@ class TestCallFanServiceWithContext:
         later, unrelated event."""
         engine = _make_automation_engine({CONF_FAN_MODE: FAN_MODE_WHOLE_HOUSE, CONF_FAN_ENTITY: "fan.whf"})
 
-        asyncio.run(engine._call_fan_service_with_context("fan", "turn_on", "fan.whf"))
-        first_id = engine._fan_command_context_id
+        with patch("custom_components.climate_advisor.automation.dt_util.now", return_value=datetime(2026, 1, 1)):
+            asyncio.run(engine._call_fan_service_with_context("fan", "turn_on", "fan.whf"))
+            first_id = engine._recent_fan_command_context_ids[-1][0]
 
-        asyncio.run(engine._call_fan_service_with_context("fan", "turn_off", "fan.whf"))
-        second_id = engine._fan_command_context_id
+            asyncio.run(engine._call_fan_service_with_context("fan", "turn_off", "fan.whf"))
+            second_id = engine._recent_fan_command_context_ids[-1][0]
 
         assert first_id is not None
         assert second_id is not None
         assert first_id != second_id
+
+    def test_overlapping_commands_both_still_match(self):
+        """Issue #561: two commands issued in quick succession must BOTH still be
+        matchable afterward — the old single last-write-wins _fan_command_context_id
+        would let the second overwrite the first, causing the first command's
+        resulting state-changed event to be misattributed as a manual override."""
+        engine = _make_automation_engine({CONF_FAN_MODE: FAN_MODE_WHOLE_HOUSE, CONF_FAN_ENTITY: "fan.whf"})
+
+        with patch("custom_components.climate_advisor.automation.dt_util.now", return_value=datetime(2026, 1, 1)):
+            asyncio.run(engine._call_fan_service_with_context("fan", "turn_on", "fan.whf"))
+            first_id = engine._recent_fan_command_context_ids[-1][0]
+
+            asyncio.run(engine._call_fan_service_with_context("fan", "turn_on", "fan.whf"))
+            second_id = engine._recent_fan_command_context_ids[-1][0]
+
+            assert engine.fan_command_context_matches(first_id, None), (
+                "the earlier command's context must still match after a second overlapping command"
+            )
+            assert engine.fan_command_context_matches(second_id, None)
+
+    def test_stale_context_does_not_match_after_30s(self):
+        """A context older than the 30s recency window must no longer match — otherwise
+        a genuinely external fan change that happens to reuse an unrelated old id
+        (astronomically unlikely, but the window bound must still hold) or a very
+        late-arriving event should not be attributed to a long-past CA command."""
+        engine = _make_automation_engine({CONF_FAN_MODE: FAN_MODE_WHOLE_HOUSE, CONF_FAN_ENTITY: "fan.whf"})
+        fixed_now = datetime(2026, 1, 1, 12, 0, 0)
+
+        with patch("custom_components.climate_advisor.automation.dt_util.now", return_value=fixed_now):
+            engine._record_fan_command_context("ctx-old")
+            # Backdate it past the 30s window directly, rather than sleeping in a test.
+            engine._recent_fan_command_context_ids[0] = (
+                "ctx-old",
+                fixed_now - timedelta(seconds=31),
+            )
+
+            assert not engine.fan_command_context_matches("ctx-old", None)

--- a/tests/test_nat_vent_activation.py
+++ b/tests/test_nat_vent_activation.py
@@ -2619,7 +2619,7 @@ class TestNoSpuriousFanCyclingEventWhenNoFanConfigured:
         engine._emit_event_callback = lambda name, payload: emitted.append((name, payload))
 
         with patch(_DT_NOW_PATH, return_value=_AWAKE_NOW):
-            asyncio.run(engine.nat_vent_temperature_check(73.0))  # >= on_threshold
+            asyncio.run(engine.nat_vent_temperature_check(73.0, outdoor=60.0))  # >= on_threshold
 
         assert engine._fan_active is False, "no fan device configured -- _activate_fan() must stay a no-op"
         event_names = [e[0] for e in emitted]
@@ -2642,7 +2642,7 @@ class TestNoSpuriousFanCyclingEventWhenNoFanConfigured:
         engine._emit_event_callback = lambda name, payload: emitted.append((name, payload))
 
         with patch(_DT_NOW_PATH, return_value=_AWAKE_NOW):
-            asyncio.run(engine.nat_vent_temperature_check(71.0))  # <= off_threshold
+            asyncio.run(engine.nat_vent_temperature_check(71.0, outdoor=None))  # <= off_threshold
 
         assert engine._fan_active is True, "no fan device configured -- _deactivate_fan() must stay a no-op"
         event_names = [e[0] for e in emitted]
@@ -2663,15 +2663,86 @@ class TestNoSpuriousFanCyclingEventWhenNoFanConfigured:
         engine._fan_active = False
         engine._last_outdoor_temp = 60.0
         engine._async_save_state = AsyncMock()
+        engine._sensor_check_callback = MagicMock(return_value=True)  # windows open -> legitimate session
 
         emitted: list[tuple] = []
         engine._emit_event_callback = lambda name, payload: emitted.append((name, payload))
 
         with patch(_DT_NOW_PATH, return_value=_AWAKE_NOW):
-            asyncio.run(engine.nat_vent_temperature_check(73.0))  # >= on_threshold
+            asyncio.run(engine.nat_vent_temperature_check(73.0, outdoor=60.0))  # >= on_threshold
 
         assert engine._fan_active is True, "a real fan device must actually activate"
         event_names = [e[0] for e in emitted]
         assert "nat_vent_fan_on" in event_names, (
             f"nat_vent_fan_on must still fire when the fan really turned on; got events: {event_names}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Issue #561: WHF activated by automation with all monitored sensors closed
+# ---------------------------------------------------------------------------
+
+
+class TestNatVentSessionForceClosedWhenSensorsClosed:
+    """Issue #561: nat_vent_temperature_check() must never cycle a whole-house fan back
+    on while every monitored door/window sensor reads closed, regardless of how
+    _natural_vent_active came to be True — running a whole-house exhaust fan against a
+    sealed house has no cooling benefit and can depressurize the home. This is the
+    structural fix for the reported incident: the fan turned on with all windows closed
+    because _natural_vent_active was stale and the cycling check trusted it as a proxy
+    for "windows are open" instead of re-checking sensor state directly.
+    """
+
+    def test_whf_reactivation_refused_and_session_closed_when_sensors_closed(self):
+        """The exact reported scenario: a stale session flag, an on-threshold crossing,
+        and closed sensors. The fan must NOT activate, and the session must be force-
+        closed instead of silently cycling on."""
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=74.0, nat_vent_delta=3.0)
+        engine.config["fan_mode"] = "whole_house_fan"
+        engine.config["fan_entity"] = "fan.whole_house"
+        engine._natural_vent_active = True  # stale — no logged reactivation event caused this
+        engine._fan_active = False
+        engine._sensor_check_callback = MagicMock(return_value=False)  # every window/door closed
+        engine._async_save_state = AsyncMock()
+
+        with patch(_DT_NOW_PATH, return_value=_AWAKE_NOW):
+            # indoor >= on_threshold (72), outdoor well below indoor -- conditions that
+            # would otherwise cycle the fan straight back on.
+            asyncio.run(engine.nat_vent_temperature_check(73.0, outdoor=60.0))
+
+        assert engine._fan_active is False, "the WHF must never activate with sensors closed"
+        assert engine._natural_vent_active is False, "the stale session must be force-closed, not left open"
+
+    def test_hvac_fan_mode_reactivation_unaffected_by_sensor_state(self):
+        """FAN_MODE_HVAC has no separate physical-exterior-airflow requirement (it's the
+        thermostat's own blower, not an exhaust fan) — its cycling-on behavior must be
+        completely unaffected by monitored-sensor state, matching pre-#561 behavior."""
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=74.0, nat_vent_delta=3.0)
+        engine.config["fan_mode"] = "hvac_fan"
+        engine._natural_vent_active = True
+        engine._fan_active = False
+        engine._sensor_check_callback = MagicMock(return_value=False)  # irrelevant for this archetype
+        engine._async_save_state = AsyncMock()
+
+        with patch(_DT_NOW_PATH, return_value=_AWAKE_NOW):
+            asyncio.run(engine.nat_vent_temperature_check(73.0, outdoor=60.0))
+
+        assert engine._fan_active is True, "FAN_MODE_HVAC reactivation must not be gated on sensor state"
+        assert engine._natural_vent_active is True
+
+    def test_legitimate_open_window_session_still_cycles_normally(self):
+        """REGRESSION GUARD: a genuine open-window WHF session must still cycle the fan
+        on exactly as before — the new gate must never block a legitimate reactivation."""
+        engine = _make_engine(comfort_heat=70.0, comfort_cool=74.0, nat_vent_delta=3.0)
+        engine.config["fan_mode"] = "whole_house_fan"
+        engine.config["fan_entity"] = "fan.whole_house"
+        engine._natural_vent_active = True
+        engine._fan_active = False
+        engine._sensor_check_callback = MagicMock(return_value=True)  # a window is genuinely open
+        engine._async_save_state = AsyncMock()
+
+        with patch(_DT_NOW_PATH, return_value=_AWAKE_NOW):
+            asyncio.run(engine.nat_vent_temperature_check(73.0, outdoor=60.0))
+
+        assert engine._fan_active is True
+        assert engine._natural_vent_active is True

--- a/tests/test_nat_vent_thermostat.py
+++ b/tests/test_nat_vent_thermostat.py
@@ -553,7 +553,7 @@ class TestNatVentSleepWindowCycling:
         ae._emit_event_callback = lambda name, payload: emitted.append((name, payload))
 
         with patch(_DT_NOW_THERMO_PATH, return_value=_SLEEP_NOW_THERMO):
-            asyncio.run(ae.nat_vent_temperature_check(65.0))
+            asyncio.run(ae.nat_vent_temperature_check(65.0, outdoor=ae._last_outdoor_temp))
 
         ae._deactivate_fan.assert_called_once()
         call_kwargs = ae._deactivate_fan.call_args[1]
@@ -577,7 +577,7 @@ class TestNatVentSleepWindowCycling:
         ae._emit_event_callback = lambda name, payload: emitted.append((name, payload))
 
         with patch(_DT_NOW_THERMO_PATH, return_value=_SLEEP_NOW_THERMO):
-            asyncio.run(ae.nat_vent_temperature_check(66.0))
+            asyncio.run(ae.nat_vent_temperature_check(66.0, outdoor=ae._last_outdoor_temp))
 
         ae._deactivate_fan.assert_not_called()
         ae._activate_fan.assert_not_called()
@@ -601,7 +601,7 @@ class TestNatVentSleepWindowCycling:
         ae._emit_event_callback = lambda name, payload: emitted.append((name, payload))
 
         with patch(_DT_NOW_THERMO_PATH, return_value=_SLEEP_NOW_THERMO):
-            asyncio.run(ae.nat_vent_temperature_check(67.0))
+            asyncio.run(ae.nat_vent_temperature_check(67.0, outdoor=ae._last_outdoor_temp))
 
         ae._activate_fan.assert_called_once()
         event_names = [e[0] for e in emitted]
@@ -621,7 +621,7 @@ class TestNatVentSleepWindowCycling:
 
         # Patch _in_sleep_window to return False (daytime)
         with patch(_IN_SLEEP_WINDOW_PATH, return_value=False):
-            asyncio.run(ae.nat_vent_temperature_check(70.0))
+            asyncio.run(ae.nat_vent_temperature_check(70.0, outdoor=ae._last_outdoor_temp))
 
         ae._deactivate_fan.assert_called_once()
         # Verify the nat_vent_fan_off event carries the daytime target (71°F), not sleep target (66°F)
@@ -644,7 +644,7 @@ class TestNatVentSleepWindowCycling:
         ae._emit_event_callback = lambda name, payload: emitted.append((name, payload))
 
         with patch(_DT_NOW_THERMO_PATH, return_value=_SLEEP_NOW_THERMO):
-            asyncio.run(ae.nat_vent_temperature_check(64.0))
+            asyncio.run(ae.nat_vent_temperature_check(64.0, outdoor=ae._last_outdoor_temp))
 
         # Hard exit fires — session ends, HVAC is restored. Issue #411: this now routes
         # through _exit_nat_vent(), which relies on _deactivate_fan()'s restore_hvac=True

--- a/tests/test_restart_coalescing_fan_guard.py
+++ b/tests/test_restart_coalescing_fan_guard.py
@@ -120,7 +120,8 @@ def _make_fan_entity_coord(*, startup_coalesce_active: bool) -> object:
     ae._fan_command_pending = False
     ae._fan_override_active = False
     ae._fan_active = False
-    ae._fan_command_context_id = None
+    ae._recent_fan_command_context_ids = []
+    ae.fan_command_context_matches = MagicMock(return_value=False)
     ae.handle_fan_manual_override = MagicMock()
     ae.on_fan_turned_off = MagicMock()
     coord.automation_engine = ae

--- a/tests/test_whf_command_only.py
+++ b/tests/test_whf_command_only.py
@@ -65,6 +65,8 @@ def _make_mock_engine() -> MagicMock:
     ae._hvac_command_pending = False
     ae._manual_override_active = False
     ae._fan_command_time = None
+    ae._recent_fan_command_context_ids = []  # Issue #482/#561: event.context provenance
+    ae.fan_command_context_matches = MagicMock(return_value=False)
     ae.on_fan_turned_off = MagicMock()
     ae.handle_fan_manual_override = MagicMock()
     ae.reconcile_fan_on_startup = AsyncMock()

--- a/tests/test_whf_dual_entity.py
+++ b/tests/test_whf_dual_entity.py
@@ -68,6 +68,8 @@ def _make_coord_stub(config: dict) -> MagicMock:
     ae._fan_active = False
     ae._fan_override_active = False
     ae._fan_command_pending = False
+    ae._recent_fan_command_context_ids = []  # Issue #482/#561: event.context provenance
+    ae.fan_command_context_matches = MagicMock(return_value=False)
     ae.on_fan_turned_off = MagicMock()
     ae.handle_fan_manual_override = MagicMock()
     coord.automation_engine = ae

--- a/tools/sim_harness/run_production.py
+++ b/tools/sim_harness/run_production.py
@@ -690,7 +690,7 @@ def _dispatch_event(
         # Used by nat_vent_thermostat_cycling pending scenario to assert cycling behavior.
         indoor_temp = float(event.get("indoor_temp", event.get("indoor_f", 70.0)))
         _inject_indoor_temp(fake_hass, climate_entity, indoor_temp)
-        run_coro(engine.nat_vent_temperature_check(indoor_temp))
+        run_coro(engine.nat_vent_temperature_check(indoor_temp, outdoor=engine._last_outdoor_temp))
 
     elif etype == "external_fan_state_change":
         # Issue #482: models a genuinely external actor changing the configured WHF
@@ -786,7 +786,7 @@ def _handle_temp_update(
     new_indoor = float(indoor_f) if indoor_f is not None else None
     if coordinator is None and new_indoor is not None and new_indoor != old_indoor:
         if engine._natural_vent_active:
-            run_coro(engine.nat_vent_temperature_check(new_indoor))
+            run_coro(engine.nat_vent_temperature_check(new_indoor, outdoor=engine._last_outdoor_temp))
         if engine._fan_active or engine._natural_vent_active:
             run_coro(
                 engine.fan_thermostat_check(


### PR DESCRIPTION
## Summary

The whole-house fan (WHF) could turn itself on with every monitored door/window sensor closed, briefly switching the thermostat off for no cooling benefit — and the log misleadingly claimed "whole-house fan manually turned on" even though nobody touched it.

Root-caused to three stacked defects (full investigation and before/after occupant-scenario analysis in the linked issue):

- **A** — `nat_vent_temperature_check()`'s cycling-on branch had no contact-sensor check at all, and read a cached `self._last_outdoor_temp` instead of a fresh caller-supplied value.
- **B** — `_reconcile_fan_physical_drift()`'s drift-correction path could preserve a nat-vent session indefinitely (with zero log trace) after windows had already closed, waiting silently for temperature to cross a cycling threshold.
- **C** — `reconcile_fan_on_startup()` had no mutual exclusion across its 4 independent call sites, letting two concurrent calls each start a duplicate, permanently-uncancellable backstop timer.
- **D** — the resulting duplicate `_activate_fan()` calls raced the single-value fan-command-context bookkeeping, causing CA's own action to be misattributed as a manual override.

## Changes

- Added `AutomationEngine._any_monitored_sensor_open()` as a single choke point, replacing 3 duplicated inline checks and adding a 4th call site.
- `nat_vent_temperature_check()`'s reactivation branch now force-closes the session (via the existing `_exit_nat_vent()` choke point, WARNING logged) instead of cycling the fan on when no sensor is open — scoped to `FAN_MODE_WHOLE_HOUSE`/`FAN_MODE_BOTH` only; `FAN_MODE_HVAC` is unaffected.
- `nat_vent_temperature_check()` now takes `outdoor` as a required keyword-only parameter, mirroring `fan_thermostat_check()`'s existing convention, instead of reading a cached attribute internally.
- `_reconcile_fan_physical_drift()` only preserves the nat-vent session across a drift correction when a sensor is genuinely still open; otherwise it force-ends the session and releases any WHF HVAC suppression.
- `reconcile_fan_on_startup()` gained a `_reconcile_fan_in_progress` reentrancy guard, plus a `_fan_thermo_generation` counter on the backstop timer as defense-in-depth.
- Replaced the single last-write-wins `_fan_command_context_id` with a 30-second recency list, so overlapping commands can no longer erase each other's provenance.

## Test plan

- [x] 3649 existing tests pass, including regressions fixed from the signature/behavior changes
- [x] 9 new dedicated tests added covering all four fixes (sensor-gate force-close, HVAC-mode exemption, drift-correction session-closure, reentrancy-guard skip/completion/exception-safety, generation-counter supersession, overlapping-context matching, stale-context expiry)
- [x] `ruff check` / `ruff format` clean
- [x] Version bumped to 0.5.50 with `CHANGELOG.md` / `RELEASE_NOTES` / `KNOWN_FIXES` entries
- [x] `docs/08-COMPUTATION-REFERENCE.md` §9d/§17 updated

Closes #561