### PR TITLE
Fix #589: fan reconciliation now honors dry_run/automation-enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.5.61] — 2026-08-07
+
+- Fix #589: disabling automation (the "Automation Enabled" switch / observe-only mode) now also stops the whole-house-fan command-only reconciliation path. Previously, on installs where the fan entity only echoes commands (fan_state_feedback=False), this path kept issuing real fan on/off commands every ~30 minutes even with automation disabled — the only automated action that didn't respect the switch. It now honors dry_run like every other automated action.
+
 ## [0.5.60] — 2026-08-05
 
 - Feat #580: the dashboard's Activity Record report now defaults to the "Last 12 hours" time window instead of 24, and lists events newest-first (most recent at the top, oldest at the bottom) instead of oldest-first — so the events you actually care about no longer require scrolling past a full day of history to find. The AI Investigative Analysis report type is unaffected and keeps its own separate time-window defaults.

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,18 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.60"
+VERSION = "0.5.61"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.61": [
+        "Fix #589: disabling automation (the 'Automation Enabled' switch / observe-only"
+        " mode) now also stops the whole-house-fan command-only reconciliation path."
+        " Previously, on installs where the fan entity only echoes commands"
+        " (fan_state_feedback=False), this path kept issuing real fan on/off commands"
+        " every ~30 minutes even with automation disabled — the only automated action"
+        " that didn't respect the switch. It now honors dry_run like every other"
+        " automated action.",
+    ],
     "0.5.60": [
         "Feat #580: the dashboard's Activity Record report now defaults to the"
         ' "Last 12 hours" time window instead of 24, and lists events newest-first'
@@ -1540,6 +1549,30 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    589: {
+        "version_fixed": "0.5.61",
+        "title": (
+            "_async_command_fan_entity() (the whole-house-fan command-only"
+            " reconciliation choke point, coordinator.py) had no dry_run/"
+            "automation_enabled check — the one automated action path that ignored"
+            " the 'Automation Enabled' switch, on installs with"
+            " fan_state_feedback=False."
+        ),
+        "scope_covered": (
+            "coordinator.py: _async_command_fan_entity() now checks"
+            " self._automation_enabled before issuing the turn_on/turn_off service"
+            " call, logging '[DRY RUN] Would command fan entity ...' and returning"
+            " False instead when automation is disabled — matching the convention"
+            " already used by automation.py's other choke points (_set_hvac_mode,"
+            " _set_temperature, _activate_fan/_deactivate_fan, _notify). Changed to"
+            " return bool (True if a real service call was issued); both call sites"
+            " in the command-only reconciliation block (coordinator.py ~2248-2280)"
+            " now only update _last_commanded_fan_state when a command actually"
+            " fired, so the desired state re-asserts correctly once automation is"
+            " re-enabled instead of the bookkeeping believing a command it never"
+            " sent."
+        ),
+    },
     580: {
         "version_fixed": "0.5.60",
         "title": (

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -2262,16 +2262,16 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                         _last_cmd,
                         self.config.get(CONF_FAN_ENTITY, ""),
                     )
-                    await self._async_command_fan_entity(on=True)
-                    self._last_commanded_fan_state = True
+                    if await self._async_command_fan_entity(on=True):
+                        self._last_commanded_fan_state = True
                 elif not _desired_on and _last_cmd is not False and not _grace_on and not _override_on:
                     _LOGGER.info(
                         "Fan command-only assert: desired=off last_commanded=%s → issuing off command (fan_entity=%s)",
                         _last_cmd,
                         self.config.get(CONF_FAN_ENTITY, ""),
                     )
-                    await self._async_command_fan_entity(on=False)
-                    self._last_commanded_fan_state = False
+                    if await self._async_command_fan_entity(on=False):
+                        self._last_commanded_fan_state = False
                 else:
                     _LOGGER.debug(
                         "Fan command-only assert: desired=%s last_commanded=%s — no command needed",
@@ -3844,18 +3844,35 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                     fan_before=str(old_fan_mode), fan_after=str(new_fan_mode)
                 )
 
-    async def _async_command_fan_entity(self, *, on: bool) -> None:
+    async def _async_command_fan_entity(self, *, on: bool) -> bool:
         """Issue a turn_on or turn_off service call to the configured WHF fan entity (Issue #361).
 
         Used by command-only reconciliation; reuses the same domain-split pattern as
         automation.py ``_activate_fan()`` / ``_deactivate_fan()``.
+
+        Issue #589: this is the automation's only action choke point that did not honor
+        ``_automation_enabled``/``dry_run`` — disabling automation left this specific
+        fan-reconciliation path free to keep issuing real hardware commands. Gated here,
+        matching the "[DRY RUN] Would ..." convention used by automation.py's other
+        choke points (``_activate_fan``/``_deactivate_fan``/``_set_hvac_mode``/etc.).
+
+        Returns True if a real service call was issued, False if skipped (no fan entity
+        configured, or automation disabled).
         """
         fan_entity_id = self.config.get(CONF_FAN_ENTITY)
         if not fan_entity_id:
             _LOGGER.debug("_async_command_fan_entity: no fan_entity configured — skipping")
-            return
+            return False
         domain = fan_entity_id.split(".")[0]  # "fan" or "switch"
         service = "turn_on" if on else "turn_off"
+        if not self._automation_enabled:
+            _LOGGER.info(
+                "[DRY RUN] Would command fan entity %s.%s entity_id=%s (automation disabled)",
+                domain,
+                service,
+                fan_entity_id,
+            )
+            return False
         _LOGGER.debug(
             "_async_command_fan_entity: %s.%s entity_id=%s",
             domain,
@@ -3863,6 +3880,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             fan_entity_id,
         )
         await self.hass.services.async_call(domain, service, {"entity_id": fan_entity_id})
+        return True
 
     async def _async_fan_entity_changed(self, event: Event) -> None:
         """Detect manual fan entity state changes (Issue #37)."""

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.60"
+  "version": "0.5.61"
 }

--- a/tests/test_whf_command_only.py
+++ b/tests/test_whf_command_only.py
@@ -16,10 +16,13 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+import logging
 import sys
 import types
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock
+
+COORDINATOR_LOGGER = "custom_components.climate_advisor.coordinator"
 
 if "homeassistant" not in sys.modules:
     from tools.sim_harness.ha_stubs import install_ha_stubs
@@ -98,6 +101,9 @@ def _make_coord_stub(config: dict | None = None) -> MagicMock:
     coord._last_commanded_fan_state = None
     coord._fan_state_entity_unavailable_warned = False
     coord._is_recent_fan_command = MagicMock(return_value=False)
+    # Issue #589: explicit, not a truthy-by-default MagicMock attr — _async_command_fan_entity
+    # reads this directly to gate the dry-run/automation-disabled check.
+    coord._automation_enabled = True
 
     # Bind the real implementation so guards that call self._fan_state_feedback_enabled()
     # get the actual config value rather than a truthy MagicMock.
@@ -344,6 +350,77 @@ class TestCommandOnlyReconcile:
         asyncio.run(_run())
 
         coord.hass.services.async_call.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# TestCommandOnlyReconcileDryRun (Issue #589)
+# ---------------------------------------------------------------------------
+
+
+class TestCommandOnlyReconcileDryRun:
+    """Issue #589: command-only fan reconciliation must honor automation_enabled/dry_run.
+
+    _async_command_fan_entity() was the one action choke point in the automation
+    engine that did not check dry_run — disabling automation left this specific
+    fan-reconciliation path free to keep issuing real hardware commands every
+    ~30-min cycle. These tests confirm the gate added at that choke point.
+    """
+
+    def test_dry_run_skips_turn_on_and_returns_false(self, caplog):
+        coord = _make_coord_stub()
+        coord._automation_enabled = False
+
+        method = _bind("_async_command_fan_entity", coord)
+        with caplog.at_level(logging.INFO, logger=COORDINATOR_LOGGER):
+            result = asyncio.run(method(on=True))
+
+        assert result is False
+        coord.hass.services.async_call.assert_not_awaited()
+        dry_run_msgs = [r.message for r in caplog.records if "[DRY RUN]" in r.message]
+        assert len(dry_run_msgs) == 1
+        assert "Would command fan entity" in dry_run_msgs[0]
+
+    def test_dry_run_skips_turn_off_and_returns_false(self, caplog):
+        coord = _make_coord_stub()
+        coord._automation_enabled = False
+
+        method = _bind("_async_command_fan_entity", coord)
+        with caplog.at_level(logging.INFO, logger=COORDINATOR_LOGGER):
+            result = asyncio.run(method(on=False))
+
+        assert result is False
+        coord.hass.services.async_call.assert_not_awaited()
+
+    def test_normal_mode_issues_command_and_returns_true(self):
+        coord = _make_coord_stub()
+        coord._automation_enabled = True
+
+        method = _bind("_async_command_fan_entity", coord)
+        result = asyncio.run(method(on=True))
+
+        assert result is True
+        coord.hass.services.async_call.assert_awaited_once()
+
+    def test_reconcile_block_does_not_update_last_commanded_when_dry_run(self):
+        """Reconcile block only updates _last_commanded_fan_state when a command was actually issued —
+        so it re-asserts once automation is re-enabled instead of believing a command it never sent."""
+        coord = _make_coord_stub()
+        coord._automation_enabled = False
+        ae = coord.automation_engine
+        ae._fan_active = True
+        ae._grace_active = False
+        ae._fan_override_active = False
+        coord._last_commanded_fan_state = None
+
+        async def _run():
+            method = _bind("_async_command_fan_entity", coord)
+            if await method(on=True):
+                coord._last_commanded_fan_state = True
+
+        asyncio.run(_run())
+
+        coord.hass.services.async_call.assert_not_awaited()
+        assert coord._last_commanded_fan_state is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `_async_command_fan_entity()` (`coordinator.py`) was the one automation action choke point with no `dry_run`/`_automation_enabled` check — on installs with `fan_state_feedback=False`, the whole-house-fan command-only reconciliation path kept issuing real `fan.turn_on`/`turn_off` (or `switch.turn_on`/`turn_off`) commands every ~30-minute cycle even with automation disabled via the "Automation Enabled" switch.
- Gated it to match the convention already used by `automation.py`'s other choke points (`_set_hvac_mode`, `_set_temperature`, `_activate_fan`/`_deactivate_fan`, `_notify`): logs `"[DRY RUN] Would command fan entity ..."` and skips the service call when automation is disabled.
- `_async_command_fan_entity()` now returns `bool` (whether a real command was issued); both call sites in the reconciliation block only update `_last_commanded_fan_state` when a command actually fired, so the desired state re-asserts correctly once automation is re-enabled instead of the bookkeeping believing a command it never sent.
- Version bump 0.5.60 → 0.5.61 with `RELEASE_NOTES`/`KNOWN_FIXES`/`CHANGELOG.md` entries per project convention.

Found during the #584 investigation (tracked as Block 0 — ordered first since it's a live, currently-shipping safety-relevant gap independent of the rest of the #584 roadmap, see #584/#590-#594).

## Test plan

- [x] New `TestCommandOnlyReconcileDryRun` class in `tests/test_whf_command_only.py` — confirms `dry_run` skips both turn-on and turn-off commands, returns `False`, logs `[DRY RUN]`, and confirms normal mode is unaffected (issues the command, returns `True`)
- [x] `tests/test_dry_run.py` + `tests/test_whf_command_only.py` — 37 passed
- [x] Full suite — 3733 passed
- [x] `python -m ruff check`/`format` clean
- [x] `tests/test_version_sync.py` — const.py/manifest.json version agreement confirmed

Closes #589.