### PR TITLE
Feat #592: lifecycle-scoped decision narration (nat-vent/pause/override/grace)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.5.61] — 2026-08-07
+
+- Feat #592: the Activity Record now explains *why* several nat-vent, door/window pause, and grace-recovery decisions happened, not just that they happened — "Classification suppressed" and "Occupancy setback suppressed" rows now name which sensor is open and for how long; nat-vent fan-on/floor-skip/soft-start/ceiling-escalation rows show the actual outdoor/indoor temperatures and thresholds behind the decision instead of only a derived summary number; "Override cleared" (fan-only) and "Override confirmed" rows show the reason/trigger; and a stuck-grace recovery row now names which mode/time was stale. No automation behavior changed — same decisions, more visible reasoning.
+
 ## [0.5.60] — 2026-08-05
 
 - Feat #580: the dashboard's Activity Record report now defaults to the "Last 12 hours" time window instead of 24, and lists events newest-first (most recent at the top, oldest at the bottom) instead of oldest-first — so the events you actually care about no longer require scrolling past a full day of history to find. The AI Investigative Analysis report type is unaffected and keeps its own separate time-window defaults.

--- a/custom_components/climate_advisor/ai_skills_context.py
+++ b/custom_components/climate_advisor/ai_skills_context.py
@@ -1637,18 +1637,25 @@ def _render_setpoint_nudge(p: dict, unit: str) -> tuple[str, str]:
 def _render_override_cleared(p: dict, unit: str) -> tuple[str, str]:
     was_mode = p.get("was_mode", "")
     old_t = p.get("old_setpoint_f")
+    reason = p.get("reason", "")
     label = f"Override cleared (was {was_mode})" if was_mode else "Override cleared"
     settings = ""
     if old_t is not None:
         with contextlib.suppress(TypeError, ValueError):
             settings = f"was {format_temp(float(old_t), unit)} (manual setpoint)"
+    elif reason:
+        settings = f"fan override — {reason}"
     return label, settings
 
 
 def _render_override_confirmed(p: dict, unit: str) -> tuple[str, str]:
     mode = p.get("mode", "")
+    cls_mode = p.get("cls_mode", "")
+    source = p.get("source", "")
     label = f"Override confirmed ({mode} mode)" if mode else "Override confirmed"
-    return label, ""
+    if cls_mode and mode and cls_mode != mode:
+        label = f"{label} -- classification wanted {cls_mode}"
+    return label, f"trigger: {source}" if source else ""
 
 
 def _render_override_self_resolved(p: dict, unit: str) -> tuple[str, str]:
@@ -1702,6 +1709,7 @@ def _render_grace_expired(p: dict, unit: str) -> tuple[str, str]:
 
 def _render_nat_vent_fan_on(p: dict, unit: str) -> tuple[str, str]:
     indoor = p.get("indoor_temp")
+    outdoor = p.get("outdoor_temp")
     on_thr = p.get("on_threshold")
     fan_device = p.get("fan_device", "fan")
     label = "Nat-vent fan on (cycling)"
@@ -1710,7 +1718,11 @@ def _render_nat_vent_fan_on(p: dict, unit: str) -> tuple[str, str]:
             label = (
                 f"Nat-vent fan on -- indoor {format_temp(float(indoor), unit)} >= {format_temp(float(on_thr), unit)}"
             )
-    return label, f"{fan_device}: auto->on"
+    settings = f"{fan_device}: auto->on"
+    if outdoor is not None:
+        with contextlib.suppress(TypeError, ValueError):
+            settings = f"{settings}, outdoor {format_temp(float(outdoor), unit)}"
+    return label, settings
 
 
 def _render_nat_vent_fan_off(p: dict, unit: str) -> tuple[str, str]:
@@ -1895,6 +1907,15 @@ def _render_nat_vent_predicted_floor_exit(p: dict, unit: str) -> tuple[str, str]
         with contextlib.suppress(TypeError, ValueError):
             label = f"Nat-vent proactive exit -- floor in {float(ttf):.2f} hr"
     parts = []
+    indoor = p.get("indoor_temp")
+    heat = p.get("comfort_heat")
+    if indoor is not None and heat is not None:
+        with contextlib.suppress(TypeError, ValueError):
+            parts.append(f"{format_temp(float(indoor), unit)} -> floor {format_temp(float(heat), unit)}")
+    k_passive = p.get("k_passive")
+    if k_passive is not None:
+        with contextlib.suppress(TypeError, ValueError):
+            parts.append(f"k_passive={float(k_passive):.4f}")
     hvac_restored = p.get("hvac_mode_restored", "")
     fan_change = p.get("fan_mode_change", "")
     if hvac_restored and hvac_restored not in ("unknown", ""):
@@ -1914,9 +1935,20 @@ def _render_nat_vent_soft_start_entered(p: dict, unit: str) -> tuple[str, str]:
                 f"Nat-vent soft-start -- outdoor {format_temp(float(outdoor), unit)}"
                 f" <= indoor {format_temp(float(indoor), unit)}, past today's peak"
             )
