### PR TITLE
Fix #565: claude-sonnet-5 zero-output truncation via adaptive thinking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.5.52] — 2026-08-04
+
+- Fix #565: the AI Investigator and AI Activity Report could silently burn their entire response budget with no visible answer at all on newer Claude models (confirmed with claude-sonnet-5) — the model was doing its own internal reasoning with no cap on it, and that reasoning alone could use up the whole response length before ever getting to write an actual answer. Climate Advisor now detects this and automatically applies a bounded-reasoning setting so the model always leaves room for a real answer; it also learns per-model going forward so this self-heals after the first occurrence instead of repeating on every request.
+
 ## [0.5.51] — 2026-08-03
 
 - Fix #563: the AI Investigator was sending nearly the entire history of every fixed issue to Claude on every single run — a version-scoping check that was supposed to limit this to only recently-relevant fixes had a bug that let all 169 fixed-issue records through every time, and a separate rendering bug was expanding some of that text by roughly 15x on top of that. Investigations should now run noticeably faster and cheaper, with no loss of the "was this already fixed" cross-check the AI uses this data for.

--- a/custom_components/climate_advisor/claude_api.py
+++ b/custom_components/climate_advisor/claude_api.py
@@ -92,6 +92,20 @@ def _detect_deprecated_param(error_message: str) -> str | None:
     return match.group(1) if match else None
 
 
+# Issue #565 — some newer models (confirmed: claude-sonnet-5) reject the legacy
+# `thinking: {"type": "enabled", "budget_tokens": N}` shape outright with a 400 whose
+# message names the replacement directly: '"thinking.type.enabled" is not supported for
+# this model. Use "thinking.type.adaptive" and "output_config.effort" to control thinking
+# behavior.' Matched on the literal replacement-parameter name Anthropic's own error text
+# points at, not on the full sentence, so minor message wording changes don't break this.
+_ADAPTIVE_THINKING_RE = re.compile(r"thinking\.type\.adaptive")
+
+
+def _detect_adaptive_thinking_required(error_message: str) -> bool:
+    """Return True if Anthropic's API just rejected the legacy thinking shape for this model."""
+    return _ADAPTIVE_THINKING_RE.search(error_message) is not None
+
+
 # Per-model cost rates (USD per million tokens)
 _MODEL_COSTS: dict[str, dict[str, float]] = {
     "claude-sonnet": {"input": 3.0, "output": 15.0},
@@ -236,6 +250,11 @@ class ClaudeAPIClient:
         # rejected as deprecated for that model. In-memory only, per client instance —
         # same acceptable cost as _models_cache (resets on integration reload).
         self._unsupported_params: dict[str, set[str]] = {}
+        # Issue #565: model_ids confirmed (either reactively, via a 400 naming
+        # "thinking.type.adaptive", or after observing a zero-output full-budget
+        # truncation) to need the newer adaptive thinking shape instead of the legacy
+        # enabled/budget_tokens one. In-memory only, same lifecycle as _unsupported_params.
+        self._adaptive_thinking_models: set[str] = set()
 
     # ------------------------------------------------------------------
     # Public API
@@ -513,7 +532,15 @@ class ClaudeAPIClient:
                 break  # success
 
             except (RateLimitError, APITimeoutError, APIError, Exception) as exc:
+                # Both checks are gated on "no content streamed yet" — a retry can only be
+                # safe before anything has been yielded to the caller, since a streaming
+                # generator can't un-yield partial content already shown in the UI.
                 bad_param = None if any_content_yielded else _detect_deprecated_param(str(exc))
+                needs_adaptive = (
+                    not any_content_yielded
+                    and resolved_model not in self._adaptive_thinking_models
+                    and _detect_adaptive_thinking_required(str(exc))
+                )
                 if attempt == 1 and bad_param is not None:
                     self._unsupported_params.setdefault(resolved_model, set()).add(bad_param)
                     _LOGGER.warning(
@@ -522,6 +549,15 @@ class ClaudeAPIClient:
                         bad_param,
                     )
                     continue  # next loop iteration rebuilds kwargs without bad_param
+                if attempt == 1 and needs_adaptive:
+                    # Issue #565: model rejected the legacy thinking shape outright — learn
+                    # it and retry with thinking.type.adaptive + output_config.effort.
+                    self._adaptive_thinking_models.add(resolved_model)
+                    _LOGGER.warning(
+                        "Model '%s' rejected the legacy thinking shape — retrying stream with adaptive thinking",
+                        resolved_model,
+                    )
+                    continue  # next loop iteration rebuilds kwargs with the adaptive shape
 
                 self._circuit_breaker.consecutive_failures += 1
                 self._error_count += 1
@@ -551,8 +587,9 @@ class ClaudeAPIClient:
         )
         if truncated_empty:
             # Issue #563 follow-on: the full max_tokens budget was billed and consumed,
-            # but no "text"/"thinking" delta was ever yielded — a different, more severe
-            # problem than ordinary truncation (there's no partial content to salvage).
+            # but no visible answer text was ever yielded (thinking deltas may still have
+            # streamed) — a different, more severe problem than ordinary truncation
+            # (there's no partial content to salvage).
             _LOGGER.warning(
                 "Streaming response consumed the full max_tokens budget with zero visible "
                 "output: skill=%s model=%s output_tokens=%d max_tokens=%d "
@@ -564,6 +601,20 @@ class ClaudeAPIClient:
                 kwargs["max_tokens"],
                 resolved_reasoning,
             )
