### PR TITLE
Feat #604: safe-by-construction callback isolation for a future shadow AutomationEngine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.5.67] — 2026-08-08
+
+- Feat #604: internal refactor only, no user-visible behavior change — makes it safe to eventually build a second, non-acting engine instance for testing automation changes without risk to the live system, by giving it its own isolated set of callbacks instead of ones that could reach into the real thermostat.
+
 ## [0.5.66] — 2026-08-08
 
 - Fix #602: the daily learning record (which gates manual-override detection for setpoint-only changes, HVAC runtime tracking, comfort-violation minutes, occupancy-away minutes, door/window pause counts, and the thermal-learning watchdog) was only ever created once a day by the morning briefing — if the weather integration happened to be unavailable at that one fixed moment, all of that silently stopped working for the rest of the day, with no warning. It now also gets created by the regular classification cycle, which already retries weather forever — the gap shrinks from up to 24 hours to about 30 minutes. Fix #598: a test scenario covering Issue #505's vacation-override-cleared fix was passing by coincidence rather than exercising the real behavior — this fix gives it real coverage.

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -491,6 +491,29 @@ def compute_bedtime_setback(
         return min(raw, floor)
 
 
+@dataclass
+class AutomationEngineCallbacks:
+    """Bundle of the 9 callbacks the coordinator wires onto an AutomationEngine.
+
+    Issue #604 (Block 5, subtask N2): named-bundle form of the callback wiring the
+    coordinator has always done post-construction, so a future second ("shadow")
+    engine instance can be given its own dedicated set of callables instead of
+    reusing the production coordinator's real bound methods. Passing this bundle
+    doesn't change behavior for the existing single (production) engine — it is
+    the same 9 attributes, assigned in one step instead of nine.
+    """
+
+    revisit: Callable[[], Any] | None = None
+    sensor_check: Callable[[], bool] | None = None
+    sensor_debounce_pending: Callable[[], bool] | None = None
+    emit_event: Callable[..., None] | None = None
+    request_refresh: Callable[[], None] | None = None
+    post_grace_fan_check: Callable[[], None] | None = None
+    get_fan_physical_state: Callable[[], Any] | None = None
+    is_recent_fan_command: Callable[[], bool] | None = None
+    reclassify: Callable[[], None] | None = None
+
+
 class AutomationEngine:
     """Manages HVAC automations based on daily classification."""
 
@@ -503,6 +526,9 @@ class AutomationEngine:
         notify_service: str,
         config: dict[str, Any],
         sensor_polarity_inverted: bool = False,
+        *,
+        callbacks: AutomationEngineCallbacks | None = None,
+        role: str = "production",
     ) -> None:
         """Initialize the automation engine."""
         self.hass = hass
@@ -512,6 +538,11 @@ class AutomationEngine:
         self.notify_service = notify_service
         self.config = config
         self.sensor_polarity_inverted = sensor_polarity_inverted
+        # Issue #604: label only, for logging/future observability — never branched on
+        # inside this class or the 9 coordinator callback methods. Isolation between a
+        # production and a future shadow engine is structural (which callables get wired
+        # in, via AutomationEngineCallbacks), not a runtime role check.
+        self.role = role
         self._active_listeners: list[Any] = []
         self._current_classification: DayClassification | None = None
         self._paused_by_door = False
@@ -761,6 +792,21 @@ class AutomationEngine:
 
         # Occupancy mode — synced by coordinator (Issue #85)
         self._occupancy_mode: str = OCCUPANCY_HOME
