### PR TITLE
Feat #613: Block 5 Phase 4 (subtask Q) — live shadow engine for nat-vent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.3] — 2026-08-08
+
+- Feat #613: internal refactor only, no user-visible behavior change — a second, permanently inert copy of the automation engine now runs live alongside the real one, fed the same nat-vent sensor/classification inputs, and can never issue a real command. A new diagnostic sensor shows whether it agrees with the real engine's conclusions. This is groundwork for a future safe-rollout mechanism and does not change today's HVAC behavior.
+
 ## [0.6.2] — 2026-08-08
 
 - Feat #611: internal refactor only, no user-visible behavior change — added an offline test harness that proves a second, inert "shadow" copy of the automation engine can run alongside the real one without ever issuing a real command or changing what the real engine does. This is groundwork for a future safe-rollout mechanism (test new automation logic silently before it's ever allowed to control the thermostat) and does not change today's behavior.

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,17 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.2"
+VERSION = "0.6.3"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.3": [
+        "Feat #613: internal refactor only, no user-visible behavior change — a second,"
+        " permanently inert copy of the automation engine now runs live alongside the"
+        " real one, fed the same nat-vent sensor/classification inputs, and can never"
+        " issue a real command. A new diagnostic sensor shows whether it agrees with the"
+        " real engine's conclusions. This is groundwork for a future safe-rollout"
+        " mechanism and does not change today's HVAC behavior.",
+    ],
     "0.6.2": [
         "Feat #611: internal refactor only, no user-visible behavior change —"
         " added an offline test harness that proves a second, inert 'shadow'"
@@ -1637,6 +1645,66 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    613: {
+        "version_fixed": "0.6.3",
+        "title": (
+            "Block 5 (epic #594) sequencing item Q ('live shadow mode — a genuine"
+            " second engine instance computing decisions from the same live"
+            " inputs, fully inert per N2's redesign, with agreement/disagreement"
+            " surfaced via a new diagnostic sensor') had no implementation."
+            " Item O (#611/#612) proved N2's isolation held offline against 60"
+            " golden/pending scenarios; this issue builds the real, live second"
+            " engine instance inside the running coordinator."
+        ),
+        "scope_covered": (
+            "coordinator.shadow_automation_engine (superseding N2's None"
+            " placeholder): a real AutomationEngine, role='shadow',"
+            " dry_run=True set immediately after construction and never"
+            " toggled (no owner switch this phase — that's subtask R)."
+            " New coordinator._build_shadow_automation_callbacks(): the 4"
+            " callables N2 traced as reaching production (revisit,"
+            " request_refresh, post_grace_fan_check, reclassify) are cut off"
+            " structurally — revisit left None (a no-op lambda would crash,"
+            " since _schedule_revisit() awaits it via async_create_task), the"
+            " other 3 are no-op lambdas (safe: automation.py calls them"
+            " synchronously, never via async_create_task); read-only callbacks"
+            " (sensor_check, sensor_debounce_pending, get_fan_physical_state,"
+            " is_recent_fan_command) are shared with production; emit_event is"
+            " shadow-local (_on_shadow_emit_event, capped list, never the"
+            " production event log). New coordinator._mirror_to_shadow():"
+            " replays apply_classification/handle_door_window_open/"
+            " handle_all_doors_windows_closed/check_natural_vent_conditions/"
+            " nat_vent_temperature_check on the shadow engine immediately after"
+            " each production call, with the same args; any shadow-side"
+            " exception (including from the diagnostic recompute that follows"
+            " it) is caught, logged at WARNING, and swallowed — never"
+            " propagated. New coordinator._update_shadow_engine_diagnostic():"
+            " compares derive_nat_vent_lifecycle_state() (Issue #606) between"
+            " both engines against the real live clock. New"
+            " ClimateAdvisorShadowEngineStatusSensor (sensor.py): a"
+            " diagnostic-category entity (state agree/disagree/inactive,"
+            " attributes carry both derived states + timestamp) — deliberately"
+            " not wired into any occupant-facing Status-tab card (Issue #527"
+            " ontology), zero HVAC impact. shadow_automation_engine.cleanup()"
+            " added to coordinator.async_shutdown() (the shadow schedules real"
+            " async_call_later timers directly, independent of dry_run)."
+            " New tests/test_shadow_engine_live.py (18 tests) +"
+            " tests/test_shadow_engine_sensor.py (6 tests): construction,"
+            " callback isolation with a positive control reproducing the N2"
+            " hazard, mirror exception/diagnostic isolation with positive"
+            " controls, agreement/disagreement diagnostic with a positive"
+            " control, shutdown cleanup, sensor state/attributes. Also added"
+            " homeassistant.helpers.entity/EntityCategory to the test harness's"
+            " HA stub layer (ha_stubs.py) — the first diagnostic-category"
+            " entity in this codebase. Full suite (4066 tests) + golden"
+            " (74/74) + pending (4/4), zero regressions. No production"
+            " automation.py behavior changed for the real engine; two"
+            " secondary apply_classification() call sites (once-daily"
+            " briefing generation, post-WHF-release reassertion) are"
+            " deliberately not mirrored — low-frequency, shadow re-syncs on"
+            " the next regular cycle."
+        ),
+    },
     611: {
         "version_fixed": "0.6.2",
         "title": (

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -366,13 +366,30 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             callbacks=self._build_production_automation_callbacks(),
             role="production",
         )
-        # Issue #604 (Block 5, subtask N2): placeholder for a future second, non-acting
-        # AutomationEngine instance (Block 5 subtask Q). Always None until Q — kept here
-        # so any status/diagnostics schema field exists from N2 onward rather than being
-        # bundled into Q later. A shadow engine must be constructed with its own
-        # AutomationEngineCallbacks bundle — never the production callbacks below — see
-        # docs/02-ARCHITECTURE-REFERENCE.md "Engine Callback Isolation".
-        self.shadow_automation_engine: AutomationEngine | None = None
+        # Issue #613 (Block 5, subtask Q): a real, live second AutomationEngine instance
+        # computing decisions from the same inputs as production, permanently inert.
+        # dry_run is set True immediately below and MUST NEVER be toggled elsewhere —
+        # unlike production's dry_run (tied to automation_enabled), the shadow engine has
+        # no owner-facing switch this phase; that's Phase 5/subtask R. Built with its own
+        # isolated callback bundle (_build_shadow_automation_callbacks) — never the
+        # production callbacks above — per N2's confirmed HIGH-risk finding: a shadow
+        # engine given production's callbacks could reach real production state/side
+        # effects (e.g. reconcile_fan_on_startup) regardless of the shadow's own dry_run.
+        # See docs/02-ARCHITECTURE-REFERENCE.md "Engine Callback Isolation".
+        self._shadow_event_log: list[dict[str, Any]] = []
+        self._shadow_engine_diagnostic: dict[str, Any] | None = None
+        self.shadow_automation_engine: AutomationEngine = AutomationEngine(
+            hass=hass,
+            climate_entity=config["climate_entity"],
+            weather_entity=config["weather_entity"],
+            door_window_sensors=config.get("door_window_sensors", []),
+            notify_service=config["notify_service"],
+            config=config,
+            sensor_polarity_inverted=config.get(CONF_SENSOR_POLARITY_INVERTED, False),
+            callbacks=self._build_shadow_automation_callbacks(),
+            role="shadow",
+        )
+        self.shadow_automation_engine.dry_run = True
         _LOGGER.debug(
             "Climate Advisor startup: temp_unit=%s, comfort_heat=%.1f, comfort_cool=%.1f",
             config.get("temp_unit", "fahrenheit"),
@@ -556,6 +573,133 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             # hours-stale captured mode.
             reclassify=self._on_whf_release_reclassify,
         )
+
+    def _build_shadow_automation_callbacks(self) -> AutomationEngineCallbacks:
+        """Build the callback bundle wired onto the inert shadow AutomationEngine.
+
+        Issue #613 (Block 5, subtask Q). Every callback here is either a pure read
+        (safe to share with production — it observes ground truth, it doesn't act)
+        or a no-op (the ones N2 confirmed can reach real production side effects):
+
+          - ``sensor_check``/``sensor_debounce_pending``/``get_fan_physical_state``/
+            ``is_recent_fan_command`` are read-only observations of live HA/production
+            state — reused as-is, same callables the production bundle uses.
+          - ``emit_event`` is shadow-local (``_on_shadow_emit_event``) — appends to its
+            own capped log, never touches ``_event_log`` or the pre-cool rescheduling
+            side effect ``_emit_event`` triggers on a nat-vent exit transition.
+          - ``request_refresh``, ``post_grace_fan_check``, and ``reclassify`` are
+            no-op lambdas — each is invoked as a plain synchronous call (never
+            ``async_create_task(callback())``), so a lambda returning ``None`` is a
+            safe true no-op. These are exactly three of the four callables N2's
+            investigation traced as capable of reaching production: request_refresh
+            schedules a real coordinator refresh, post_grace_fan_check can reach
+            ``automation_engine.reconcile_fan_on_startup()`` (real fan commands gated
+            only by production's own live dry_run), and reclassify triggers a real
+            setpoint reassert task. The shadow engine's own dry_run only guards its
+            own service-call choke points — it has no bearing on what these callbacks
+            do once invoked, so isolation must be structural (no-op), not dry_run-based.
+          - ``revisit`` is left unset (``None``), not a no-op lambda: unlike the three
+            above, ``_schedule_revisit()`` invokes it as ``hass.async_create_task(
+            revisit_cb())`` — a lambda returning ``None`` would crash there (``None``
+            is not awaitable). Passing ``None`` makes ``AutomationEngine`` see
+            ``has_revisit_callback=False`` and skip scheduling the follow-up timer
+            entirely, which is the correct no-op for an engine whose actions are
+            always dry-run anyway.
+        """
+        return AutomationEngineCallbacks(
+            revisit=None,
+            sensor_check=self._any_sensor_open,
+            sensor_debounce_pending=lambda: bool(self._door_open_timers),
+            emit_event=self._on_shadow_emit_event,
+            request_refresh=lambda: None,
+            post_grace_fan_check=lambda: None,
+            get_fan_physical_state=self._get_fan_physical_state,
+            is_recent_fan_command=self._is_recent_fan_command,
+            reclassify=lambda: None,
+        )
+
+    def _on_shadow_emit_event(self, event_type: str, data: dict) -> None:
+        """Shadow-engine event sink (Issue #613) — a capped local log only.
+
+        Deliberately NOT ``_emit_event``: that method also mutates ``_nat_vent_was_active``
+        and can trigger ``_maybe_reschedule_pre_cool_on_nat_vent_exit()``, a real production
+        side effect keyed off the production engine's nat-vent transition, not the shadow's.
+        """
+        entry: dict[str, Any] = {"time": dt_util.now().isoformat(), "type": event_type, **data}
+        self._shadow_event_log.append(entry)
+        if len(self._shadow_event_log) > EVENT_LOG_CAP:
+            self._shadow_event_log.pop(0)
+
+    async def _mirror_to_shadow(self, method_name: str, *args: Any, **kwargs: Any) -> None:
+        """Replay a production nat-vent decision call on the shadow engine (Issue #613).
+
+        Isolated by construction (see ``_build_shadow_automation_callbacks``) and, on
+        top of that, isolated here: any exception raised by the shadow call is logged
+        and swallowed, never re-raised — a bug in the shadow engine's decision code
+        must never be able to affect production's own control flow.
+        """
+        try:
+            method = getattr(self.shadow_automation_engine, method_name)
+            await method(*args, **kwargs)
+        except Exception as exc:  # noqa: BLE001 — shadow errors must never affect production
+            _LOGGER.warning(
+                "Shadow engine mirror of %s() failed (isolated, no production impact): %s",
+                method_name,
+                exc,
+            )
+        finally:
+            try:
+                self._update_shadow_engine_diagnostic()
+            except Exception as diag_exc:  # noqa: BLE001 — diagnostic is best-effort observability
+                _LOGGER.warning(
+                    "Shadow engine diagnostic update failed (isolated, no production impact): %s",
+                    diag_exc,
+                )
+
+    def _update_shadow_engine_diagnostic(self) -> None:
+        """Recompute production/shadow nat-vent lifecycle state agreement (Issue #613).
+
+        Reuses ``derive_nat_vent_lifecycle_state()`` (Issue #606) directly — the same
+        pure function both engines' state already agreed on in Phase 3's offline sweep
+        of 60 golden/pending scenarios. Live ``now`` is real wall-clock time here (not
+        a scenario timestamp), since this runs against the live coordinator.
+        """
+        from .nat_vent_lifecycle import NatVentLifecycleInputs, derive_nat_vent_lifecycle_state
+
+        now = dt_util.now()
+
+        def _state_for(ae: AutomationEngine) -> str:
+            inputs = NatVentLifecycleInputs(
+                natural_vent_active=bool(ae._natural_vent_active),
+                nat_vent_soft_start=bool(ae._nat_vent_soft_start),
+                paused_by_door=bool(ae._paused_by_door),
+                outdoor_exit_time=ae._nat_vent_outdoor_exit_time,
+                now=now,
+                lockout_seconds=300,
+            )
+            return derive_nat_vent_lifecycle_state(inputs).value
+
+        production_state = _state_for(self.automation_engine)
+        shadow_state = _state_for(self.shadow_automation_engine)
+        agrees = production_state == shadow_state
+        self._shadow_engine_diagnostic = {
+            "production_state": production_state,
+            "shadow_state": shadow_state,
+            "agrees": agrees,
+            "checked_at": now.isoformat(),
+        }
+        if not agrees:
+            _LOGGER.warning(
+                "Shadow engine disagreement (Issue #613): production=%s shadow=%s",
+                production_state,
+                shadow_state,
+            )
+
+    @property
+    def shadow_engine_diagnostic(self) -> dict[str, Any] | None:
+        """Latest production/shadow nat-vent lifecycle agreement snapshot, or None
+        before the first mirrored decision has run."""
+        return self._shadow_engine_diagnostic
 
     @property
     def automation_enabled(self) -> bool:
@@ -1602,6 +1746,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             first_sensor = open_sensors[0]
             _LOGGER.debug("[coalesce-diag] before handle_door_window_open(%s)", first_sensor)
             await self.automation_engine.handle_door_window_open(first_sensor)
+            await self._mirror_to_shadow("handle_door_window_open", first_sensor)
             _LOGGER.debug("[coalesce-diag] after handle_door_window_open(%s)", first_sensor)
             nat_vent_activated = self.automation_engine._natural_vent_active
             _LOGGER.info(
@@ -1625,6 +1770,9 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 c,
                 predicted_indoor=self._last_predicted_indoor,
                 indoor_temp=indoor_temp,
+            )
+            await self._mirror_to_shadow(
+                "apply_classification", c, predicted_indoor=self._last_predicted_indoor, indoor_temp=indoor_temp
             )
             _LOGGER.debug("[coalesce-diag] after apply_classification() [coalesce path]")
             hvac_commanded = True
@@ -2030,6 +2178,12 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                     predicted_indoor=self._last_predicted_indoor,
                     indoor_temp=self._get_indoor_temp(),
                 )
+                await self._mirror_to_shadow(
+                    "apply_classification",
+                    self._current_classification,
+                    predicted_indoor=self._last_predicted_indoor,
+                    indoor_temp=self._get_indoor_temp(),
+                )
                 _LOGGER.debug("[coalesce-diag] after apply_classification() [regular cycle path]")
 
             # If the day type changed since the briefing was generated,
@@ -2096,6 +2250,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             if self._any_sensor_open():
                 _LOGGER.debug("[coalesce-diag] before check_natural_vent_conditions()")
                 await self.automation_engine.check_natural_vent_conditions()
+                await self._mirror_to_shadow("check_natural_vent_conditions")
                 _LOGGER.debug("[coalesce-diag] after check_natural_vent_conditions()")
 
             # Save state after classification update
@@ -3297,6 +3452,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                             c.windows_recommended if c else False,
                         )
                         await self.automation_engine.handle_door_window_open(eid)
