### PR TITLE
Fix #600: guard reconcile_fan_on_startup() adopt-on branch against duplicate re-adoption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.5.61] — 2026-08-07
+
+- Fix #600: after an HA restart or grace-period expiry with the whole-house fan already running for natural ventilation, the Activity Record no longer shows the same "Fan activated" adoption logged 2-3 times in the same minute — the fan itself only ever turned on once; only the redundant log/event entries are gone. Also fixes the displayed nat-vent session start time silently jumping forward on each redundant re-confirmation.
+
 ## [0.5.60] — 2026-08-05
 
 - Feat #580: the dashboard's Activity Record report now defaults to the "Last 12 hours" time window instead of 24, and lists events newest-first (most recent at the top, oldest at the bottom) instead of oldest-first — so the events you actually care about no longer require scrolling past a full day of history to find. The AI Investigative Analysis report type is unaffected and keeps its own separate time-window defaults.

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -3822,8 +3822,19 @@ class AutomationEngine:
         if nat_vent_eligible:
             # Adopt the running fan as CA-owned nat-vent
             decision = "adopt-on"
+            # Issue #600: this method has 4 independent callers (ha_restart,
+            # backstop_30min, post_grace_expiry, thermostat_state_change) with no
+            # coordination between sequential (non-overlapping) triggers — the Issue #561
+            # mutex only blocks concurrent re-entry and explicitly lets a second sequential
+            # trigger through ("the caller that lost the race gets another chance on its
+            # own next trigger"). Without this guard, two triggers landing minutes apart
+            # each redundantly re-adopt an already-owned session: duplicate "Fan activated"
+            # Activity Record entries for one real event, and _fan_on_since silently
+            # jumping forward each time, understating the displayed session duration.
+            _already_adopted = self._natural_vent_active
             self._fan_active = True
-            self._fan_on_since = dt_util.now().isoformat()
+            if self._fan_on_since is None:
+                self._fan_on_since = dt_util.now().isoformat()
             self._natural_vent_active = True
             # Start the thermostatic backstop now that CA owns this fan session
             self._start_fan_thermo_backstop()
@@ -3834,6 +3845,13 @@ class AutomationEngine:
                 decision,
                 archetype,
             )