+
+        # Issue #604: seed the 9 callback attributes from the bundle, if one was given.
+        # Omitted (None) → every _x_callback attribute stays None, exactly as before this
+        # dataclass existed. Applied last so it can't be shadowed by any of the plain
+        # `self._x_callback: Any | None = None` assignments above.
+        if callbacks is not None:
+            self._revisit_callback = callbacks.revisit
+            self._sensor_check_callback = callbacks.sensor_check
+            self._sensor_debounce_pending_callback = callbacks.sensor_debounce_pending
+            self._emit_event_callback = callbacks.emit_event
+            self._request_refresh_callback = callbacks.request_refresh
+            self._post_grace_fan_check_callback = callbacks.post_grace_fan_check
+            self._get_fan_physical_state_callback = callbacks.get_fan_physical_state
+            self._is_recent_fan_command_callback = callbacks.is_recent_fan_command
+            self._reclassify_callback = callbacks.reclassify
 
     async def _notify(self, message: str, title: str, notification_type: str) -> None:
         """Send a notification via configured channels, filtered by per-event preferences."""

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,16 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.5.66"
+VERSION = "0.5.67"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.5.67": [
+        "Feat #604: internal refactor only, no user-visible behavior change — makes it"
+        " safe to eventually build a second, non-acting engine instance for testing"
+        " automation changes without risk to the live system, by giving it its own"
+        " isolated set of callbacks instead of ones that could reach into the real"
+        " thermostat.",
+    ],
     "0.5.66": [
         "Fix #602: the daily learning record (which gates manual-override detection for"
         " setpoint-only changes, HVAC runtime tracking, comfort-violation minutes,"
@@ -1602,6 +1609,39 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    604: {
+        "version_fixed": "0.5.67",
+        "title": (
+            "AutomationEngine's 9 coordinator-wired callback attributes (revisit,"
+            " sensor_check, sensor_debounce_pending, emit_event, request_refresh,"
+            " post_grace_fan_check, get_fan_physical_state, is_recent_fan_command,"
+            " reclassify) were always closures/bound methods over the single production"
+            " coordinator instance, not parameterized by which engine instance invoked"
+            " them. At least 4 (post_grace_fan_check, emit_event, request_refresh, and"
+            " the request_refresh lambda) reach into real production state or trigger"
+            " real side effects regardless of which engine fired them — unsafe for any"
+            " future second (shadow) AutomationEngine instance (Block 5 / epic #594)."
+            " AutomationEngine itself has no hidden shared state and was already safe to"
+            " instantiate twice; only the coordinator's callback wiring was the hazard."
+        ),
+        "scope_covered": (
+            "automation.py: new AutomationEngineCallbacks dataclass (9 named fields) and"
+            " optional keyword-only callbacks/role constructor params on AutomationEngine"
+            " — omitted (default) leaves all 9 attributes None exactly as before this"
+            " change. coordinator.py: extracted the 9 existing post-construction"
+            " assignments into _build_production_automation_callbacks(), passed at"
+            " construction time; added a shadow_automation_engine=None placeholder"
+            " attribute (stays None until Block 5 subtask Q builds a real second engine)."
+            " docs/02-ARCHITECTURE-REFERENCE.md: new 'Engine Callback Isolation'"
+            " subsection documenting the contract and naming the unsafe callables so a"
+            " future shadow-engine implementer can't miss them. Pure construction-time"
+            " refactor — zero behavior change for the existing single (production)"
+            " engine, verified via full test suite (3864 tests) + golden (74/74) +"
+            " pending (4/4) suites, all passing with zero regressions. Does not build"
+            " the shadow engine itself, any state machine, or any comparator — those are"
+            " separately scoped Block 5 subtasks P/O/Q/R."
+        ),
+    },
     602: {
         "version_fixed": "0.5.66",
         "title": (

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -38,6 +38,7 @@ from homeassistant.util import dt as dt_util
 
 from .automation import (
     AutomationEngine,
+    AutomationEngineCallbacks,
     _in_sleep_window,
     compute_bedtime_setback,
     compute_pre_cool_target,
@@ -362,28 +363,16 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             notify_service=config["notify_service"],
             config=config,
             sensor_polarity_inverted=config.get(CONF_SENSOR_POLARITY_INVERTED, False),
+            callbacks=self._build_production_automation_callbacks(),
+            role="production",
         )
-        self.automation_engine._revisit_callback = self.async_request_refresh
-        self.automation_engine._sensor_check_callback = self._any_sensor_open
-        # Issue #504: lets check_natural_vent_conditions()'s idle_open branch tell whether
-        # any currently-open monitored sensor is still within its CONF_SENSOR_DEBOUNCE
-        # settle window (i.e. still tracked in _door_open_timers) — reused as-is rather than
-        # introducing a second debounce/lockout concept.
-        self.automation_engine._sensor_debounce_pending_callback = lambda: bool(self._door_open_timers)
-        self.automation_engine._emit_event_callback = self._emit_event
-        self.automation_engine._request_refresh_callback = lambda: self.hass.async_create_task(
-            self.async_request_refresh()
-        )
-        # Issue #359: post-grace fan check callback — called by engine when any grace period expires
-        self.automation_engine._post_grace_fan_check_callback = self._on_post_grace_fan_check
-        # Issue #423: physical fan ground-truth callbacks for _reconcile_fan_physical_drift()
-        self.automation_engine._get_fan_physical_state_callback = self._get_fan_physical_state
-        self.automation_engine._is_recent_fan_command_callback = self._is_recent_fan_command
-        # Issue #495: reclassify callback — called by _release_whf_and_reclassify() when a
-        # manual/remote WHF session ends, reusing the existing fan-off reassert path (Issue
-        # #359 Fix A) so the thermostat converges on CA's current classification rather than
-        # a blindly-restored, potentially hours-stale captured mode.
-        self.automation_engine._reclassify_callback = self._on_whf_release_reclassify
+        # Issue #604 (Block 5, subtask N2): placeholder for a future second, non-acting
+        # AutomationEngine instance (Block 5 subtask Q). Always None until Q — kept here
+        # so any status/diagnostics schema field exists from N2 onward rather than being
+        # bundled into Q later. A shadow engine must be constructed with its own
+        # AutomationEngineCallbacks bundle — never the production callbacks below — see
+        # docs/02-ARCHITECTURE-REFERENCE.md "Engine Callback Isolation".
+        self.shadow_automation_engine: AutomationEngine | None = None
         _LOGGER.debug(
             "Climate Advisor startup: temp_unit=%s, comfort_heat=%.1f, comfort_cool=%.1f",
             config.get("temp_unit", "fahrenheit"),
@@ -529,6 +518,44 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         self.last_update_error: str | None = None
         self.last_update_error_time: str | None = None
         self.consecutive_failure_count: int = 0
+
+    def _build_production_automation_callbacks(self) -> AutomationEngineCallbacks:
+        """Build the callback bundle wired onto the real, acting AutomationEngine.
+
+        Issue #604 (Block 5, subtask N2): extracted verbatim from the 9 post-hoc
+        ``self.automation_engine._x_callback = ...`` assignments this coordinator used
+        to make right after construction — same callables, same behavior, just built
+        as a named bundle so construction is one step instead of nine. A future shadow
+        engine (Block 5 subtask Q) MUST NOT be given this bundle — several of these
+        callables reach into real production state or trigger real side effects
+        regardless of which engine instance invoked them (see
+        docs/02-ARCHITECTURE-REFERENCE.md "Engine Callback Isolation").
+        """
+        return AutomationEngineCallbacks(
+            revisit=self.async_request_refresh,
+            sensor_check=self._any_sensor_open,
+            # Issue #504: lets check_natural_vent_conditions()'s idle_open branch tell
+            # whether any currently-open monitored sensor is still within its
+            # CONF_SENSOR_DEBOUNCE settle window (i.e. still tracked in
+            # _door_open_timers) — reused as-is rather than introducing a second
+            # debounce/lockout concept.
+            sensor_debounce_pending=lambda: bool(self._door_open_timers),
+            emit_event=self._emit_event,
+            request_refresh=lambda: self.hass.async_create_task(self.async_request_refresh()),
+            # Issue #359: post-grace fan check callback — called by engine when any
+            # grace period expires.
+            post_grace_fan_check=self._on_post_grace_fan_check,
+            # Issue #423: physical fan ground-truth callbacks for
+            # _reconcile_fan_physical_drift().
+            get_fan_physical_state=self._get_fan_physical_state,
+            is_recent_fan_command=self._is_recent_fan_command,
+            # Issue #495: reclassify callback — called by _release_whf_and_reclassify()
+            # when a manual/remote WHF session ends, reusing the existing fan-off
+            # reassert path (Issue #359 Fix A) so the thermostat converges on CA's
+            # current classification rather than a blindly-restored, potentially
+            # hours-stale captured mode.
+            reclassify=self._on_whf_release_reclassify,
+        )
 
     @property
     def automation_enabled(self) -> bool:

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.5.66"
+  "version": "0.5.67"
 }

--- a/docs/02-ARCHITECTURE-REFERENCE.md
+++ b/docs/02-ARCHITECTURE-REFERENCE.md
@@ -20,6 +20,7 @@
 | Where is the Tier 3 spec for the Activity Report per-event table — event vocabulary, setpoint convention, renderer runbook? | The Territory spec covers 34 event types in 6 groups, `_format_band_setpoint` single-setpoint convention, `EVENT_RENDERERS` registry, `_default_renderer` contract, dedup mechanics, and the four-step runbook for adding a new renderer. | [Activity Report Table Spec](activity-report-table.md) |
 | What replaced the ClimateSimulator and how does the production harness work? | Issue #236 eliminated the standalone simulator engine. `tools/sim_harness/` drives the real `AutomationEngine` headless via FakeHass + FakeScheduler. `tools/simulate.py` is now a CLI/MANIFEST shell only. | [Sim Harness Brief](sim-harness-brief.md) |
 | What are the full contracts for FakeHass, FakeScheduler, run_production, and outcomes? | FakeHass service-bus interception + state-feedback loop; FakeScheduler virtual clock patching contract; run_production event dispatch table including predicted_indoor ODE re-classification; outcomes custom assertion types. | [Sim Harness Spec](sim-harness-spec.md) |
+| Is it safe to construct a second `AutomationEngine` instance, and what must a future shadow engine never share with production? | `AutomationEngine` has no hidden shared state — safe to instantiate twice. The coordinator's 9 callback attributes are not: 4 reach into real production state/side effects regardless of which engine fired them. `AutomationEngineCallbacks` (Issue #604) makes isolation structural, not a runtime check. | [§Engine Callback Isolation](02-ARCHITECTURE-REFERENCE.md#engine-callback-isolation-issue-604-block-5-subtask-n2) |
 
 ## File Structure
 
@@ -310,6 +311,53 @@ INFO  [DRY RUN] Would send notification: Climate Advisor — 🏠 Welcome home! 
 ### Implementation
 
 Guards are placed at the 3 thermostat primitives (`_set_hvac_mode`, `_set_temperature`, `_notify`) in `AutomationEngine` plus the briefing notification in the coordinator. Higher-level logic (classification application, door/window pause tracking, grace periods, occupancy handling) continues unaffected.
+
+## Engine Callback Isolation (Issue #604, Block 5 subtask N2)
+
+`AutomationEngine` itself has no hidden shared/global mutable state — every grace/timer
+cancel-token, flag, and its `_decision_lock` (a per-instance `asyncio.Lock`) live on the
+instance. It is safe to construct more than one. What is **not** safe by default is the
+coordinator's callback wiring: `ClimateAdvisorCoordinator.__init__` wires 9 callback
+attributes onto `self.automation_engine` (`_revisit_callback`, `_sensor_check_callback`,
+`_sensor_debounce_pending_callback`, `_emit_event_callback`, `_request_refresh_callback`,
+`_post_grace_fan_check_callback`, `_get_fan_physical_state_callback`,
+`_is_recent_fan_command_callback`, `_reclassify_callback`) — all closures/bound methods over
+the single coordinator instance, not parameterized by which engine invoked them. At least 4
+of these reach into real production state or trigger real side effects regardless of which
+engine fired them:
+
+- `coordinator._on_post_grace_fan_check` (→ `_async_post_grace_fan_reconcile`) hardcodes
+  `ae = self.automation_engine` and can issue a real `_activate_fan`/`_deactivate_fan` command.
+- `coordinator._emit_event` reads `self.automation_engine._natural_vent_active` — the
+  hardcoded production engine's attribute — to decide whether to call a real,
+  non-dry-run-gated side effect (`_maybe_reschedule_pre_cool_on_nat_vent_exit`).
+- `coordinator.async_request_refresh` and the `_request_refresh_callback` lambda that wraps
+  it both trigger a full real `_async_update_data_impl()` cycle.
+
+**The contract**: `AutomationEngine.__init__` takes an optional keyword-only
+`callbacks: AutomationEngineCallbacks | None = None` (a 9-field dataclass, one field per
+callback above) and `role: str = "production"` (a label for logging/future observability
+only — never branched on inside the engine or inside any of the 9 coordinator methods).
+Isolation between the production engine and any future second ("shadow") engine is
+**structural**, not a runtime check someone can forget: a shadow engine simply is never
+given a bundle containing the 4 hazardous callables above, so there is nothing to check.
+
+The coordinator's own wiring is built by `_build_production_automation_callbacks()` — a
+behavior-preserving extraction of what used to be 9 individual post-construction
+assignments, now one bundle passed at construction time
+(`AutomationEngine(..., callbacks=self._build_production_automation_callbacks(),
+role="production")`). `coordinator.shadow_automation_engine` exists as a placeholder
+(`None` until Block 5 subtask Q) so the schema field is stable from N2 onward.
+
+**Rule for any future second `AutomationEngine` instance (Block 5 subtask Q and beyond)**:
+build a dedicated `AutomationEngineCallbacks` bundle for it. It must **never** reuse
+`coordinator._on_post_grace_fan_check`, `coordinator._emit_event`,
+`coordinator.async_request_refresh`, or the `_request_refresh_callback` lambda that wraps
+it — reusing any of those lets the second engine's events/decisions mutate real production
+state and event history regardless of the second engine's own `dry_run`/`role`.
+`tests/test_engine_callback_isolation.py::TestHazardCharacterization` reproduces this exact
+hazard today (a second engine built with the production bundle leaks an event into the
+production event log) as a concrete negative example for review.
 
 ## Automation Engine — Occupancy Methods
 

--- a/tests/test_engine_callback_isolation.py
+++ b/tests/test_engine_callback_isolation.py
@@ -1,0 +1,203 @@
+"""Tests for Issue #604 (Block 5, subtask N2): callback-bundle isolation on AutomationEngine.
+
+Covers:
+  - Back-compat characterization: no ``callbacks`` arg → all 9 attributes stay None.
+  - Bundle application: passing ``AutomationEngineCallbacks`` sets exactly those 9.
+  - Coordinator regression: ``_build_production_automation_callbacks()`` is a
+    behavior-preserving refactor of the old post-hoc assignment block.
+  - Hazard characterization: documents (does not defend against) the real danger of
+    handing a second engine instance the production coordinator's own callables —
+    a concrete negative example for Block 5 subtask Q's review.
+"""
+
+from __future__ import annotations
+
+from tools.sim_harness.build_coordinator import build_headless_coordinator
+from tools.sim_harness.ha_stubs import install_ha_stubs
+
+install_ha_stubs()
+
+from custom_components.climate_advisor.automation import (  # noqa: E402
+    AutomationEngine,
+    AutomationEngineCallbacks,
+)
+
+_CALLBACK_ATTRS = (
+    "_revisit_callback",
+    "_sensor_check_callback",
+    "_sensor_debounce_pending_callback",
+    "_emit_event_callback",
+    "_request_refresh_callback",
+    "_post_grace_fan_check_callback",
+    "_get_fan_physical_state_callback",
+    "_is_recent_fan_command_callback",
+    "_reclassify_callback",
+)
+
+
+def _make_bare_engine() -> AutomationEngine:
+    return AutomationEngine(
+        hass=None,
+        climate_entity="climate.test",
+        weather_entity="weather.test",
+        door_window_sensors=[],
+        notify_service="notify.test",
+        config={},
+    )
+
+
+class TestBackCompatDefault:
+    def test_no_callbacks_arg_leaves_all_nine_none(self) -> None:
+        engine = _make_bare_engine()
+        for attr in _CALLBACK_ATTRS:
+            assert getattr(engine, attr) is None, f"{attr} should default to None"
+        assert engine.role == "production"
+
+
+class TestCallbackBundleApplication:
+    def test_bundle_sets_exactly_the_nine_attributes(self) -> None:
+        def _revisit():
+            return None
+
+        def _sensor_check():
+            return True
+
+        def _sensor_debounce():
+            return False
+
+        def _emit(event_type, data):
+            return None
+
+        def _refresh():
+            return None
+
+        def _post_grace():
+            return None
+
+        def _fan_state():
+            return "on"
+
+        def _recent_fan():
+            return False
+
+        def _reclassify():
+            return None
+
+        bundle = AutomationEngineCallbacks(
+            revisit=_revisit,
+            sensor_check=_sensor_check,
+            sensor_debounce_pending=_sensor_debounce,
+            emit_event=_emit,
+            request_refresh=_refresh,
+            post_grace_fan_check=_post_grace,
+            get_fan_physical_state=_fan_state,
+            is_recent_fan_command=_recent_fan,
+            reclassify=_reclassify,
+        )
+        engine = AutomationEngine(
+            hass=None,
+            climate_entity="climate.test",
+            weather_entity="weather.test",
+            door_window_sensors=[],
+            notify_service="notify.test",
+            config={},
+            callbacks=bundle,
+            role="shadow",
+        )
+        assert engine._revisit_callback is _revisit
+        assert engine._sensor_check_callback is _sensor_check
+        assert engine._sensor_debounce_pending_callback is _sensor_debounce
+        assert engine._emit_event_callback is _emit
+        assert engine._request_refresh_callback is _refresh
+        assert engine._post_grace_fan_check_callback is _post_grace
+        assert engine._get_fan_physical_state_callback is _fan_state
+        assert engine._is_recent_fan_command_callback is _recent_fan
+        assert engine._reclassify_callback is _reclassify
+        assert engine.role == "shadow"
+
+    def test_partial_bundle_leaves_unset_fields_none(self) -> None:
+        def _emit(event_type, data):
+            return None
+
+        bundle = AutomationEngineCallbacks(emit_event=_emit)
+        engine = AutomationEngine(
+            hass=None,
+            climate_entity="climate.test",
+            weather_entity="weather.test",
+            door_window_sensors=[],
+            notify_service="notify.test",
+            config={},
+            callbacks=bundle,
+        )
+        assert engine._emit_event_callback is _emit
+        for attr in _CALLBACK_ATTRS:
+            if attr == "_emit_event_callback":
+                continue
+            assert getattr(engine, attr) is None
+
+
+class TestCoordinatorRefactorIsBehaviorPreserving:
+    def test_production_engine_callbacks_are_the_coordinators_own_bound_methods(self) -> None:
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        ae = coordinator.automation_engine
+
+        assert ae.role == "production"
+        assert ae._revisit_callback == coordinator.async_request_refresh
+        assert ae._sensor_check_callback == coordinator._any_sensor_open
+        # build_headless_coordinator() intentionally overrides _emit_event_callback
+        # post-construction (see its own docstring) to redirect into the flat
+        # scenario event_log instead of coordinator._emit_event — so this one
+        # attribute doesn't stay identical to coordinator._emit_event here. Every
+        # other callback is untouched by that harness step and must still match.
+        assert ae._post_grace_fan_check_callback == coordinator._on_post_grace_fan_check
+        assert ae._get_fan_physical_state_callback == coordinator._get_fan_physical_state
+        assert ae._is_recent_fan_command_callback == coordinator._is_recent_fan_command
+        assert ae._reclassify_callback == coordinator._on_whf_release_reclassify
+        assert ae._sensor_debounce_pending_callback() == bool(coordinator._door_open_timers)
+
+    def test_shadow_automation_engine_placeholder_is_none(self) -> None:
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        assert coordinator.shadow_automation_engine is None
+
+
+class TestHazardCharacterization:
+    """Documents the real danger a shadow engine must avoid (Block 5 subtask Q).
+
+    There is no runtime defense here by design (see the plan's Design Decision
+    section) — isolation is structural, enforced by which callables get wired at
+    construction time, not by a check inside these methods. This test proves the
+    documented hazard is real and reproducible today: reusing the production
+    coordinator's own callbacks on a second engine instance lets that second
+    engine's events land in the SAME production event log and trigger the SAME
+    real side effects as the production engine, regardless of which instance
+    fired them.
+    """
+
+    def test_second_engine_sharing_production_callbacks_writes_into_production_event_log(
+        self,
+    ) -> None:
+        coordinator, _fake_hass, _scheduler, event_log = build_headless_coordinator()
+
+        # Deliberately misconfigured — as subtask Q's review must never allow:
+        # a second engine built with the PRODUCTION coordinator's own bundle.
+        hazardous_bundle = coordinator._build_production_automation_callbacks()
+        second_engine = AutomationEngine(
+            hass=None,
+            climate_entity="climate.test",
+            weather_entity="weather.test",
+            door_window_sensors=[],
+            notify_service="notify.test",
+            config={},
+            callbacks=hazardous_bundle,
+            role="shadow",
+        )
+
+        assert second_engine._emit_event_callback is not None
+        second_engine._emit_event_callback("hazard_probe_event", {"source": "second_engine"})
+
+        assert any(evt[0] == "hazard_probe_event" for evt in event_log), (
+            "A second engine built with the production coordinator's own callbacks "
+            "leaked an event into the production event log — exactly the hazard "
+            "AutomationEngineCallbacks exists to make structurally impossible for "
+            "a real shadow engine (Block 5 subtask Q must build its own bundle)."
+        )


### PR DESCRIPTION
## Summary
- Block 5 (epic #594) subtask N2, the confirmed blocking prerequisite before any second ("shadow") `AutomationEngine` instance can safely exist.
- Adds `AutomationEngineCallbacks` (automation.py): a named dataclass bundle of the 9 callback attributes the coordinator wires onto the engine post-construction. `AutomationEngine.__init__` gains optional keyword-only `callbacks`/`role` params — omitted, behavior is identical to before this PR.
- Extracts the coordinator's existing 9-line wiring block into `_build_production_automation_callbacks()`, passed at construction time. Adds a `shadow_automation_engine: AutomationEngine | None = None` placeholder attribute (stays `None` until subtask Q).
- Documents the isolation contract in `docs/02-ARCHITECTURE-REFERENCE.md`, naming the 4 confirmed-unsafe callables (`_on_post_grace_fan_check`, `_emit_event`, `async_request_refresh`, and the `_request_refresh_callback` lambda) so a future shadow-engine implementer can't miss them.

No occupant-visible behavior change — pure construction-time refactor.

## Test plan
- [x] New `tests/test_engine_callback_isolation.py` (6 tests): back-compat default, bundle application (full + partial), coordinator-refactor identity regression, shadow-engine placeholder, and a hazard-characterization test proving today's real danger (a second engine given the production bundle leaks events into the production event log).
- [x] Full suite: 3864 passed, `-W error::pytest.PytestUnraisableExceptionWarning -W error::RuntimeWarning`.
- [x] Golden simulations: 74/74 passed.
- [x] Pending simulations: 4/4 passed.
- [x] `ruff check` + `ruff format` clean.
- [x] Version bump: 0.5.66 → 0.5.67 (`const.py`, `manifest.json`, `RELEASE_NOTES`, `KNOWN_FIXES[604]`, `CHANGELOG.md`).