### PR TITLE
Feat #573: defer options-flow reload to explicit Save / Save and Reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.5.57] — 2026-08-05
+
+- Feat #573: editing several AI/comfort/schedule settings sections in one visit to Configure used to reload Climate Advisor after every single section's Submit, rebuilding the coordinator and AI client each time. Each section now just saves; the main Options menu has two new entries — "Save" (closes the settings screen; changes are stored and will apply next time Climate Advisor reloads or Home Assistant restarts) and "Save and Reload" (closes the screen and applies everything you just changed in one reload, right away).
+
 ## [0.5.56] — 2026-08-05
 
 - Fix #572: claude-sonnet-5's first request after being selected could silently hang for up to 90 seconds with no visible output at all before failing — a known model quirk that #565/#568/#569 tried to work around by learning it from a live failure and remembering that lesson, but a genuine Home Assistant restart could silently erase the lesson, so the failure kept coming back. Climate Advisor now ships pre-verified, correct settings for every supported Claude model instead of learning them from a failure — so a supported model's very first request already works correctly, no failed attempt required.

--- a/custom_components/climate_advisor/config_flow.py
+++ b/custom_components/climate_advisor/config_flow.py
@@ -124,7 +124,9 @@ INDOOR_SOURCE_OPTIONS = [
     selector.SelectOptionDict(value=TEMP_SOURCE_INPUT_NUMBER, label="Input helper (input_number)"),
 ]
 