+            if _already_adopted:
+                _LOGGER.debug(
+                    "%s reconcile re-confirmed an already-adopted nat-vent session —"
+                    " skipping duplicate Activity Record entry",
+                    trigger,
+                )
+                return
             # Issue #402 follow-up: this branch previously left zero activity-log trace of
             # the fan being adopted as CA-owned at startup — the fan silently starts being
             # managed with no record of why, unlike the turn-off branch below which does

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,17 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.60"
+VERSION = "0.5.61"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.61": [
+        "Fix #600: after an HA restart or grace-period expiry with the whole-house fan"
+        " already running for natural ventilation, the Activity Record no longer shows"
+        ' the same "Fan activated" adoption logged 2-3 times in the same minute — the'
+        " fan itself only ever turned on once; only the redundant log/event entries are"
+        " gone. Also fixes the displayed nat-vent session start time silently jumping"
+        " forward on each redundant re-confirmation.",
+    ],
     "0.5.60": [
         "Feat #580: the dashboard's Activity Record report now defaults to the"
         ' "Last 12 hours" time window instead of 24, and lists events newest-first'
@@ -1540,6 +1548,28 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    600: {
+        "version_fixed": "0.5.61",
+        "title": (
+            "reconcile_fan_on_startup()'s adopt-on branch had no guard against being"
+            " re-entered by a second sequential trigger (of its 4 independent callers)"
+            " while nat-vent was already CA-owned, producing 2-3 duplicate 'Fan"
+            " activated' Activity Record entries for one real fan-on event, and"
+            " silently resetting the displayed session start time on each redundant"
+            " re-confirmation."
+        ),
+        "scope_covered": (
+            "automation.py: _reconcile_fan_on_startup_locked()'s adopt-on branch"
+            " (~line 3822) now checks self._natural_vent_active before mutating"
+            " flags/recording/emitting — a redundant re-confirmation still refreshes"
+            " _fan_active/_natural_vent_active/the thermo backstop timer, but returns"
+            " before _record_action()/_emit_event_callback('fan_activated', ...)."
+            " _fan_on_since is now only stamped on true first adoption"
+            " (`if self._fan_on_since is None`), not on every re-entry. The sibling"
+            " 'turn-off' branch already had its own cooldown (Issue #446) and was"
+            " not touched."
+        ),
+    },
     580: {
         "version_fixed": "0.5.60",
         "title": (

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.60"
+  "version": "0.5.61"
 }

--- a/tests/test_fan_control.py
+++ b/tests/test_fan_control.py
@@ -2559,6 +2559,81 @@ class TestReconcileFanOnStartupReentrancyGuard:
         assert engine._natural_vent_active is True, "a second, sequential call must still be processed"
 
 
+class TestReconcileFanOnStartupDuplicateAdoptGuard:
+    """Issue #600: reconcile_fan_on_startup() has 4 independent callers (ha_restart,
+    backstop_30min, post_grace_expiry, thermostat_state_change) with no coordination
+    between sequential (non-overlapping) triggers — the Issue #561 mutex only blocks
+    concurrent re-entry, not a second trigger landing minutes later. Without a guard, two
+    triggers landing while nat-vent is already CA-owned each redundantly re-adopt: duplicate
+    "Fan activated" Activity Record entries for one real event, and _fan_on_since silently
+    jumping forward each time.
+    """
+
+    def _engine(self, fan_mode=FAN_MODE_WHOLE_HOUSE):
+        engine = _make_automation_engine({CONF_FAN_MODE: fan_mode})
+        engine._deactivate_fan = AsyncMock()
+        engine._start_fan_thermo_backstop = MagicMock()
+        return engine
+
+    def test_reconfirm_of_already_adopted_session_does_not_reemit(self):
+        """A second adopt-eligible reconcile while nat-vent is already CA-owned must not
+        record another activity-log entry or emit a second fan_activated event."""
+        engine = self._engine()
+        engine._emit_event_callback = MagicMock()
+        engine._record_action = MagicMock()
+
+        asyncio.run(
+            engine.reconcile_fan_on_startup(
+                indoor=75.0, outdoor=65.0, thermostat_fan_running=True, any_sensor_open=True
+            )
+        )
+        assert engine._record_action.call_count == 1
+        assert engine._emit_event_callback.call_count == 1
+
+        # Second, sequential trigger — session is already CA-owned (_natural_vent_active
+        # stays True from the first call, matching the real cross-trigger scenario).
+        asyncio.run(
+            engine.reconcile_fan_on_startup(
+                indoor=75.0, outdoor=65.0, thermostat_fan_running=True, any_sensor_open=True
+            )
+        )
+        assert engine._record_action.call_count == 1, "re-confirmation must not record a second entry"
+        assert engine._emit_event_callback.call_count == 1, "re-confirmation must not emit a second event"
+        assert engine._natural_vent_active is True
+        assert engine._fan_active is True
+
+    def test_reconfirm_of_already_adopted_session_preserves_fan_on_since(self):
+        """_fan_on_since must be stamped once, at true first adoption — a redundant
+        re-confirmation must not overwrite it with a later timestamp (Issue #600)."""
+        engine = self._engine()
+        engine._emit_event_callback = MagicMock()
+
+        with patch(
+            "custom_components.climate_advisor.automation.dt_util.now",
+            return_value=datetime(2026, 8, 7, 20, 12, 0),
+        ):
+            asyncio.run(
+                engine.reconcile_fan_on_startup(
+                    indoor=75.0, outdoor=65.0, thermostat_fan_running=True, any_sensor_open=True
+                )
+            )
+        first_since = engine._fan_on_since
+        assert first_since is not None
+
+        with patch(
+            "custom_components.climate_advisor.automation.dt_util.now",
+            return_value=datetime(2026, 8, 7, 20, 17, 0),
+        ):
+            asyncio.run(
+                engine.reconcile_fan_on_startup(
+                    indoor=75.0, outdoor=65.0, thermostat_fan_running=True, any_sensor_open=True
+                )
+            )
+        assert engine._fan_on_since == first_since, (
+            "a redundant re-confirmation must not jump the displayed session start time forward"
+        )
+
+
 class TestFanThermoBackstopGenerationGuard:
     """Issue #561 defense-in-depth: self._fan_thermo_cancel can only ever hold one live
     cancel handle, so if two backstop timer chains are ever started concurrently, the


### PR DESCRIPTION
## Summary
- `reconcile_fan_on_startup()` has 4 independent callers (`ha_restart`, `backstop_30min`, `post_grace_expiry`, `thermostat_state_change`) with no coordination between sequential triggers -- the Issue #561 mutex only blocks concurrent overlap, not a second trigger landing minutes/seconds later.
- Observed in production (2026-08-07, 20:17): a restart + grace-expiry cascade produced 2 redundant "Fan activated" Activity Record entries plus the 1 real one, for a single physical fan-on event.
- Adds a state-flip guard to the adopt-on branch (`_natural_vent_active` already True → skip record/emit) and only stamps `_fan_on_since` on true first adoption.
- No HVAC/hardware behavior changes -- the adopt-on branch never calls `_activate_fan()`, only sets in-memory flags and narrates. The sibling "turn-off" branch already has its own cooldown (Issue #446) and was not touched.
- Closes #600.

## Test plan
- [x] 2 new regression tests (`TestReconcileFanOnStartupDuplicateAdoptGuard`) covering no-reemit and `_fan_on_since` preservation
- [x] `tests/test_fan_control.py` -- 202 passed
- [x] All 6 test files touching `reconcile_fan_on_startup()` -- 101 passed, no regressions
- [x] Full suite -- 3731 passed
- [x] Golden simulation suite -- 74/74 passed, no decision drift
- [x] Version bump (0.5.60 -> 0.5.61) + RELEASE_NOTES + KNOWN_FIXES + CHANGELOG