+                        await self._mirror_to_shadow("handle_door_window_open", eid)
                         # Trigger coordinator refresh so sensor entities reflect post-evaluation state
                         self.hass.async_create_task(self.async_request_refresh())
                         if self._today_record:
@@ -3349,6 +3505,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 ):
                     self._today_record.window_physical_close_time = dt_util.now().isoformat()
                 await self.automation_engine.handle_all_doors_windows_closed()
+                await self._mirror_to_shadow("handle_all_doors_windows_closed")
                 # Issue #489: post-decision refresh, mirroring the open path's
                 # post-handle_door_window_open refresh above — covers the real-pause-
                 # resume case (HVAC mode/temp restored, grace started), not just the
@@ -3393,6 +3550,16 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         ):
             await self.automation_engine.nat_vent_temperature_check(
                 float(_new_temp_attr), outdoor=self._last_outdoor_temp
+            )
+        # Issue #613: mirrored unconditionally (not gated on production's own
+        # _natural_vent_active) — nat_vent_temperature_check() internally no-ops on
+        # `self._natural_vent_active` (the SHADOW's own flag when bound to the shadow
+        # instance), which is exactly the independent-conclusion check this diagnostic
+        # needs: does the shadow's own state agree production should even be running
+        # this check right now.
+        if _new_temp_attr is not None and _new_temp_attr != _old_temp_attr:
+            await self._mirror_to_shadow(
+                "nat_vent_temperature_check", float(_new_temp_attr), outdoor=self._last_outdoor_temp
             )
 
         # Issue #327: Thermostatic fan re-evaluation on every indoor temp tick.
