### PR TITLE
Fix #567: WHF automation actions confused as manual overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.5.54] — 2026-08-05
+
+- Fix #567: the whole-house fan's own automation-issued commands could get heard back on the QuietCool remote's RF channel and misread as a person pressing the physical remote — falsely handing fan control away from Climate Advisor for up to 3 hours and mislabeling the Activity Report as a manual action that never happened. Also fixed a related report-only issue: when Climate Advisor quietly corrects its own stale fan-tracking (no user involved at all), the Activity Report now says so instead of also claiming "user turned off".
+
 ## [0.5.53] — 2026-08-05
 
 - Fix #568: the AI model-compatibility learning added in #565 (so Climate Advisor adapts automatically to a newer Claude model's quirks after the first request) was being silently wiped every time AI settings were saved or Home Assistant restarted — so it could never actually stick. It's now saved the same way as other AI usage stats, so it survives both. Also added clearer AI request logging so any future model-compatibility issue can be diagnosed directly from the logs.

--- a/custom_components/climate_advisor/ai_skills_context.py
+++ b/custom_components/climate_advisor/ai_skills_context.py
@@ -1819,10 +1819,22 @@ def _render_fan_untracked_cleared(p: dict, unit: str) -> tuple[str, str]:
 
 
 def _render_fan_cancel(p: dict, unit: str) -> tuple[str, str]:
+    """Issue #567: branch on `trigger` — not every fan_cancel event is a user action.
+
+    `physical_drift_correction` is CA noticing its own _fan_active bookkeeping was stale
+    (the fan had already stopped) and correcting it — no user touched anything. Rendering
+    that identically to a genuine user-detected fan-off misled the Activity Report into
+    implying a manual action that never happened.
+    """
     fan_before = str(p.get("fan_before", "?")).strip()
     fan_after = str(p.get("fan_after", "?")).strip()
     fan_device = p.get("fan_device", "fan")
     settings = f"{fan_device}: {fan_before}->{fan_after}" if fan_before and fan_after else ""