+    parts = []
     peak = p.get("outdoor_today_peak")
-    detail = f"today's peak: {format_temp(float(peak), unit)}" if peak is not None else ""
-    return label, detail
+    if peak is not None:
+        with contextlib.suppress(TypeError, ValueError):
+            parts.append(f"today's peak: {format_temp(float(peak), unit)}")
+    heat = p.get("comfort_heat")
+    margin = p.get("decline_margin_f")
+    if heat is not None:
+        with contextlib.suppress(TypeError, ValueError):
+            parts.append(f"floor: {format_temp(float(heat), unit)}")
+    if margin is not None:
+        with contextlib.suppress(TypeError, ValueError):
+            parts.append(f"decline margin: {float(margin):.1f}°")
+    return label, ", ".join(parts)
 
 
 def _render_nat_vent_ceiling_escalation(p: dict, unit: str) -> tuple[str, str]:
@@ -1929,7 +1961,20 @@ def _render_nat_vent_ceiling_escalation(p: dict, unit: str) -> tuple[str, str]:
                 f"Nat-vent escalated to AC -- indoor {format_temp(float(indoor), unit)}"
                 f" > ceiling {format_temp(float(cool), unit)}"
             )
-    return label, "mode: off->cool"
+    parts = ["mode: off->cool"]
+    hours = p.get("hours_to_breach")
+    lead = p.get("lead_min")
+    k_cool = p.get("k_active_cool")
+    if hours is not None:
+        with contextlib.suppress(TypeError, ValueError):
+            parts.append(f"breach in {float(hours):.1f}h")
+    if lead is not None:
+        with contextlib.suppress(TypeError, ValueError):
+            parts.append(f"lead={int(lead)}min")
+    if k_cool is not None:
+        with contextlib.suppress(TypeError, ValueError):
+            parts.append(f"k_cool={float(k_cool):.3f}")
+    return label, ", ".join(parts)
 
 
 def _render_nat_vent_ac_assist_armed(p: dict, unit: str) -> tuple[str, str]:
@@ -1978,6 +2023,15 @@ def _render_sensor_opened(p: dict, unit: str) -> tuple[str, str]:
         parts.append(f"mode: {hvac_change}")
     if fan_change:
         parts.append(f"fan: {fan_change}")
+    outdoor = p.get("outdoor_temp")
+    indoor = p.get("indoor_temp")
+    threshold = p.get("threshold")
+    if outdoor is not None and indoor is not None:
+        with contextlib.suppress(TypeError, ValueError):
+            parts.append(f"outdoor {format_temp(float(outdoor), unit)} < indoor {format_temp(float(indoor), unit)}")
+    if threshold is not None:
+        with contextlib.suppress(TypeError, ValueError):
+            parts.append(f"threshold {format_temp(float(threshold), unit)}")
     return label, ", ".join(parts)
 
 
@@ -2014,7 +2068,17 @@ def _render_nat_vent_floor_imminent_skip(p: dict, unit: str) -> tuple[str, str]:
     if ttf is not None:
         with contextlib.suppress(TypeError, ValueError):
             label = f"Nat-vent skipped -- floor in {float(ttf):.2f} hr (thermal model)"
-    return label, ""
+    parts = []
+    indoor = p.get("indoor_temp")
+    heat = p.get("comfort_heat")
+    if indoor is not None and heat is not None:
+        with contextlib.suppress(TypeError, ValueError):
+            parts.append(f"{format_temp(float(indoor), unit)} -> floor {format_temp(float(heat), unit)}")
+    k_passive = p.get("k_passive")
+    if k_passive is not None:
+        with contextlib.suppress(TypeError, ValueError):
+            parts.append(f"k_passive={float(k_passive):.4f}")
+    return label, ", ".join(parts)
 
 
 def _render_bedtime_setback_skipped(p: dict, unit: str) -> tuple[str, str]:
@@ -2096,11 +2160,14 @@ def _render_startup_coalesced(p: dict, unit: str) -> tuple[str, str]:
 
 def _render_stuck_grace_recovered(p: dict, unit: str) -> tuple[str, str]:
     grace_end = p.get("grace_end_time", "")
+    stale_mode = p.get("stale_mode", "")
+    stale_since = p.get("stale_since", "")
+    settings = f"was {stale_mode} since {stale_since}" if stale_mode else ""
     if p.get("reason") == "grace_without_override":
         # Issue #508's watchdog mirror: grace_end_time is typically still in the future here
         # (the timer would have fired correctly on its own) — "expired" would be misleading.
-        return "Stuck grace recovered (no override was active to protect it)", ""
-    return f"Stuck grace recovered (expired {grace_end})", ""
+        return "Stuck grace recovered (no override was active to protect it)", settings
+    return f"Stuck grace recovered (expired {grace_end})", settings
 
 
 def _render_state_contradiction_warning(p: dict, unit: str) -> tuple[str, str]:
@@ -2144,13 +2211,35 @@ def _render_warm_day_comfort_gap(p: dict, unit: str) -> tuple[str, str]:
     return "Warm-day comfort gap -- heating before shutoff", ""
 
 
+def _render_paused_entity_settings(p: dict) -> str:
+    """Shared settings-cell rendering for the door/window pause lifecycle (Issue #592).
+
+    ``paused_entity``/``paused_minutes`` are threaded from the same ``_paused_entity``/
+    ``_paused_since`` state on the engine at every pause-suppression emit site, so the
+    Settings cell shows which sensor and for how long consistently across all of them.
+    """
+    entity = p.get("paused_entity")
+    minutes = p.get("paused_minutes")
+    if not entity:
+        return ""
+    settings = entity
+    if isinstance(minutes, (int, float)):
+        settings = f"{settings} (open {int(minutes)} min)"
+    return settings
+
+
 def _render_classification_suppressed_paused(p: dict, unit: str) -> tuple[str, str]:
-    return "Classification suppressed (windows open)", ""
+    day_type = p.get("day_type", "")
+    hvac_mode = p.get("hvac_mode", "")
+    label = "Classification suppressed — windows open"
+    if day_type or hvac_mode:
+        label = f"{label} (day={day_type}, mode={hvac_mode})"
+    return label, _render_paused_entity_settings(p)
 
 
 def _render_occupancy_setback_suppressed_paused(p: dict, unit: str) -> tuple[str, str]:
     occupancy = p.get("occupancy", "away")
-    return f"Occupancy setback suppressed (windows open, {occupancy})", ""
+    return f"Occupancy setback suppressed (windows open, {occupancy})", _render_paused_entity_settings(p)
 
 
 # Registry: event_type -> renderer

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -523,6 +523,11 @@ class AutomationEngine:
         # #504) must keep running every cycle in the former case, since nothing else will
         # ever re-trigger it otherwise. Only _pause_for_door_window() sets this True.
         self._paused_with_hvac_already_off = False
+        # Issue #592: which entity triggered the current door/window pause, and when it
+        # started — threaded into classification_suppressed_paused so the Activity Record
+        # can say *which* sensor and *how long*, not just that a pause is in effect.
+        self._paused_entity: str | None = None
+        self._paused_since: datetime | None = None
 
         # Issue #392 Fix 3: serialize the six automation decision-pass entry points
         # (apply_classification, handle_door_window_open, handle_all_doors_windows_closed,
@@ -926,7 +931,7 @@ class AutomationEngine:
         # was active (guarded on _manual_override_active); a fan-only override cleared here would
         # otherwise leave zero trace in the Activity Report.
         if had_fan and not had_manual and self._emit_event_callback:
-            self._emit_event_callback("override_cleared", {"was_mode": None, "old_setpoint_f": None})
+            self._emit_event_callback("override_cleared", {"was_mode": None, "old_setpoint_f": None, "reason": reason})
 
         # Force the same reconciliation a natural grace expiry always performs, instead of
         # relying on the next incidental event or the next 30-min classification cycle.
@@ -1498,7 +1503,12 @@ class AutomationEngine:
                 if self._emit_event_callback:
                     self._emit_event_callback(
                         "override_confirmed",
-                        {"mode": current_mode, "confirm_delay_seconds": confirm_seconds},
+                        {
+                            "mode": current_mode,
+                            "confirm_delay_seconds": confirm_seconds,
+                            "cls_mode": cls_mode,
+                            "source": source,
+                        },
                     )
             else:
                 # PATH B: State resolved — transient event, no override
@@ -1769,9 +1779,19 @@ class AutomationEngine:
                 else:
                     _LOGGER.info("apply_classification: thermostat already off — no mode change needed (windows open)")
                 if self._emit_event_callback:
+                    _pause_minutes = (
+                        (dt_util.now() - self._paused_since).total_seconds() / 60.0
+                        if self._paused_since is not None
+                        else None
+                    )
                     self._emit_event_callback(
                         "classification_suppressed_paused",
-                        {"day_type": classification.day_type, "hvac_mode": classification.hvac_mode},
+                        {
+                            "day_type": classification.day_type,
+                            "hvac_mode": classification.hvac_mode,
+                            "paused_entity": self._paused_entity,
+                            "paused_minutes": round(_pause_minutes) if _pause_minutes is not None else None,
+                        },
                     )
                 return
 
@@ -2006,6 +2026,9 @@ class AutomationEngine:
                                             "indoor": _indoor_cg,
                                             "outdoor": _outdoor,
                                             "comfort_cool": _comfort_cool_cg,
+                                            "hours_to_breach": round(_hours_to_breach, 2),
+                                            "lead_min": round(_lead_min),
+                                            "k_active_cool": _k_active_cool,
                                         },
                                     )
                             _cs_cg = self.hass.states.get(self.climate_entity)