+            # Issue #565: this exact symptom (full budget, zero visible text) is what
+            # uncapped implicit thinking on a newer model looks like at reasoning tiers
+            # that never requested thinking control at all — arm the adaptive-thinking
+            # capability for this model so the NEXT call (streaming or non-streaming)
+            # applies bounded thinking from the start instead of repeating this failure.
+            # This call already streamed thinking deltas to the caller and can't be
+            # retried in place.
+            if resolved_model not in self._adaptive_thinking_models:
+                self._adaptive_thinking_models.add(resolved_model)
+                _LOGGER.warning(
+                    "Model '%s' will use adaptive thinking control on future requests "
+                    "to recover from zero-output truncation",
+                    resolved_model,
+                )
         elif truncated:
             _LOGGER.warning(
                 "Response truncated: skill=%s stop_reason=max_tokens output_tokens=%d max_tokens=%d",
@@ -923,11 +974,23 @@ class ClaudeAPIClient:
             "temperature": temperature,
         }
 
-        # Extended thinking for high reasoning effort
-        # Claude API requirements when thinking is enabled:
-        #   1. temperature must be exactly 1
-        #   2. max_tokens must exceed budget_tokens
-        if reasoning_effort == AI_REASONING_HIGH:
+        if model in self._adaptive_thinking_models:
+            # Issue #565: this model rejects the legacy enabled/budget_tokens shape and
+            # performs its own uncapped internal reasoning whenever no thinking control is
+            # sent at all — confirmed to silently consume the entire max_tokens budget on
+            # real-sized prompts, at every reasoning_effort tier, not just "high" (unlike
+            # older models, where only "high" ever requested extended thinking). Apply the
+            # newer thinking.type.adaptive + output_config.effort shape at every tier so
+            # thinking is always bounded and some max_tokens headroom is left for the
+            # visible answer. `effort` maps directly from the configured reasoning_effort.
+            kwargs["temperature"] = 1  # same API requirement as the legacy shape below
+            kwargs["thinking"] = {"type": "adaptive"}
+            kwargs["output_config"] = {"effort": reasoning_effort}
+        elif reasoning_effort == AI_REASONING_HIGH:
+            # Extended thinking for high reasoning effort (legacy shape).
+            # Claude API requirements when thinking is enabled:
+            #   1. temperature must be exactly 1
+            #   2. max_tokens must exceed budget_tokens
             budget = AI_REASONING_BUDGET_TOKENS.get(AI_REASONING_HIGH, 16384)
             kwargs["temperature"] = 1  # required by API — overrides configured value
             if kwargs["max_tokens"] <= budget:
@@ -1117,7 +1180,7 @@ class ClaudeAPIClient:
 
         for attempt in range(1, AI_MAX_RETRIES + 1):
             try:
-                return await self._single_api_call(
+                response = await self._single_api_call(
                     system_prompt=system_prompt,
                     user_message=user_message,
                     model=model,
@@ -1126,6 +1189,28 @@ class ClaudeAPIClient:
                     reasoning_effort=reasoning_effort,
                     start_time=start_time,
                 )
+                if response.truncated_empty and model not in self._adaptive_thinking_models:
+                    # Issue #565: full max_tokens budget consumed with zero visible
+                    # answer text — a newer model's uncapped implicit thinking left no
+                    # room for the answer. Unlike the streaming path, nothing has been
+                    # shown to the caller yet (this is a single atomic response), so a
+                    # same-attempt retry with bounded thinking is safe.
+                    self._adaptive_thinking_models.add(model)
+                    _LOGGER.warning(
+                        "Model '%s' consumed the full budget with zero output — retrying "
+                        "with adaptive thinking control",
+                        model,
+                    )
+                    return await self._single_api_call(
+                        system_prompt=system_prompt,
+                        user_message=user_message,
+                        model=model,
+                        max_tokens=max_tokens,
+                        temperature=temperature,
+                        reasoning_effort=reasoning_effort,
+                        start_time=start_time,
+                    )
+                return response
 
             except RateLimitError as exc:
                 last_error = f"Rate limit error: {exc}"
@@ -1151,6 +1236,11 @@ class ClaudeAPIClient:
                 # shapes (a 400 param-deprecation vs a 404 model-not-found), so only
                 # one generic "last_error" tail is needed for whichever wasn't hit.
                 bad_param = _detect_deprecated_param(str(exc))
+                needs_adaptive = (
+                    bad_param is None
+                    and model not in self._adaptive_thinking_models
+                    and _detect_adaptive_thinking_required(str(exc))
+                )
                 if bad_param is not None:
                     self._unsupported_params.setdefault(model, set()).add(bad_param)
                     _LOGGER.warning(
@@ -1171,6 +1261,27 @@ class ClaudeAPIClient:
                     except Exception as retry_exc:  # noqa: BLE001
                         last_error = f"API error even after dropping '{bad_param}': {retry_exc}"
                         _LOGGER.warning("Retry without '%s' also failed: %s", bad_param, retry_exc)
+                elif needs_adaptive:
+                    # Issue #565: model rejected the legacy thinking shape outright —
+                    # learn it and retry with thinking.type.adaptive + output_config.effort.
+                    self._adaptive_thinking_models.add(model)
+                    _LOGGER.warning(
+                        "Model '%s' rejected the legacy thinking shape — retrying with adaptive thinking",
+                        model,
+                    )
+                    try:
+                        return await self._single_api_call(
+                            system_prompt=system_prompt,
+                            user_message=user_message,
+                            model=model,
+                            max_tokens=max_tokens,
+                            temperature=temperature,
+                            reasoning_effort=reasoning_effort,
+                            start_time=start_time,
+                        )
+                    except Exception as retry_exc:  # noqa: BLE001
+                        last_error = f"API error even after switching to adaptive thinking: {retry_exc}"
+                        _LOGGER.warning("Retry with adaptive thinking also failed: %s", retry_exc)
                 else:
                     # Issue #563: an invalid/deprecated model won't succeed on retry —
                     # skip the backoff loop and try one same-tier replacement instead.

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,20 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.51"
+VERSION = "0.5.52"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.52": [
+        "Fix #565: the AI Investigator and AI Activity Report could silently burn their"
+        " entire response budget with no visible answer at all on newer Claude models"
+        " (confirmed with claude-sonnet-5) — the model was doing its own internal"
+        " reasoning with no cap on it, and that reasoning alone could use up the whole"
+        " response length before ever getting to write an actual answer. Climate Advisor"
+        " now detects this and automatically applies a bounded-reasoning setting so the"
+        " model always leaves room for a real answer; it also learns per-model going"
+        " forward so this self-heals after the first occurrence instead of repeating on"
+        " every request.",
+    ],
     "0.5.51": [
         "Fix #563: the AI Investigator was sending nearly the entire history of every"
         " fixed issue to Claude on every single run — a version-scoping check that was"
@@ -1448,6 +1459,69 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    565: {
+        "version_fixed": "0.5.52",
+        "title": (
+            "Both the AI Investigator (streaming) and AI Activity Report (non-streaming)"
+            " could return stop_reason=max_tokens with zero visible answer text on"
+            " claude-sonnet-5, at reasoning_effort=medium — the exact zero-output cause"
+            " Issue #563 left as an open follow-up. Root-caused via a live diagnostic"
+            " bypassing claude_api.py entirely (direct AsyncAnthropic calls dumping the"
+            " full raw response, all content block types, and the complete usage object):"
+            " claude-sonnet-5 (A) rejects the `temperature` parameter outright — already"
+            " self-healed correctly by #563's reactive capability detection, confirmed"
+            " working in production logs, NOT the cause of this issue — and (B) rejects"
+            " the legacy `thinking: {type: enabled, budget_tokens: N}` shape outright with"
+            " a 400 naming the replacement directly ('Use thinking.type.adaptive and"
+            " output_config.effort'). Because claude_api.py only ever sent thinking"
+            " control at reasoning_effort=='high' (using the now-incompatible legacy"
+            " shape), medium/low requests sent no thinking control at all — leaving this"
+            " model's own internal reasoning completely uncapped. Reproduced live: on a"
+            " production-sized context, claude-sonnet-5 consumed the entire 8192-token"
+            " (and separately the entire 16384-token) budget purely on invisible internal"
+            " reasoning, stop_reason=max_tokens, zero text, matching live HA logs exactly"
+            " (8192 output_tokens, ~93s streaming call, zero visible output). Confirmed"
+            " fix live: sending thinking={'type':'adaptive'}, output_config={'effort':"
+            " reasoning_effort} on the same context returned stop_reason=end_turn with a"
+            " real answer."
+        ),
+        "scope_covered": (
+            "claude_api.py: added _detect_adaptive_thinking_required() (matches the"
+            " 'thinking.type.adaptive' replacement-parameter name in Anthropic's 400"
+            " message body, mirroring the existing _detect_deprecated_param() pattern) and"
+            " a new self._adaptive_thinking_models: set[str] per-model capability cache"
+            " (same in-memory, per-client-instance lifecycle as self._unsupported_params)."
+            " _build_request_kwargs() now applies thinking={'type':'adaptive'},"
+            " output_config={'effort': reasoning_effort} at EVERY reasoning tier (not just"
+            " 'high') for any model in _adaptive_thinking_models — output_config.effort"
+            " maps directly from the configured low/medium/high reasoning_effort, so no"
+            " separate budget_tokens table is needed for adaptive-shape models. The"
+            " unsupported-params strip still runs last, after this block, so a model"
+            " already known not to accept temperature never gets it re-added (same"
+            " ordering guarantee as the existing high-tier legacy path). Reactive"
+            " learning: both the streaming retry loop (async_request_streaming, gated on"
+            " 'no content yielded yet' — a stream can't un-yield thinking deltas already"
+            " shown to the caller) and the non-streaming retry loop"
+            " (_async_call_with_retry's APIError branch) now catch a 400 naming"
+            " thinking.type.adaptive, learn the model, and retry once with the adaptive"
+            " shape, mirroring the existing deprecated-parameter retry exactly."
+            " Additionally — since the medium/low failure mode never raises an exception"
+            " at all (it's a 'successful' HTTP response with truncated_empty=True) —"
+            " _async_call_with_retry now also detects a truncated_empty response after a"
+            " successful call and retries once in place (safe: nothing has been shown to"
+            " the caller yet, unlike streaming). The streaming path cannot retry"
+            " truncated_empty in place for the reason above, but arms"
+            " _adaptive_thinking_models on that detection so the *next* call (streaming or"
+            " non-streaming, same client instance) applies the adaptive shape from the"
+            " start. Test coverage: tests/test_claude_api.py"
+            " (TestAdaptiveThinkingKwargsShape, TestAdaptiveThinkingReactiveFallback,"
+            " TestAdaptiveThinkingTruncatedEmptyRecovery) — kwargs-shape correctness at"
+            " every reasoning tier, parameter-strip ordering, both reactive-retry paths,"
+            " both truncated_empty-recovery paths, and confirms an unlearned model (e.g."
+            " claude-sonnet-4-6) is completely unaffected — no regression risk for models"
+            " never observed to need this."
+        ),
+    },
     563: {
         "version_fixed": "0.5.51",
         "title": (

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.51"
+  "version": "0.5.52"
 }

--- a/docs/claude-api-spec.md
+++ b/docs/claude-api-spec.md
@@ -13,14 +13,15 @@
 | Which error types cause a retry, and what is the backoff schedule for `AI_MAX_RETRIES = 3`? | All four exception types retry: `RateLimitError`, `APITimeoutError`, `APIError`, and bare `Exception`. Delays are `1.0 s`, `2.0 s` between attempts 1→2 and 2→3; no sleep after attempt 3. | [Rate Limiting and Retry](#rate-limiting-and-retry) |
 | What happens to the circuit breaker failure counter when the circuit is half-open and the probe fails? | The failure counter increments (`consecutive_failures += 1`) via the same post-call path as any other failure. If it meets or exceeds `AI_CIRCUIT_BREAKER_THRESHOLD` (5), the breaker transitions back to `"open"` and `opened_at` is reset. | [Circuit Breaker State Machine](#circuit-breaker-state-machine) |
 | What config keys does `ClaudeAPIClient.__init__()` read, and what happens if `CONF_AI_API_KEY` is absent or empty? | It reads only `CONF_AI_API_KEY` at init time. If absent or empty, `self._client` remains `None` and a WARNING is logged; all subsequent `async_request()` calls return `ClaudeResponse(success=False, error="Anthropic client not initialized…")`. | [Initialization and Configuration](#initialization-and-configuration) |
+| A configured model rejects a request parameter, or needs a different extended-thinking shape, or silently returns zero visible text while consuming the full `max_tokens` budget — does the client keep failing forever? | No. `_build_request_kwargs()` is the single source of truth for both request paths; two per-model in-memory capability caches (`_unsupported_params`, `_adaptive_thinking_models`) are populated reactively — from a 400 error naming the rejected parameter/shape, or (for the zero-output case, which is a "successful" empty response, not an exception) from observing `truncated_empty=True`. Once learned, every subsequent request for that model is built correctly from the start; only the first occurrence per model per client-instance lifetime pays the cost of discovering it. | [Reactive Per-Model Capability Detection](#reactive-per-model-capability-detection) |
 
 ---
 
 ## Scope
 
 - **File:** `custom_components/climate_advisor/claude_api.py`
-- **Approximate line range:** L1 – L742 (entire file)
-- **Primary entry points:** `ClaudeAPIClient.async_request()` (L150), `ClaudeAPIClient.__init__()` (L113)
+- **Approximate line range:** L1 – L1365 (entire file)
+- **Primary entry points:** `ClaudeAPIClient.async_request()` (L278), `ClaudeAPIClient.__init__()` (L215)
 
 This spec covers `ClaudeAPIClient` and the supporting dataclasses (`ClaudeResponse`, `_CircuitBreaker`, `_RateLimitCounters`, `_BudgetTracker`). It does NOT cover:
 
@@ -89,7 +90,7 @@ After a failed `async_request()` call (`response.success = False`):
 
 9. **Request history is capped.** `self.request_history` is a `deque(maxlen=AI_REQUEST_HISTORY_CAP)` — Python enforces the cap automatically; no explicit eviction logic is required.
 
-10. **Extended thinking forces `temperature=1`.** When `reasoning_effort == AI_REASONING_HIGH`, the `kwargs["temperature"]` value is overwritten to `1` inside `_async_call_with_retry()`, regardless of the caller-supplied temperature. This is the only code path that does so.
+10. **Extended thinking forces `temperature=1`.** `_build_request_kwargs()` (the single kwargs-building source for both the streaming and non-streaming paths — see [Reactive Per-Model Capability Detection](#reactive-per-model-capability-detection)) overwrites `kwargs["temperature"]` to `1`, regardless of the caller-supplied temperature, whenever it attaches a `thinking` parameter: unconditionally at `reasoning_effort == AI_REASONING_HIGH` (legacy `{"type": "enabled", "budget_tokens": N}` shape), and at every reasoning tier once a model has been learned to need the newer `{"type": "adaptive"}` + `output_config.effort` shape (Issue #565). The per-model unsupported-parameter strip always runs last, after this override, so a model already known to reject `temperature` never has it silently re-added.
 
 11. **The circuit breaker failure counter is never decremented.** It is only zeroed (on success, in `async_request()`) or incremented (on failure, in `async_request()`). There is no partial-credit decay.
 
@@ -155,6 +156,32 @@ async def async_request(
 - Success: zero `consecutive_failures`, set state `"closed"`, add cost to `monthly_cost`, increment appropriate daily counter
 - Failure: increment `consecutive_failures` and `_error_count`; if `consecutive_failures >= AI_CIRCUIT_BREAKER_THRESHOLD`: set state `"open"`, record `opened_at`
 - Always: increment `_total_requests`, record `_last_request_time`, append to `request_history`
+
+---
+
+## Reactive Per-Model Capability Detection
+
+Anthropic's Models API exposes `id`/`display_name`/`created_at` — never a per-model sampling-parameter or extended-thinking-shape schema. There is no way to know ahead of time that a given model no longer accepts `temperature`, or that it requires a different `thinking` parameter shape than an older model in the same family. `ClaudeAPIClient` handles this by learning per-model, in-memory, from the API's own error responses (or from a symptom that isn't an error at all — see below) — never by hardcoding a model-ID list.
+
+Two per-model capability caches, both `dict`/`set` keyed on the resolved model ID, both reset on integration reload (in-memory only, same acceptable cost as `_models_cache`):
+
+| Cache | Populated when | Effect on `_build_request_kwargs()` |
+|---|---|---|
+| `self._unsupported_params: dict[str, set[str]]` | A 400 whose message matches `` `(\w+)` is deprecated for this model `` (`_detect_deprecated_param()`, Issue #563 follow-on) | Every key ever learned for that model is popped from `kwargs` — this strip always runs LAST, after every other kwargs-building step, so a forced value (e.g. `temperature=1` from extended thinking) is never silently re-added |
+| `self._adaptive_thinking_models: set[str]` | A 400 whose message names `thinking.type.adaptive` (`_detect_adaptive_thinking_required()`, Issue #565), OR a "successful" response with `truncated_empty=True` (see below) | At every `reasoning_effort` tier (not just `"high"`), `kwargs["thinking"] = {"type": "adaptive"}` and `kwargs["output_config"] = {"effort": reasoning_effort}` are attached instead of the legacy `{"type": "enabled", "budget_tokens": N}` shape |
+
+### Why `_adaptive_thinking_models` exists (Issue #565)
+
+Confirmed live (`claude-sonnet-5`, direct-API diagnostic bypassing this client entirely): some newer models reject the legacy `thinking.type.enabled` shape outright, and — critically — before that's discovered, they still perform their own internal reasoning even when `reasoning_effort != "high"` and no `thinking` parameter is sent at all. Because `_build_request_kwargs()` previously only ever attached thinking control at the `"high"` tier, a `"medium"`/`"low"` request to such a model left its internal reasoning completely uncapped. On a production-sized prompt this reasoning alone consumed the *entire* `max_tokens` budget before the model ever started the visible answer — `stop_reason == "max_tokens"`, `response.truncated_empty == True` (or, for streaming, `any_text_yielded == False` — see the `ClaudeResponse`/stream `"stop"` event fields), with no exception raised anywhere; the API call is a "successful" HTTP response that is simply unusable. This is the failure mode `_adaptive_thinking_models` exists to self-heal from — see the retry rules below.
+
+### Retry rules (asymmetric between the two request paths)
+
+Both `_async_call_with_retry()` (non-streaming) and `async_request_streaming()` (streaming) catch a 400 matching either detector and learn the corresponding cache entry, then retry once with corrected kwargs — mirroring each other exactly for the exception case. They diverge only for the *non-exception* `truncated_empty` symptom, because a streaming generator cannot un-yield content already shown to the caller:
+
+- **Non-streaming** (`_async_call_with_retry()`): nothing is exposed to the caller until the whole `ClaudeResponse` is returned, so a `truncated_empty` result is safe to retry in place — one extra `_single_api_call()` with `_adaptive_thinking_models` now including this model, same call.
+- **Streaming** (`async_request_streaming()`): thinking deltas may already have streamed to the caller (visible in the UI) by the time `truncated_empty` is known, at the very end of the generator. This call surfaces the failure exactly as before the fix; the only thing that changes is `self._adaptive_thinking_models.add(resolved_model)` fires before the generator ends, so the *next* call for this model — streaming or non-streaming, same client instance — builds corrected kwargs from the start and does not repeat the failure.
+
+A brand-new model's very first streaming call can therefore still exhibit one zero-output truncation before self-healing; every call after that (for that model, for the lifetime of this client instance) does not.
 
 ---
 
@@ -313,21 +340,29 @@ If `from anthropic import ...` raises `ImportError`:
 | Unexpected exception | `_async_call_with_retry()` | Same retry/backoff | `ClaudeResponse(success=False, error="Unexpected error: …")` after all retries |
 | `restore_persistent_stats()` with bad `counter_date` string | `date.fromisoformat()` | `except (KeyError, ValueError)`: resets `counter_date = date.today()` | Counter starts fresh for the day |
 | `_estimate_cost()` with unrecognized model | Prefix lookup miss | Falls through to Sonnet rates as default | Cost estimate uses $3.00/$15.00 per 1M tokens |
+| 400 naming a deprecated request parameter (e.g. `` `temperature` is deprecated for this model `` ) | `_detect_deprecated_param()` in the `APIError` branch of `_async_call_with_retry()` / `async_request_streaming()` | Learn into `_unsupported_params[model]`; retry once immediately (no backoff) with that param stripped | Success on retry: normal response. Retry also fails: falls through to the generic `APIError` last-error path |
+| 400 naming the adaptive thinking shape (`thinking.type.adaptive`) | `_detect_adaptive_thinking_required()`, same branches as above | Learn into `_adaptive_thinking_models`; retry once immediately with `thinking.type.adaptive` + `output_config.effort` | Same success/failure shape as the deprecated-parameter case |
+| Full `max_tokens` budget consumed with zero visible answer text (`truncated_empty=True`), no exception at all — see [Reactive Per-Model Capability Detection](#reactive-per-model-capability-detection) | Computed post-response in `_single_api_call()` / after the stream completes in `async_request_streaming()` | Non-streaming: learn + retry once in place. Streaming: learn only (cannot retry in place); this call still surfaces the empty result | Non-streaming: usually a real answer on retry. Streaming: `{"type": "stop", "truncated_empty": True}`; caller must treat this as no usable content, same as before the fix, but only once per model |
 
 ---
 
 ## Code Reference
 
-- [`ClaudeAPIClient.__init__`](../custom_components/climate_advisor/claude_api.py#L113) — construction, client init, dataclass setup
-- [`ClaudeAPIClient.async_request`](../custom_components/climate_advisor/claude_api.py#L150) — main public entry point; guard sequence + counter updates
-- [`_check_circuit_breaker`](../custom_components/climate_advisor/claude_api.py#L505) — state machine query; transitions `"open"` → `"half_open"` on cooldown expiry
-- [`_async_call_with_retry`](../custom_components/climate_advisor/claude_api.py#L595) — retry loop with exponential backoff; extended thinking injection
-- [`_check_budget`](../custom_components/climate_advisor/claude_api.py#L533) — month-roll detection and cap check
-- [`_check_rate_limit`](../custom_components/climate_advisor/claude_api.py#L460) — daily counter check for `"auto"` vs `"manual"` callers
-- [`check_investigator_rate_limit`](../custom_components/climate_advisor/claude_api.py#L477) — separate investigator gate; also checks `CONF_AI_INVESTIGATOR_ENABLED`
-- [`update_config`](../custom_components/climate_advisor/claude_api.py#L434) — hot-reload config; tears down and recreates client on key change
-- [`get_persistent_stats`](../custom_components/climate_advisor/claude_api.py#L368) — serializes counters + monthly cost for HA state persistence
-- [`restore_persistent_stats`](../custom_components/climate_advisor/claude_api.py#L390) — rehydrates counters after HA restart
-- [`ClaudeResponse`](../custom_components/climate_advisor/claude_api.py#L68) — response dataclass; all fields documented above
-- [`_CircuitBreaker`](../custom_components/climate_advisor/claude_api.py#L84) — state machine storage dataclass
-- [`_MODEL_COSTS`](../custom_components/climate_advisor/claude_api.py#L56) — per-model-prefix cost rates
+- [`ClaudeAPIClient.__init__`](../custom_components/climate_advisor/claude_api.py#L215) — construction, client init, dataclass setup, capability-cache init
+- [`ClaudeAPIClient.async_request`](../custom_components/climate_advisor/claude_api.py#L278) — main public entry point; guard sequence + counter updates
+- [`async_request_streaming`](../custom_components/climate_advisor/claude_api.py#L425) — streaming entry point; capability-detection retry loop (before any content yielded), post-hoc `truncated_empty` handling
+- [`_check_circuit_breaker`](../custom_components/climate_advisor/claude_api.py#L862) — state machine query; transitions `"open"` → `"half_open"` on cooldown expiry
+- [`_build_request_kwargs`](../custom_components/climate_advisor/claude_api.py#L952) — single kwargs-building source for both request paths; extended-thinking shape selection + unsupported-parameter strip (see [Reactive Per-Model Capability Detection](#reactive-per-model-capability-detection))
+- [`_single_api_call`](../custom_components/climate_advisor/claude_api.py#L1010) — one atomic non-streaming API call + response parsing; no retry policy of its own
+- [`_async_call_with_retry`](../custom_components/climate_advisor/claude_api.py#L1154) — non-streaming retry loop with exponential backoff; capability-detection retries; `truncated_empty` in-place retry
+- [`_detect_deprecated_param`](../custom_components/climate_advisor/claude_api.py#L89) — regex match for a "param deprecated for this model" 400 (Issue #563 follow-on)
+- [`_detect_adaptive_thinking_required`](../custom_components/climate_advisor/claude_api.py#L104) — regex match for a "use thinking.type.adaptive" 400 (Issue #565)
+- [`_check_budget`](../custom_components/climate_advisor/claude_api.py#L890) — month-roll detection and cap check
+- [`_check_rate_limit`](../custom_components/climate_advisor/claude_api.py#L817) — daily counter check for `"auto"` vs `"manual"` callers
+- [`check_investigator_rate_limit`](../custom_components/climate_advisor/claude_api.py#L834) — separate investigator gate; also checks `CONF_AI_INVESTIGATOR_ENABLED`
+- [`update_config`](../custom_components/climate_advisor/claude_api.py#L791) — hot-reload config; tears down and recreates client on key change
+- [`get_persistent_stats`](../custom_components/climate_advisor/claude_api.py#L725) — serializes counters + monthly cost for HA state persistence
+- [`restore_persistent_stats`](../custom_components/climate_advisor/claude_api.py#L747) — rehydrates counters after HA restart
+- [`ClaudeResponse`](../custom_components/climate_advisor/claude_api.py#L123) — response dataclass; all fields documented above
+- [`_CircuitBreaker`](../custom_components/climate_advisor/claude_api.py#L147) — state machine storage dataclass
+- [`_MODEL_COSTS`](../custom_components/climate_advisor/claude_api.py#L110) — per-model-prefix cost rates

--- a/tests/test_claude_api.py
+++ b/tests/test_claude_api.py
@@ -1122,4 +1122,227 @@ class TestDeprecatedParameterFallback:
             raised = True
 
         assert raised is True
+
+
+# ---------------------------------------------------------------------------
+# Issue #565 — claude-sonnet-5 rejects the legacy thinking shape and performs
+# uncapped implicit reasoning at reasoning tiers that never request thinking
+# control, silently consuming the full max_tokens budget with zero visible
+# output. Confirmed live: the model 400s on `thinking.type.enabled` and names
+# the replacement directly ("thinking.type.adaptive" + "output_config.effort").
+# ---------------------------------------------------------------------------
+
+
+class TestAdaptiveThinkingKwargsShape:
+    """Once a model is known to need adaptive thinking, every reasoning tier — not
+    just 'high' — must send the new shape, since the failure was observed at medium."""
+
+    def test_learned_model_uses_adaptive_shape_at_medium_reasoning(self):
+        mock_api = _make_mock_api_client()
+        client = _make_client(mock_api, ai_model="claude-sonnet-5")
+        client._adaptive_thinking_models.add("claude-sonnet-5")
+
+        kwargs = client._build_request_kwargs(
+            model="claude-sonnet-5",
+            max_tokens=8192,
+            temperature=0.3,
+            reasoning_effort="medium",
+            system_prompt="System.",
+            user_message="User.",
+        )
+
+        assert kwargs["thinking"] == {"type": "adaptive"}
+        assert kwargs["output_config"] == {"effort": "medium"}
+        assert kwargs["temperature"] == 1
+        assert kwargs["max_tokens"] == 8192  # adaptive mode needs no headroom bump
+
+    def test_learned_model_maps_effort_from_reasoning_tier(self):
+        mock_api = _make_mock_api_client()
+        client = _make_client(mock_api, ai_model="claude-sonnet-5")
+        client._adaptive_thinking_models.add("claude-sonnet-5")
+
+        kwargs = client._build_request_kwargs(
+            model="claude-sonnet-5",
+            max_tokens=8192,
+            temperature=0.3,
+            reasoning_effort="low",
+            system_prompt="System.",
+            user_message="User.",
+        )
+
+        assert kwargs["output_config"] == {"effort": "low"}
+
+    def test_unlearned_model_keeps_legacy_high_only_behavior(self):
+        """A model never seen to need adaptive thinking must be unaffected — no
+        regression for models this session never confirmed the failure on."""
+        mock_api = _make_mock_api_client()
+        client = _make_client(mock_api, ai_model="claude-sonnet-4-6")
+
+        kwargs = client._build_request_kwargs(
+            model="claude-sonnet-4-6",
+            max_tokens=4096,
+            temperature=0.3,
+            reasoning_effort="medium",
+            system_prompt="System.",
+            user_message="User.",
+        )
+
+        assert "thinking" not in kwargs
+        assert "output_config" not in kwargs
+        assert kwargs["temperature"] == 0.3
+
+    def test_dropped_param_strip_still_runs_after_adaptive_shape(self):
+        """Same ordering guarantee as the legacy high-tier case: a param learned
+        unsupported for this model must never be re-added by the adaptive branch."""
+        mock_api = _make_mock_api_client()
+        client = _make_client(mock_api, ai_model="claude-sonnet-5")
+        client._adaptive_thinking_models.add("claude-sonnet-5")
+        client._unsupported_params["claude-sonnet-5"] = {"temperature"}
+
+        kwargs = client._build_request_kwargs(
+            model="claude-sonnet-5",
+            max_tokens=8192,
+            temperature=0.3,
+            reasoning_effort="medium",
+            system_prompt="System.",
+            user_message="User.",
+        )
+
+        assert "temperature" not in kwargs
+        assert kwargs["thinking"] == {"type": "adaptive"}
+
+
+class TestAdaptiveThinkingReactiveFallback:
+    """A 400 naming 'thinking.type.adaptive' must be learned and switched to,
+    not blindly retried with backoff (Issue #565)."""
+
+    def test_non_streaming_retries_with_adaptive_shape_and_learns_it(self):
+        mock_api = _make_mock_api_client()
+        mock_api.messages.create.side_effect = [
+            _ClaudeApiAPIError(
+                '"thinking.type.enabled" is not supported for this model. Use '
+                '"thinking.type.adaptive" and "output_config.effort" to control thinking behavior.'
+            ),
+            _mock_message("recovered with adaptive thinking"),
+        ]
+        client = _make_client(mock_api, ai_model="claude-sonnet-5")
+
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            response = asyncio.run(client.async_request("System.", "User.", reasoning_effort="high"))
+
+        assert response.success is True
+        assert mock_api.messages.create.call_count == 2
+        second_kwargs = mock_api.messages.create.call_args.kwargs
+        assert second_kwargs["thinking"] == {"type": "adaptive"}
+        assert second_kwargs["output_config"] == {"effort": "high"}
+        assert client._adaptive_thinking_models == {"claude-sonnet-5"}
+        mock_sleep.assert_not_called()
+
+    def test_streaming_retries_with_adaptive_shape_before_any_content_yielded(self):
+        mock_api = _make_mock_api_client()
+        final_msg = MagicMock()
+        final_msg.usage = MagicMock(input_tokens=10, output_tokens=20)
+        final_msg.stop_reason = "end_turn"
+        good_stream = _FakeStreamCM([_mock_text_delta_event("recovered")], final_msg)
+        bad_stream = _FakeFailingStreamCM(
+            Exception(
+                '"thinking.type.enabled" is not supported for this model. Use '
+                '"thinking.type.adaptive" and "output_config.effort" to control thinking behavior.'
+            )
+        )
+        mock_api.messages.stream = MagicMock(side_effect=[bad_stream, good_stream])
+        client = _make_client(mock_api, ai_model="claude-sonnet-5")
+
+        async def _collect():
+            events = []
+            async for event in client.async_request_streaming("System.", "User.", reasoning_effort="high"):
+                events.append(event)
+            return events
+
+        events = asyncio.run(_collect())
+
+        text_events = [e for e in events if e.get("type") == "text"]
+        assert text_events == [{"type": "text", "text": "recovered"}]
+        assert mock_api.messages.stream.call_count == 2
+        assert client._adaptive_thinking_models == {"claude-sonnet-5"}
+
+    def test_unrelated_400_error_does_not_learn_adaptive_thinking(self):
+        mock_api = _make_mock_api_client()
+        mock_api.messages.create.side_effect = _ClaudeApiAPIError("invalid_request_error: bad JSON")
+        client = _make_client(mock_api, ai_model="claude-sonnet-5")
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            response = asyncio.run(client.async_request("System.", "User."))
+
+        assert response.success is False
+        assert client._adaptive_thinking_models == set()
+
+
+class TestAdaptiveThinkingTruncatedEmptyRecovery:
+    """The confirmed production symptom (full budget, zero visible text, no explicit
+    thinking param ever sent) must self-heal — the model never raises an exception
+    here, it just returns an unusable 'successful' response."""
+
+    def test_non_streaming_truncated_empty_response_retries_with_adaptive_thinking(self, caplog):
+        mock_api = _make_mock_api_client()
+        empty_msg = _mock_message("", output_tokens=8192, stop_reason="max_tokens")
+        empty_msg.content = []
+        mock_api.messages.create.side_effect = [
+            empty_msg,
+            _mock_message("recovered on retry", stop_reason="end_turn"),
+        ]
+        client = _make_client(mock_api, ai_model="claude-sonnet-5")
+
+        with caplog.at_level("WARNING"):
+            response = asyncio.run(client.async_request("System.", "User."))
+
+        assert response.success is True
+        assert response.content == "recovered on retry"
+        assert response.truncated_empty is False
+        assert mock_api.messages.create.call_count == 2
+        second_kwargs = mock_api.messages.create.call_args.kwargs
+        assert second_kwargs["thinking"] == {"type": "adaptive"}
+        assert client._adaptive_thinking_models == {"claude-sonnet-5"}
+
+    def test_second_request_after_learning_uses_adaptive_shape_from_the_start(self):
+        mock_api = _make_mock_api_client()
+        client = _make_client(mock_api, ai_model="claude-sonnet-5")
+        client._adaptive_thinking_models.add("claude-sonnet-5")
+        mock_api.messages.create.return_value = _mock_message("clean response", stop_reason="end_turn")
+
+        response = asyncio.run(client.async_request("System.", "User."))
+
+        assert response.success is True
+        assert mock_api.messages.create.call_count == 1
+        assert mock_api.messages.create.call_args.kwargs["thinking"] == {"type": "adaptive"}
+
+    def test_streaming_truncated_empty_learns_for_next_call_but_cannot_retry_in_place(self, caplog):
+        """Thinking deltas may already be visible to the caller by the time truncation
+        is detected — this call surfaces the same failure as today, but arms the
+        capability flag so the *next* call (streaming or non-streaming) is fixed."""
+        mock_api = _make_mock_api_client()
+        thinking_event = MagicMock()
+        thinking_event.type = "content_block_delta"
+        thinking_event.delta = MagicMock()
+        thinking_event.delta.type = "thinking_delta"
+        thinking_event.delta.thinking = "pondering..."
+        final_msg = MagicMock()
+        final_msg.usage = MagicMock(input_tokens=50, output_tokens=8192)
+        final_msg.stop_reason = "max_tokens"
+        mock_api.messages.stream = MagicMock(return_value=_FakeStreamCM([thinking_event], final_msg))
+        client = _make_client(mock_api, ai_model="claude-sonnet-5")
+
+        async def _collect():
+            events = []
+            async for event in client.async_request_streaming("System.", "User."):
+                events.append(event)
+            return events
+
+        with caplog.at_level("WARNING"):
+            events = asyncio.run(_collect())
+
+        stop_events = [e for e in events if e.get("type") == "stop"]
+        assert stop_events[0]["truncated_empty"] is True
+        assert mock_api.messages.stream.call_count == 1  # no mid-stream retry
+        assert client._adaptive_thinking_models == {"claude-sonnet-5"}
         assert mock_api.messages.stream.call_count == 1


### PR DESCRIPTION
## Summary

- Root-caused via a live diagnostic (direct `AsyncAnthropic` calls bypassing `claude_api.py` entirely, dumping the full raw response — all content block types, complete `usage` object) rather than guessing: `claude-sonnet-5` rejects the legacy `thinking: {"type": "enabled", "budget_tokens": N}` shape outright (400, naming the replacement directly: `thinking.type.adaptive` + `output_config.effort`). Because `claude_api.py` only ever sent thinking control at `reasoning_effort == "high"`, requests at `medium`/`low` (the reported config) left this model's own internal reasoning completely uncapped.
- Reproduced live on a production-sized context: the model consumed the *entire* 8192-token (and separately 16384-token) budget purely on invisible internal reasoning — `stop_reason=max_tokens`, zero visible text — matching live HA logs exactly (8192 output tokens, ~93s streaming call, zero visible output). Confirmed the fix live: sending the adaptive shape on the same context returns `stop_reason=end_turn` with a real answer.
- The `temperature` rejection reported in the original issue was a red herring — #563/#564's existing reactive capability detection already handles it correctly and was confirmed working in production logs.
- Adds reactive per-model learning (mirrors the existing `_unsupported_params` pattern): a model is learned to need the adaptive shape either from a 400 naming `thinking.type.adaptive`, or from a "successful" response that came back `truncated_empty`. Non-streaming self-heals in place; streaming arms the flag for the next call since thinking deltas may already be visible mid-stream by the time truncation is detected. Models never observed to need this (e.g. `claude-sonnet-4-6`) are completely unaffected.
- Updates `docs/claude-api-spec.md` (Tier 3), which never documented #563's capability-detection system at all — adds a full section, fixes a stale invariant, and refreshes code-reference line numbers.

## Test plan

- [x] 10 new tests in `tests/test_claude_api.py` covering kwargs-shape correctness at every reasoning tier, parameter-strip ordering, both reactive-retry paths (streaming + non-streaming), both `truncated_empty`-recovery paths, and confirming an unlearned model is unaffected
- [x] `pytest tests/test_claude_api.py` — 65/65 pass
- [x] Full suite — 3708/3708 pass
- [x] `ruff check` / `ruff format` clean
- [x] `test_version_sync.py` — version bumped to 0.5.52 across `const.py`/`manifest.json`

Related: #563, #564