+    trigger = p.get("trigger")
+    if trigger == "physical_drift_correction":
+        return "Fan ownership corrected -- stale flag cleared (was already off)", settings
+    if trigger == "timer_boundary_settle":
+        return "Fan cancel -- RF timer session ended", settings
     return "Fan cancel (user turned off)", settings
 
 

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,18 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.53"
+VERSION = "0.5.54"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.54": [
+        "Fix #567: the whole-house fan's own automation-issued commands could get heard"
+        " back on the QuietCool remote's RF channel and misread as a person pressing the"
+        " physical remote — falsely handing fan control away from Climate Advisor for up"
+        " to 3 hours and mislabeling the Activity Report as a manual action that never"
+        " happened. Also fixed a related report-only issue: when Climate Advisor quietly"
+        " corrects its own stale fan-tracking (no user involved at all), the Activity"
+        " Report now says so instead of also claiming 'user turned off'.",
+    ],
     "0.5.53": [
         "Fix #568: the AI model-compatibility learning added in #565 (so Climate Advisor"
         " adapts automatically to a newer Claude model's quirks after the first request)"
@@ -1468,6 +1477,42 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    567: {
+        "version_fixed": "0.5.54",
+        "title": (
+            "WHF automation actions were being confused as manual ones. The QuietCool device"
+            " transmits AND receives on the same RF channel, so a CA-issued fan command"
+            " (confirmed live: nat_vent_cycling_on) could be heard back by the same"
+            " receive-side event.quietcool_remote entity ~1.7s later and misread as a fresh"
+            " remote press. _async_fan_remote_changed()/_flush_fan_remote_burst() (added in"
+            " #486/#519) never called the existing _is_recent_fan_command() echo guard that"
+            " the sibling physical-fan-entity handler has used since Fix #239 — an original"
+            " design gap, not a regression. The false override then cascaded: a later"
+            " legitimate nat-vent exit deferred to the (false) active override and skipped"
+            " deactivating the fan, so a genuine physical fan-off ~18 minutes later wasn't"
+            " caught until the 2-tick drift-reconciliation backstop fired 10 minutes after"
+            " that — and that backstop's own fan_cancel event was unconditionally rendered"
+            " 'Fan cancel (user turned off)' regardless of its actual trigger, a second,"
+            " independent mislabeling bug surfaced by the same investigation."
+        ),
+        "scope_covered": (
+            "coordinator.py: _async_fan_remote_changed() now calls _is_recent_fan_command"
+            "(threshold_seconds=30.0) at ingestion, before any burst is opened — mirrors the"
+            " existing guard in _async_fan_entity_changed() (Fix #239); event.context matching"
+            " isn't usable here since CA never calls a service on this receive-only entity."
+            " _is_recent_fan_command()'s docstring and the Issue #417 sibling-comment in"
+            " _async_thermostat_changed() now cross-reference this call site so a future new"
+            " fan-state listener doesn't repeat the same missed-guard defect a third time."
+            " ai_skills_context.py: _render_fan_cancel() branches on the fan_cancel event's"
+            " existing trigger field (fan_off / timer_boundary_settle / physical_drift_correction"
+            " — all three already emitted by automation.py, previously ignored by the renderer)"
+            " so CA's own drift-reconciliation self-correction no longer renders as a user"
+            " action. tests: TestFanRemoteEchoGuard in test_fan_remote.py (4 cases, revert-tested);"
+            " TestFanOwnershipAnnotations additions in test_activity_renderers.py (4 cases,"
+            " revert-tested); fixed a latent MagicMock-truthiness gap this change exposed in"
+            " test_restart_coalescing_fan_guard.py's coordinator stub."
+        ),
+    },
     568: {
         "version_fixed": "0.5.53",
         "title": (

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -1512,7 +1512,16 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         return (dt_util.now() - cmd_time).total_seconds() < threshold_seconds
 
     def _is_recent_fan_command(self, threshold_seconds: float = 30.0) -> bool:
-        """Check if a fan command was issued recently (race guard)."""
+        """Check if a fan command was issued recently (race guard).
+
+        Adding a new fan-state listener (physical entity, RF remote, or otherwise)?
+        This is the shared echo-suppression primitive — call it before treating any
+        transition/event as external. Current call sites: coordinator.py ~3627/3785/3862
+        (see the Issue #417 sibling list at ~3621), coordinator.py ~4029
+        (_async_fan_entity_changed), and coordinator.py ~4106 (_async_fan_remote_changed,
+        Issue #567). Missing this guard on a new listener has shipped as a production bug
+        twice (#417, #567) — don't add a third.
+        """
         cmd_time = self.automation_engine._fan_command_time
         if cmd_time is None:
             return False
@@ -3619,10 +3628,11 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             and not _ae_347._natural_vent_active
             and not _ae_347._fan_override_active
             # Issue #417: every sibling race-sensitive check in this file (e.g. lines
-            # ~2875, ~2916, ~2939, ~3225, ~3300) guards against CA's own in-flight fan
-            # commands with these two checks — this was the one place that didn't,
-            # letting a CA-issued nat-vent cycle-on transiently look "unowned" to this
-            # listener before _activate_fan()'s flags settle.
+            # ~2875, ~2916, ~2939, ~3225, ~3300, and _async_fan_remote_changed() ~4106,
+            # added for Issue #567) guards against CA's own in-flight fan commands with
+            # these two checks — this was the one place that didn't, letting a CA-issued
+            # nat-vent cycle-on transiently look "unowned" to this listener before
+            # _activate_fan()'s flags settle.
             and not _ae_347._fan_command_pending
             and not self._is_recent_fan_command(threshold_seconds=30.0)
         ):
@@ -4101,6 +4111,19 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         # entity can re-announce its last retained event_type (a stale timer press) while
         # HA is still settling right after restart, indistinguishable from a fresh press.
         if self._suppress_during_startup_coalescing(f"fan remote event_type={event_type}"):
+            return
+
+        # Issue #567: echo guard — the QuietCool device transmits AND receives on the same
+        # RF channel (see fan-remote-spec.md), so a CA-issued fan command can be heard back
+        # by this same receive-side entity and misread as a fresh manual press. Mirrors the
+        # existing echo guard in _async_fan_entity_changed() (see the sibling-site list at
+        # _is_recent_fan_command()'s definition) — event.context matching isn't available
+        # here since CA never calls a service on this receive-only entity.
+        if self._is_recent_fan_command(threshold_seconds=30.0):
+            _LOGGER.debug(
+                "Fan RF remote event ignored — recent CA-issued fan command (echo guard), event_type=%s",
+                event_type,
+            )
             return
 
         is_timer, hours = parse_remote_timer_event(event_type)

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.53"
+  "version": "0.5.54"
 }

--- a/docs/fan-remote-spec.md
+++ b/docs/fan-remote-spec.md
@@ -19,6 +19,7 @@
 | Can a stale/repeated remote event trigger a false override? | It used to. The `event.*` entity flaps to `unavailable` at arbitrary times (not just restart) and re-announces its STALE last `event_type` with the SAME state (the entity's `state` field IS the event timestamp). Issue #495 added a dedup guard (`_last_fan_remote_event_ts`) that ignores a re-announced identical timestamp — confirmed live: without it, a phantom 2h override fired with zero user action when the entity restored a 6-hour-stale `timer_2h`. | [§ Stale-Event Dedup](#stale-event-dedup) |
 | Does the dashboard's remote-timer display stay accurate? | As of Issue #495, yes. Previously `handle_fan_manual_override()` unconditionally overwrote `_fan_remote_timer_hours` on every call — including plain non-remote re-stamps (e.g. the WHF fan entity re-reporting "on") — which nulled an active remote timer within seconds of a genuine press. Fixed by only overwriting when the caller is the remote itself (`is_remote_event=True`) or supplies a genuine value. `_fan_remote_speed` (Issue #519) uses the identical guarded-overwrite idiom. | [§ Timer Value Durability](#timer-value-durability) |
 | How does CA find the ambient speed sensor without new config? | Auto-discovery via HA's entity/device registry, keyed off the already-configured `fan_remote_entity` — resolves its `device_id`, then scans sibling entities for a `sensor.*` matching an object-id hint. No new user-facing config field; a discovery miss (older firmware, or registry not yet populated at startup) degrades to "speed unknown," which IS the auto-detect + fallback mechanism. | [§ Ambient Speed Sensor Discovery](#ambient-speed-sensor-discovery-issue-519) |
+| Can CA's OWN fan command be misread as a remote press? | It used to. The QuietCool device transmits AND receives on the same RF channel, so a CA-issued command can be heard back by this same receive-side entity within ~1-2 seconds. Issue #567 added an echo guard (`_is_recent_fan_command()`, the same 30s-window primitive `_async_fan_entity_changed()` already used) at the top of `_async_fan_remote_changed()` — event-context matching isn't available here since CA never calls a service on this receive-only entity. | [§ CA's Own Command Echo Suppression](#cas-own-command-echo-suppression-issue-567) |
 
 ---
 
@@ -27,7 +28,8 @@
 **Files:**
 - `custom_components/climate_advisor/fan_status.py` — `parse_remote_timer_event()`, the single source of truth for the event-token → hours mapping; `parse_remote_speed_event()` (Issue #519), the sibling for the speed-token family
 - `custom_components/climate_advisor/const.py` — `CONF_FAN_REMOTE_ENTITY`, `REMOTE_TIMER_EVENT_HOURS`; `REMOTE_SPEED_TOKENS`, `REMOTE_BURST_WINDOW_SECONDS`, `REMOTE_SPEED_SENSOR_OBJECT_ID_HINTS` (Issue #519)
-- `custom_components/climate_advisor/coordinator.py` — subscription (`async_setup`) + `_async_fan_remote_changed()` dispatch handler; `_last_fan_remote_event_ts` (Issue #495 stale-event dedup); `_PendingFanRemoteBurst`, `_arm_fan_remote_burst()`/`_cancel_fan_remote_burst()`/`_flush_fan_remote_burst()` (Issue #519 burst combining + classification); `_resolve_fan_remote_speed_sensor()`/`_read_fan_remote_speed()` (Issue #519 ambient sensor discovery)
+- `custom_components/climate_advisor/coordinator.py` — subscription (`async_setup`) + `_async_fan_remote_changed()` dispatch handler; `_last_fan_remote_event_ts` (Issue #495 stale-event dedup); `_PendingFanRemoteBurst`, `_arm_fan_remote_burst()`/`_cancel_fan_remote_burst()`/`_flush_fan_remote_burst()` (Issue #519 burst combining + classification); `_resolve_fan_remote_speed_sensor()`/`_read_fan_remote_speed()` (Issue #519 ambient sensor discovery); `_is_recent_fan_command()` echo guard at ingestion (Issue #567)
+- `custom_components/climate_advisor/ai_skills_context.py` — `_render_fan_cancel()` branches on the `fan_cancel` event's `trigger` field so CA's own drift-reconciliation self-correction (`physical_drift_correction`) doesn't render as "user turned off" (Issue #567)
 - `custom_components/climate_advisor/automation.py` — `handle_fan_manual_override(duration_override=..., is_remote_event=..., remote_speed=...)`, `_start_grace_period(duration_override=...)`, the suppression WARNING at `_deactivate_fan()` and `fan_thermostat_check()`, `_suppress_hvac_for_whf()`/`_release_whf_and_reclassify()` (Issue #495 HVAC suppression + reclassify-on-exit); `handle_fan_speed_observed()` (Issue #519 comfort-only path)
 - `custom_components/climate_advisor/api.py` + `custom_components/climate_advisor/frontend/index.html` — `fan_remote_speed` status field + dashboard display (Issue #519)
 - `gunkl/quietcool-house-fan` `component.yaml` (separate repo) — the new `text_sensor.quietcool_speed` ambient entity (Issue #519)
@@ -338,6 +340,45 @@ apart from a fresh button press by inspecting the event alone, so it now calls
 5-minute window `_async_thermostat_changed()` already used (Issue #321), now shared. A
 real remote press in the first 5 minutes after a restart is not acted on during that
 window — an accepted tradeoff, consistent with the existing thermostat-override behavior.
+
+---
+
+## CA's Own Command Echo Suppression (Issue #567)
+
+**Occupant impact:** CA turns the fan on for a legitimate reason (e.g. resuming a nat-vent
+cycle at the end of the night). Without this guard, that automation action could get
+misread as the occupant pressing the physical remote, be relabeled "manual override" in the
+Activity Report, and hand fan control away from CA for hours on the strength of a false
+detection — precisely the confusion this section closes.
+
+**Why this is possible:** the QuietCool ESPHome device is a single transceiver — the same
+component that exposes CA's control entity also decodes RF traffic for `event.quietcool_remote`
+(see [§ Firmware Event Contract](#firmware-event-contract): "extends the upstream
+**transmit-only** component with **receive** capability"). A command CA transmits can be heard
+back on the same channel and decoded indistinguishably from a real remote press — confirmed
+live: a `nat_vent_cycling_on` command at `T` was followed 1.742 seconds later by a `low` speed
+token on `event.quietcool_remote`, which the (unguarded) burst classifier treated as a fresh
+press and armed a 3-hour manual override with zero actual user involvement (Issue #567).
+
+**Fix:** `_async_fan_remote_changed()` now checks `_is_recent_fan_command(threshold_seconds=30.0)`
+at ingestion, before any burst is opened — the same shared primitive
+`_async_fan_entity_changed()` already used for the physical fan-entity path since Fix #239. See
+`_is_recent_fan_command()`'s docstring in `coordinator.py` for the full list of guarded call
+sites; this project has shipped the "a new fan-state listener forgot this guard" defect twice
+(#417, #567), so any new listener should consult that list before assuming its own event source
+is exempt.
+
+**Why not `event.context` matching** (the *primary*, stronger signal
+`_async_fan_entity_changed()` uses)? Structurally unavailable here: `event.quietcool_remote` is
+receive-only — CA never calls an HA service on it, so HA never attaches a CA-issued `Context` to
+its state-changed events. The time-window heuristic is the correct mechanism for this entity, not
+a fallback shortcut.
+
+**Tradeoff:** a genuine human remote press landing within 30 seconds of a CA-issued fan command
+is silently dropped instead of acted on. This is the same tradeoff already accepted for the
+physical-entity path since Fix #239 — timer/speed presses are deliberate, non-urgent actions, so
+a 30s silent window is a small cost against a guaranteed-false override every time CA's own
+command echoes back.
 
 ---
 

--- a/tests/test_activity_renderers.py
+++ b/tests/test_activity_renderers.py
@@ -974,6 +974,40 @@ class TestFanOwnershipAnnotations:
         # The renderer defaults to "?" for missing fan states — settings is non-empty but informative
         assert isinstance(st, str)  # no crash, returns a string
 
+    def test_fan_cancel_renderer_physical_drift_correction_is_not_user_turned_off(self):
+        """Issue #567: a fan_cancel emitted by the drift-reconciliation backstop
+        (trigger=physical_drift_correction) is CA correcting its OWN stale bookkeeping —
+        no user touched anything. Must not render as "user turned off"."""
+        ev, _st = _act_mod.EVENT_RENDERERS["fan_cancel"](
+            {"trigger": "physical_drift_correction"},
+            "fahrenheit",
+        )
+        assert "user turned off" not in ev.lower()
+
+    def test_fan_cancel_renderer_timer_boundary_settle_is_not_user_turned_off(self):
+        """trigger=timer_boundary_settle is the tail of an RF-timer session ending, not a
+        fresh user action distinct from the timer press that already started it."""
+        ev, _st = _act_mod.EVENT_RENDERERS["fan_cancel"](
+            {"trigger": "timer_boundary_settle"},
+            "fahrenheit",
+        )
+        assert "user turned off" not in ev.lower()
+
+    def test_fan_cancel_renderer_genuine_fan_off_still_says_user_turned_off(self):
+        """trigger=fan_off is a genuine externally-detected physical fan-off — the one case
+        that IS a real user action. Must render unchanged from before this fix."""
+        ev, _st = _act_mod.EVENT_RENDERERS["fan_cancel"](
+            {"fan_before": "on", "fan_after": "off", "trigger": "fan_off"},
+            "fahrenheit",
+        )
+        assert "user turned off" in ev.lower()
+
+    def test_fan_cancel_renderer_no_trigger_defaults_to_user_turned_off(self):
+        """Missing/unknown trigger falls back to the pre-existing label — never less
+        informative than before this fix."""
+        ev, _st = _act_mod.EVENT_RENDERERS["fan_cancel"]({}, "fahrenheit")
+        assert "user turned off" in ev.lower()
+
     def test_nat_vent_fan_off_ownership_annotation_in_ev_text(self):
         """When user owns fan, the NOTE annotation is added to ev_text in the renderer block.
 

--- a/tests/test_fan_remote.py
+++ b/tests/test_fan_remote.py
@@ -25,7 +25,7 @@ import asyncio
 import importlib
 import sys
 import types
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # Ensure HA stubs are installed before any coordinator import.
@@ -51,6 +51,7 @@ from custom_components.climate_advisor.fan_status import (  # noqa: E402
 _PATCH_CALL_LATER = "custom_components.climate_advisor.automation.async_call_later"
 _PATCH_CALLBACK = "custom_components.climate_advisor.automation.callback"
 _PATCH_DT_NOW = "custom_components.climate_advisor.automation.dt_util.now"
+_PATCH_COORDINATOR_DT_NOW = "custom_components.climate_advisor.coordinator.dt_util.now"
 _FIXED_NOW = datetime(2026, 7, 12, 20, 0, 0)
 
 
@@ -109,6 +110,7 @@ def _make_mock_engine() -> MagicMock:
     ae._override_confirm_pending = False
     ae._fan_remote_timer_hours = None
     ae._fan_remote_speed = None
+    ae._fan_command_time = None  # Issue #567: default to "no recent CA command" for the echo guard
     ae.handle_fan_manual_override = MagicMock()
     ae.handle_fan_speed_observed = MagicMock()
     return ae
@@ -160,6 +162,10 @@ def _make_coordinator_stub(config: dict | None = None, *, physical_on: bool | No
     coord._arm_fan_remote_burst = types.MethodType(mod.ClimateAdvisorCoordinator._arm_fan_remote_burst, coord)
     coord._cancel_fan_remote_burst = types.MethodType(mod.ClimateAdvisorCoordinator._cancel_fan_remote_burst, coord)
     coord._flush_fan_remote_burst = types.MethodType(mod.ClimateAdvisorCoordinator._flush_fan_remote_burst, coord)
+    # Issue #567: bind the REAL echo guard (not a MagicMock auto-attr, which would be
+    # truthy and silently swallow every dispatch in this file) so it reads
+    # automation_engine._fan_command_time exactly as production does.
+    coord._is_recent_fan_command = types.MethodType(mod.ClimateAdvisorCoordinator._is_recent_fan_command, coord)
     return coord
 
 
@@ -975,3 +981,75 @@ class TestFanRemoteStatusFieldsWiring:
         result = coord._compute_fan_remote_status_fields()
         assert result["fan_remote_timer_hours"] is None
         assert result["fan_remote_timer_ends"] is None
+
+
+# ---------------------------------------------------------------------------
+# 11. Issue #567: CA-command echo guard on _async_fan_remote_changed
+# ---------------------------------------------------------------------------
+
+
+class TestFanRemoteEchoGuard:
+    """The QuietCool device transmits AND receives on the same RF channel, so a CA-issued
+    fan command can be heard back by this same receive-side entity and misread as a fresh
+    manual press. Mirrors the existing _is_recent_fan_command() echo guard already used by
+    _async_fan_entity_changed() (Fix #239) -- see the sibling-site list at
+    _is_recent_fan_command()'s definition in coordinator.py.
+    """
+
+    def test_event_within_30s_of_ca_command_is_ignored(self):
+        coord = _make_coordinator_stub(physical_on=True)
+        ae = coord.automation_engine
+        ae._fan_command_time = _FIXED_NOW - timedelta(seconds=5)  # CA just issued a command
+
+        new_state = _make_fake_state("2026-07-12T20:00:00+00:00", {"event_type": "low"})
+        with patch(_PATCH_COORDINATOR_DT_NOW, return_value=_FIXED_NOW):
+            asyncio.run(_dispatch_and_flush(coord, _make_fake_event(new_state)))
+
+        ae.handle_fan_manual_override.assert_not_called()
+        ae.handle_fan_speed_observed.assert_not_called()
+
+    def test_timer_event_within_30s_of_ca_command_is_also_ignored(self):
+        """The guard applies before any burst-combining logic runs -- a timer press
+        (normally an unconditional override, see TestFanRemoteBurstClassification) must be
+        suppressed too when it lands inside the echo window."""
+        coord = _make_coordinator_stub(physical_on=True)
+        ae = coord.automation_engine
+        ae._fan_command_time = _FIXED_NOW - timedelta(seconds=1)
+
+        new_state = _make_fake_state("2026-07-12T20:00:00+00:00", {"event_type": "timer_8h"})
+        with patch(_PATCH_COORDINATOR_DT_NOW, return_value=_FIXED_NOW):
+            asyncio.run(_dispatch_and_flush(coord, _make_fake_event(new_state)))
+
+        ae.handle_fan_manual_override.assert_not_called()
+
+    def test_event_outside_30s_window_still_classifies_normally(self):
+        """Proves the guard doesn't over-suppress -- a remote press well clear of any CA
+        command still drives the shared override entry point as before."""
+        coord = _make_coordinator_stub(physical_on=False)
+        ae = coord.automation_engine
+        ae._fan_command_time = _FIXED_NOW - timedelta(seconds=45)
+
+        new_state = _make_fake_state("2026-07-12T20:00:00+00:00", {"event_type": "high"})
+        with patch(_PATCH_COORDINATOR_DT_NOW, return_value=_FIXED_NOW):
+            asyncio.run(_dispatch_and_flush(coord, _make_fake_event(new_state)))
+
+        ae.handle_fan_manual_override.assert_called_once_with(
+            fan_before="?",
+            fan_after="on",
+            duration_override=None,
+            remote_timer_hours=None,
+            remote_speed="high",
+            is_remote_event=True,
+        )
+
+    def test_no_recent_command_still_classifies_normally(self):
+        """Default state (no CA command ever issued) must behave exactly as before this
+        fix -- the guard is opt-in via a real recent timestamp, not opt-out."""
+        coord = _make_coordinator_stub(physical_on=False)
+        ae = coord.automation_engine
+        assert ae._fan_command_time is None
+
+        new_state = _make_fake_state("2026-07-12T20:00:00+00:00", {"event_type": "timer_2h"})
+        asyncio.run(_dispatch_and_flush(coord, _make_fake_event(new_state)))
+
+        ae.handle_fan_manual_override.assert_called_once()

--- a/tests/test_restart_coalescing_fan_guard.py
+++ b/tests/test_restart_coalescing_fan_guard.py
@@ -183,6 +183,7 @@ def _make_fan_remote_coord(*, startup_coalesce_active: bool) -> object:
 
     ae = MagicMock()
     ae.handle_fan_manual_override = MagicMock()
+    ae._fan_command_time = None  # Issue #567: no recent CA command by default (echo guard)
     coord.automation_engine = ae
 
     coord._startup_coalesce_active = startup_coalesce_active
@@ -204,6 +205,10 @@ def _make_fan_remote_coord(*, startup_coalesce_active: bool) -> object:
     coord._arm_fan_remote_burst = types.MethodType(ClimateAdvisorCoordinator._arm_fan_remote_burst, coord)
     coord._cancel_fan_remote_burst = types.MethodType(ClimateAdvisorCoordinator._cancel_fan_remote_burst, coord)
     coord._flush_fan_remote_burst = types.MethodType(ClimateAdvisorCoordinator._flush_fan_remote_burst, coord)
+    # Issue #567: bind the REAL echo guard so it reads automation_engine._fan_command_time
+    # exactly as production does, instead of a MagicMock auto-attr (truthy, would swallow
+    # every dispatch in this class).
+    coord._is_recent_fan_command = types.MethodType(ClimateAdvisorCoordinator._is_recent_fan_command, coord)
     return coord
 
 


### PR DESCRIPTION
## Summary

- CA's own fan commands could be heard back on the QuietCool remote's RF receive channel and misread as a physical remote press — `_async_fan_remote_changed()`/`_flush_fan_remote_burst()` (added in #486/#519) never picked up the existing `_is_recent_fan_command()` echo guard the sibling physical-fan-entity handler has used since Fix #239. Confirmed live from log evidence: a `nat_vent_cycling_on` automation command was followed 1.7s later by a burst-classified "manual override" with a 3-hour grace period and zero real user action.
- Also fixes a second, independent bug the same investigation surfaced: `_render_fan_cancel()` unconditionally labeled every `fan_cancel` event "user turned off", including CA's own drift-reconciliation self-correction (`trigger=physical_drift_correction`) — now branches on the `trigger` field each emit site already supplies.
- Cross-references both guarded/unguarded fan-listener call sites at `_is_recent_fan_command()`'s definition and the existing Issue #417 sibling comment, so a future new fan-state listener doesn't repeat this same missed-guard defect a third time.

## Test plan

- [x] `TestFanRemoteEchoGuard` (4 new cases in `tests/test_fan_remote.py`) — revert-tested: fail without the fix, pass with it
- [x] `TestFanOwnershipAnnotations` additions (4 new cases in `tests/test_activity_renderers.py`) — revert-tested: fail without the fix, pass with it
- [x] Fixed a latent MagicMock-truthiness gap this change exposed in `test_restart_coalescing_fan_guard.py`'s coordinator stub
- [x] Full suite: `pytest tests/ -W error::pytest.PytestUnraisableExceptionWarning -W error::RuntimeWarning` — 3728 passed
- [x] `ruff check` / `ruff format` clean
- [x] `python tools/validate.py` — all checks passed
- [x] Version bump (0.5.53 → 0.5.54), RELEASE_NOTES, KNOWN_FIXES[567], CHANGELOG.md, `docs/fan-remote-spec.md` updated