### PR TITLE
Fix #568: persist AI capability learning across reload/restart + observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.5.53] — 2026-08-05
+
+- Fix #568: the AI model-compatibility learning added in #565 (so Climate Advisor adapts automatically to a newer Claude model's quirks after the first request) was being silently wiped every time AI settings were saved or Home Assistant restarted — so it could never actually stick. It's now saved the same way as other AI usage stats, so it survives both. Also added clearer AI request logging so any future model-compatibility issue can be diagnosed directly from the logs.
+
 ## [0.5.52] — 2026-08-04
 
 - Fix #565: the AI Investigator and AI Activity Report could silently burn their entire response budget with no visible answer at all on newer Claude models (confirmed with claude-sonnet-5) — the model was doing its own internal reasoning with no cap on it, and that reasoning alone could use up the whole response length before ever getting to write an actual answer. Climate Advisor now detects this and automatically applies a bounded-reasoning setting so the model always leaves room for a real answer; it also learns per-model going forward so this self-heals after the first occurrence instead of repeating on every request.

--- a/custom_components/climate_advisor/claude_api.py
+++ b/custom_components/climate_advisor/claude_api.py
@@ -512,6 +512,7 @@ class ClaudeAPIClient:
                 system_prompt=system_prompt,
                 user_message=user_message,
             )
+            self._log_request_kwargs_decision(resolved_model, resolved_reasoning, kwargs)
             try:
                 async with self._client.messages.stream(**kwargs) as stream:
                     async for event in stream:
@@ -559,6 +560,19 @@ class ClaudeAPIClient:
                     )
                     continue  # next loop iteration rebuilds kwargs with the adaptive shape
 
+                if isinstance(exc, APIError) and bad_param is None and not needs_adaptive:
+                    # Issue #568: a 400-class error that matches neither known
+                    # capability-detection pattern — e.g. a genuinely new failure shape
+                    # (a context-length-exceeded error is a documented risk for newer
+                    # models with a different tokenizer). Mark it distinctly so it's
+                    # immediately greppable and never mistaken for one of the two known,
+                    # already-handled shapes.
+                    _LOGGER.warning(
+                        "Unrecognized API error shape for model '%s' (streaming) — full message: %s",
+                        resolved_model,
+                        exc,
+                    )
+
                 self._circuit_breaker.consecutive_failures += 1
                 self._error_count += 1
                 if self._circuit_breaker.consecutive_failures >= AI_CIRCUIT_BREAKER_THRESHOLD:
@@ -580,9 +594,10 @@ class ClaudeAPIClient:
         truncated_empty = truncated and not any_text_yielded
         skill_name = self._extract_skill_name(system_prompt)
         _LOGGER.debug(
-            "Claude streaming response finished: skill=%s stop_reason=%s output_tokens=%d",
+            "Claude streaming response finished: skill=%s stop_reason=%s input_tokens=%d output_tokens=%d",
             skill_name,
             stop_reason,
+            input_tokens,
             output_tokens,
         )
         if truncated_empty:
@@ -742,6 +757,14 @@ class ClaudeAPIClient:
             "counter_date": self._rate_counters.counter_date.isoformat(),
             "investigator_requests_today": self._investigator_requests_today,
             "investigator_requests_date": self._investigator_requests_date,
+            # Issue #568: without this, learned per-model capability (Issue #563's
+            # _unsupported_params, Issue #565's _adaptive_thinking_models) was pure
+            # in-memory state, wiped by any config reload (e.g. an options-flow save —
+            # Issue #557 made these save+reload immediately) or HA restart, forcing the
+            # first-call-fails-once discovery cost to repeat indefinitely instead of
+            # self-healing once and staying healed.
+            "unsupported_params": {model: sorted(params) for model, params in self._unsupported_params.items()},
+            "adaptive_thinking_models": sorted(self._adaptive_thinking_models),
         }
 
     def restore_persistent_stats(self, data: dict[str, Any]) -> None:
@@ -767,6 +790,17 @@ class ClaudeAPIClient:
             self._rate_counters.counter_date = date.today()
         self._investigator_requests_today = int(data.get("investigator_requests_today", 0))
         self._investigator_requests_date = data.get("investigator_requests_date", "")