@@ -7809,6 +7976,11 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         self._unsub_listeners.clear()
         self._unsubscribe_door_window_listeners()
         self.automation_engine.cleanup()
+        # Issue #613: the shadow engine schedules its own real async_call_later timers
+        # (grace, fan min-cycle, thermo backstop, etc.) via the real HA event loop even
+        # though its dry_run=True guards only the service-call choke points — cleanup()
+        # cancels those the same way it does for production.
+        self.shadow_automation_engine.cleanup()
 
 
 def _decide_pre_cool_reschedule(

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.2"
+  "version": "0.6.3"
 }

--- a/custom_components/climate_advisor/sensor.py
+++ b/custom_components/climate_advisor/sensor.py
@@ -14,6 +14,7 @@ from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, Sen
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -83,6 +84,7 @@ async def async_setup_entry(
         ClimateAdvisorOutdoorTempSensor(coordinator, entry),
         ClimateAdvisorForecastHighSensor(coordinator, entry),
         ClimateAdvisorForecastLowSensor(coordinator, entry),
+        ClimateAdvisorShadowEngineStatusSensor(coordinator, entry),
     ]
 
     async_add_entities(entities)
@@ -459,3 +461,42 @@ class ClimateAdvisorForecastLowSensor(ClimateAdvisorBaseSensor):
     def __init__(self, coordinator: ClimateAdvisorCoordinator, entry: ConfigEntry) -> None:
         """Initialize the forecast low temperature sensor."""
         super().__init__(coordinator, entry, ATTR_FORECAST_LOW, "Forecast Low", "mdi:thermometer-chevron-down")