@@ -2583,6 +2606,8 @@ class AutomationEngine:
             self._pre_pause_mode = mode
             self._paused_by_door = True
             self._paused_with_hvac_already_off = False
+            self._paused_entity = entity_label
+            self._paused_since = dt_util.now()
             await self._set_hvac_mode("off", reason=f"{reason}, was {mode} mode")
             await self._notify(notify_message, "Climate Advisor", notification_type=notify_type)
             if self._emit_event_callback:
@@ -2594,6 +2619,8 @@ class AutomationEngine:
         if mode == "off":
             self._paused_by_door = True
             self._paused_with_hvac_already_off = True
+            self._paused_entity = entity_label
+            self._paused_since = dt_util.now()
             _LOGGER.info(
                 "Door/window pause (%s): HVAC already off — pause flag set, no mode change needed",
                 entity_label,
@@ -2725,6 +2752,9 @@ class AutomationEngine:
                                             "nat_vent_floor_imminent_skip",
                                             {
                                                 "time_to_floor_hr": round(time_to_floor, 2),
+                                                "indoor_temp": round(indoor, 1),
+                                                "comfort_heat": round(comfort_heat, 1),
+                                                "k_passive": round(k_passive, 4),
                                                 "fan_device": _fan_device_label(self.config),
                                             },
                                         )
@@ -2836,6 +2866,8 @@ class AutomationEngine:
 
             self._paused_by_door = False
             self._paused_with_hvac_already_off = False
+            self._paused_entity = None
+            self._paused_since = None
             if self._pre_pause_mode:
                 await self._set_hvac_mode(
                     self._pre_pause_mode,
@@ -2999,6 +3031,8 @@ class AutomationEngine:
                                 "outdoor": outdoor,
                                 "indoor": _indoor,
                                 "outdoor_today_peak": self._outdoor_temp_today_peak,
+                                "comfort_heat": _comfort_heat,
+                                "decline_margin_f": PEAK_DECLINE_MARGIN_F,
                             },
                         )
                 return