-# Menu options for the options flow (Issue #50)
+# Menu options for the options flow (Issue #50). "save"/"save_reload" (Issue #573)
+# are the terminal actions — every other entry is a settings section whose Submit
+# only writes the config entry, no reload.
 OPTIONS_MENU_OPTIONS = [
     "core",
     "setpoints",
@@ -137,6 +139,8 @@ OPTIONS_MENU_OPTIONS = [
     "classification_thresholds",
     "ai_settings",
     "github_settings",
+    "save",
+    "save_reload",
 ]
 
 TEMP_UNIT_OPTIONS = [
@@ -611,13 +615,16 @@ class ClimateAdvisorOptionsFlow(config_entries.OptionsFlow):
         self._updates.update(user_input)
 
     async def _commit_section(self, user_input: dict[str, Any], clearable_keys: tuple[str, ...] = ()) -> None:
-        """Persist one section's submitted values immediately and reload (Issue #557).
+        """Persist one section's submitted values immediately — write only, no reload (Issue #573).
 
-        Previously, section steps only staged values into ``self._updates`` and
-        a separate "Save & Close" menu step was the only thing that ever wrote
-        to the config entry — so re-opening a section before hitting Save showed
-        stale data. Submit now commits directly: every section step's success
-        branch calls this instead of staging, so "Submit" always means "saved."
+        Previously (Issue #557), Submit both wrote the config entry AND
+        immediately reloaded the coordinator, so editing several sections in one
+        settings session tore down and rebuilt the coordinator/AI client once
+        per section. Submit now writes only — ``hass.config_entries.async_update_entry()``
+        makes the change visible immediately if a section is reopened before
+        closing the flow (still solving the original #557 staleness problem),
+        but the running coordinator keeps using the old config until the user
+        explicitly reloads via the "Save and Reload" menu option.
         """
         if clearable_keys:
             self._apply_step_input(user_input, clearable_keys)
@@ -629,8 +636,7 @@ class ClimateAdvisorOptionsFlow(config_entries.OptionsFlow):
             data.pop(key, None)
 
         self.hass.config_entries.async_update_entry(self.config_entry, data=data)
-        await self.hass.config_entries.async_reload(self.config_entry.entry_id)
-        _LOGGER.info("Options section saved — reload triggered (cleared=%d)", len(self._removed))
+        _LOGGER.info("Options section saved (cleared=%d) — reload not yet applied", len(self._removed))
 
         # Everything just flushed to config_entry.data; reset scratch state so
         # the next section's commit starts clean.
@@ -645,6 +651,23 @@ class ClimateAdvisorOptionsFlow(config_entries.OptionsFlow):
             step_id="init",
             menu_options=OPTIONS_MENU_OPTIONS,
         )
+
+    async def async_step_save(self, user_input: dict[str, Any] | None = None) -> config_entries.ConfigFlowResult:
+        """Close the options flow without reloading (Issue #573).
+
+        Every section already wrote its own fields on Submit — this just ends
+        the flow cleanly. The running coordinator keeps using its current
+        (pre-this-session) config until "Save and Reload" is used instead, or
+        the entry is reloaded/HA is restarted some other way.
+        """
+        _LOGGER.info("Options flow closed via Save — no reload")
+        return self.async_create_entry(title="", data={})
+
+    async def async_step_save_reload(self, user_input: dict[str, Any] | None = None) -> config_entries.ConfigFlowResult:
+        """Close the options flow and reload once, applying every section edited this session."""
+        await self.hass.config_entries.async_reload(self.config_entry.entry_id)
+        _LOGGER.info("Options flow closed via Save and Reload — reload triggered")
+        return self.async_create_entry(title="", data={})
 
     # ---- Core Settings ----
 

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,18 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.56"
+VERSION = "0.5.57"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.57": [
+        "Feat #573: editing several AI/comfort/schedule settings sections in one visit"
+        " to Configure used to reload Climate Advisor after every single section's"
+        " Submit, rebuilding the coordinator and AI client each time. Each section now"
+        ' just saves; the main Options menu has two new entries — "Save" (closes the'
+        " settings screen; changes are stored and will apply next time Climate Advisor"
+        ' reloads or Home Assistant restarts) and "Save and Reload" (closes the screen'
+        " and applies everything you just changed in one reload, right away).",
+    ],
     "0.5.56": [
         "Fix #572: claude-sonnet-5's first request after being selected could silently"
         " hang for up to 90 seconds with no visible output at all before failing — a"
@@ -1497,6 +1506,38 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    573: {
+        "version_fixed": "0.5.57",
+        "title": (
+            "The options-flow menu-based navigation added in Issue #50, and the"
+            " immediate-persist-on-Submit behavior added in Issue #557, together meant"
+            " every single section's Submit both wrote the config entry AND immediately"
+            " called hass.config_entries.async_reload() — so a settings session touching"
+            " several sections (e.g. Core Settings then AI Settings then Schedule) tore"
+            " down and rebuilt the coordinator/AI client once per section instead of"
+            " once per session. Changed by explicit user request during the Issue #572"
+            " investigation, once it became clear the same reload was involved in that"
+            " AI capability-persistence chain of bugs."
+        ),
+        "scope_covered": (
+            "config_flow.py: _commit_section() no longer calls async_reload() — it only"
+            " calls hass.config_entries.async_update_entry(), same as before, so"
+            " re-opening a section within the same options-flow session still shows the"
+            " just-saved value (the original Issue #557 fix this preserves). Two new"
+            " terminal steps in OPTIONS_MENU_OPTIONS: async_step_save() closes the flow"
+            " with no reload (every section already wrote its own fields); async_step_"
+            " save_reload() closes the flow and reloads the entry exactly once, applying"
+            " every section edited during the session in a single coordinator rebuild."
+            " This is a config-entry reload only (config_entries.async_reload(), the same"
+            " mechanism Submit already used) — not a homeassistant.restart service call,"
+            " which would be an out-of-scope HA Boundary Rule violation; that alternative"
+            " was explicitly considered and rejected during design. strings.json and"
+            " translations/en.json both updated with the new menu labels. Test coverage:"
+            " tests/test_config_flow.py (TestOptionsFlowMenu — section Submit no longer"
+            " reloads, Save closes without reloading, Save and Reload reloads exactly"
+            " once and reflects all pending section edits)."
+        ),
+    },
     572: {
         "version_fixed": "0.5.56",
         "title": (

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.56"
+  "version": "0.5.57"
 }

--- a/custom_components/climate_advisor/strings.json
+++ b/custom_components/climate_advisor/strings.json
@@ -146,7 +146,9 @@
           "advanced": "Learning & Behavior",
           "classification_thresholds": "Day-Type Thresholds",
           "ai_settings": "AI Settings (Claude)",
-          "github_settings": "GitHub Integration"
+          "github_settings": "GitHub Integration",
+          "save": "Save",
+          "save_reload": "Save and Reload"
         }
       },
       "core": {

--- a/custom_components/climate_advisor/translations/en.json
+++ b/custom_components/climate_advisor/translations/en.json
@@ -150,7 +150,9 @@
           "advanced": "Learning & Behavior",
           "classification_thresholds": "Day-Type Thresholds",
           "ai_settings": "AI Settings (Claude)",
-          "github_settings": "GitHub Integration"
+          "github_settings": "GitHub Integration",
+          "save": "Save",
+          "save_reload": "Save and Reload"
         }
       },
       "core": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1859,6 +1859,8 @@ class TestOptionsFlowMenu:
             "classification_thresholds",
             "ai_settings",
             "github_settings",
+            "save",
+            "save_reload",
         ]
         assert expected == OPTIONS_MENU_OPTIONS
 
@@ -1868,20 +1870,21 @@ class TestOptionsFlowMenu:
 
         assert "notifications" in OPTIONS_MENU_OPTIONS
 
-    def test_menu_has_no_separate_save_step(self):
-        """Issue #557 — there is no separate "Save & Close" menu item or step.
+    def test_menu_has_save_and_save_reload_steps(self):
+        """Issue #573 — Save and Save and Reload are real terminal menu steps.
 
-        Each section persists immediately on submit; a distinct save step
-        re-introduces the stage-then-save design whose stale-value bug this
-        issue fixed.
+        Section Submit only writes now (no reload); these two are the only
+        ways to close the options flow.
         """
         from custom_components.climate_advisor.config_flow import (
             OPTIONS_MENU_OPTIONS,
             ClimateAdvisorOptionsFlow,
         )
 
-        assert "save" not in OPTIONS_MENU_OPTIONS
-        assert not hasattr(ClimateAdvisorOptionsFlow, "async_step_save")
+        assert "save" in OPTIONS_MENU_OPTIONS
+        assert "save_reload" in OPTIONS_MENU_OPTIONS
+        assert hasattr(ClimateAdvisorOptionsFlow, "async_step_save")
+        assert hasattr(ClimateAdvisorOptionsFlow, "async_step_save_reload")
 
     def test_section_commit_merges_updates(self):
         """A single section's commit merges into entry data and preserves untouched fields."""
@@ -1894,18 +1897,42 @@ class TestOptionsFlowMenu:
         # Untouched fields preserved
         assert data["weather_entity"] == "weather.forecast_home"
 
-    def test_section_submit_persists_without_separate_save(self):
-        """Issue #557 regression guard: submitting ONE section must itself persist and
-        reload — re-opening that section must not require a separate save step to see
-        the new value, since config_entry.data is what forms read their defaults from.
-        """
+    def test_section_submit_persists_but_does_not_reload(self):
+        """Issue #573: submitting a section writes config_entry.data immediately (so
+        re-opening that section shows the new value — the original #557 fix this
+        preserves) but must NOT reload the coordinator. Reload is deferred to an
+        explicit "Save and Reload" menu action."""
         flow, captured = _make_options_flow(dict(FULL_CONFIG))
 
         asyncio.run(flow.async_step_advanced({"learning_enabled": False, "aggressive_savings": True}))
 
-        assert "data" in captured, "async_update_entry must be called on section submit, not deferred"
+        assert "data" in captured, "async_update_entry must be called on section submit"
         assert flow.config_entry.data["learning_enabled"] is False
+        flow.hass.config_entries.async_reload.assert_not_called()
+
+    def test_save_closes_flow_without_reload(self):
+        """ "Save" ends the options flow without reloading — every section already
+        wrote its own fields on Submit."""
+        flow, _ = _make_options_flow(dict(FULL_CONFIG))
+
+        result = asyncio.run(flow.async_step_save())
+
+        flow.hass.config_entries.async_reload.assert_not_called()
+        assert result["type"] == "create_entry"
+
+    def test_save_reload_closes_flow_and_reloads_once(self):
+        """ "Save and Reload" ends the flow and reloads the entry exactly once,
+        applying every section edited during the session."""
+        flow, captured = _make_options_flow(dict(FULL_CONFIG))
+
+        asyncio.run(flow.async_step_advanced({"learning_enabled": False, "aggressive_savings": True}))
+        asyncio.run(flow.async_step_notifications({"push_briefing": False}))
+        result = asyncio.run(flow.async_step_save_reload())
+
+        assert flow.config_entry.data["learning_enabled"] is False
+        assert flow.config_entry.data["push_briefing"] is False
         flow.hass.config_entries.async_reload.assert_called_once_with(flow.config_entry.entry_id)
+        assert result["type"] == "create_entry"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Today, every options-flow section's Submit both writes the config entry AND immediately calls `hass.config_entries.async_reload()` (Issue #557) — so editing several sections in one settings session tears down and rebuilds the coordinator/AI client once per section, not once per session.
- Section Submit now writes only (`async_update_entry`, no reload). Reopening a section still shows the just-saved values, preserving the original #557 fix (the whole reason Submit started persisting immediately). The running coordinator keeps using the old config until reload is explicitly requested.
- The top-level "Climate Advisor Options" menu gets two more entries:
  - **Save** — closes the flow, no reload (everything was already written per-section).
  - **Save and Reload** — closes the flow and calls `async_reload()` once, applying every section edited in the session in a single reload.
- This is a config-entry reload only — the exact same mechanism Submit already used today (`config_entries.async_reload()`), not a `homeassistant.restart` service call, which was explicitly considered and rejected as an out-of-scope HA Boundary Rule violation per this project's CLAUDE.md.

## Test plan

- [x] `tests/test_config_flow.py::TestOptionsFlowMenu` updated/added — section Submit no longer reloads, Save closes without reloading, Save and Reload reloads exactly once and reflects all pending section edits — 139/139 pass
- [x] Full suite — 3730/3730 pass
- [x] `ruff check` / `ruff format` clean
- [x] `tools/validate.py` clean
- [x] `strings.json` / `translations/en.json` kept in sync
- [x] `test_version_sync.py` — version bumped to 0.5.56 across `const.py`/`manifest.json`