+
+
+class ClimateAdvisorShadowEngineStatusSensor(ClimateAdvisorBaseSensor):
+    """Diagnostic sensor: agreement between the live production and shadow automation
+    engines' nat-vent lifecycle state (Issue #613, Block 5 / epic #594, subtask Q).
+
+    The shadow engine is permanently dry_run=True and never issues a real command —
+    this sensor has zero occupant HVAC impact. It exists to validate the Block 5
+    architecture migration, not to inform HVAC behavior, so it is deliberately NOT
+    wired into any of the four occupant-facing Status-tab cards (see CLAUDE.md's
+    Status Card Ontology, Issue #527) — those each answer an occupant-facing
+    question this sensor doesn't.
+    """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator: ClimateAdvisorCoordinator, entry: ConfigEntry) -> None:
+        """Initialize the shadow engine status sensor."""
+        super().__init__(coordinator, entry, "shadow_engine_status", "Shadow Engine Status", "mdi:compare")
+
+    @property
+    def native_value(self) -> str:
+        """Return "agree", "disagree", or "inactive" (before the first mirrored decision)."""
+        diag = self.coordinator.shadow_engine_diagnostic
+        if diag is None:
+            return "inactive"
+        return "agree" if diag["agrees"] else "disagree"
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Both engines' derived lifecycle state and when the comparison last ran."""
+        diag = self.coordinator.shadow_engine_diagnostic
+        if diag is None:
+            return {}
+        return {
+            "production_state": diag["production_state"],
+            "shadow_state": diag["shadow_state"],
+            "checked_at": diag["checked_at"],
+        }

--- a/docs/02-ARCHITECTURE-REFERENCE.md
+++ b/docs/02-ARCHITECTURE-REFERENCE.md
@@ -20,7 +20,7 @@
 | Where is the Tier 3 spec for the Activity Report per-event table — event vocabulary, setpoint convention, renderer runbook? | The Territory spec covers 34 event types in 6 groups, `_format_band_setpoint` single-setpoint convention, `EVENT_RENDERERS` registry, `_default_renderer` contract, dedup mechanics, and the four-step runbook for adding a new renderer. | [Activity Report Table Spec](activity-report-table.md) |
 | What replaced the ClimateSimulator and how does the production harness work? | Issue #236 eliminated the standalone simulator engine. `tools/sim_harness/` drives the real `AutomationEngine` headless via FakeHass + FakeScheduler. `tools/simulate.py` is now a CLI/MANIFEST shell only. | [Sim Harness Brief](sim-harness-brief.md) |
 | What are the full contracts for FakeHass, FakeScheduler, run_production, and outcomes? | FakeHass service-bus interception + state-feedback loop; FakeScheduler virtual clock patching contract; run_production event dispatch table including predicted_indoor ODE re-classification; outcomes custom assertion types. | [Sim Harness Spec](sim-harness-spec.md) |
