### PR TITLE
Feat #580: Activity Record defaults to 12h window, newest-first order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.5.60] — 2026-08-05
+
+- Feat #580: the dashboard's Activity Record report now defaults to the "Last 12 hours" time window instead of 24, and lists events newest-first (most recent at the top, oldest at the bottom) instead of oldest-first — so the events you actually care about no longer require scrolling past a full day of history to find. The AI Investigative Analysis report type is unaffected and keeps its own separate time-window defaults.
+
 ## [0.5.59] — 2026-08-05
 
 - Fix #578: several AI Investigative Analysis report-quality fixes from user feedback — the "Submit GitHub Issue" button now titles the issue "AI Investigative Analysis - <date>" instead of grabbing the first sentence of the report as the title; target_temp_low/high reading "unknown" while the HVAC is legitimately off (e.g. running whole-house-fan/nat-vent only) is now labeled as expected instead of flagged as a data-quality issue; the weather bias cap is now included in the report's context so the AI can actually check against it; "Manual Overrides Today" now shows a separate fan override count alongside the setpoint override count so the two no longer look contradictory; and "System Errors/Warnings" now reflects real captured WARNING/ERROR log records instead of a name-matching quirk that almost never caught anything. The AI Activity Report feature (separate from AI Investigative Analysis) has been retired entirely — it was superseded by the deterministic, non-AI Activity Record and had not written new data since the #563 skill merge. The Investigative Analysis report's default time window is now "Last 1 day" instead of 7 days, and new installs now default to Sonnet 5 at low reasoning effort instead of an outdated model at medium effort.

--- a/custom_components/climate_advisor/ai_skills_context.py
+++ b/custom_components/climate_advisor/ai_skills_context.py
@@ -2297,6 +2297,7 @@ def build_event_timeline_table(
     config: dict[str, Any],
     hours: float,
     now: datetime.datetime,
+    newest_first: bool = False,
 ) -> str:
     """Build a deterministic markdown timeline table from the event log.
 
@@ -2306,6 +2307,10 @@ def build_event_timeline_table(
     Consecutive same-type events (excluding types in _NO_DEDUP) are collapsed
     into a single row with a xN count and time range.  The Settings cell of the
     collapsed row is taken from the LAST event in the run (most recent setpoint wins).
+
+    Rows are built in chronological order internally (dedup depends on forward
+    iteration). When `newest_first` is True, the final row order is reversed for
+    display — most recent event first, oldest last.
     """
     unit: str = config.get("temp_unit", "fahrenheit")
     if now.tzinfo is None:
@@ -2462,7 +2467,8 @@ def build_event_timeline_table(
     # ---- format as markdown ----
     header = "| Time | Event | Settings | Source | Indoor | Outdoor |"
     sep = "|---|---|---|---|---|---|"
-    row_lines = [f"| {t} | {ev} | {st} | {src} | {ind} | {out} |" for t, ev, st, src, ind, out in rows]
+    ordered_rows = list(reversed(rows)) if newest_first else rows
+    row_lines = [f"| {t} | {ev} | {st} | {src} | {ind} | {out} |" for t, ev, st, src, ind, out in ordered_rows]
     table = "\n".join([header, sep, *row_lines])
 
     return _maybe_prepend_whf_warning(table, config)

--- a/custom_components/climate_advisor/api.py
+++ b/custom_components/climate_advisor/api.py
@@ -729,9 +729,9 @@ class ClimateAdvisorActivityRecordView(HomeAssistantView):
             return self.json({"error": "Climate Advisor not loaded"}, status_code=503)
 
         try:
-            hours = float(request.query.get("hours", 24))
+            hours = float(request.query.get("hours", 12))
         except (TypeError, ValueError):
-            hours = 24.0
+            hours = 12.0
         hours = max(1.0, min(hours, 168.0))
 
         from homeassistant.util import dt as dt_util
@@ -741,6 +741,7 @@ class ClimateAdvisorActivityRecordView(HomeAssistantView):
             coordinator.config or {},
             hours,
             dt_util.now(),
+            newest_first=True,
         )
         return self.json(
             {

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,17 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.59"
+VERSION = "0.5.60"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.60": [
+        "Feat #580: the dashboard's Activity Record report now defaults to the"
+        ' "Last 12 hours" time window instead of 24, and lists events newest-first'
+        " (most recent at the top, oldest at the bottom) instead of oldest-first —"
+        " so the events you actually care about no longer require scrolling past a"
+        " full day of history to find. The AI Investigative Analysis report type is"
+        " unaffected and keeps its own separate time-window defaults.",
+    ],
     "0.5.59": [
         "Fix #578: several AI Investigative Analysis report-quality fixes from user"
         ' feedback — the "Submit GitHub Issue" button now titles the issue'
@@ -1532,6 +1540,30 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    580: {
+        "version_fixed": "0.5.60",
+        "title": (
+            "Dashboard Activity Record report defaulted to a 24-hour window and"
+            " rendered events oldest-first (ascending), putting the most recent"
+            " activity at the bottom of a potentially long table."
+        ),
+        "scope_covered": (
+            "api.py: ClimateAdvisorActivityRecordView.get() default `hours` query"
+            " param changed from 24 to 12, and now calls build_event_timeline_table()"
+            " with newest_first=True. ai_skills_context.py: build_event_timeline_table()"
+            " gained an opt-in `newest_first` parameter (default False) that reverses"
+            " the already-deduplicated row list immediately before markdown rendering —"
+            " the dedup/collapse loop itself still iterates forward-chronologically,"
+            " since that's what the run-collapsing logic depends on. The AI"
+            " investigation context caller (build_activity_timeline_context()) does"
+            " not pass newest_first, so LLM-facing context keeps chronological order."
+            " frontend/index.html: the Activity Record time-window dropdown (both the"
+            " static markup and the updateReportTypeUI() rebuild) now defaults to"
+            ' "Last 12 hours", and the JS fallback in _runActivityRecord() changed from'
+            " `|| 24` to `|| 12`. The separate AI Investigative Analysis report type's"
+            " dropdown and defaults are untouched."
+        ),
+    },
     578: {
         "version_fixed": "0.5.59",
         "title": (

--- a/custom_components/climate_advisor/frontend/index.html
+++ b/custom_components/climate_advisor/frontend/index.html
@@ -671,8 +671,8 @@
       <label style="font-size:0.85rem;color:var(--text-secondary);">Time window:</label>
       <select id="report-time-window" style="padding:4px 8px;border-radius:4px;border:1px solid var(--border);background:var(--card-bg);color:var(--text);">
         <option value="6">Last 6 hours</option>
-        <option value="12">Last 12 hours</option>
-        <option value="24" selected>Last 24 hours</option>
+        <option value="12" selected>Last 12 hours</option>
+        <option value="24">Last 24 hours</option>
         <option value="48">Last 48 hours</option>
         <option value="168">Last 7 days</option>
       </select>
@@ -2571,8 +2571,8 @@
     const btn = document.getElementById('run-report-btn');
     if (type === 'activity_record') {
       twSelect.innerHTML = '<option value="6">Last 6 hours</option>'
-        + '<option value="12">Last 12 hours</option>'
-        + '<option value="24" selected>Last 24 hours</option>'
+        + '<option value="12" selected>Last 12 hours</option>'
+        + '<option value="24">Last 24 hours</option>'
         + '<option value="48">Last 48 hours</option>'
         + '<option value="168">Last 7 days</option>';
       focusControls.style.display = 'none';
@@ -2604,7 +2604,7 @@
   // ---- Activity Record (deterministic, no AI) ----
 
   async function _runActivityRecord() {
-    const hours = parseInt(document.getElementById('report-time-window').value, 10) || 24;
+    const hours = parseInt(document.getElementById('report-time-window').value, 10) || 12;
     const btn = document.getElementById('run-report-btn');
     const loading = document.getElementById('report-loading');
     const status = document.getElementById('report-status');

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.59"
+  "version": "0.5.60"
 }

--- a/tests/test_activity_renderers.py
+++ b/tests/test_activity_renderers.py
@@ -42,7 +42,7 @@ def _make_event(
     return {"time": ts.isoformat(), "type": event_type, **payload}
 
 
-def _build_table(events: list[dict], hours: float = 24.0, unit: str = "fahrenheit") -> str:
+def _build_table(events: list[dict], hours: float = 24.0, unit: str = "fahrenheit", newest_first: bool = False) -> str:
     """Call build_event_timeline_table with a fixed now and return the result."""
     from custom_components.climate_advisor.ai_skills_context import (
         build_event_timeline_table,
@@ -55,6 +55,7 @@ def _build_table(events: list[dict], hours: float = 24.0, unit: str = "fahrenhei
             config=config,
             hours=hours,
             now=_REAL_NOW,
+            newest_first=newest_first,
         )
 
 
@@ -1131,3 +1132,44 @@ class TestCeilingGuardFiredRenderer:
         )
         assert "mode:" not in st
         assert "78" in st
+
+
+# ---------------------------------------------------------------------------
+# TestNewestFirstOrdering (Activity Record newest-first display order)
+# ---------------------------------------------------------------------------
+
+
+class TestNewestFirstOrdering:
+    """build_event_timeline_table(newest_first=...) controls display row order.
+
+    The Activity Record endpoint (api.py) requests newest_first=True so the most
+    recent event renders at the top. The AI investigation context builder keeps
+    the default (chronological / oldest-first) so the LLM sees cause-before-effect.
+    """
+
+    def _data_rows(self, table: str) -> list[str]:
+        lines = table.splitlines()
+        return lines[2:]  # skip header + separator
+
+    def test_default_is_chronological_oldest_first(self):
+        events = [
+            _make_event("fan_activated", hours_ago=3.0, trigger="natural_vent"),
+            _make_event("sensor_opened", hours_ago=1.0),
+        ]
+        rows = self._data_rows(_build_table(events))
+        # First row is the earlier (3h ago) event, last row is the later (1h ago) event.
+        assert rows[0].split("|")[1].strip() < rows[-1].split("|")[1].strip()
+
+    def test_newest_first_reverses_row_order(self):
+        events = [
+            _make_event("fan_activated", hours_ago=3.0, trigger="natural_vent"),
+            _make_event("sensor_opened", hours_ago=1.0),
+        ]
+        chrono_rows = self._data_rows(_build_table(events, newest_first=False))
+        newest_rows = self._data_rows(_build_table(events, newest_first=True))
+        assert newest_rows == list(reversed(chrono_rows))
+        # Most recent event's time cell should now be first.
+        assert newest_rows[0].split("|")[1].strip() > newest_rows[-1].split("|")[1].strip()
+
+    def test_newest_first_empty_log_unaffected(self):
+        assert _build_table([], newest_first=True) == _build_table([], newest_first=False)


### PR DESCRIPTION
## Summary
- Dashboard Activity Record report now defaults to "Last 12 hours" instead of 24h (backend `ClimateAdvisorActivityRecordView` in `api.py`, and the frontend dropdown/JS fallback in `index.html`).
- Events now display newest-first (most recent at top, oldest at bottom) instead of oldest-first. `build_event_timeline_table()` gained an opt-in `newest_first` parameter; the Activity Record endpoint passes `newest_first=True`, while the AI Investigation context builder keeps chronological order (better for the LLM's cause/effect reasoning).
- The separate "AI Investigative Analysis" report type keeps its own independent time-window dropdown and defaults, unchanged.
- Version bumped 0.5.59 -> 0.5.60 with RELEASE_NOTES/KNOWN_FIXES/CHANGELOG entries.

Closes #580

## Test plan
- [x] `pytest tests/test_activity_renderers.py tests/test_whf_command_only.py tests/test_ai_skills_context_activity_timeline.py tests/test_version_sync.py` — 101 passed
- [x] Full suite: `pytest tests/` — 3729 passed
- [x] `ruff check` / `ruff format` clean on all modified files
- [ ] Manual: open dashboard Status tab -> Generate Report -> Activity Record, confirm "Last 12 hours" is selected by default and the most recent event renders at the top