+        # Issue #568: type-validated per the project's JSON-from-disk convention — any
+        # malformed shape (hand-edited state file, downgrade from a future version)
+        # degrades to "nothing learned yet" rather than raising.
+        raw_unsupported = data.get("unsupported_params", {})
+        self._unsupported_params = (
+            {model: set(params) for model, params in raw_unsupported.items() if isinstance(params, list)}
+            if isinstance(raw_unsupported, dict)
+            else {}
+        )
+        raw_adaptive = data.get("adaptive_thinking_models", [])
+        self._adaptive_thinking_models = set(raw_adaptive) if isinstance(raw_adaptive, list) else set()
         # Apply daily reset if rebooted after midnight
         self._reset_daily_counters_if_needed()
         _LOGGER.debug(
@@ -1007,6 +1041,25 @@ class ClaudeAPIClient:
 
         return kwargs
 
+    def _log_request_kwargs_decision(self, model: str, reasoning_effort: str, kwargs: dict[str, Any]) -> None:
+        """Log the resolved request-shape decision right before an API call (Issue #568).
+
+        Answers "did the adaptive-thinking branch actually fire, and was the learned
+        unsupported-parameter strip applied" directly from `ha_logs.py`, for every future
+        request — no special live test or diagnostic script needed to see this.
+        """
+        _LOGGER.debug(
+            "Claude request kwargs decision: model=%s reasoning_effort=%s adaptive_thinking=%s "
+            "unsupported_params=%s max_tokens=%d has_thinking=%s has_output_config=%s",
+            model,
+            reasoning_effort,
+            model in self._adaptive_thinking_models,
+            sorted(self._unsupported_params.get(model, ())),
+            kwargs.get("max_tokens", 0),
+            "thinking" in kwargs,
+            "output_config" in kwargs,
+        )
+
     async def _single_api_call(
         self,
         *,
@@ -1034,6 +1087,7 @@ class ClaudeAPIClient:
             system_prompt=system_prompt,
             user_message=user_message,
         )
+        self._log_request_kwargs_decision(model, reasoning_effort, kwargs)
 
         api_response = await self._client.messages.create(**kwargs)
 
@@ -1053,9 +1107,10 @@ class ClaudeAPIClient:
         truncated_empty = truncated and not content_text
         skill_name = self._extract_skill_name(system_prompt)
         _LOGGER.debug(
-            "Claude response finished: skill=%s stop_reason=%s output_tokens=%d",
+            "Claude response finished: skill=%s stop_reason=%s input_tokens=%d output_tokens=%d",
             skill_name,
             stop_reason,
+            input_tokens,
             output_tokens,
         )
         if truncated_empty:
@@ -1303,6 +1358,18 @@ class ClaudeAPIClient:
                             return fallback
                         # No usable same-tier replacement — fall through to the
                         # normal error handling/backoff below.
+                    else:
+                        # Issue #568: a 400-class error that matches neither known
+                        # capability-detection pattern and isn't a NotFoundError — e.g. a
+                        # genuinely new failure shape (a context-length-exceeded error is
+                        # a documented risk for newer models with a different tokenizer).
+                        # Mark it distinctly so it's immediately greppable and never
+                        # mistaken for one of the two known, already-handled shapes.
+                        _LOGGER.warning(
+                            "Unrecognized API error shape for model '%s' — full message: %s",
+                            model,
+                            exc,
+                        )
                     last_error = f"API error: {exc}"
                     _LOGGER.warning(
                         "Claude API error on attempt %d/%d: %s",

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,18 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.52"
+VERSION = "0.5.53"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.53": [
+        "Fix #568: the AI model-compatibility learning added in #565 (so Climate Advisor"
+        " adapts automatically to a newer Claude model's quirks after the first request)"
+        " was being silently wiped every time AI settings were saved or Home Assistant"
+        " restarted — so it could never actually stick. It's now saved the same way as"
+        " other AI usage stats, so it survives both. Also added clearer AI request"
+        " logging so any future model-compatibility issue can be diagnosed directly from"
+        " the logs.",
+    ],
     "0.5.52": [
         "Fix #565: the AI Investigator and AI Activity Report could silently burn their"
         " entire response budget with no visible answer at all on newer Claude models"
@@ -1459,6 +1468,51 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    568: {
+        "version_fixed": "0.5.53",
+        "title": (
+            "After #565 shipped, the user reported claude-sonnet-5 'still doesn't work' while"
+            " claude-sonnet-4-6 kept working. Root-caused from live log evidence (not a live"
+            " retest): the two per-model capability caches (#563's _unsupported_params, #565's"
+            " _adaptive_thinking_models) were pure in-memory ClaudeAPIClient instance state."
+            " Direct log evidence: 'Options section saved — reload triggered (cleared=0)' fired"
+            " 4 seconds after the model had just learned it needed adaptive thinking —"
+            " hass.config_entries.async_reload() (triggered by any options-flow save, immediate"
+            " since #557) tears down and reconstructs the entire coordinator including a"
+            " brand-new ClaudeAPIClient, silently discarding everything just learned."
+            " ClaudeAPIClient.update_config() — the one method that updates config without"
+            " discarding capability state — was confirmed to have zero production call sites;"
+            " every real config change goes through async_reload() instead. So the reactive"
+            " self-heal from #565 could only ever survive within a single process lifetime,"
+            " which routine restarts and any settings change reset — a user actively testing"
+            " which model works would never observe it."
+        ),
+        "scope_covered": (
+            "claude_api.py: both self._unsupported_params and self._adaptive_thinking_models are"
+            " now included in get_persistent_stats() (serialized as JSON-safe dict[str,"
+            " list[str]] / list[str]) and restored by restore_persistent_stats() (type-validated"
+            " per the project's JSON-from-disk convention — any malformed shape degrades to"
+            " empty rather than raising). This reuses the same bridge already wired through"
+            " coordinator._async_save_state()/async_restore_state() for monthly_cost/rate"
+            " counters, so both caches now survive config reloads and HA restarts, not just the"
+            " lifetime of one ClaudeAPIClient instance. Also added observability requested"
+            " during investigation, so a future occurrence is diagnosable from logs alone rather"
+            " than needing another live diagnostic: _log_request_kwargs_decision() logs the"
+            " resolved model/reasoning_effort/adaptive-thinking-active/unsupported-params/"
+            " max_tokens/thinking-and-output_config-presence before every API call (both"
+            " request paths); 'response finished' log lines now include input_tokens alongside"
+            " output_tokens (claude-sonnet-5's updated tokenizer is documented to parse the same"
+            " text into meaningfully more input tokens than claude-sonnet-4-6 — a distinct,"
+            " not-yet-observed, input-side context-window risk this makes visible in trend"
+            " data); and any APIError matching neither known capability-detection regex (and not"
+            " a NotFoundError) now logs a distinct 'Unrecognized API error shape' WARNING with"
+            " the full raw message, so a genuinely new failure mode is immediately greppable"
+            " instead of blending into generic retry-failure text. Test coverage:"
+            " tests/test_claude_api.py (TestPersistentStats capability-cache round-trip +"
+            " malformed-data cases, TestUnrecognizedApiErrorObservability,"
+            " TestRequestKwargsDecisionLogging)."
+        ),
+    },
     565: {
         "version_fixed": "0.5.52",
         "title": (

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.52"
+  "version": "0.5.53"
 }

--- a/docs/claude-api-spec.md
+++ b/docs/claude-api-spec.md
@@ -13,14 +13,15 @@
 | Which error types cause a retry, and what is the backoff schedule for `AI_MAX_RETRIES = 3`? | All four exception types retry: `RateLimitError`, `APITimeoutError`, `APIError`, and bare `Exception`. Delays are `1.0 s`, `2.0 s` between attempts 1→2 and 2→3; no sleep after attempt 3. | [Rate Limiting and Retry](#rate-limiting-and-retry) |
 | What happens to the circuit breaker failure counter when the circuit is half-open and the probe fails? | The failure counter increments (`consecutive_failures += 1`) via the same post-call path as any other failure. If it meets or exceeds `AI_CIRCUIT_BREAKER_THRESHOLD` (5), the breaker transitions back to `"open"` and `opened_at` is reset. | [Circuit Breaker State Machine](#circuit-breaker-state-machine) |
 | What config keys does `ClaudeAPIClient.__init__()` read, and what happens if `CONF_AI_API_KEY` is absent or empty? | It reads only `CONF_AI_API_KEY` at init time. If absent or empty, `self._client` remains `None` and a WARNING is logged; all subsequent `async_request()` calls return `ClaudeResponse(success=False, error="Anthropic client not initialized…")`. | [Initialization and Configuration](#initialization-and-configuration) |
-| A configured model rejects a request parameter, or needs a different extended-thinking shape, or silently returns zero visible text while consuming the full `max_tokens` budget — does the client keep failing forever? | No. `_build_request_kwargs()` is the single source of truth for both request paths; two per-model in-memory capability caches (`_unsupported_params`, `_adaptive_thinking_models`) are populated reactively — from a 400 error naming the rejected parameter/shape, or (for the zero-output case, which is a "successful" empty response, not an exception) from observing `truncated_empty=True`. Once learned, every subsequent request for that model is built correctly from the start; only the first occurrence per model per client-instance lifetime pays the cost of discovering it. | [Reactive Per-Model Capability Detection](#reactive-per-model-capability-detection) |
+| A configured model rejects a request parameter, or needs a different extended-thinking shape, or silently returns zero visible text while consuming the full `max_tokens` budget — does the client keep failing forever? | No. `_build_request_kwargs()` is the single source of truth for both request paths; two per-model capability caches (`_unsupported_params`, `_adaptive_thinking_models`) are populated reactively — from a 400 error naming the rejected parameter/shape, or (for the zero-output case, which is a "successful" empty response, not an exception) from observing `truncated_empty=True`. Once learned, every subsequent request for that model is built correctly from the start. Since Issue #568 both caches round-trip through `get_persistent_stats()`/`restore_persistent_stats()`, so only the very first occurrence ever, per model, survives a config reload or HA restart to pay the discovery cost — not every reload. | [Reactive Per-Model Capability Detection](#reactive-per-model-capability-detection) |
+| How do I tell, from logs alone, which request-shape branch actually fired for a given AI call, without a live diagnostic script? | `_log_request_kwargs_decision()` logs one DEBUG line before every API call: model, reasoning_effort, whether adaptive thinking is active, current unsupported-params, max_tokens, and whether `thinking`/`output_config` made it into the built kwargs. "Response finished" lines also log `input_tokens` alongside `output_tokens`. Any `APIError` matching neither known capability-detection pattern (and not a `NotFoundError`) logs a distinct `"Unrecognized API error shape"` WARNING with the full raw message. | [Observability](#observability-issue-568) |
 
 ---
 
 ## Scope
 
 - **File:** `custom_components/climate_advisor/claude_api.py`
-- **Approximate line range:** L1 – L1365 (entire file)
+- **Approximate line range:** L1 – L1432 (entire file)
 - **Primary entry points:** `ClaudeAPIClient.async_request()` (L278), `ClaudeAPIClient.__init__()` (L215)
 
 This spec covers `ClaudeAPIClient` and the supporting dataclasses (`ClaudeResponse`, `_CircuitBreaker`, `_RateLimitCounters`, `_BudgetTracker`). It does NOT cover:
@@ -163,7 +164,7 @@ async def async_request(
 
 Anthropic's Models API exposes `id`/`display_name`/`created_at` — never a per-model sampling-parameter or extended-thinking-shape schema. There is no way to know ahead of time that a given model no longer accepts `temperature`, or that it requires a different `thinking` parameter shape than an older model in the same family. `ClaudeAPIClient` handles this by learning per-model, in-memory, from the API's own error responses (or from a symptom that isn't an error at all — see below) — never by hardcoding a model-ID list.
 
-Two per-model capability caches, both `dict`/`set` keyed on the resolved model ID, both reset on integration reload (in-memory only, same acceptable cost as `_models_cache`):
+Two per-model capability caches, both `dict`/`set` keyed on the resolved model ID. Unlike `_models_cache`, these are **not** in-memory-only: Issue #568 found (via direct log evidence on a live instance) that a config reload — including an options-flow save, which reloads immediately per Issue #557 — reconstructs `ClaudeAPIClient` from scratch via `coordinator.py`, silently discarding anything learned so far and forcing the one-time discovery cost (see "Retry rules" below) to repeat indefinitely on any install where settings get touched or HA restarts periodically. Both caches are therefore included in `get_persistent_stats()`/`restore_persistent_stats()` (same bridge already used for `monthly_cost`/rate counters — see [Budget Tracking](#budget-tracking) below) and round-trip through the coordinator's state file, surviving both config reloads and HA restarts. `ClaudeAPIClient.update_config()` — the one method that updates config without reconstructing the client — is not used by this path; it exists but has no production call site, so it must not be relied on to preserve these caches.
 
 | Cache | Populated when | Effect on `_build_request_kwargs()` |
 |---|---|---|
@@ -181,7 +182,11 @@ Both `_async_call_with_retry()` (non-streaming) and `async_request_streaming()` 
 - **Non-streaming** (`_async_call_with_retry()`): nothing is exposed to the caller until the whole `ClaudeResponse` is returned, so a `truncated_empty` result is safe to retry in place — one extra `_single_api_call()` with `_adaptive_thinking_models` now including this model, same call.
 - **Streaming** (`async_request_streaming()`): thinking deltas may already have streamed to the caller (visible in the UI) by the time `truncated_empty` is known, at the very end of the generator. This call surfaces the failure exactly as before the fix; the only thing that changes is `self._adaptive_thinking_models.add(resolved_model)` fires before the generator ends, so the *next* call for this model — streaming or non-streaming, same client instance — builds corrected kwargs from the start and does not repeat the failure.
 
-A brand-new model's very first streaming call can therefore still exhibit one zero-output truncation before self-healing; every call after that (for that model, for the lifetime of this client instance) does not.
+A brand-new model's very first streaming call can therefore still exhibit one zero-output truncation before self-healing; every call after that (for that model — now durable across reloads/restarts per Issue #568, not just "for the lifetime of this client instance") does not.
+
+### Observability (Issue #568)
+
+Diagnosing which branch of the above actually fired for a given request no longer requires a live diagnostic script or a special test call — `_log_request_kwargs_decision()` logs one DEBUG line immediately before every API call (both request paths) with `model`, `reasoning_effort`, whether the model is in `_adaptive_thinking_models`, its current `_unsupported_params` entries, `max_tokens`, and whether `thinking`/`output_config` ended up in the built kwargs. The existing "response finished" DEBUG lines also include `input_tokens` (previously `output_tokens` only) — relevant because claude-sonnet-5's updated tokenizer is documented to parse the same source text into meaningfully more input tokens than claude-sonnet-4-6, which could push a large prompt toward the model's context window on the input side (a distinct failure mode from the output-side `max_tokens` truncation this section otherwise covers) — no occurrence has been observed live yet, but this makes it visible in `input_tokens` trend data the moment one does. Finally, any `APIError` matching neither `_detect_deprecated_param()` nor `_detect_adaptive_thinking_required()` (and, on the non-streaming path, not a `NotFoundError`) logs a distinct `"Unrecognized API error shape for model '%s' — full message: %s"` WARNING, so a genuinely new failure shape is immediately greppable from `tools/ha_logs.py --filter claude` and never conflated with one of the two already-handled ones.
 
 ---
 
@@ -203,7 +208,7 @@ A brand-new model's very first streaming call can therefore still exhibit one ze
 
 **Accumulation timing:** `monthly_cost += response.estimated_cost` runs in `async_request()` only after `_async_call_with_retry()` returns a success response. Retries that ultimately fail contribute zero.
 
-**Persistence:** `monthly_cost` and `budget_month` are included in `get_persistent_stats()` and restored by `restore_persistent_stats()`. Month-roll is re-applied by `_reset_daily_counters_if_needed()` / `_check_budget()` on the first call after HA restarts across a month boundary.
+**Persistence:** `monthly_cost` and `budget_month` are included in `get_persistent_stats()` and restored by `restore_persistent_stats()`. Month-roll is re-applied by `_reset_daily_counters_if_needed()` / `_check_budget()` on the first call after HA restarts across a month boundary. Since Issue #568, the same dict also carries `unsupported_params`/`adaptive_thinking_models` (see [Reactive Per-Model Capability Detection](#reactive-per-model-capability-detection)) — both type-validated on restore (`isinstance` checks degrade any malformed shape to empty rather than raising, per the project's JSON-from-disk convention).
 
 ---
 
@@ -351,18 +356,19 @@ If `from anthropic import ...` raises `ImportError`:
 - [`ClaudeAPIClient.__init__`](../custom_components/climate_advisor/claude_api.py#L215) — construction, client init, dataclass setup, capability-cache init
 - [`ClaudeAPIClient.async_request`](../custom_components/climate_advisor/claude_api.py#L278) — main public entry point; guard sequence + counter updates
 - [`async_request_streaming`](../custom_components/climate_advisor/claude_api.py#L425) — streaming entry point; capability-detection retry loop (before any content yielded), post-hoc `truncated_empty` handling
-- [`_check_circuit_breaker`](../custom_components/climate_advisor/claude_api.py#L862) — state machine query; transitions `"open"` → `"half_open"` on cooldown expiry
-- [`_build_request_kwargs`](../custom_components/climate_advisor/claude_api.py#L952) — single kwargs-building source for both request paths; extended-thinking shape selection + unsupported-parameter strip (see [Reactive Per-Model Capability Detection](#reactive-per-model-capability-detection))
-- [`_single_api_call`](../custom_components/climate_advisor/claude_api.py#L1010) — one atomic non-streaming API call + response parsing; no retry policy of its own
-- [`_async_call_with_retry`](../custom_components/climate_advisor/claude_api.py#L1154) — non-streaming retry loop with exponential backoff; capability-detection retries; `truncated_empty` in-place retry
+- [`_check_circuit_breaker`](../custom_components/climate_advisor/claude_api.py#L896) — state machine query; transitions `"open"` → `"half_open"` on cooldown expiry
+- [`_build_request_kwargs`](../custom_components/climate_advisor/claude_api.py#L986) — single kwargs-building source for both request paths; extended-thinking shape selection + unsupported-parameter strip (see [Reactive Per-Model Capability Detection](#reactive-per-model-capability-detection))
+- [`_log_request_kwargs_decision`](../custom_components/climate_advisor/claude_api.py#L1044) — DEBUG-logs the resolved request shape before every API call (Issue #568)
+- [`_single_api_call`](../custom_components/climate_advisor/claude_api.py#L1063) — one atomic non-streaming API call + response parsing; no retry policy of its own
+- [`_async_call_with_retry`](../custom_components/climate_advisor/claude_api.py#L1209) — non-streaming retry loop with exponential backoff; capability-detection retries; `truncated_empty` in-place retry
 - [`_detect_deprecated_param`](../custom_components/climate_advisor/claude_api.py#L89) — regex match for a "param deprecated for this model" 400 (Issue #563 follow-on)
 - [`_detect_adaptive_thinking_required`](../custom_components/climate_advisor/claude_api.py#L104) — regex match for a "use thinking.type.adaptive" 400 (Issue #565)
-- [`_check_budget`](../custom_components/climate_advisor/claude_api.py#L890) — month-roll detection and cap check
-- [`_check_rate_limit`](../custom_components/climate_advisor/claude_api.py#L817) — daily counter check for `"auto"` vs `"manual"` callers
-- [`check_investigator_rate_limit`](../custom_components/climate_advisor/claude_api.py#L834) — separate investigator gate; also checks `CONF_AI_INVESTIGATOR_ENABLED`
-- [`update_config`](../custom_components/climate_advisor/claude_api.py#L791) — hot-reload config; tears down and recreates client on key change
-- [`get_persistent_stats`](../custom_components/climate_advisor/claude_api.py#L725) — serializes counters + monthly cost for HA state persistence
-- [`restore_persistent_stats`](../custom_components/climate_advisor/claude_api.py#L747) — rehydrates counters after HA restart
+- [`_check_budget`](../custom_components/climate_advisor/claude_api.py#L924) — month-roll detection and cap check
+- [`_check_rate_limit`](../custom_components/climate_advisor/claude_api.py#L851) — daily counter check for `"auto"` vs `"manual"` callers
+- [`check_investigator_rate_limit`](../custom_components/climate_advisor/claude_api.py#L868) — separate investigator gate; also checks `CONF_AI_INVESTIGATOR_ENABLED`
+- [`update_config`](../custom_components/climate_advisor/claude_api.py#L825) — updates config in place without discarding capability caches; **not called from production code** — every real config change goes through `async_reload()` instead (see [Reactive Per-Model Capability Detection](#reactive-per-model-capability-detection))
+- [`get_persistent_stats`](../custom_components/climate_advisor/claude_api.py#L740) — serializes counters + monthly cost + capability caches for HA state persistence
+- [`restore_persistent_stats`](../custom_components/climate_advisor/claude_api.py#L770) — rehydrates counters + capability caches after HA restart or config reload
 - [`ClaudeResponse`](../custom_components/climate_advisor/claude_api.py#L123) — response dataclass; all fields documented above
 - [`_CircuitBreaker`](../custom_components/climate_advisor/claude_api.py#L147) — state machine storage dataclass
 - [`_MODEL_COSTS`](../custom_components/climate_advisor/claude_api.py#L110) — per-model-prefix cost rates

--- a/tests/test_claude_api.py
+++ b/tests/test_claude_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import sys
 import time
@@ -542,6 +543,55 @@ class TestPersistentStats:
         client = ClaudeAPIClient(_make_config())
         client.restore_persistent_stats({"counter_date": "not-a-date"})
         assert client._rate_counters.counter_date == date.today()
+
+    def test_roundtrip_preserves_capability_caches(self):
+        """Issue #568: learned capability must survive a save/restore cycle — this is what
+        makes it survive a config reload or HA restart, not just live in memory."""
+        client = ClaudeAPIClient(_make_config())
+        client._unsupported_params = {"claude-sonnet-5": {"temperature"}, "claude-opus-5": {"top_p", "top_k"}}
+        client._adaptive_thinking_models = {"claude-sonnet-5"}
+
+        stats = client.get_persistent_stats()
+
+        client2 = ClaudeAPIClient(_make_config())
+        client2.restore_persistent_stats(stats)
+
+        assert client2._unsupported_params == {
+            "claude-sonnet-5": {"temperature"},
+            "claude-opus-5": {"top_p", "top_k"},
+        }
+        assert client2._adaptive_thinking_models == {"claude-sonnet-5"}
+
+    def test_empty_dict_restores_capability_caches_to_empty(self):
+        """Old state files (pre-#568) lack these keys entirely — must not crash."""
+        client = ClaudeAPIClient(_make_config())
+        client.restore_persistent_stats({})
+        assert client._unsupported_params == {}
+        assert client._adaptive_thinking_models == set()
+
+    def test_malformed_capability_cache_data_degrades_to_empty(self):
+        """Type-validated per project convention: a hand-edited or corrupted state file
+        must never crash restore — degrade to 'nothing learned yet' instead."""
+        client = ClaudeAPIClient(_make_config())
+        client.restore_persistent_stats(
+            {
+                "unsupported_params": "not-a-dict",
+                "adaptive_thinking_models": "not-a-list",
+            }
+        )
+        assert client._unsupported_params == {}
+        assert client._adaptive_thinking_models == set()
+
+    def test_malformed_capability_cache_entry_is_skipped(self):
+        """A single malformed entry (e.g. params not a list) is skipped, not fatal to the
+        whole restore."""
+        client = ClaudeAPIClient(_make_config())
+        client.restore_persistent_stats(
+            {
+                "unsupported_params": {"claude-sonnet-5": ["temperature"], "claude-opus-5": "not-a-list"},
+            }
+        )
+        assert client._unsupported_params == {"claude-sonnet-5": {"temperature"}}
 
 
 # ---------------------------------------------------------------------------
@@ -1346,3 +1396,150 @@ class TestAdaptiveThinkingTruncatedEmptyRecovery:
         assert mock_api.messages.stream.call_count == 1  # no mid-stream retry
         assert client._adaptive_thinking_models == {"claude-sonnet-5"}
         assert mock_api.messages.stream.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Issue #568 — observability: an API error matching neither known
+# capability-detection pattern must be marked distinctly, not logged as
+# indistinguishable generic text (e.g. a documented context-length-exceeded
+# risk on newer models with a different tokenizer, never yet seen live).
+# ---------------------------------------------------------------------------
+
+
+class TestUnrecognizedApiErrorObservability:
+    def test_non_streaming_unrecognized_error_gets_distinct_marker(self, caplog):
+        mock_api = _make_mock_api_client()
+        mock_api.messages.create.side_effect = _ClaudeApiAPIError(
+            "invalid_request_error: prompt is too long: 205000 tokens > 200000 maximum"
+        )
+        client = _make_client(mock_api, ai_model="claude-sonnet-5")
+
+        with caplog.at_level("WARNING"), patch("asyncio.sleep", new_callable=AsyncMock):
+            response = asyncio.run(client.async_request("System.", "User."))
+
+        assert response.success is False
+        assert any("Unrecognized API error shape" in rec.message for rec in caplog.records)
+
+    def test_non_streaming_known_deprecated_param_error_does_not_get_marker(self, caplog):
+        mock_api = _make_mock_api_client()
+        mock_api.messages.create.side_effect = [
+            _ClaudeApiAPIError("`temperature` is deprecated for this model."),
+            _mock_message("recovered"),
+        ]
+        client = _make_client(mock_api, ai_model="claude-sonnet-4-6")
+
+        with caplog.at_level("WARNING"), patch("asyncio.sleep", new_callable=AsyncMock):
+            asyncio.run(client.async_request("System.", "User."))
+
+        assert not any("Unrecognized API error shape" in rec.message for rec in caplog.records)
+
+    def test_non_streaming_known_adaptive_thinking_error_does_not_get_marker(self, caplog):
+        mock_api = _make_mock_api_client()
+        mock_api.messages.create.side_effect = [
+            _ClaudeApiAPIError(
+                '"thinking.type.enabled" is not supported for this model. Use '
+                '"thinking.type.adaptive" and "output_config.effort" to control thinking behavior.'
+            ),
+            _mock_message("recovered"),
+        ]
+        client = _make_client(mock_api, ai_model="claude-sonnet-5")
+
+        with caplog.at_level("WARNING"), patch("asyncio.sleep", new_callable=AsyncMock):
+            asyncio.run(client.async_request("System.", "User.", reasoning_effort="high"))
+
+        assert not any("Unrecognized API error shape" in rec.message for rec in caplog.records)
+
+    def test_streaming_unrecognized_error_gets_distinct_marker(self, caplog):
+        mock_api = _make_mock_api_client()
+        bad_stream = _FakeFailingStreamCM(
+            _ClaudeApiAPIError("invalid_request_error: prompt is too long: 205000 tokens > 200000 maximum")
+        )
+        mock_api.messages.stream = MagicMock(return_value=bad_stream)
+        client = _make_client(mock_api, ai_model="claude-sonnet-5")
+
+        async def _collect():
+            events = []
+            async for event in client.async_request_streaming("System.", "User."):
+                events.append(event)
+            return events
+
+        with caplog.at_level("WARNING"), contextlib.suppress(Exception):
+            asyncio.run(_collect())
+
+        assert any("Unrecognized API error shape" in rec.message for rec in caplog.records)
+
+
+class TestRequestKwargsDecisionLogging:
+    """Issue #568: the resolved request shape must be visible in DEBUG logs for every
+    call, without needing a special live test to know whether adaptive thinking fired."""
+
+    def test_non_streaming_logs_kwargs_decision(self, caplog):
+        mock_api = _make_mock_api_client()
+        mock_api.messages.create.return_value = _mock_message("ok")
+        client = _make_client(mock_api, ai_model="claude-sonnet-5")
+        client._adaptive_thinking_models.add("claude-sonnet-5")
+
+        with caplog.at_level("DEBUG"):
+            asyncio.run(client.async_request("System.", "User."))
+
+        decision_lines = [rec.message for rec in caplog.records if "kwargs decision" in rec.message]
+        assert len(decision_lines) == 1
+        assert "adaptive_thinking=True" in decision_lines[0]
+        assert "has_thinking=True" in decision_lines[0]
+        assert "has_output_config=True" in decision_lines[0]
+
+    def test_streaming_logs_kwargs_decision(self, caplog):
+        mock_api = _make_mock_api_client()
+        final_msg = MagicMock()
+        final_msg.usage = MagicMock(input_tokens=10, output_tokens=20)
+        final_msg.stop_reason = "end_turn"
+        mock_api.messages.stream = MagicMock(return_value=_FakeStreamCM([_mock_text_delta_event("ok")], final_msg))
+        client = _make_client(mock_api, ai_model="claude-sonnet-4-6")
+
+        async def _collect():
+            events = []
+            async for event in client.async_request_streaming("System.", "User."):
+                events.append(event)
+            return events
+
+        with caplog.at_level("DEBUG"):
+            asyncio.run(_collect())
+
+        decision_lines = [rec.message for rec in caplog.records if "kwargs decision" in rec.message]
+        assert len(decision_lines) == 1
+        assert "adaptive_thinking=False" in decision_lines[0]
+
+    def test_non_streaming_finished_log_includes_input_tokens(self, caplog):
+        mock_api = _make_mock_api_client()
+        mock_api.messages.create.return_value = _mock_message("ok", input_tokens=4961, output_tokens=20)
+        client = _make_client(mock_api)
+
+        with caplog.at_level("DEBUG"):
+            asyncio.run(client.async_request("System.", "User."))
+
+        finished_lines = [rec.message for rec in caplog.records if "response finished" in rec.message]
+        assert len(finished_lines) == 1
+        assert "input_tokens=4961" in finished_lines[0]
+        assert "output_tokens=20" in finished_lines[0]
+
+    def test_streaming_finished_log_includes_input_tokens(self, caplog):
+        mock_api = _make_mock_api_client()
+        final_msg = MagicMock()
+        final_msg.usage = MagicMock(input_tokens=4961, output_tokens=20)
+        final_msg.stop_reason = "end_turn"
+        mock_api.messages.stream = MagicMock(return_value=_FakeStreamCM([_mock_text_delta_event("ok")], final_msg))
+        client = _make_client(mock_api)
+
+        async def _collect():
+            events = []
+            async for event in client.async_request_streaming("System.", "User."):
+                events.append(event)
+            return events
+
+        with caplog.at_level("DEBUG"):
+            asyncio.run(_collect())
+
+        finished_lines = [rec.message for rec in caplog.records if "response finished" in rec.message]
+        assert len(finished_lines) == 1
+        assert "input_tokens=4961" in finished_lines[0]
+        assert "output_tokens=20" in finished_lines[0]


### PR DESCRIPTION
## Summary

- After #565 shipped (PR #566), the user reported claude-sonnet-5 "still doesn't work" while claude-sonnet-4-6 kept working. Root-caused from live log evidence, not another live retest: the two per-model capability caches (#563's `_unsupported_params`, #565's `_adaptive_thinking_models`) are pure in-memory `ClaudeAPIClient` instance state.
- Direct log evidence: `"Options section saved — reload triggered (cleared=0)"` fired 4 seconds after `claude-sonnet-5` had just learned it needed adaptive thinking. `hass.config_entries.async_reload()` (triggered by any options-flow save, immediate since #557) tears down and reconstructs the entire coordinator including a brand-new `ClaudeAPIClient`, silently discarding everything just learned. `ClaudeAPIClient.update_config()` — the one method that updates config without discarding capability state — was confirmed to have **zero production call sites**; every real config change goes through `async_reload()` instead.
- So the reactive self-heal from #565 could only ever survive within a single process lifetime — which routine restarts and any settings change reset. A user actively testing which model works would never observe it.
- **Fix**: both capability caches now round-trip through the existing `get_persistent_stats()`/`restore_persistent_stats()` bridge (already used for request counters/budget, already wired through `coordinator._async_save_state()`/`async_restore_state()`), type-validated on restore per the project's JSON-from-disk convention.
- **Observability** (requested during investigation instead of another one-off diagnostic script): a DEBUG line logs the resolved model/reasoning_effort/adaptive-thinking-active/unsupported-params/max_tokens/thinking-shape decision before every API call; `input_tokens` now logs alongside `output_tokens` on every finished-response line (relevant to a documented, not-yet-observed risk: claude-sonnet-5's updated tokenizer parses the same text into meaningfully more input tokens, which could push a large prompt toward the context window on the input side); and any `APIError` matching neither known capability-detection pattern now logs a distinct `"Unrecognized API error shape"` WARNING with the full raw message.
- Updates `docs/claude-api-spec.md` (Anchors, the Reactive Per-Model Capability Detection section, a new Observability subsection, refreshed code-reference line numbers).

## Test plan

- [x] 12 new tests in `tests/test_claude_api.py`: capability-cache persistence round-trip + malformed-data handling, unrecognized-API-error-shape marker (streaming + non-streaming, and confirms it does NOT fire for the two known shapes), kwargs-decision logging, input_tokens logging
- [x] `pytest tests/test_claude_api.py` — 77/77 pass
- [x] Full suite — 3720/3720 pass
- [x] `ruff check` / `ruff format` clean
- [x] `test_version_sync.py` — version bumped to 0.5.53 across `const.py`/`manifest.json`

Related: #563, #565, PR #566