-| Is it safe to construct a second `AutomationEngine` instance, and what must a future shadow engine never share with production? | `AutomationEngine` has no hidden shared state — safe to instantiate twice. The coordinator's 9 callback attributes are not: 4 reach into real production state/side effects regardless of which engine fired them. `AutomationEngineCallbacks` (Issue #604) makes isolation structural, not a runtime check. | [§Engine Callback Isolation](02-ARCHITECTURE-REFERENCE.md#engine-callback-isolation-issue-604-block-5-subtask-n2) |
+| Is there a live second `AutomationEngine` instance, and what does it never share with production? | Yes — `coordinator.shadow_automation_engine` (Issue #613), permanently `dry_run=True`, `role="shadow"`. The coordinator's 9 callback attributes are not automatically safe to reuse: 4 reach into real production state/side effects regardless of which engine fired them, so the shadow gets its own bundle (`_build_shadow_automation_callbacks()`). `AutomationEngineCallbacks` (Issue #604) makes isolation structural, not a runtime check. | [§Engine Callback Isolation](02-ARCHITECTURE-REFERENCE.md#engine-callback-isolation-issue-604-block-5-subtask-n2) |
 
 ## File Structure
 
@@ -346,18 +346,44 @@ The coordinator's own wiring is built by `_build_production_automation_callbacks
 behavior-preserving extraction of what used to be 9 individual post-construction
 assignments, now one bundle passed at construction time
 (`AutomationEngine(..., callbacks=self._build_production_automation_callbacks(),
-role="production")`). `coordinator.shadow_automation_engine` exists as a placeholder
-(`None` until Block 5 subtask Q) so the schema field is stable from N2 onward.
+role="production")`).
 
-**Rule for any future second `AutomationEngine` instance (Block 5 subtask Q and beyond)**:
-build a dedicated `AutomationEngineCallbacks` bundle for it. It must **never** reuse
-`coordinator._on_post_grace_fan_check`, `coordinator._emit_event`,
-`coordinator.async_request_refresh`, or the `_request_refresh_callback` lambda that wraps
-it — reusing any of those lets the second engine's events/decisions mutate real production
-state and event history regardless of the second engine's own `dry_run`/`role`.
-`tests/test_engine_callback_isolation.py::TestHazardCharacterization` reproduces this exact
-hazard today (a second engine built with the production bundle leaks an event into the
-production event log) as a concrete negative example for review.
+**Block 5 subtask Q (Issue #613) built the second instance** N2 scaffolded a placeholder
+for: `coordinator.shadow_automation_engine` is now a real, live `AutomationEngine`,
+`role="shadow"`, `dry_run=True` set immediately after construction and never toggled
+(no owner-facing switch this phase — that's Phase 5/subtask R). It is built with its own
+`_build_shadow_automation_callbacks()` bundle:
+
+- The 4 hazardous callables above are cut off structurally, not dry_run-gated: `revisit`
+  is left `None` (not a no-op lambda — `_schedule_revisit()` calls it via
+  `hass.async_create_task(revisit_cb())`, which would crash on a lambda returning `None`);
+  `request_refresh`, `post_grace_fan_check`, and `reclassify` are no-op lambdas (safe here
+  because `automation.py` invokes all three as plain synchronous calls, never wrapped in
+  `async_create_task`).
+- `sensor_check`, `sensor_debounce_pending`, `get_fan_physical_state`,
+  `is_recent_fan_command` are pure reads — safely shared with production's own bundle.
+- `emit_event` is shadow-local (`coordinator._on_shadow_emit_event`, a capped list),
+  never `coordinator._emit_event`.
+
+Production's nat-vent decision calls (`apply_classification`, `handle_door_window_open`,
+`handle_all_doors_windows_closed`, `check_natural_vent_conditions`,
+`nat_vent_temperature_check`) are each replayed on the shadow engine via
+`coordinator._mirror_to_shadow()` immediately after the production call, with the same
+arguments — isolated by a try/except that swallows (and logs at WARNING) any shadow-side
+exception, including one from the agreement-diagnostic recompute that follows it, so a
+shadow-engine bug can never affect production's own control flow. Full detail —
+mirrored call sites, the diagnostic sensor, shutdown/cleanup — is in
+`docs/nat-vent-lifecycle-spec.md`'s "Live Shadow Engine" section, not duplicated here.
+
+**Rule for any future second `AutomationEngine` instance**: build a dedicated
+`AutomationEngineCallbacks` bundle for it, following `_build_shadow_automation_callbacks()`'s
+pattern. It must **never** reuse `coordinator._on_post_grace_fan_check`,
+`coordinator._emit_event`, `coordinator.async_request_refresh`, or the
+`_request_refresh_callback` lambda that wraps it — reusing any of those lets the second
+engine's events/decisions mutate real production state and event history regardless of the
+second engine's own `dry_run`/`role`. `tests/test_engine_callback_isolation.py::TestHazardCharacterization`
+reproduces this exact hazard today (a second engine built with the production bundle leaks
+an event into the production event log) as a concrete negative example for review.
 
 ## Automation Engine — Occupancy Methods
 

--- a/docs/nat-vent-lifecycle-spec.md
+++ b/docs/nat-vent-lifecycle-spec.md
@@ -14,6 +14,7 @@
 | How was this spec's accuracy verified? | Differential replay: `derive_nat_vent_lifecycle_state()` run against the real final engine flags from all 74 golden + 4 pending scenarios (Issue #606), plus 3 hand-reasoned ground-truth scenarios. | [Verification](#verification) |
 | Does `check_natural_vent_conditions()`'s exit chain always decide WHY a session ends? | No — confirmed by direct experiment (Issue #608): `nat_vent_temperature_check()` and `fan_thermostat_check()` (both dispatched from the same `temp_update`/thermostat-attribute-change trigger, both already pure-extracted by Issue #441) run FIRST and independently implement equivalent comfort-floor and outdoor-rise-style stops — they win the race and exit the session before `check_natural_vent_conditions()`'s chain ever evaluates, for every golden scenario tested. | [Known Duplicate-Logic Race](#known-duplicate-logic-race-issue-608-finding) |
 | Has a shadow engine instance been proven safe to construct alongside production, offline? | Yes — `tools/sim_harness/shadow_engine_pair.py` (Issue #611) proves, across 60 offline-eligible golden+pending scenarios, that a dry_run=True shadow instance never issues a real action AND never changes what production itself does. | [Offline Whole-Engine Shadow-Pair Validation](#offline-whole-engine-shadow-pair-validation-issue-611-subtask-o) |
+| Is there a real, live shadow engine running inside the coordinator today? | Yes — `coordinator.shadow_automation_engine` (Issue #613), permanently `dry_run=True`, fed the same nat-vent lifecycle inputs as production via `coordinator._mirror_to_shadow()`. Zero occupant/HVAC impact; surfaced via a diagnostic sensor, not any Status-tab card. | [Live Shadow Engine](#live-shadow-engine-issue-613-subtask-q) |
 
 ## Scope
 
@@ -113,6 +114,32 @@ This is a real, if narrow, test of the epic's own flagged HIGH-risk finding ("a 
 
 **A real canonicalization gap was found and fixed during this validation**, not merely a testing artifact: `differential.py`'s existing `_canon_action_log()` falls back to `repr(obj)` for a service call's `context` field (a real HA `Context`, carrying a random per-call UUID by design). Reusing it produced 7/78 false-positive "divergences" — two independent runs of *identical* code, differing only because their Context objects had different random ids/memory addresses, not because production actually behaved differently. `shadow_engine_pair.py` uses its own `_canon_action_log_ignoring_context()` instead, excluding that field from the comparison it needs (domain/service/entity_id/data/timestamp).
 
+## Live Shadow Engine (Issue #613, subtask Q)
+
+Epic #594's sequencing item **Q** ("live shadow mode — a genuine second engine instance computing decisions from the same live inputs, fully inert per N2's redesign, with agreement/disagreement surfaced via a new diagnostic sensor") is now live for the nat-vent lifecycle. `coordinator.shadow_automation_engine` (superseding N2's `None` placeholder) is a real `AutomationEngine`, constructed alongside production at coordinator `__init__`, `role="shadow"`, `dry_run=True` set immediately and never toggled — there is no owner-facing switch for it this phase (that's Phase 5 / subtask R).
+
+**Callback isolation** (`coordinator._build_shadow_automation_callbacks()`): the four callables N2's investigation traced as capable of reaching production are structurally cut off, not dry_run-gated —
+
+- `sensor_check`, `sensor_debounce_pending`, `get_fan_physical_state`, `is_recent_fan_command` — pure reads, safely SHARED with production's own bundle (they observe ground truth, they don't act).
+- `emit_event` — shadow-local (`coordinator._on_shadow_emit_event`), a capped list, never the production `_event_log` ring buffer or its pre-cool-reschedule side effect.
+- `request_refresh`, `post_grace_fan_check`, `reclassify` — no-op lambdas. Each is invoked as a plain synchronous call in `automation.py` (never wrapped in `hass.async_create_task`), so a lambda returning `None` is a genuine no-op.
+- `revisit` — left unset (`None`), not a no-op lambda: `_schedule_revisit()` invokes it as `hass.async_create_task(revisit_cb())`, which would crash on a lambda returning `None` (not awaitable). `None` makes `has_revisit_callback` False, so the follow-up timer is never scheduled — correct for an engine whose actions are always dry-run anyway.
+
+**Mirrored call sites** — the nat-vent lifecycle's real entry points, each production call immediately followed by `await coordinator._mirror_to_shadow(method_name, *same_args)`:
+
+- `apply_classification()` — both the regular per-cycle path and the startup-coalesce path.
+- `handle_door_window_open()` / `handle_all_doors_windows_closed()` — the real `_async_door_window_changed` listener, both the debounced-open branch and the all-closed branch.
+- `check_natural_vent_conditions()` — the "any sensor still open" re-evaluation inside the regular cycle.
+- `nat_vent_temperature_check()` — mirrored **unconditionally** on every thermostat temperature tick (not gated on production's own `_natural_vent_active`, unlike the production call site): the method internally no-ops on `self._natural_vent_active` — the SHADOW's own flag when bound to the shadow instance — which is exactly the "does the shadow reach the same conclusion independently" property this diagnostic exists to check.
+
+Two secondary `apply_classification()` call sites (the once-daily briefing-generation path, and the rare post-WHF-release setpoint reassertion path) are deliberately **not** mirrored — both are low-frequency and the shadow re-syncs on the next regular cycle either way; mirroring every call site in the file was judged unnecessary complexity for this slice.
+
+**Isolation of the mirror itself** (`coordinator._mirror_to_shadow()`): any exception from the shadow call, and separately any exception from the diagnostic recompute that follows it, is caught, logged at WARNING, and swallowed — never re-raised. A bug in the shadow engine's decision code, or a `None`/mock-shaped `shadow_automation_engine` (several older tests partially instantiate the coordinator via `object.__new__()` without a full `__init__`), must never be able to affect `_async_update_data()`'s own control flow.
+
+**Diagnostic** (`coordinator._update_shadow_engine_diagnostic()`, `coordinator.shadow_engine_diagnostic`): reuses `derive_nat_vent_lifecycle_state()` (Issue #606) — the same pure function both engines' state already agreed on in Phase 3's offline sweep — computed for both `automation_engine` and `shadow_automation_engine` against the real live clock, recomputed after every mirrored call. Surfaced via `ClimateAdvisorShadowEngineStatusSensor` (`sensor.py`), a `diagnostic`-category entity: state is `"agree"` / `"disagree"` / `"inactive"` (before the first mirrored decision), attributes carry both derived states and the check timestamp. Deliberately **not** wired into any of the four occupant-facing Status-tab cards (`docs/07-...`/CLAUDE.md's Status Card Ontology, Issue #527) — the shadow engine has zero HVAC impact; this is an internal architecture-validation signal, not an automation-behavior explanation.
+
+**Cleanup**: `coordinator.async_shutdown()` calls `shadow_automation_engine.cleanup()` alongside production's — the shadow engine schedules its own real `async_call_later` timers (grace, fan min-cycle, thermo backstop) directly on the real HA event loop regardless of `dry_run` (which only guards the service-call choke points), so it needs the same timer cancellation at shutdown.
+
 ## Code Reference
 
 - [`derive_nat_vent_lifecycle_state`](../custom_components/climate_advisor/nat_vent_lifecycle.py) — pure derivation
@@ -122,3 +149,5 @@ This is a real, if narrow, test of the epic's own flagged HIGH-risk finding ("a 
 - [`decide_nat_vent_gate`, `decide_nat_vent_soft_start_gate`](../custom_components/climate_advisor/nat_vent_gate.py) — entry gates
 - [`is_reactivation_locked_out`](../custom_components/climate_advisor/nat_vent_reactivation_lockout.py) — lockout predicate
 - [`run_shadow_pair_scenario`](../tools/sim_harness/shadow_engine_pair.py) — offline whole-engine shadow-pair comparator (Issue #611)
+- [`ClimateAdvisorCoordinator._mirror_to_shadow`, `_build_shadow_automation_callbacks`, `_update_shadow_engine_diagnostic`](../custom_components/climate_advisor/coordinator.py) — live shadow engine wiring (Issue #613)
+- [`ClimateAdvisorShadowEngineStatusSensor`](../custom_components/climate_advisor/sensor.py) — diagnostic sensor (Issue #613)

--- a/tests/test_engine_callback_isolation.py
+++ b/tests/test_engine_callback_isolation.py
@@ -155,9 +155,20 @@ class TestCoordinatorRefactorIsBehaviorPreserving:
         assert ae._reclassify_callback == coordinator._on_whf_release_reclassify
         assert ae._sensor_debounce_pending_callback() == bool(coordinator._door_open_timers)
 
-    def test_shadow_automation_engine_placeholder_is_none(self) -> None:
+    def test_shadow_automation_engine_is_constructed_with_its_own_isolated_bundle(self) -> None:
+        """Superseded by Issue #613 (Block 5 subtask Q): the coordinator now builds a
+        real shadow engine at construction time, not the ``None`` placeholder N2 left
+        here. See ``tests/test_shadow_engine_live.py`` for full Q-phase coverage —
+        this test just confirms N2's own bundle-isolation building blocks are what Q
+        actually used, not a hand-rolled reimplementation.
+        """
         coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
-        assert coordinator.shadow_automation_engine is None
+        shadow = coordinator.shadow_automation_engine
+        assert shadow is not None
+        assert shadow.role == "shadow"
+        assert shadow is not coordinator.automation_engine
+        assert shadow._revisit_callback is None
+        assert shadow._request_refresh_callback is not coordinator.automation_engine._request_refresh_callback
 
 
 class TestHazardCharacterization:

--- a/tests/test_shadow_engine_live.py
+++ b/tests/test_shadow_engine_live.py
@@ -1,0 +1,218 @@
+"""Tests for Issue #613 (Block 5, subtask Q): live shadow AutomationEngine.
+
+Covers:
+  - Construction: the coordinator now builds a REAL, distinct, permanently
+    dry_run=True shadow engine (superseding N2's ``None`` placeholder).
+  - Callback isolation: the four callbacks N2 traced as capable of reaching
+    production (revisit, request_refresh, post_grace_fan_check, reclassify)
+    are structurally unable to on the shadow bundle — proven both directly
+    and via a positive control showing the SAME test would catch the N2
+    hazard (production's own bundle) if isolation broke.
+  - ``_mirror_to_shadow``: replays a call on the shadow engine, never lets a
+    shadow-side exception escape, and always recomputes the diagnostic.
+  - ``_update_shadow_engine_diagnostic``: agreement/disagreement detection,
+    including a positive control that forces disagreement.
+  - Shutdown: shadow engine timers get cancelled alongside production's.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from tools.sim_harness._loop import run_coro
+from tools.sim_harness.build_coordinator import build_headless_coordinator
+from tools.sim_harness.ha_stubs import install_ha_stubs
+
+install_ha_stubs()
+
+from custom_components.climate_advisor.automation import AutomationEngine  # noqa: E402
+
+
+class TestShadowEngineConstruction:
+    def test_shadow_engine_is_real_and_distinct(self) -> None:
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        assert isinstance(coordinator.shadow_automation_engine, AutomationEngine)
+        assert coordinator.shadow_automation_engine is not coordinator.automation_engine
+
+    def test_shadow_engine_dry_run_always_true(self) -> None:
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        assert coordinator.shadow_automation_engine.dry_run is True
+
+    def test_shadow_engine_role_is_shadow(self) -> None:
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        assert coordinator.shadow_automation_engine.role == "shadow"
+        assert coordinator.automation_engine.role == "production"
+
+    def test_shadow_bundle_hazardous_callbacks_differ_from_production(self) -> None:
+        """The 4 callables N2 flagged as reachable-to-production must not be the
+        coordinator's own production-bound methods on the shadow engine."""
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        shadow = coordinator.shadow_automation_engine
+        prod = coordinator.automation_engine
+        assert shadow._revisit_callback is None
+        assert shadow._request_refresh_callback is not prod._request_refresh_callback
+        assert shadow._post_grace_fan_check_callback is not prod._post_grace_fan_check_callback
+        assert shadow._reclassify_callback is not prod._reclassify_callback
+
+    def test_shadow_bundle_read_only_callbacks_are_shared(self) -> None:
+        """Pure reads are safe (and correct) to share — they observe ground truth,
+        never act. Structural proof they're the SAME bound methods, not reimplemented."""
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        shadow = coordinator.shadow_automation_engine
+        assert shadow._sensor_check_callback == coordinator._any_sensor_open
+        assert shadow._get_fan_physical_state_callback == coordinator._get_fan_physical_state
+        assert shadow._is_recent_fan_command_callback == coordinator._is_recent_fan_command
+
+
+class TestShadowCallbackIsolation:
+    """Proves the 4 hazardous callbacks are true no-ops against the real coordinator,
+    with a positive control showing this test suite would catch the N2 hazard."""
+
+    def test_request_refresh_does_not_trigger_coordinator_refresh(self) -> None:
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        calls: list[Any] = []
+        coordinator.async_request_refresh = lambda: calls.append(1)  # type: ignore[assignment]
+        coordinator.shadow_automation_engine._request_refresh_callback()
+        assert calls == []
+
+    def test_post_grace_fan_check_does_not_reach_production_reconcile(self) -> None:
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        calls: list[Any] = []
+        coordinator._on_post_grace_fan_check = lambda: calls.append(1)  # type: ignore[assignment]
+        coordinator.shadow_automation_engine._post_grace_fan_check_callback()
+        assert calls == []
+
+    def test_reclassify_does_not_reassert_production_setpoint(self) -> None:
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        calls: list[Any] = []
+        coordinator._on_whf_release_reclassify = lambda: calls.append(1)  # type: ignore[assignment]
+        coordinator.shadow_automation_engine._reclassify_callback()
+        assert calls == []
+
+    def test_positive_control_production_bundle_would_have_leaked(self) -> None:
+        """If the shadow engine were (mis)built with the PRODUCTION callback bundle —
+        exactly the N2 hazard — request_refresh WOULD reach the coordinator. Proves
+        the isolation tests above are not vacuously passing."""
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        calls: list[Any] = []
+        coordinator.async_request_refresh = lambda: calls.append(1)  # type: ignore[assignment]
+        hazardous = AutomationEngine(
+            hass=coordinator.hass,
+            climate_entity="climate.test",
+            weather_entity="weather.test",
+            door_window_sensors=[],
+            notify_service="notify.test",
+            config={},
+            callbacks=coordinator._build_production_automation_callbacks(),
+            role="shadow",
+        )
+        hazardous._request_refresh_callback()
+        assert calls == [1], "positive control failed to reproduce the N2 hazard"
+
+
+class TestMirrorToShadow:
+    def test_mirror_calls_shadow_method_with_same_args(self) -> None:
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        captured: list[tuple] = []
+
+        async def _fake_apply(classification, **kwargs):
+            captured.append((classification, kwargs))
+
+        coordinator.shadow_automation_engine.apply_classification = _fake_apply
+        _run(coordinator._mirror_to_shadow("apply_classification", "day-marker", indoor_temp=70.0))
+        assert captured == [("day-marker", {"indoor_temp": 70.0})]
+
+    def test_mirror_swallows_shadow_exception_without_raising(self) -> None:
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+
+        async def _boom(*args, **kwargs):
+            raise RuntimeError("shadow blew up")
+
+        coordinator.shadow_automation_engine.apply_classification = _boom
+        # Must not raise — production's own control flow must never depend on the
+        # shadow engine succeeding.
+        _run(coordinator._mirror_to_shadow("apply_classification", None))
+
+    def test_mirror_logs_warning_on_shadow_exception(self, caplog) -> None:
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+
+        async def _boom(*args, **kwargs):
+            raise RuntimeError("shadow blew up")
+
+        coordinator.shadow_automation_engine.apply_classification = _boom
+        with caplog.at_level(logging.WARNING, logger="custom_components.climate_advisor.coordinator"):
+            _run(coordinator._mirror_to_shadow("apply_classification", None))
+        assert any("shadow blew up" in r.message for r in caplog.records)
+
+    def test_mirror_swallows_diagnostic_update_exception_too(self) -> None:
+        """Positive control: the diagnostic recompute itself is best-effort — a bug
+        reading either engine's state (e.g. a partial-instantiation test double with
+        MagicMock attributes, the exact shape several older coordinator tests use)
+        must not propagate out of ``_mirror_to_shadow`` either."""
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+
+        async def _noop(*args, **kwargs):
+            return None
+
+        coordinator.shadow_automation_engine.apply_classification = _noop
+
+        def _boom():
+            raise RuntimeError("diagnostic blew up")
+
+        coordinator._update_shadow_engine_diagnostic = _boom
+        # Must not raise.
+        _run(coordinator._mirror_to_shadow("apply_classification", None))
+
+    def test_mirror_recomputes_diagnostic_even_after_exception(self) -> None:
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        assert coordinator.shadow_engine_diagnostic is None
+
+        async def _boom(*args, **kwargs):
+            raise RuntimeError("shadow blew up")
+
+        coordinator.shadow_automation_engine.apply_classification = _boom
+        _run(coordinator._mirror_to_shadow("apply_classification", None))
+        assert coordinator.shadow_engine_diagnostic is not None
+
+
+class TestShadowEngineDiagnostic:
+    def test_diagnostic_agrees_by_default(self) -> None:
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        coordinator._update_shadow_engine_diagnostic()
+        diag = coordinator.shadow_engine_diagnostic
+        assert diag is not None
+        assert diag["agrees"] is True
+        assert diag["production_state"] == diag["shadow_state"]
+
+    def test_positive_control_disagreement_is_detected(self) -> None:
+        """Forces a real divergence (shadow thinks nat-vent is active, production
+        doesn't) and confirms the diagnostic — and its WARNING log — catch it."""
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        coordinator.shadow_automation_engine._natural_vent_active = True
+        coordinator.automation_engine._natural_vent_active = False
+        coordinator._update_shadow_engine_diagnostic()
+        diag = coordinator.shadow_engine_diagnostic
+        assert diag["agrees"] is False
+        assert diag["production_state"] != diag["shadow_state"]
+
+    def test_disagreement_logs_warning(self, caplog) -> None:
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        coordinator.shadow_automation_engine._natural_vent_active = True
+        coordinator.automation_engine._natural_vent_active = False
+        with caplog.at_level(logging.WARNING, logger="custom_components.climate_advisor.coordinator"):
+            coordinator._update_shadow_engine_diagnostic()
+        assert any("Shadow engine disagreement" in r.message for r in caplog.records)
+
+
+class TestShadowEngineShutdown:
+    def test_async_shutdown_cleans_up_shadow_timers(self) -> None:
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        cleaned: list[Any] = []
+        coordinator.shadow_automation_engine.cleanup = lambda: cleaned.append(1)  # type: ignore[assignment]
+        _run(coordinator.async_shutdown())
+        assert cleaned == [1]
+
+
+def _run(coro):
+    return run_coro(coro)

--- a/tests/test_shadow_engine_sensor.py
+++ b/tests/test_shadow_engine_sensor.py
@@ -1,0 +1,72 @@
+"""Tests for Issue #613 (Block 5, subtask Q): ClimateAdvisorShadowEngineStatusSensor.
+
+Diagnostic-category sensor exposing production/shadow nat-vent lifecycle agreement.
+Deliberately not tied to coordinator.data (unlike most sensors here) — instantiated
+directly against a MagicMock coordinator exposing `.shadow_engine_diagnostic`,
+mirroring the pattern already established for other sensors reading a coordinator
+attribute directly (see test_status_sensors.py's compliance-sensor helper).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from tools.sim_harness.ha_stubs import install_ha_stubs
+
+install_ha_stubs()
+
+from custom_components.climate_advisor.sensor import ClimateAdvisorShadowEngineStatusSensor  # noqa: E402
+
+
+def _make_sensor(diagnostic):
+    coordinator = MagicMock()
+    coordinator.shadow_engine_diagnostic = diagnostic
+    entry = MagicMock()
+    entry.entry_id = "test_entry"
+    return ClimateAdvisorShadowEngineStatusSensor(coordinator, entry)
+
+
+class TestNativeValue:
+    def test_inactive_before_first_diagnostic(self) -> None:
+        sensor = _make_sensor(None)
+        assert sensor.native_value == "inactive"
+
+    def test_agree(self) -> None:
+        sensor = _make_sensor(
+            {"production_state": "active", "shadow_state": "active", "agrees": True, "checked_at": "t"}
+        )
+        assert sensor.native_value == "agree"
+
+    def test_disagree(self) -> None:
+        sensor = _make_sensor(
+            {"production_state": "active", "shadow_state": "idle", "agrees": False, "checked_at": "t"}
+        )
+        assert sensor.native_value == "disagree"
+
+
+class TestExtraStateAttributes:
+    def test_empty_before_first_diagnostic(self) -> None:
+        sensor = _make_sensor(None)
+        assert sensor.extra_state_attributes == {}
+
+    def test_reports_both_states_and_timestamp(self) -> None:
+        sensor = _make_sensor(
+            {
+                "production_state": "active",
+                "shadow_state": "idle",
+                "agrees": False,
+                "checked_at": "2026-08-08T12:00:00",
+            }
+        )
+        attrs = sensor.extra_state_attributes
+        assert attrs["production_state"] == "active"
+        assert attrs["shadow_state"] == "idle"
+        assert attrs["checked_at"] == "2026-08-08T12:00:00"
+
+
+class TestEntityCategory:
+    def test_is_diagnostic(self) -> None:
+        from homeassistant.helpers.entity import EntityCategory
+
+        sensor = _make_sensor(None)
+        assert sensor._attr_entity_category == EntityCategory.DIAGNOSTIC

--- a/tools/sim_harness/ha_stubs.py
+++ b/tools/sim_harness/ha_stubs.py
@@ -35,6 +35,7 @@ _HA_MODULES = [
     "homeassistant.const",
     "homeassistant.core",
     "homeassistant.helpers",
+    "homeassistant.helpers.entity",
     "homeassistant.helpers.update_coordinator",
     "homeassistant.helpers.entity_platform",
     "homeassistant.helpers.event",
@@ -248,6 +249,14 @@ class _UnitOfTemperature(_enum.StrEnum):
     KELVIN = "K"
 
 
+class _EntityCategory(_enum.StrEnum):
+    """Issue #613: first diagnostic-category entity in this codebase
+    (ClimateAdvisorShadowEngineStatusSensor)."""
+
+    CONFIG = "config"
+    DIAGNOSTIC = "diagnostic"
+
+
 def install_ha_stubs() -> None:
     """Install homeassistant.* mock modules into sys.modules (idempotent).
 
@@ -286,6 +295,10 @@ def install_ha_stubs() -> None:
     helpers = sys.modules["homeassistant.helpers"]
     helpers.entity_registry = sys.modules["homeassistant.helpers.entity_registry"]
     helpers.device_registry = sys.modules["homeassistant.helpers.device_registry"]
+    helpers.entity = sys.modules["homeassistant.helpers.entity"]
+
+    entity_mod = sys.modules["homeassistant.helpers.entity"]
+    entity_mod.EntityCategory = _EntityCategory
 
     core = sys.modules["homeassistant.core"]
     core.Context = _MockContext


### PR DESCRIPTION
## Summary

Part of epic #594 (Block 5). Follows Phase 3 (#611/#612, v0.6.2), which proved offline that N2's callback-isolation fix (#604/#605) holds. This is the live version: closes #613.

- `coordinator.shadow_automation_engine` is now a real `AutomationEngine` instance (superseding N2's `None` placeholder), `role="shadow"`, permanently `dry_run=True` — no owner switch yet, that's Phase 5/subtask R.
- Its own callback bundle (`_build_shadow_automation_callbacks()`) cuts off the 4 callables N2 traced as reachable-to-production (`revisit`, `request_refresh`, `post_grace_fan_check`, `reclassify`) structurally, not via dry_run. Pure-read callbacks are safely shared with production.
- Production's nat-vent decision calls (`apply_classification`, `handle_door_window_open`, `handle_all_doors_windows_closed`, `check_natural_vent_conditions`, `nat_vent_temperature_check`) are mirrored onto the shadow via `coordinator._mirror_to_shadow()`, which swallows any shadow-side exception (including from the diagnostic recompute) so a shadow bug can never affect production.
- A new diagnostic-category sensor (`ClimateAdvisorShadowEngineStatusSensor`) surfaces production/shadow agreement on `derive_nat_vent_lifecycle_state()` — deliberately not wired into any of the four occupant-facing Status-tab cards (zero HVAC impact).
- `async_shutdown()` now cleans up the shadow engine's own real timers too.

No production `automation.py` behavior changed. Two secondary `apply_classification()` call sites (once-daily briefing, post-WHF-release reassertion) are deliberately not mirrored — low-frequency, shadow re-syncs on the next regular cycle.

## Test plan
- [x] Full suite: 4066 passed
- [x] Golden scenarios: 74/74
- [x] Pending scenarios: 4/4
- [x] `tools/validate.py`: all checks passed
- [x] New tests with positive controls: callback isolation (incl. a control reproducing the N2 hazard), mirror exception/diagnostic-exception swallowing, agreement/disagreement diagnostic, shutdown cleanup, sensor state/attributes
- [x] `docs/nat-vent-lifecycle-spec.md` and `docs/02-ARCHITECTURE-REFERENCE.md` updated