@@ -3169,6 +3203,9 @@ class AutomationEngine:
                                         "nat_vent_predicted_floor_exit",
                                         {
                                             "time_to_floor_hr": round(time_to_floor, 2),
+                                            "indoor_temp": round(_indoor_now, 1),
+                                            "comfort_heat": round(comfort_heat_now, 1),
+                                            "k_passive": round(k_passive, 4),
                                             "fan_mode_change": "on→auto",
                                             "fan_device": _fan_device_label(self.config),
                                             "hvac_mode_restored": (
@@ -3275,6 +3312,8 @@ class AutomationEngine:
                     self._natural_vent_active = True
                     self._paused_by_door = False
                     self._paused_with_hvac_already_off = False
+                    self._paused_entity = None
+                    self._paused_since = None
                     _LOGGER.info(
                         "Natural vent activated: outdoor %.1f°F < indoor %.1f°F − %.1f°F hysteresis,"
                         " outdoor ≤ threshold %.1f°F while paused",
@@ -3305,6 +3344,8 @@ class AutomationEngine:
                     self._nat_vent_soft_start = True
                     self._paused_by_door = False
                     self._paused_with_hvac_already_off = False
+                    self._paused_entity = None
+                    self._paused_since = None
                     _LOGGER.info(
                         "Nat-vent soft-start activated while paused: outdoor %.1f°F <= indoor %.1f°F,"
                         " past today's peak %.1f°F by >= %.1f°F",
@@ -3320,6 +3361,8 @@ class AutomationEngine:
                                 "outdoor": outdoor,
                                 "indoor": indoor,
                                 "outdoor_today_peak": self._outdoor_temp_today_peak,
+                                "comfort_heat": comfort_heat,
+                                "decline_margin_f": PEAK_DECLINE_MARGIN_F,
                             },
                         )
                     await self._apply_nat_vent_hvac_state()
@@ -3426,6 +3469,10 @@ class AutomationEngine:
                             "comfort_heat": _hard_floor,
                             "source": "temp_check",
                             "fan_device": _fan_device_label(self.config),
+                            "fan_mode_change": "on→auto",
+                            "hvac_mode_restored": (
+                                self._current_classification.hvac_mode if self._current_classification else "unknown"
+                            ),
                         },
                     )
                 await self._exit_nat_vent(
@@ -3506,6 +3553,7 @@ class AutomationEngine:
                         "nat_vent_fan_on",
                         {
                             "indoor_temp": current_temp,
+                            "outdoor_temp": outdoor,
                             "on_threshold": on_threshold,
                             "target": nat_vent_target,
                             "fan_device": _fan_device_label(self.config),
@@ -3921,6 +3969,8 @@ class AutomationEngine:
         _LOGGER.info("Manual HVAC override detected during door/window pause")
         self._paused_by_door = False
         self._paused_with_hvac_already_off = False
+        self._paused_entity = None
+        self._paused_since = None
         self._pre_pause_mode = None
         # Start confirmation period — wait before formally accepting the override
         self.start_override_confirmation(
@@ -3945,6 +3995,8 @@ class AutomationEngine:
         _LOGGER.info("User resumed HVAC from door/window pause via dashboard")
         self._paused_by_door = False
         self._paused_with_hvac_already_off = False
+        self._paused_entity = None
+        self._paused_since = None
         self._pre_pause_mode = None
         self._resumed_from_pause = True
 
@@ -4231,7 +4283,16 @@ class AutomationEngine:
                     nat_vent_threshold,
                 )
                 if self._emit_event_callback:
-                    self._emit_event_callback("sensor_opened", {"entity": "re-check", "result": "natural_ventilation"})
+                    self._emit_event_callback(
+                        "sensor_opened",
+                        {
+                            "entity": "re-check",
+                            "result": "natural_ventilation",
+                            "outdoor_temp": outdoor,
+                            "indoor_temp": indoor,
+                            "threshold": nat_vent_threshold,
+                        },
+                    )
                 return
             await self._pause_for_door_window(
                 entity_label="re-check",
@@ -4276,9 +4337,19 @@ class AutomationEngine:
                 "skipping setback band; occupancy recorded, HVAC remains off"
             )
             if self._emit_event_callback:
+                _away_pause_minutes = (
+                    (dt_util.now() - self._paused_since).total_seconds() / 60.0
+                    if self._paused_since is not None
+                    else None
+                )
                 self._emit_event_callback(
                     "occupancy_setback_suppressed_paused",
-                    {"occupancy": "away", "reason": "paused_by_door"},
+                    {
+                        "occupancy": "away",
+                        "reason": "paused_by_door",
+                        "paused_entity": self._paused_entity,
+                        "paused_minutes": round(_away_pause_minutes) if _away_pause_minutes is not None else None,
+                    },
                 )
             return
         if self._manual_override_active:
@@ -4375,9 +4446,19 @@ class AutomationEngine:
                 "skipping setback band; occupancy recorded, HVAC remains off"
             )
             if self._emit_event_callback:
+                _vac_pause_minutes = (
+                    (dt_util.now() - self._paused_since).total_seconds() / 60.0
+                    if self._paused_since is not None
+                    else None
+                )
                 self._emit_event_callback(
                     "occupancy_setback_suppressed_paused",
-                    {"occupancy": "vacation", "reason": "paused_by_door"},
+                    {
+                        "occupancy": "vacation",
+                        "reason": "paused_by_door",
+                        "paused_entity": self._paused_entity,
+                        "paused_minutes": round(_vac_pause_minutes) if _vac_pause_minutes is not None else None,
+                    },
                 )
             return
         if self._manual_override_active:
@@ -4553,7 +4634,11 @@ class AutomationEngine:
         if _gate == ScheduledBandGate.DEFER_NAT_VENT and self._emit_event_callback:
             self._emit_event_callback(
                 "nat_vent_bedtime_continue",
-                {"fan_device": _fan_device_label(self.config)},
+                {
+                    "fan_device": _fan_device_label(self.config),
+                    "outdoor_temp": self._last_outdoor_temp,
+                    "sleep_cool": _sleep_band.ceiling,
+                },
             )
         if self._today_record is not None:
             # Issue #402: key off _sleep_band.active (the edge _apply_comfort_band() actually

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,20 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.60"
+VERSION = "0.5.61"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.61": [
+        "Feat #592: the Activity Record now explains *why* several nat-vent, door/window"
+        " pause, and grace-recovery decisions happened, not just that they happened —"
+        ' "Classification suppressed" and "Occupancy setback suppressed" rows now name'
+        " which sensor is open and for how long; nat-vent fan-on/floor-skip/soft-start/"
+        " ceiling-escalation rows show the actual outdoor/indoor temperatures and"
+        " thresholds behind the decision instead of only a derived summary number;"
+        ' "Override cleared" (fan-only) and "Override confirmed" rows show the reason/'
+        " trigger; and a stuck-grace recovery row now names which mode/time was stale."
+        " No automation behavior changed — same decisions, more visible reasoning.",
+    ],
     "0.5.60": [
         "Feat #580: the dashboard's Activity Record report now defaults to the"
         ' "Last 12 hours" time window instead of 24, and lists events newest-first'
@@ -1540,6 +1551,40 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    592: {
+        "version_fixed": "0.5.61",
+        "title": (
+            "Activity Record payload-completeness sweep for the four lifecycle-scoped"
+            " decision families (nat-vent, door/window pause, override, grace) — many"
+            " emit sites discarded locally-computed inputs (outdoor/indoor temps,"
+            " thresholds, k_passive, pause duration/entity, override reason/trigger) that"
+            " were never threaded into the event payload, so the renderer could only show"
+            " a bare verdict with no visible reasoning behind it."
+        ),
+        "scope_covered": (
+            "automation.py: classification_suppressed_paused and"
+            " occupancy_setback_suppressed_paused now carry paused_entity/paused_minutes"
+            " (new self._paused_entity/self._paused_since state, set in"
+            " _pause_for_door_window() and cleared at every resume site); nat_vent_fan_on"
+            " gained outdoor_temp; nat_vent_predicted_floor_exit/"
+            " nat_vent_floor_imminent_skip gained indoor_temp/comfort_heat/k_passive;"
+            " nat_vent_soft_start_entered gained comfort_heat/decline_margin_f (both call"
+            " sites); nat_vent_ceiling_escalation gained hours_to_breach/lead_min/"
+            " k_active_cool; nat_vent_bedtime_continue gained outdoor_temp/sleep_cool;"
+            " sensor_opened at the _re_pause_for_open_sensor() re-check site gained"
+            " outdoor_temp/indoor_temp/threshold; override_cleared's fan-only variant"
+            " gained reason; override_confirmed gained cls_mode/source;"
+            " nat_vent_comfort_floor_exit's temp_check call site now matches its sibling's"
+            " fan_mode_change/hvac_mode_restored shape. coordinator.py:"
+            " stuck_grace_recovered at the Issue #321 watchdog site gained"
+            " stale_mode/stale_since (captured before clear_manual_override() resets"
+            " them). ai_skills_context.py: renderers for all of the above updated to"
+            " surface the new fields in the Event/Settings cells; added a shared"
+            " _render_paused_entity_settings() helper for the two pause-suppression"
+            " renderers. No decision logic changed — golden suite (74/74) and pending"
+            " suite (4/4) show zero behavior change."
+        ),
+    },
     580: {
         "version_fixed": "0.5.60",
         "title": (

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -1959,8 +1959,17 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                         " override (Issue #321).",
                         _ae._grace_end_time,
                     )
+                    _stale_mode = _ae._manual_override_mode
+                    _stale_since = _ae._manual_override_time
                     _ae.clear_manual_override(reason="stuck_grace_recovery")
-                    self._emit_event("stuck_grace_recovered", {"grace_end_time": _ae._grace_end_time})
+                    self._emit_event(
+                        "stuck_grace_recovered",
+                        {
+                            "grace_end_time": _ae._grace_end_time,
+                            "stale_mode": _stale_mode,
+                            "stale_since": _stale_since,
+                        },
+                    )
 
             self._check_orphaned_grace()
 

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.60"
+  "version": "0.5.61"
 }

--- a/tests/test_activity_renderers.py
+++ b/tests/test_activity_renderers.py
@@ -1173,3 +1173,168 @@ class TestNewestFirstOrdering:
 
     def test_newest_first_empty_log_unaffected(self):
         assert _build_table([], newest_first=True) == _build_table([], newest_first=False)
+
+
+# ---------------------------------------------------------------------------
+# TestLifecycleScopedNarration (Issue #592 — nat-vent/pause/override/grace payload
+# completeness). Confirms the newly-threaded fields actually reach the rendered
+# Event/Settings cells, not just the emit-site payload.
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycleScopedNarration:
+    def test_classification_suppressed_paused_shows_day_hvac_and_pause_info(self):
+        ev, st = _act_mod.EVENT_RENDERERS["classification_suppressed_paused"](
+            {
+                "day_type": "hot",
+                "hvac_mode": "cool",
+                "paused_entity": "binary_sensor.back_door",
+                "paused_minutes": 42,
+            },
+            "fahrenheit",
+        )
+        assert "day=hot" in ev
+        assert "mode=cool" in ev
+        assert "binary_sensor.back_door" in st
+        assert "42" in st
+
+    def test_classification_suppressed_paused_no_pause_info_yields_empty_settings(self):
+        ev, st = _act_mod.EVENT_RENDERERS["classification_suppressed_paused"](
+            {"day_type": "hot", "hvac_mode": "cool", "paused_entity": None, "paused_minutes": None},
+            "fahrenheit",
+        )
+        assert st == ""
+
+    def test_occupancy_setback_suppressed_paused_shows_pause_info(self):
+        ev, st = _act_mod.EVENT_RENDERERS["occupancy_setback_suppressed_paused"](
+            {
+                "occupancy": "away",
+                "reason": "paused_by_door",
+                "paused_entity": "binary_sensor.window",
+                "paused_minutes": 5,
+            },
+            "fahrenheit",
+        )
+        assert "away" in ev
+        assert "binary_sensor.window" in st
+        assert "5" in st
+
+    def test_nat_vent_fan_on_shows_outdoor_temp(self):
+        ev, st = _act_mod.EVENT_RENDERERS["nat_vent_fan_on"](
+            {"indoor_temp": 76.0, "outdoor_temp": 68.0, "on_threshold": 75.0, "fan_device": "whf"},
+            "fahrenheit",
+        )
+        assert "outdoor" in st
+        assert "68" in st
+
+    def test_nat_vent_predicted_floor_exit_shows_raw_inputs(self):
+        ev, st = _act_mod.EVENT_RENDERERS["nat_vent_predicted_floor_exit"](
+            {
+                "time_to_floor_hr": 0.5,
+                "indoor_temp": 68.0,
+                "comfort_heat": 66.0,
+                "k_passive": -0.15,
+                "fan_mode_change": "on->auto",
+                "hvac_mode_restored": "heat",
+            },
+            "fahrenheit",
+        )
+        assert "68" in st
+        assert "66" in st
+        assert "k_passive=-0.1500" in st
+
+    def test_nat_vent_floor_imminent_skip_shows_raw_inputs(self):
+        ev, st = _act_mod.EVENT_RENDERERS["nat_vent_floor_imminent_skip"](
+            {"time_to_floor_hr": 0.3, "indoor_temp": 67.0, "comfort_heat": 66.0, "k_passive": -0.2},
+            "fahrenheit",
+        )
+        assert "67" in st
+        assert "66" in st
+        assert "k_passive=-0.2000" in st
+
+    def test_nat_vent_soft_start_entered_shows_floor_and_margin(self):
+        ev, st = _act_mod.EVENT_RENDERERS["nat_vent_soft_start_entered"](
+            {
+                "outdoor": 75.0,
+                "indoor": 75.0,
+                "outdoor_today_peak": 82.0,
+                "comfort_heat": 68.0,
+                "decline_margin_f": 2.0,
+            },
+            "fahrenheit",
+        )
+        assert "floor" in st
+        assert "68" in st
+        assert "decline margin" in st
+
+    def test_nat_vent_ceiling_escalation_shows_breach_lead_and_k(self):
+        ev, st = _act_mod.EVENT_RENDERERS["nat_vent_ceiling_escalation"](
+            {"indoor": 78.0, "comfort_cool": 76.0, "hours_to_breach": 0.4, "lead_min": 15, "k_active_cool": -0.55},
+            "fahrenheit",
+        )
+        assert "breach in 0.4h" in st
+        assert "lead=15min" in st
+        assert "k_cool=-0.550" in st
+
+    def test_nat_vent_bedtime_continue_shows_outdoor_and_sleep_cool(self):
+        ev, st = _act_mod.EVENT_RENDERERS["nat_vent_bedtime_continue"](
+            {"fan_device": "whf", "outdoor_temp": 70.0, "sleep_cool": 74.0},
+            "fahrenheit",
+        )
+        assert "70" in ev
+        assert "74" in ev
+
+    def test_sensor_opened_re_check_shows_outdoor_indoor_threshold(self):
+        ev, st = _act_mod.EVENT_RENDERERS["sensor_opened"](
+            {
+                "entity": "re-check",
+                "result": "natural_ventilation",
+                "outdoor_temp": 68.0,
+                "indoor_temp": 74.0,
+                "threshold": 77.0,
+            },
+            "fahrenheit",
+        )
+        assert "68" in st
+        assert "74" in st
+        assert "77" in st
+
+    def test_override_cleared_fan_only_shows_reason(self):
+        ev, st = _act_mod.EVENT_RENDERERS["override_cleared"](
+            {"was_mode": None, "old_setpoint_f": None, "reason": "user_cancel"},
+            "fahrenheit",
+        )
+        assert "user_cancel" in st
+
+    def test_override_confirmed_shows_cls_mode_and_source(self):
+        ev, st = _act_mod.EVENT_RENDERERS["override_confirmed"](
+            {"mode": "cool", "confirm_delay_seconds": 300, "cls_mode": "heat", "source": "setpoint"},
+            "fahrenheit",
+        )
+        assert "cool" in ev
+        assert "heat" in ev
+        assert "setpoint" in st
+
+    def test_stuck_grace_recovered_shows_stale_mode_and_time(self):
+        ev, st = _act_mod.EVENT_RENDERERS["stuck_grace_recovered"](
+            {"grace_end_time": "2026-06-17T10:00:00", "stale_mode": "cool", "stale_since": "2026-06-17T08:00:00"},
+            "fahrenheit",
+        )
+        assert "cool" in st
+        assert "2026-06-17T08:00:00" in st
+
+    def test_nat_vent_comfort_floor_exit_temp_check_site_has_full_shape(self):
+        """Both call sites now emit fan_mode_change/hvac_mode_restored (Issue #592)."""
+        ev, st = _act_mod.EVENT_RENDERERS["nat_vent_comfort_floor_exit"](
+            {
+                "indoor_temp": 65.0,
+                "comfort_heat": 66.0,
+                "source": "temp_check",
+                "fan_device": "whf",
+                "fan_mode_change": "on->auto",
+                "hvac_mode_restored": "heat",
+            },
+            "fahrenheit",
+        )
+        assert "mode: off->heat" in st
+        assert "fan: on->auto" in st

--- a/tests/test_door_window.py
+++ b/tests/test_door_window.py
@@ -952,7 +952,12 @@ class TestOccupancyAwayWhilePaused:
 
         suppressed = [e for e in events if e[0] == "occupancy_setback_suppressed_paused"]
         assert len(suppressed) == 1
-        assert suppressed[0][1] == {"occupancy": "away", "reason": "paused_by_door"}
+        assert suppressed[0][1] == {
+            "occupancy": "away",
+            "reason": "paused_by_door",
+            "paused_entity": None,
+            "paused_minutes": None,
+        }
 
 
 class TestOccupancyVacationWhilePaused:
@@ -988,7 +993,12 @@ class TestOccupancyVacationWhilePaused:
 
         suppressed = [e for e in events if e[0] == "occupancy_setback_suppressed_paused"]
         assert len(suppressed) == 1
-        assert suppressed[0][1] == {"occupancy": "vacation", "reason": "paused_by_door"}
+        assert suppressed[0][1] == {
+            "occupancy": "vacation",
+            "reason": "paused_by_door",
+            "paused_entity": None,
+            "paused_minutes": None,
+        }
 
 
 class TestAutomationStatusPausedWithOccupancy:
@@ -1141,7 +1151,7 @@ class TestApplyClassificationPausedGuard:
         # Must have emitted classification_suppressed_paused
         engine._emit_event_callback.assert_called_once_with(
             "classification_suppressed_paused",
-            {"day_type": "hot", "hvac_mode": "cool"},
+            {"day_type": "hot", "hvac_mode": "cool", "paused_entity": None, "paused_minutes": None},
         )
 
         # Must NOT have called _apply_comfort_band
@@ -1160,7 +1170,7 @@ class TestApplyClassificationPausedGuard:
         # Must still emit classification_suppressed_paused
         engine._emit_event_callback.assert_called_once_with(
             "classification_suppressed_paused",
-            {"day_type": "hot", "hvac_mode": "cool"},
+            {"day_type": "hot", "hvac_mode": "cool", "paused_entity": None, "paused_minutes": None},
         )
 
         # Must NOT have called _apply_comfort_band
@@ -1212,7 +1222,7 @@ class TestApplyClassificationPausedGuard:
 
         engine._emit_event_callback.assert_called_once_with(
             "classification_suppressed_paused",
-            {"day_type": "cold", "hvac_mode": "heat"},
+            {"day_type": "cold", "hvac_mode": "heat", "paused_entity": None, "paused_minutes": None},
         )
 
         engine._apply_comfort_band.assert_not_called()


### PR DESCRIPTION
## Summary

Block 3 of #584's roadmap (full investigation/plan there). Threads locally-computed inputs that were being discarded at 12 emit sites across the four lifecycles named in the architecture review (nat-vent, door/window pause, override, grace) — so the Activity Record shows the reasoning behind a decision, not just the verdict. Closes #592.

- `classification_suppressed_paused` / `occupancy_setback_suppressed_paused`: new `self._paused_entity`/`self._paused_since` engine state (set in `_pause_for_door_window()`, cleared at every resume site), threaded as `paused_entity`/`paused_minutes`; renderers stop discarding `day_type`/`hvac_mode` that were already in the payload.
- `nat_vent_fan_on`: `outdoor_temp`.
- `nat_vent_predicted_floor_exit` / `nat_vent_floor_imminent_skip`: raw `indoor_temp`/`comfort_heat`/`k_passive` behind the derived `time_to_floor_hr`.
- `nat_vent_soft_start_entered`: `comfort_heat`/`decline_margin_f` (both call sites).
- `nat_vent_ceiling_escalation`: `hours_to_breach`/`lead_min`/`k_active_cool`.
- `nat_vent_bedtime_continue`: `outdoor_temp`/`sleep_cool` (renderer already expected these keys — was previously always empty).
- `sensor_opened` at the `_re_pause_for_open_sensor()` re-check site: `outdoor_temp`/`indoor_temp`/`threshold`.
- `override_cleared` (fan-only variant): `reason` (was previously an empty payload).
- `override_confirmed`: `cls_mode`/`source`.
- `stuck_grace_recovered` (Issue #321 watchdog site in `coordinator.py`): `stale_mode`/`stale_since`, captured before `clear_manual_override()` resets them.
- `nat_vent_comfort_floor_exit`: standardized both call sites on the richer `fan_mode_change`/`hvac_mode_restored` payload shape.

No decision logic changed — this is payload/narration only.

## Test plan

- [x] `python -m pytest tests/` — 3743 passed
- [x] `python tools/simulate.py` — 74/74 golden scenarios pass, zero behavior change
- [x] `python tools/simulate.py --pending` — 4/4 pass
- [x] `python -m ruff check` / `ruff format` — clean
- [x] New `TestLifecycleScopedNarration` class in `tests/test_activity_renderers.py` covers every renderer fix
- [x] `tests/test_door_window.py` payload assertions updated for the new `paused_entity`/`paused_minutes` fields