### PR TITLE
Feat #637: door/window pause FSM (Block 5 Phase 2, shadow-only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.14] — 2026-08-14
+
+- Feat #637: internal refactor only, no user-visible behavior change — Block 5 Phase 2 builds the unified door/window pause/grace transition table, the next diagnostic-only shadow comparison point after 0.6.13's nat-vent one. Confirmed (via new test scenarios, not just static analysis) that production can genuinely be paused-by-door and in-grace at the same time — the new state models that combination rather than assuming it can't happen. Purely observational — nothing it computes is ever acted on.
+
 ## [0.6.13] — 2026-08-13
 
 - Feat #633: internal refactor only, no user-visible behavior change — the diagnostic-only decision table added in 0.6.12 now actually runs alongside production on every natural-ventilation check, compared against what production really did. Still purely observational — nothing it computes is ever acted on.

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,19 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.13"
+VERSION = "0.6.14"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.14": [
+        "Feat #637: internal refactor only, no user-visible behavior change — Block 5"
+        " Phase 2 builds the unified door/window pause/grace transition table"
+        " (door_window_fsm.py), the next diagnostic-only shadow comparison point after"
+        " 0.6.13's nat-vent one. Confirmed (via new pending scenarios, not just static"
+        " analysis) that production can genuinely be paused-by-door and in-grace at the"
+        " same time — the new PAUSED_DURING_GRACE state models that combination rather"
+        " than assuming it can't happen. Purely observational — nothing it computes is"
+        " ever acted on.",
+    ],
     "0.6.13": [
         "Feat #633: internal refactor only, no user-visible behavior change — the"
         " diagnostic-only decision table added in 0.6.12 now actually runs"
@@ -1738,6 +1748,36 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    637: {
+        "version_fixed": "0.6.14",
+        "title": (
+            "Block 5 epic #594 Phase 2: builds the unified door/window pause/grace"
+            " transition table (5 new pure functions + door_window_fsm.py assembly),"
+            " following the exact pattern #633's nat-vent FSM established. Discovered"
+            " and confirmed-by-scenario (not just static trace) that "
+            "`_paused_by_door`/`_grace_active` are NOT mutually exclusive in"
+            " production — modeled as a new PAUSED_DURING_GRACE state rather than"
+            " assumed unreachable. Wired into the shadow engine's existing diagnostic"
+            " as a third comparison point, purely observational — never wired into any"
+            " decision path that can act."
+        ),
+        "scope_covered": (
+            "New: door_window_lifecycle.py (5-state derivation), door_window_pause_entry.py, "
+            "door_window_open_response.py, door_window_close_response.py, "
+            "door_window_grace_expiry.py, door_window_fsm.py (assembly). Coordinator: "
+            "_evaluate_door_window_fsm()/_current_hvac_mode(), extended "
+            "_update_shadow_engine_diagnostic() with door_window_production_state/"
+            "door_window_shadow_state/door_window_fsm_state/door_window_mirror_agrees/"
+            "door_window_fsm_agrees, wired into _mirror_to_shadow() for "
+            "handle_door_window_open/handle_all_doors_windows_closed/"
+            "handle_manual_override_during_pause (the 3 mirrored methods with an "
+            "unambiguous door/window FSM event-kind correspondence). New pending "
+            "scenarios issue_637_paused_during_grace_open_fallthrough.json and "
+            "issue_637_paused_during_grace_nat_vent_exit.json confirm PAUSED_DURING_GRACE "
+            "is reachable via 2 structurally distinct production paths, pending user "
+            "review before promotion to golden/."
+        ),
+    },
     633: {
         "version_fixed": "0.6.13",
         "title": (

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -228,6 +228,7 @@ from .const import (
     VACATION_SETBACK_EXTRA,
     VERSION,
 )
+from .door_window_lifecycle import DoorWindowLifecycleState
 from .fan_status import (
     is_ca_fan_running,
     parse_remote_speed_event,
@@ -342,6 +343,21 @@ def _pick_daily_line(pool: tuple[str, ...], salt: str) -> str:
     return pool[index]
 
 
+# Issue #637: which mirrored automation.py methods correspond to which door/window
+# FSM event kind. Narrower than the FSM's own 7-member DoorWindowFsmEventKind enum —
+# GRACE_TIMER_EXPIRED/DASHBOARD_RESUME/NAT_VENT_EXITED_SENSOR_STILL_OPEN/SYNC_RECONCILE
+# have no _mirror_to_shadow() call site today (see _sync_shadow_inputs()'s own
+# docstring on why _on_grace_expired can't be reached that way), same v1-scope-
+# narrowing precedent as #633's nat-vent FSM (only check_natural_vent_conditions is
+# wired, not every gate/exit-adjacent call site). Additional future work, not this
+# increment.
+_DOOR_WINDOW_FSM_EVENT_KINDS: dict[str, str] = {
+    "handle_door_window_open": "sensor_opened",
+    "handle_all_doors_windows_closed": "all_sensors_closed",
+    "handle_manual_override_during_pause": "manual_override_during_pause",
+}
+
+
 class ClimateAdvisorCoordinator(DataUpdateCoordinator):
     """Coordinate all Climate Advisor activities."""
 
@@ -403,6 +419,10 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         # INACTIVE unconditionally (same clean-slate convention as restore_state()'s
         # documented design for _natural_vent_active).
         self._nat_vent_fsm_state: NatVentLifecycleState = NatVentLifecycleState.INACTIVE
+        # Issue #637: the unified door/window pause/grace FSM's own independently-
+        # tracked state — same third-comparison-point convention as #633 above.
+        # Starts NORMAL unconditionally (no persisted pause/grace on a fresh coordinator).
+        self._door_window_fsm_state: DoorWindowLifecycleState = DoorWindowLifecycleState.NORMAL
         self.shadow_automation_engine: AutomationEngine = AutomationEngine(
             hass=hass,
             climate_entity=config["climate_entity"],
@@ -759,6 +779,14 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                         "Nat-vent FSM evaluation failed (isolated, no production impact): %s",
                         fsm_exc,
                     )
+            if method_name in _DOOR_WINDOW_FSM_EVENT_KINDS:
+                try:
+                    self._evaluate_door_window_fsm(method_name)
+                except Exception as fsm_exc:  # noqa: BLE001 — FSM errors must never affect production
+                    _LOGGER.warning(
+                        "Door/window FSM evaluation failed (isolated, no production impact): %s",
+                        fsm_exc,
+                    )
             try:
                 self._update_shadow_engine_diagnostic()
             except Exception as diag_exc:  # noqa: BLE001 — diagnostic is best-effort observability
@@ -830,6 +858,57 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         result = transition(self._nat_vent_fsm_state, event)
         self._nat_vent_fsm_state = result.to_state
 
+    def _evaluate_door_window_fsm(self, method_name: str) -> None:
+        """Run the unified door/window pause/grace FSM (Issue #637) against
+        production's current live readings and track its own independently-
+        derived state.
+
+        v1 scope, narrowed to the 3 event kinds a mirrored method exists for
+        today (see ``_DOOR_WINDOW_FSM_EVENT_KINDS``) — same precedent as
+        ``_evaluate_nat_vent_fsm()``'s own v1 scope note. The FSM's own tracked
+        state (``self._door_window_fsm_state``) is never written back onto
+        either engine — a third, independent computation, purely for
+        comparison against production's real derived state. Isolated the same
+        way: any exception here is logged and swallowed by the caller, never
+        allowed to affect production.
+        """
+        from .door_window_fsm import DoorWindowFsmEvent, DoorWindowFsmEventKind, DoorWindowFsmInputs, transition
+
+        ae = self.automation_engine
+        now = dt_util.now()
+        config = self.config
+
+        event = DoorWindowFsmEvent(
+            kind=DoorWindowFsmEventKind(_DOOR_WINDOW_FSM_EVENT_KINDS[method_name]),
+            inputs=DoorWindowFsmInputs(
+                hvac_mode=self._current_hvac_mode(),
+                outdoor=ae._last_outdoor_temp,
+                indoor=ae._get_indoor_temp_f(),
+                comfort_heat=ae._nat_vent_reactivation_floor(),
+                comfort_cool=float(config.get("comfort_cool", DEFAULT_COMFORT_COOL)),
+                nat_vent_delta=float(config.get(CONF_NATURAL_VENT_DELTA, DEFAULT_NATURAL_VENT_DELTA)),
+                fan_mode=str(config.get(CONF_FAN_MODE, "whole_house_fan")),
+                aggressive_savings=bool(config.get("aggressive_savings", False)),
+                within_planned_window=ae._is_within_planned_window_period(),
+                any_sensor_open=ae._any_monitored_sensor_open(),
+                sensor_debounce_pending=bool(ae._sensor_debounce_pending),
+                override_matches_current_decision=ae._override_matches_current_decision(ae._current_classification),
+                grace_source=ae._last_resume_source or "automation",
+                natural_vent_active=bool(ae._natural_vent_active),
+                whf_owns_hvac=bool(ae._whf_owns_hvac()),
+                now=now,
+            ),
+        )
+        result = transition(self._door_window_fsm_state, event)
+        self._door_window_fsm_state = result.to_state
+
+    def _current_hvac_mode(self) -> str | None:
+        """Live thermostat mode read, shared by the door/window FSM evaluation
+        (matches ``_pause_for_door_window()``'s own ``self.hass.states.get(
+        self.climate_entity)`` read)."""
+        state = self.hass.states.get(self.automation_engine.climate_entity)
+        return state.state if state else None
+
     def _update_shadow_engine_diagnostic(self) -> None:
         """Recompute production/shadow nat-vent lifecycle state agreement (Issue #613),
         plus (Issue #633) the independent nat-vent FSM's agreement with production.
@@ -859,11 +938,34 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         fsm_state = self._nat_vent_fsm_state.value
         mirror_agrees = production_state == shadow_state
         fsm_agrees = production_state == fsm_state
-        agrees = mirror_agrees and fsm_agrees
+
+        # Issue #637: door/window pause/grace FSM's own agreement, same pattern.
+        from .door_window_lifecycle import DoorWindowLifecycleInputs, derive_door_window_lifecycle_state
+
+        def _door_window_state_for(ae: AutomationEngine) -> str:
+            inputs = DoorWindowLifecycleInputs(
+                paused_by_door=bool(ae._paused_by_door),
+                paused_with_hvac_already_off=bool(ae._paused_with_hvac_already_off),
+                grace_active=bool(ae._grace_active),
+            )
+            return derive_door_window_lifecycle_state(inputs).value
+
+        door_window_production_state = _door_window_state_for(self.automation_engine)
+        door_window_shadow_state = _door_window_state_for(self.shadow_automation_engine)
+        door_window_fsm_state = self._door_window_fsm_state.value
+        door_window_mirror_agrees = door_window_production_state == door_window_shadow_state
+        door_window_fsm_agrees = door_window_production_state == door_window_fsm_state
+
+        agrees = mirror_agrees and fsm_agrees and door_window_mirror_agrees and door_window_fsm_agrees
         self._shadow_engine_diagnostic = {
             "production_state": production_state,
             "shadow_state": shadow_state,
             "nat_vent_fsm_state": fsm_state,
+            "door_window_production_state": door_window_production_state,
+            "door_window_shadow_state": door_window_shadow_state,
+            "door_window_fsm_state": door_window_fsm_state,
+            "door_window_mirror_agrees": door_window_mirror_agrees,
+            "door_window_fsm_agrees": door_window_fsm_agrees,
             "agrees": agrees,
             "checked_at": now.isoformat(),
         }
@@ -878,6 +980,18 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 "Nat-vent FSM disagreement (Issue #633): production=%s fsm=%s",
                 production_state,
                 fsm_state,
+            )
+        if not door_window_mirror_agrees:
+            _LOGGER.warning(
+                "Door/window shadow engine disagreement (Issue #637): production=%s shadow=%s",
+                door_window_production_state,
+                door_window_shadow_state,
+            )
+        if not door_window_fsm_agrees:
+            _LOGGER.warning(
+                "Door/window FSM disagreement (Issue #637): production=%s fsm=%s",
+                door_window_production_state,
+                door_window_fsm_state,
             )
 
     @property

--- a/custom_components/climate_advisor/door_window_close_response.py
+++ b/custom_components/climate_advisor/door_window_close_response.py
@@ -1,0 +1,46 @@
+"""Pure decision core for all-doors-windows-closed (Issue #637, Block 5 Phase 2).
+
+Reimplements ``handle_all_doors_windows_closed()``'s post-nat-vent-check
+``if self._pre_pause_mode:`` split — the #523 bug's exit-side twin (the entry
+side is ``door_window_pause_entry.py``).
+
+**Explicit scope boundary.** The nat-vent handoff (``if self._natural_vent_active:
+await self._exit_nat_vent(...); return``) and Issue #277's whole-house-fan stop
+are NOT modeled here — both are cross-lifecycle/shell concerns the assembly FSM
+handles as its own transition branch BEFORE calling this function, same as
+``nat_vent_fsm.py``'s active-session dispatch happening before its own gate
+calls. This module only answers "given we are NOT in a nat-vent handoff, what
+should happen to the pause state?"
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class DoorCloseResponseOutcome(Enum):
+    NOOP_NOT_PAUSED = "noop_not_paused"
+    RESTORE_AND_GRACE = "restore_and_grace"
+    CLEAR_NO_GRACE = "clear_no_grace"
+
+
+@dataclass(frozen=True)
+class DoorCloseResponseInputs:
+    """Field-by-field correspondence to ``handle_all_doors_windows_closed()``:
+
+    paused_by_door -> self._paused_by_door
+    pre_pause_mode -> self._pre_pause_mode
+    """
+
+    paused_by_door: bool
+    pre_pause_mode: str | None
+
+
+def decide_door_close_response(inputs: DoorCloseResponseInputs) -> DoorCloseResponseOutcome:
+    """Pure reimplementation of the post-nat-vent-check pause-clear branch."""
+    if not inputs.paused_by_door:
+        return DoorCloseResponseOutcome.NOOP_NOT_PAUSED
+    if inputs.pre_pause_mode:
+        return DoorCloseResponseOutcome.RESTORE_AND_GRACE
+    return DoorCloseResponseOutcome.CLEAR_NO_GRACE

--- a/custom_components/climate_advisor/door_window_fsm.py
+++ b/custom_components/climate_advisor/door_window_fsm.py
@@ -1,0 +1,461 @@
+"""Door/window pause/grace lifecycle FSM — the unified transition table (Issue #637,
+Block 5 Phase 2, epic #594).
+
+Assembles the 5 new pure pieces this phase built into one explicit
+``(state, event) -> Transition`` function, mirroring ``nat_vent_fsm.py``'s shape
+exactly:
+
+- ``door_window_lifecycle.derive_door_window_lifecycle_state()`` — the 5-state
+  enum this module reuses unchanged.
+- ``door_window_pause_entry.decide_pause_entry()`` — the mode-gated
+  active-vs-idle pause split (Issue #523).
+- ``door_window_open_response.decide_door_open_response()`` — the fresh-open
+  guard chain.
+- ``door_window_close_response.decide_door_close_response()`` — the
+  all-closed pause-clear split.
+- ``door_window_grace_expiry.decide_grace_expiry_outcome()`` — the grace-expiry
+  first-match-wins chain.
+- ``nat_vent_gate.decide_nat_vent_gate()`` (existing, reused unchanged) — the
+  shared reactivation gate, called from two sites (fresh-open eligibility and
+  the grace-expiry re-pause recheck), same as production calls
+  ``_nat_vent_may_reactivate()`` from both ``handle_door_window_open()`` and
+  ``_re_pause_for_open_sensor()``.
+
+**Refinement vs. the Phase 2 plan's file-by-file dependency list**: the plan
+noted ``door_window_open_response.py`` "reuses ``nat_vent_gate.decide_nat_vent_gate()``
+... caller resolves the bool, passes it in." That composition happens HERE, in
+the assembly module, not inside ``door_window_open_response.py`` itself — the
+leaf module stays a pure, dependency-free function (same shape as
+``door_window_pause_entry.py``), and this module owns cross-piece composition,
+exactly matching ``nat_vent_fsm.py``'s own convention (its ``_gate_inputs``/
+``_exit_inputs`` adapters call into ``nat_vent_gate.py`` from the assembly layer,
+not from ``nat_vent_exit.py`` itself). Reuse-not-duplicate is honored either
+way; this keeps the dependency direction consistent project-wide.
+
+This module does not re-derive or duplicate any of the 5 pure pieces' own
+logic — it is integration/wiring only.
+
+**Markov property, with one documented exception.** Every transition is
+computed from (current 5-state enum, event) — but where production's own
+choice of live wall-clock inputs (esp. ``hvac_mode``) determines *which*
+underlying flag combination a transition lands on (e.g. whether exiting
+``PAUSED_DURING_GRACE`` back to a plain paused state resolves to
+``PAUSED_ACTIVE`` or ``PAUSED_IDLE``), this module reads that from the event's
+own live-inputs snapshot — never from hidden extra memory. This is the same
+convention ``nat_vent_fsm.py``'s own docstring already establishes ("an event
+carrying a live-inputs snapshot"), not a new exception.
+
+**Explicit scope boundary — new findings surfaced during implementation, not
+just the plan's original two.** In addition to the two mutual-exclusion
+violation paths already documented in the Phase 2 plan
+(``handle_door_window_open()``'s grace-fallthrough,
+``_exit_nat_vent()``'s sensor-still-open branch), reading
+``_re_pause_for_open_sensor()`` in full during implementation found a THIRD,
+narrower case: when grace expires from ``PAUSED_DURING_GRACE`` with a sensor
+still open (``RE_PAUSE``), and the nested nat-vent reactivation recheck inside
+``_re_pause_for_open_sensor()`` then succeeds, ``_paused_by_door`` is NOT
+cleared by that nat-vent-activation branch — unlike the structurally similar
+branch in ``check_natural_vent_conditions()`` (automation.py:3486/3518), which
+DOES clear it. This is a genuine inconsistency between two nat-vent entry
+paths, not a bug this shadow-only phase fixes (would be a production behavior
+change) — noted here so it isn't silently modeled as clean. Net effect on
+THIS module: from ``PAUSED_DURING_GRACE``, the ``RE_PAUSE`` outcome always
+lands on a plain paused state regardless of whether the nested nat-vent recheck
+succeeds, since neither of its sub-branches clears ``_paused_by_door`` — so
+(unlike the same recheck from plain ``GRACE``, where it genuinely decides
+paused-vs-normal) this module does not need to evaluate the nested gate at all
+for that specific origin state. See ``_transition_from_paused_during_grace()``.
+
+**Cross-lifecycle inputs.** ``natural_vent_active`` and ``whf_owns_hvac`` are
+state *reads* from other lifecycles (Issue #631's "communicating automata"
+design) — legacy flag-derived today, same convention as ``nat_vent_fsm.py``'s
+own ``paused_by_door`` read.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+
+from .door_window_close_response import (
+    DoorCloseResponseInputs,
+    DoorCloseResponseOutcome,
+    decide_door_close_response,
+)
+from .door_window_grace_expiry import (
+    GraceExpiryInputs,
+    GraceExpiryOutcome,
+    decide_grace_expiry_outcome,
+)
+from .door_window_lifecycle import DoorWindowLifecycleState
+from .door_window_open_response import (
+    DoorOpenResponse,
+    DoorOpenResponseInputs,
+    decide_door_open_response,
+)
+from .door_window_pause_entry import PauseEntryInputs, PauseEntryOutcome, decide_pause_entry
+from .nat_vent_gate import NatVentGateInputs, decide_nat_vent_gate
+
+
+class DoorWindowFsmEventKind(Enum):
+    """What prompted this transition evaluation — one per real production
+    entry point, unlike nat-vent's single re-evaluated-every-tick model
+    (door/window's handlers are each triggered by a distinct event, not a
+    periodic re-check)."""
+
+    SENSOR_OPENED = "sensor_opened"
+    ALL_SENSORS_CLOSED = "all_sensors_closed"
+    GRACE_TIMER_EXPIRED = "grace_timer_expired"
+    MANUAL_OVERRIDE_DURING_PAUSE = "manual_override_during_pause"
+    DASHBOARD_RESUME = "dashboard_resume"
+    NAT_VENT_EXITED_SENSOR_STILL_OPEN = "nat_vent_exited_sensor_still_open"
+    SYNC_RECONCILE = "sync_reconcile"  # Issue #620's 4 reconcile call sites
+
+
+@dataclass(frozen=True)
+class DoorWindowFsmInputs:
+    """Every live reading this FSM's transition function may consult —
+    explicit, nothing hidden.
+
+    Field-by-field correspondence to the real ``AutomationEngine`` attributes:
+      hvac_mode                         -> self.hass.states.get(self.climate_entity).state
+      outdoor                            -> self._last_outdoor_temp
+      indoor                              -> self._get_indoor_temp_f()
+      comfort_heat                        -> self._nat_vent_reactivation_floor() —
+                                             already sleep-aware; passed to
+                                             NatVentGateInputs as both
+                                             comfort_heat_raw and sleep_heat
+                                             (in_sleep_window is therefore moot)
+      comfort_cool                        -> config comfort_cool
+      nat_vent_delta                      -> config CONF_NATURAL_VENT_DELTA
+      fan_mode                            -> config CONF_FAN_MODE
+      aggressive_savings                  -> config aggressive_savings
+      within_planned_window               -> self._is_within_planned_window_period()
+      any_sensor_open                     -> self._any_monitored_sensor_open()
+      sensor_debounce_pending             -> self._sensor_debounce_pending
+      override_matches_current_decision   -> self._override_matches_current_decision(
+                                              self._current_classification)
+      grace_source                        -> self._last_resume_source ("manual" | "automation")
+      natural_vent_active                 -> self._natural_vent_active (cross-lifecycle read)
+      whf_owns_hvac                       -> self._whf_owns_hvac() (cross-lifecycle read) —
+                                             added beyond the Phase 2 plan's literal field
+                                             list: required for faithful SYNC_RECONCILE
+                                             modeling (_sync_paused_by_door_with_live_sensors()'s
+                                             own guard reads it)
+      now                                  -> caller-resolved wall-clock time
+    """
+
+    hvac_mode: str | None
+    outdoor: float | None
+    indoor: float | None
+    comfort_heat: float
+    comfort_cool: float
+    nat_vent_delta: float
+    fan_mode: str
+    aggressive_savings: bool
+    within_planned_window: bool
+    any_sensor_open: bool
+    sensor_debounce_pending: bool
+    override_matches_current_decision: bool
+    grace_source: str
+    natural_vent_active: bool
+    whf_owns_hvac: bool
+    now: datetime
+
+
+@dataclass(frozen=True)
+class DoorWindowFsmEvent:
+    kind: DoorWindowFsmEventKind
+    inputs: DoorWindowFsmInputs
+
+
+@dataclass(frozen=True)
+class DoorWindowTransition:
+    """The transition's full record — audit trail by construction."""
+
+    from_state: DoorWindowLifecycleState
+    to_state: DoorWindowLifecycleState
+    event_kind: DoorWindowFsmEventKind
+    outcome: str | None = None
+    at: datetime | None = None
+
+    @property
+    def changed(self) -> bool:
+        return self.from_state != self.to_state
+
+
+def _nat_vent_gate_inputs(inputs: DoorWindowFsmInputs) -> NatVentGateInputs:
+    return NatVentGateInputs(
+        outdoor=inputs.outdoor,
+        indoor=inputs.indoor,
+        comfort_heat_raw=inputs.comfort_heat,
+        sleep_heat=inputs.comfort_heat,
+        in_sleep_window=False,
+        comfort_cool=inputs.comfort_cool,
+        nat_vent_delta=inputs.nat_vent_delta,
+        hysteresis=0.0,
+        fan_mode=inputs.fan_mode,
+        aggressive_savings=inputs.aggressive_savings,
+    )
+
+
+def _pause_sub_state(outcome: PauseEntryOutcome) -> DoorWindowLifecycleState | None:
+    """Maps a ``PauseEntryOutcome`` to its plain (non-grace) paused state, or
+    ``None`` for ``NOOP_NOT_APPLICABLE`` (no pause recorded)."""
+    if outcome == PauseEntryOutcome.PAUSE_ACTIVE:
+        return DoorWindowLifecycleState.PAUSED_ACTIVE
+    if outcome == PauseEntryOutcome.PAUSE_IDLE:
+        return DoorWindowLifecycleState.PAUSED_IDLE
+    return None
+
+
+def _active_pause_mode(hvac_mode: str | None) -> bool:
+    """Mirrors ``_exit_nat_vent()``'s sensor-still-open branch: unlike
+    ``_pause_for_door_window()``, this call site sets ``_paused_by_door = True``
+    UNCONDITIONALLY (no mode gate at all) and separately derives
+    ``_pre_pause_mode`` as ``state.state if state and state.state != "off" else
+    None``. So "active" here means "mode present and not off" — this includes
+    ``"unavailable"``/``"unknown"`` (production would literally store
+    ``pre_pause_mode="unavailable"``, a non-None string), unlike
+    ``decide_pause_entry()``'s 3-way split, which treats those as a distinct
+    no-op outcome (not applicable here because this call site never has a
+    not-applicable branch — it unconditionally pauses). Only a missing state
+    object (``None``) or a literal ``"off"`` mode collapses to idle."""
+    return bool(hvac_mode) and hvac_mode != "off"
+
+
+def _transition_from_normal(current_state: DoorWindowLifecycleState, event: DoorWindowFsmEvent) -> DoorWindowTransition:
+    inputs = event.inputs
+    kind = event.kind
+
+    if kind == DoorWindowFsmEventKind.SENSOR_OPENED:
+        response = decide_door_open_response(
+            DoorOpenResponseInputs(
+                paused_by_door=False,
+                grace_active=False,
+                outdoor=inputs.outdoor,
+                comfort_cool=inputs.comfort_cool,
+                nat_vent_delta=inputs.nat_vent_delta,
+                within_planned_window=inputs.within_planned_window,
+                nat_vent_gate_entered=decide_nat_vent_gate(_nat_vent_gate_inputs(inputs)),
+            )
+        )
+        if response == DoorOpenResponse.PAUSE:
+            next_state = _pause_sub_state(decide_pause_entry(PauseEntryInputs(hvac_mode=inputs.hvac_mode)))
+            next_state = next_state or current_state
+        else:
+            next_state = current_state
+        return DoorWindowTransition(current_state, next_state, kind, response.value, inputs.now)
+
+    if kind == DoorWindowFsmEventKind.SYNC_RECONCILE:
+        next_state = _sync_reconcile_next_state(current_state, inputs)
+        return DoorWindowTransition(current_state, next_state, kind, "sync_reconcile", inputs.now)
+
+    if kind == DoorWindowFsmEventKind.NAT_VENT_EXITED_SENSOR_STILL_OPEN:
+        next_state = (
+            DoorWindowLifecycleState.PAUSED_ACTIVE
+            if _active_pause_mode(inputs.hvac_mode)
+            else DoorWindowLifecycleState.PAUSED_IDLE
+        )
+        return DoorWindowTransition(current_state, next_state, kind, "nat_vent_exit_pause", inputs.now)
+
+    if kind == DoorWindowFsmEventKind.ALL_SENSORS_CLOSED:
+        outcome = decide_door_close_response(DoorCloseResponseInputs(paused_by_door=False, pre_pause_mode=None))
+        return DoorWindowTransition(current_state, current_state, kind, outcome.value, inputs.now)
+
+    # GRACE_TIMER_EXPIRED / MANUAL_OVERRIDE_DURING_PAUSE / DASHBOARD_RESUME: not
+    # reachable from NORMAL in production (each has its own early-return guard
+    # keyed on paused_by_door/an active grace timer, neither of which exists
+    # here) — modeled as a defensive no-op rather than silently ignored.
+    return DoorWindowTransition(current_state, current_state, kind, "unreachable_from_normal", inputs.now)
+
+
+def _sync_reconcile_next_state(
+    current_state: DoorWindowLifecycleState, inputs: DoorWindowFsmInputs
+) -> DoorWindowLifecycleState:
+    """Pure reimplementation of ``_sync_paused_by_door_with_live_sensors()`` (Issue #620),
+    for the two origin states where its own guard doesn't immediately no-op
+    (NORMAL, GRACE — both have ``paused_by_door=False``)."""
+    if inputs.natural_vent_active or inputs.whf_owns_hvac:
+        return current_state
+    if inputs.within_planned_window:
+        return current_state
+    if inputs.sensor_debounce_pending or not inputs.any_sensor_open:
+        return current_state
+
+    sub_state = _pause_sub_state(decide_pause_entry(PauseEntryInputs(hvac_mode=inputs.hvac_mode)))
+    if sub_state is None:
+        return current_state
+    if current_state == DoorWindowLifecycleState.GRACE:
+        return DoorWindowLifecycleState.PAUSED_DURING_GRACE
+    return sub_state
+
+
+def _transition_from_paused(current_state: DoorWindowLifecycleState, event: DoorWindowFsmEvent) -> DoorWindowTransition:
+    inputs = event.inputs
+    kind = event.kind
+
+    if kind == DoorWindowFsmEventKind.ALL_SENSORS_CLOSED:
+        outcome = decide_door_close_response(
+            DoorCloseResponseInputs(
+                paused_by_door=True,
+                pre_pause_mode="restored" if current_state == DoorWindowLifecycleState.PAUSED_ACTIVE else None,
+            )
+        )
+        next_state = (
+            DoorWindowLifecycleState.GRACE
+            if outcome == DoorCloseResponseOutcome.RESTORE_AND_GRACE
+            else DoorWindowLifecycleState.NORMAL
+        )
+        return DoorWindowTransition(current_state, next_state, kind, outcome.value, inputs.now)
+
+    if kind == DoorWindowFsmEventKind.MANUAL_OVERRIDE_DURING_PAUSE:
+        return DoorWindowTransition(
+            current_state, DoorWindowLifecycleState.NORMAL, kind, "override_confirmation_started", inputs.now
+        )
+
+    if kind == DoorWindowFsmEventKind.DASHBOARD_RESUME:
+        return DoorWindowTransition(current_state, DoorWindowLifecycleState.GRACE, kind, "resumed", inputs.now)
+
+    # SENSOR_OPENED / SYNC_RECONCILE: both guard on paused_by_door already
+    # being True and no-op. GRACE_TIMER_EXPIRED / NAT_VENT_EXITED_SENSOR_STILL_OPEN:
+    # not reachable from a plain paused state (no grace timer running; nat-vent
+    # cannot be active while already paused per the two evidenced entry paths).
+    return DoorWindowTransition(current_state, current_state, kind, "noop_already_paused", inputs.now)
+
+
+def _transition_from_grace(current_state: DoorWindowLifecycleState, event: DoorWindowFsmEvent) -> DoorWindowTransition:
+    inputs = event.inputs
+    kind = event.kind
+
+    if kind == DoorWindowFsmEventKind.SENSOR_OPENED:
+        response = decide_door_open_response(
+            DoorOpenResponseInputs(
+                paused_by_door=False,
+                grace_active=True,
+                outdoor=inputs.outdoor,
+                comfort_cool=inputs.comfort_cool,
+                nat_vent_delta=inputs.nat_vent_delta,
+                within_planned_window=inputs.within_planned_window,
+                nat_vent_gate_entered=decide_nat_vent_gate(_nat_vent_gate_inputs(inputs)),
+            )
+        )
+        if response == DoorOpenResponse.PAUSE:
+            # _pause_for_door_window() runs with grace untouched — the
+            # confirmed-reachable violation path #1 (see module docstring).
+            sub = decide_pause_entry(PauseEntryInputs(hvac_mode=inputs.hvac_mode))
+            next_state = (
+                DoorWindowLifecycleState.PAUSED_DURING_GRACE
+                if sub != PauseEntryOutcome.NOOP_NOT_APPLICABLE
+                else current_state
+            )
+        else:
+            next_state = current_state
+        return DoorWindowTransition(current_state, next_state, kind, response.value, inputs.now)
+
+    if kind == DoorWindowFsmEventKind.SYNC_RECONCILE:
+        next_state = _sync_reconcile_next_state(current_state, inputs)
+        return DoorWindowTransition(current_state, next_state, kind, "sync_reconcile", inputs.now)
+
+    if kind == DoorWindowFsmEventKind.NAT_VENT_EXITED_SENSOR_STILL_OPEN:
+        # Unconditional pause set, grace untouched — violation path #2.
+        return DoorWindowTransition(
+            current_state, DoorWindowLifecycleState.PAUSED_DURING_GRACE, kind, "nat_vent_exit_pause", inputs.now
+        )
+
+    if kind == DoorWindowFsmEventKind.ALL_SENSORS_CLOSED:
+        outcome = decide_door_close_response(DoorCloseResponseInputs(paused_by_door=False, pre_pause_mode=None))
+        return DoorWindowTransition(current_state, current_state, kind, outcome.value, inputs.now)
+
+    if kind == DoorWindowFsmEventKind.GRACE_TIMER_EXPIRED:
+        outcome = decide_grace_expiry_outcome(
+            GraceExpiryInputs(
+                within_planned_window=inputs.within_planned_window,
+                any_sensor_open=inputs.any_sensor_open,
+                source=inputs.grace_source,
+                override_matches_current_decision=inputs.override_matches_current_decision,
+            )
+        )
+        if outcome == GraceExpiryOutcome.RE_PAUSE:
+            # From plain GRACE, the nested nat-vent recheck inside
+            # _re_pause_for_open_sensor() genuinely decides NORMAL (nat-vent
+            # handoff) vs a plain paused state — unlike from
+            # PAUSED_DURING_GRACE, see _transition_from_paused_during_grace().
+            if decide_nat_vent_gate(_nat_vent_gate_inputs(inputs)):
+                next_state = DoorWindowLifecycleState.NORMAL
+            else:
+                sub = _pause_sub_state(decide_pause_entry(PauseEntryInputs(hvac_mode=inputs.hvac_mode)))
+                next_state = sub or DoorWindowLifecycleState.NORMAL
+        else:
+            next_state = DoorWindowLifecycleState.NORMAL
+        return DoorWindowTransition(current_state, next_state, kind, outcome.value, inputs.now)
+
+    # MANUAL_OVERRIDE_DURING_PAUSE / DASHBOARD_RESUME: both guard on
+    # paused_by_door being True and no-op from plain GRACE.
+    return DoorWindowTransition(current_state, current_state, kind, "noop_not_paused", inputs.now)
+
+
+def _transition_from_paused_during_grace(
+    current_state: DoorWindowLifecycleState, event: DoorWindowFsmEvent
+) -> DoorWindowTransition:
+    inputs = event.inputs
+    kind = event.kind
+
+    if kind == DoorWindowFsmEventKind.GRACE_TIMER_EXPIRED:
+        # All 4 real outcomes clear grace (_cancel_grace_timers()) without
+        # touching _paused_by_door — including RE_PAUSE, whose nested nat-vent
+        # recheck (unlike the plain-GRACE case above) does NOT clear
+        # _paused_by_door either way (see module docstring's third finding).
+        # So every outcome converges on the same next-state logic: grace
+        # clears, pause remains, sub-state re-derived from the live hvac_mode
+        # on THIS event (the composite state doesn't itself retain which
+        # plain sub-state it came from — same live-inputs-on-the-event
+        # convention nat_vent_fsm.py already establishes).
+        outcome = decide_grace_expiry_outcome(
+            GraceExpiryInputs(
+                within_planned_window=inputs.within_planned_window,
+                any_sensor_open=inputs.any_sensor_open,
+                source=inputs.grace_source,
+                override_matches_current_decision=inputs.override_matches_current_decision,
+            )
+        )
+        sub = _pause_sub_state(decide_pause_entry(PauseEntryInputs(hvac_mode=inputs.hvac_mode)))
+        next_state = sub or DoorWindowLifecycleState.PAUSED_ACTIVE
+        return DoorWindowTransition(current_state, next_state, kind, outcome.value, inputs.now)
+
+    if kind == DoorWindowFsmEventKind.ALL_SENSORS_CLOSED:
+        # Grace was already running; closing sensors clears the pause and
+        # either refreshes grace (RESTORE_AND_GRACE) or leaves the existing
+        # grace timer untouched (CLEAR_NO_GRACE) — both land on plain GRACE,
+        # never NORMAL, since neither branch cancels grace outright.
+        outcome = decide_door_close_response(DoorCloseResponseInputs(paused_by_door=True, pre_pause_mode="restored"))
+        return DoorWindowTransition(current_state, DoorWindowLifecycleState.GRACE, kind, outcome.value, inputs.now)
+
+    if kind == DoorWindowFsmEventKind.MANUAL_OVERRIDE_DURING_PAUSE:
+        # Clears pause, leaves grace running (untouched) — lands on GRACE.
+        return DoorWindowTransition(
+            current_state, DoorWindowLifecycleState.GRACE, kind, "override_confirmation_started", inputs.now
+        )
+
+    if kind == DoorWindowFsmEventKind.DASHBOARD_RESUME:
+        # Clears pause, unconditionally re-arms grace — lands on GRACE.
+        return DoorWindowTransition(current_state, DoorWindowLifecycleState.GRACE, kind, "resumed", inputs.now)
+
+    # SENSOR_OPENED / SYNC_RECONCILE: both guard on paused_by_door already
+    # being True and no-op. NAT_VENT_EXITED_SENSOR_STILL_OPEN: not reachable
+    # (nat-vent cannot be active while already paused, per the evidenced entry
+    # paths — see module docstring).
+    return DoorWindowTransition(current_state, current_state, kind, "noop_already_paused_during_grace", inputs.now)
+
+
+def transition(current_state: DoorWindowLifecycleState, event: DoorWindowFsmEvent) -> DoorWindowTransition:
+    """The single entry point: given the current state and an event carrying a
+    live-inputs snapshot, return the next state (and why)."""
+    if current_state == DoorWindowLifecycleState.NORMAL:
+        return _transition_from_normal(current_state, event)
+    if current_state in (DoorWindowLifecycleState.PAUSED_ACTIVE, DoorWindowLifecycleState.PAUSED_IDLE):
+        return _transition_from_paused(current_state, event)
+    if current_state == DoorWindowLifecycleState.GRACE:
+        return _transition_from_grace(current_state, event)
+    return _transition_from_paused_during_grace(current_state, event)

--- a/custom_components/climate_advisor/door_window_grace_expiry.py
+++ b/custom_components/climate_advisor/door_window_grace_expiry.py
@@ -1,0 +1,63 @@
+"""Pure decision core for grace-period expiry (Issue #637, Block 5 Phase 2).
+
+Reimplements ``_on_grace_expired()``'s first-match-wins chain: planned-window
+exemption, sensor-still-open re-pause, Issue #483's adopt-matching-decision
+check, and the plain clear.
+
+**Explicit scope boundary.** Issue #530's RF-timer-boundary settle-window side
+effect (arming ``_timer_boundary_settle_until`` before any branch below is
+even evaluated) is NOT modeled — it is orthogonal to which outcome fires, a
+pure side effect keyed on ``source == "manual"`` and a separate flag, and stays
+shell-side, same discipline as nat-vent's soft-start-escalation exclusion.
+Notification text selection also stays shell-side (I/O).
+
+``override_matches_current_decision`` is caller-resolved (via the real
+``_override_matches_current_decision()``, which needs live ``DayClassification``
+comparison this module has no business re-deriving) rather than computed here —
+same "no logic duplicated across modules" rule as
+``door_window_open_response.py``'s ``nat_vent_gate_entered`` field.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class GraceExpiryOutcome(Enum):
+    CLEAR_PLANNED_WINDOW = "clear_planned_window"
+    RE_PAUSE = "re_pause"
+    ADOPT_OVERRIDE = "adopt_override"
+    CLEAR_NORMAL = "clear_normal"
+
+
+@dataclass(frozen=True)
+class GraceExpiryInputs:
+    """Field-by-field correspondence to ``_on_grace_expired()``:
+
+    within_planned_window            -> self._is_within_planned_window_period()
+    any_sensor_open                   -> self._any_monitored_sensor_open()
+    source                             -> the grace's own source ("manual" | "automation")
+    override_matches_current_decision -> self._override_matches_current_decision(
+                                          self._current_classification), only ever
+                                          consulted when source == "manual"
+    """
+
+    within_planned_window: bool
+    any_sensor_open: bool
+    source: str
+    override_matches_current_decision: bool
+
+
+def decide_grace_expiry_outcome(inputs: GraceExpiryInputs) -> GraceExpiryOutcome:
+    """Pure reimplementation of ``_on_grace_expired()``'s first-match-wins chain."""
+    if inputs.within_planned_window:
+        return GraceExpiryOutcome.CLEAR_PLANNED_WINDOW
+
+    if inputs.any_sensor_open:
+        return GraceExpiryOutcome.RE_PAUSE
+
+    if inputs.source == "manual" and inputs.override_matches_current_decision:
+        return GraceExpiryOutcome.ADOPT_OVERRIDE
+
+    return GraceExpiryOutcome.CLEAR_NORMAL

--- a/custom_components/climate_advisor/door_window_lifecycle.py
+++ b/custom_components/climate_advisor/door_window_lifecycle.py
@@ -1,0 +1,91 @@
+"""Pure session-state derivation for the door/window pause/grace lifecycle (Issue #637,
+Block 5 Phase 2, epic #594).
+
+Mirrors ``nat_vent_lifecycle.py``'s role for nat-vent: answers "given the engine's
+current flags, what SESSION state is door/window pause/grace in right now?" — a
+question ``docs/grace-periods-spec.md`` itself flags as having no named state enum
+in the code today, only an undifferentiated NORMAL/PAUSED/GRACE table plus a
+"special case" nat-vent overlap row.
+
+**Five states, not three.** ``_paused_with_hvac_already_off`` (Issue #523's fix)
+makes "all sensors close" resolve to two different destinations depending on
+whether HVAC was actively interrupted when the pause started — a flag-only
+PAUSED can't express that distinction as a clean state read without re-deriving
+history, so ``PAUSED_ACTIVE``/``PAUSED_IDLE`` are separate states here, same
+precedent as nat-vent's own ``ACTIVE_SOFT_START``/``ACTIVE_FULL_GATE`` split.
+
+**``PAUSED_DURING_GRACE`` — confirmed reachable, not hypothetical.** The
+production invariant "``_paused_by_door`` and ``_grace_active`` are mutually
+exclusive" does not actually hold: two reachable paths set one without clearing
+the other — ``handle_door_window_open()`` falling through to
+``_pause_for_door_window()`` while ``_grace_active`` is still True (its own
+outdoor-too-warm guard only blocks the branch, it never re-checks after falling
+through to the nat-vent-gate-failed pause), and ``_exit_nat_vent()``'s
+sensor-still-open branch setting ``_paused_by_door = True`` directly without
+touching ``_grace_active`` at all. See the Phase 2 plan
+(``docs/grace-periods-spec.md`` and the epic #594 tracking issue) for the full
+static-trace evidence. This module models the combination as a legitimate fifth
+state rather than silently collapsing it — the alternative (picking a winner)
+would misrepresent what production is actually doing, which is exactly the risk
+this whole FSM effort exists to eliminate.
+
+Purely a read of existing truth — no new state is stored anywhere. Not called
+from any production decision path; differentially validated in shadow mode
+only, same discipline as ``nat_vent_lifecycle.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class DoorWindowLifecycleState(Enum):
+    """The five states the door/window pause/grace lifecycle can be in."""
+
+    NORMAL = "normal"
+    PAUSED_ACTIVE = "paused_active"
+    PAUSED_IDLE = "paused_idle"
+    GRACE = "grace"
+    PAUSED_DURING_GRACE = "paused_during_grace"
+
+
+@dataclass(frozen=True)
+class DoorWindowLifecycleInputs:
+    """Every flag the derivation reads — explicit, nothing hidden.
+
+    Field-by-field correspondence to the real ``AutomationEngine`` attributes:
+      paused_by_door              -> self._paused_by_door
+      paused_with_hvac_already_off -> self._paused_with_hvac_already_off (Issue #523)
+      grace_active                -> self._grace_active
+    """
+
+    paused_by_door: bool
+    paused_with_hvac_already_off: bool
+    grace_active: bool
+
+
+def derive_door_window_lifecycle_state(inputs: DoorWindowLifecycleInputs) -> DoorWindowLifecycleState:
+    """Pure derivation of the current door/window lifecycle state from existing flags.
+
+    Precedence:
+
+    1. ``paused_by_door`` and ``grace_active`` both True — ``PAUSED_DURING_GRACE``
+       (the confirmed-reachable composite state, see module docstring).
+    2. ``paused_by_door`` alone — ``PAUSED_ACTIVE`` or ``PAUSED_IDLE``, split on
+       ``paused_with_hvac_already_off``.
+    3. ``grace_active`` alone — ``GRACE``.
+    4. Neither — ``NORMAL``.
+    """
+    if inputs.paused_by_door and inputs.grace_active:
+        return DoorWindowLifecycleState.PAUSED_DURING_GRACE
+
+    if inputs.paused_by_door:
+        if inputs.paused_with_hvac_already_off:
+            return DoorWindowLifecycleState.PAUSED_IDLE
+        return DoorWindowLifecycleState.PAUSED_ACTIVE
+
+    if inputs.grace_active:
+        return DoorWindowLifecycleState.GRACE
+
+    return DoorWindowLifecycleState.NORMAL

--- a/custom_components/climate_advisor/door_window_open_response.py
+++ b/custom_components/climate_advisor/door_window_open_response.py
@@ -1,0 +1,92 @@
+"""Pure decision core for a fresh door/window open event (Issue #637, Block 5 Phase 2).
+
+Reimplements ``handle_door_window_open()``'s guard chain (already-paused check,
+grace suppression, planned-window exemption, nat-vent eligibility) up to the
+point where production either hands off to nat-vent or falls through to a pause.
+
+**Deviation from the Phase 2 plan's initial outcome list**: the plan's draft
+listed a standalone ``GRACE_FALL_THROUGH`` outcome alongside the terminal ones.
+On implementation, "grace suppressed but outdoor is cool enough to continue
+evaluating" is not itself a distinguishable decision a caller needs to act on —
+production's own code re-enters the SAME planned-window/nat-vent/pause chain
+below it, not a different one. Modeling it as a separate terminal outcome would
+require the assembly FSM to call this function twice for one event (once to
+learn "fell through", again for what happens next) — extra indirection with no
+behavioral payoff, and a DRY violation against this project's own
+``desired_state.decide_scheduled_band_gate()`` precedent (one gate, evaluated
+once, not staged). The fall-through is handled as plain internal control flow
+instead; only outcomes that require the assembly FSM to route to a genuinely
+different next state are modeled as enum members.
+
+**Nat-vent gate reuse**: ``nat_vent_gate_entered`` is caller-resolved (via
+``nat_vent_gate.decide_nat_vent_gate()``, hysteresis=0.0 — matching this call
+site's real behavior) rather than re-derived here, per the "no logic duplicated
+across modules" rule this whole FSM effort is built around.
+
+**Explicit scope boundary — Phase 2 forecast/thermal-floor nat-vent guards.**
+NOT modeled here, same discipline as ``nat_vent_fsm.py``'s own exclusions:
+production's ``handle_door_window_open()`` applies two additional guards
+(rising-forecast lookahead, thermal-floor imminence) AFTER the nat-vent gate
+passes, which can still skip nat-vent and fall through to pause even when this
+module returns ``NAT_VENT_ELIGIBLE``. Neither guard has its own pure extraction
+yet — folding them in here would silently introduce unvalidated behavior.
+Candidate for a future revision once evidenced by their own pure extraction.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class DoorOpenResponse(Enum):
+    ALREADY_PAUSED_NOOP = "already_paused_noop"
+    GRACE_SUPPRESSED = "grace_suppressed"
+    PLANNED_WINDOW_NOOP = "planned_window_noop"
+    NAT_VENT_ELIGIBLE = "nat_vent_eligible"
+    PAUSE = "pause"
+
+
+@dataclass(frozen=True)
+class DoorOpenResponseInputs:
+    """Field-by-field correspondence to ``handle_door_window_open()``:
+
+    paused_by_door        -> self._paused_by_door
+    grace_active           -> self._grace_active
+    outdoor                 -> self._last_outdoor_temp
+    comfort_cool            -> config comfort_cool
+    nat_vent_delta          -> config CONF_NATURAL_VENT_DELTA
+    within_planned_window   -> self._is_within_planned_window_period()
+    nat_vent_gate_entered   -> self._nat_vent_may_reactivate(..., hysteresis=0.0) —
+                                caller-resolved via nat_vent_gate.decide_nat_vent_gate()
+    """
+
+    paused_by_door: bool
+    grace_active: bool
+    outdoor: float | None
+    comfort_cool: float
+    nat_vent_delta: float
+    within_planned_window: bool
+    nat_vent_gate_entered: bool
+
+
+def decide_door_open_response(inputs: DoorOpenResponseInputs) -> DoorOpenResponse:
+    """Pure reimplementation of ``handle_door_window_open()``'s guard chain."""
+    if inputs.paused_by_door:
+        return DoorOpenResponse.ALREADY_PAUSED_NOOP
+
+    if inputs.grace_active:
+        threshold = inputs.comfort_cool + inputs.nat_vent_delta
+        outdoor_cool_enough = inputs.outdoor is not None and inputs.outdoor < threshold
+        if not outdoor_cool_enough:
+            return DoorOpenResponse.GRACE_SUPPRESSED
+        # else: outdoor cool enough — fall through to the same chain below,
+        # matching production's `pass  # outdoor cool enough — fall through`.
+
+    if inputs.within_planned_window:
+        return DoorOpenResponse.PLANNED_WINDOW_NOOP
+
+    if inputs.nat_vent_gate_entered:
+        return DoorOpenResponse.NAT_VENT_ELIGIBLE
+
+    return DoorOpenResponse.PAUSE

--- a/custom_components/climate_advisor/door_window_pause_entry.py
+++ b/custom_components/climate_advisor/door_window_pause_entry.py
@@ -1,0 +1,58 @@
+"""Pure decision core for entering a door/window pause (Issue #637, Block 5 Phase 2).
+
+Reimplements the branch structure of ``_pause_for_door_window()`` — the single
+choke point Issue #523 introduced after ``handle_door_window_open()`` and
+``_re_pause_for_open_sensor()`` used to hand-roll this off-vs-already-off split
+separately and drifted out of sync.
+
+Scope: this module answers "given the current HVAC mode, what should happen on
+pause entry?" as a pure function. It does NOT perform the mode write, the
+notification, or the event emission — those stay shell-side (they're I/O),
+exactly as ``nat_vent_gate.py``'s split from its own shell callers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class PauseEntryOutcome(Enum):
+    """Mirrors ``_pause_for_door_window()``'s three-way branch on live HVAC mode."""
+
+    PAUSE_ACTIVE = "pause_active"  # mode not in (off, unavailable, unknown) — real mode transition
+    PAUSE_IDLE = "pause_idle"  # mode == "off" — flag-only pause, Issue #523
+    NOOP_NOT_APPLICABLE = "noop_not_applicable"  # mode in (unavailable, unknown) — no pause recorded
+
+
+@dataclass(frozen=True)
+class PauseEntryInputs:
+    """Field-by-field correspondence to the real code:
+
+    hvac_mode -> ``self.hass.states.get(self.climate_entity)`` -> ``state.state``
+                 (``None`` when the entity itself is missing, distinct from the
+                 string ``"unavailable"``/``"unknown"`` — the real code checks
+                 ``mode and mode not in (...)`` so ``None`` also falls to the
+                 not-applicable branch)
+    """
+
+    hvac_mode: str | None
+
+
+_NOT_ACTIVE_MODES = ("off", "unavailable", "unknown")
+
+
+def decide_pause_entry(inputs: PauseEntryInputs) -> PauseEntryOutcome:
+    """Pure reimplementation of ``_pause_for_door_window()``'s mode branch.
+
+    Precedence mirrors the real code exactly: a mode outside (off, unavailable,
+    unknown) — including ``None`` — is an active pause; ``"off"`` is an idle
+    pause; ``"unavailable"``/``"unknown"`` is a no-op (the real method's implicit
+    fall-through — neither branch's condition matches, so nothing is set).
+    """
+    mode = inputs.hvac_mode
+    if mode and mode not in _NOT_ACTIVE_MODES:
+        return PauseEntryOutcome.PAUSE_ACTIVE
+    if mode == "off":
+        return PauseEntryOutcome.PAUSE_IDLE
+    return PauseEntryOutcome.NOOP_NOT_APPLICABLE

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.13"
+  "version": "0.6.14"
 }

--- a/tests/test_door_window_fsm.py
+++ b/tests/test_door_window_fsm.py
@@ -1,0 +1,278 @@
+"""Wiring tests for Issue #637 (Block 5 Phase 2): door/window pause FSM assembly.
+
+Each of the 5 pure pieces this FSM assembles already has its own exhaustive
+unit coverage (``tests/test_door_window_pure_modules.py``) — these tests focus
+on wiring correctness: does ``transition()`` route to the right pure function
+given the right adapted inputs, and land on the state the corresponding real
+``automation.py`` code path actually reaches. Mirrors
+``tests/test_nat_vent_fsm.py``'s structure.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from custom_components.climate_advisor.door_window_fsm import (
+    DoorWindowFsmEvent,
+    DoorWindowFsmEventKind,
+    DoorWindowFsmInputs,
+    transition,
+)
+from custom_components.climate_advisor.door_window_lifecycle import DoorWindowLifecycleState
+
+_NOW = datetime(2026, 8, 14, 12, 0, 0, tzinfo=UTC)
+
+
+def _inputs(**overrides) -> DoorWindowFsmInputs:
+    base = dict(
+        hvac_mode="cool",
+        outdoor=85.0,
+        indoor=76.0,
+        comfort_heat=68.0,
+        comfort_cool=78.0,
+        nat_vent_delta=2.0,
+        fan_mode="disabled",
+        aggressive_savings=False,
+        within_planned_window=False,
+        any_sensor_open=True,
+        sensor_debounce_pending=False,
+        override_matches_current_decision=False,
+        grace_source="manual",
+        natural_vent_active=False,
+        whf_owns_hvac=False,
+        now=_NOW,
+    )
+    base.update(overrides)
+    return DoorWindowFsmInputs(**base)
+
+
+def _ev(kind: DoorWindowFsmEventKind, **overrides) -> DoorWindowFsmEvent:
+    return DoorWindowFsmEvent(kind=kind, inputs=_inputs(**overrides))
+
+
+class TestFromNormal:
+    def test_sensor_opened_active_pause(self):
+        # outdoor 85 > threshold 80 -> nat-vent gate fails -> pause; hvac_mode "cool" -> active
+        t = transition(DoorWindowLifecycleState.NORMAL, _ev(DoorWindowFsmEventKind.SENSOR_OPENED))
+        assert t.to_state == DoorWindowLifecycleState.PAUSED_ACTIVE
+        assert t.changed
+
+    def test_sensor_opened_idle_pause(self):
+        t = transition(DoorWindowLifecycleState.NORMAL, _ev(DoorWindowFsmEventKind.SENSOR_OPENED, hvac_mode="off"))
+        assert t.to_state == DoorWindowLifecycleState.PAUSED_IDLE
+
+    def test_sensor_opened_nat_vent_eligible_stays_normal(self):
+        # outdoor 60 < indoor 76, outdoor < threshold 80 -> nat-vent gate passes
+        t = transition(DoorWindowLifecycleState.NORMAL, _ev(DoorWindowFsmEventKind.SENSOR_OPENED, outdoor=60.0))
+        assert t.to_state == DoorWindowLifecycleState.NORMAL
+        assert t.outcome == "nat_vent_eligible"
+
+    def test_sensor_opened_planned_window_noop(self):
+        t = transition(
+            DoorWindowLifecycleState.NORMAL,
+            _ev(DoorWindowFsmEventKind.SENSOR_OPENED, within_planned_window=True),
+        )
+        assert t.to_state == DoorWindowLifecycleState.NORMAL
+        assert t.outcome == "planned_window_noop"
+
+    def test_all_sensors_closed_noop(self):
+        t = transition(DoorWindowLifecycleState.NORMAL, _ev(DoorWindowFsmEventKind.ALL_SENSORS_CLOSED))
+        assert t.to_state == DoorWindowLifecycleState.NORMAL
+
+    def test_dashboard_resume_unreachable_noop(self):
+        t = transition(DoorWindowLifecycleState.NORMAL, _ev(DoorWindowFsmEventKind.DASHBOARD_RESUME))
+        assert t.to_state == DoorWindowLifecycleState.NORMAL
+
+    def test_sync_reconcile_pauses_when_sensor_open_and_untracked(self):
+        t = transition(
+            DoorWindowLifecycleState.NORMAL,
+            _ev(DoorWindowFsmEventKind.SYNC_RECONCILE, any_sensor_open=True, hvac_mode="heat"),
+        )
+        assert t.to_state == DoorWindowLifecycleState.PAUSED_ACTIVE
+
+    def test_sync_reconcile_noop_when_no_sensor_open(self):
+        t = transition(
+            DoorWindowLifecycleState.NORMAL,
+            _ev(DoorWindowFsmEventKind.SYNC_RECONCILE, any_sensor_open=False),
+        )
+        assert t.to_state == DoorWindowLifecycleState.NORMAL
+
+    def test_sync_reconcile_noop_when_nat_vent_active(self):
+        t = transition(
+            DoorWindowLifecycleState.NORMAL,
+            _ev(DoorWindowFsmEventKind.SYNC_RECONCILE, any_sensor_open=True, natural_vent_active=True),
+        )
+        assert t.to_state == DoorWindowLifecycleState.NORMAL
+
+    def test_nat_vent_exited_sensor_still_open_active(self):
+        t = transition(
+            DoorWindowLifecycleState.NORMAL,
+            _ev(DoorWindowFsmEventKind.NAT_VENT_EXITED_SENSOR_STILL_OPEN, hvac_mode="cool"),
+        )
+        assert t.to_state == DoorWindowLifecycleState.PAUSED_ACTIVE
+
+    def test_nat_vent_exited_sensor_still_open_idle_when_mode_off(self):
+        # _exit_nat_vent()'s pre_pause_mode read is `state.state if state and
+        # state.state != "off" else None` — "unavailable" is a non-None string
+        # (production would literally store pre_pause_mode="unavailable"),
+        # which this module treats as active per the same != "off" test. Only
+        # a literal "off" mode collapses to idle.
+        t = transition(
+            DoorWindowLifecycleState.NORMAL,
+            _ev(DoorWindowFsmEventKind.NAT_VENT_EXITED_SENSOR_STILL_OPEN, hvac_mode="off"),
+        )
+        assert t.to_state == DoorWindowLifecycleState.PAUSED_IDLE
+
+
+class TestFromPaused:
+    def test_all_sensors_closed_active_restores_and_graces(self):
+        t = transition(DoorWindowLifecycleState.PAUSED_ACTIVE, _ev(DoorWindowFsmEventKind.ALL_SENSORS_CLOSED))
+        assert t.to_state == DoorWindowLifecycleState.GRACE
+
+    def test_all_sensors_closed_idle_clears_no_grace(self):
+        t = transition(DoorWindowLifecycleState.PAUSED_IDLE, _ev(DoorWindowFsmEventKind.ALL_SENSORS_CLOSED))
+        assert t.to_state == DoorWindowLifecycleState.NORMAL
+
+    def test_manual_override_during_pause_clears_to_normal(self):
+        t = transition(DoorWindowLifecycleState.PAUSED_ACTIVE, _ev(DoorWindowFsmEventKind.MANUAL_OVERRIDE_DURING_PAUSE))
+        assert t.to_state == DoorWindowLifecycleState.NORMAL
+
+    def test_dashboard_resume_starts_grace(self):
+        t = transition(DoorWindowLifecycleState.PAUSED_IDLE, _ev(DoorWindowFsmEventKind.DASHBOARD_RESUME))
+        assert t.to_state == DoorWindowLifecycleState.GRACE
+
+    def test_sensor_opened_already_paused_noop(self):
+        t = transition(DoorWindowLifecycleState.PAUSED_ACTIVE, _ev(DoorWindowFsmEventKind.SENSOR_OPENED))
+        assert t.to_state == DoorWindowLifecycleState.PAUSED_ACTIVE
+
+    def test_grace_timer_expired_unreachable_noop(self):
+        t = transition(DoorWindowLifecycleState.PAUSED_ACTIVE, _ev(DoorWindowFsmEventKind.GRACE_TIMER_EXPIRED))
+        assert t.to_state == DoorWindowLifecycleState.PAUSED_ACTIVE
+
+
+class TestFromGrace:
+    def test_sensor_opened_outdoor_too_warm_suppressed(self):
+        t = transition(DoorWindowLifecycleState.GRACE, _ev(DoorWindowFsmEventKind.SENSOR_OPENED, outdoor=90.0))
+        assert t.to_state == DoorWindowLifecycleState.GRACE
+        assert t.outcome == "grace_suppressed"
+
+    def test_sensor_opened_falls_through_to_composite_state(self):
+        # outdoor cool enough (76 < threshold 80) -> falls through past the grace
+        # guard; nat-vent gate then fails (outdoor == indoor, not strictly less)
+        # -> pause, with grace still active -> PAUSED_DURING_GRACE.
+        t = transition(
+            DoorWindowLifecycleState.GRACE,
+            _ev(DoorWindowFsmEventKind.SENSOR_OPENED, outdoor=76.0, indoor=76.0, hvac_mode="cool"),
+        )
+        assert t.to_state == DoorWindowLifecycleState.PAUSED_DURING_GRACE
+
+    def test_sensor_opened_falls_through_to_nat_vent_eligible_stays_grace(self):
+        t = transition(
+            DoorWindowLifecycleState.GRACE,
+            _ev(DoorWindowFsmEventKind.SENSOR_OPENED, outdoor=60.0, indoor=76.0),
+        )
+        assert t.to_state == DoorWindowLifecycleState.GRACE
+        assert t.outcome == "nat_vent_eligible"
+
+    def test_nat_vent_exited_sensor_still_open_to_composite_state(self):
+        t = transition(DoorWindowLifecycleState.GRACE, _ev(DoorWindowFsmEventKind.NAT_VENT_EXITED_SENSOR_STILL_OPEN))
+        assert t.to_state == DoorWindowLifecycleState.PAUSED_DURING_GRACE
+
+    def test_grace_timer_expired_planned_window_clears(self):
+        t = transition(
+            DoorWindowLifecycleState.GRACE,
+            _ev(DoorWindowFsmEventKind.GRACE_TIMER_EXPIRED, within_planned_window=True),
+        )
+        assert t.to_state == DoorWindowLifecycleState.NORMAL
+        assert t.outcome == "clear_planned_window"
+
+    def test_grace_timer_expired_re_pause_nat_vent_ineligible(self):
+        t = transition(
+            DoorWindowLifecycleState.GRACE,
+            _ev(
+                DoorWindowFsmEventKind.GRACE_TIMER_EXPIRED,
+                any_sensor_open=True,
+                outdoor=90.0,
+                hvac_mode="cool",
+            ),
+        )
+        assert t.to_state == DoorWindowLifecycleState.PAUSED_ACTIVE
+        assert t.outcome == "re_pause"
+
+    def test_grace_timer_expired_re_pause_nat_vent_eligible_goes_normal(self):
+        t = transition(
+            DoorWindowLifecycleState.GRACE,
+            _ev(
+                DoorWindowFsmEventKind.GRACE_TIMER_EXPIRED,
+                any_sensor_open=True,
+                outdoor=60.0,
+                indoor=76.0,
+            ),
+        )
+        assert t.to_state == DoorWindowLifecycleState.NORMAL
+        assert t.outcome == "re_pause"
+
+    def test_grace_timer_expired_adopt_override(self):
+        t = transition(
+            DoorWindowLifecycleState.GRACE,
+            _ev(
+                DoorWindowFsmEventKind.GRACE_TIMER_EXPIRED,
+                any_sensor_open=False,
+                grace_source="manual",
+                override_matches_current_decision=True,
+            ),
+        )
+        assert t.to_state == DoorWindowLifecycleState.NORMAL
+        assert t.outcome == "adopt_override"
+
+    def test_grace_timer_expired_clear_normal(self):
+        t = transition(
+            DoorWindowLifecycleState.GRACE,
+            _ev(DoorWindowFsmEventKind.GRACE_TIMER_EXPIRED, any_sensor_open=False),
+        )
+        assert t.to_state == DoorWindowLifecycleState.NORMAL
+        assert t.outcome == "clear_normal"
+
+    def test_manual_override_during_pause_noop_from_grace(self):
+        t = transition(DoorWindowLifecycleState.GRACE, _ev(DoorWindowFsmEventKind.MANUAL_OVERRIDE_DURING_PAUSE))
+        assert t.to_state == DoorWindowLifecycleState.GRACE
+
+
+class TestFromPausedDuringGrace:
+    def test_grace_timer_expired_re_pause_lands_on_paused_idle_when_mode_off(self):
+        t = transition(
+            DoorWindowLifecycleState.PAUSED_DURING_GRACE,
+            _ev(DoorWindowFsmEventKind.GRACE_TIMER_EXPIRED, any_sensor_open=True, hvac_mode="off"),
+        )
+        assert t.to_state == DoorWindowLifecycleState.PAUSED_IDLE
+
+    def test_grace_timer_expired_planned_window_still_leaves_pause(self):
+        t = transition(
+            DoorWindowLifecycleState.PAUSED_DURING_GRACE,
+            _ev(
+                DoorWindowFsmEventKind.GRACE_TIMER_EXPIRED,
+                within_planned_window=True,
+                hvac_mode="cool",
+            ),
+        )
+        assert t.to_state == DoorWindowLifecycleState.PAUSED_ACTIVE
+        assert t.outcome == "clear_planned_window"
+
+    def test_all_sensors_closed_lands_on_grace(self):
+        t = transition(DoorWindowLifecycleState.PAUSED_DURING_GRACE, _ev(DoorWindowFsmEventKind.ALL_SENSORS_CLOSED))
+        assert t.to_state == DoorWindowLifecycleState.GRACE
+
+    def test_dashboard_resume_lands_on_grace(self):
+        t = transition(DoorWindowLifecycleState.PAUSED_DURING_GRACE, _ev(DoorWindowFsmEventKind.DASHBOARD_RESUME))
+        assert t.to_state == DoorWindowLifecycleState.GRACE
+
+    def test_manual_override_during_pause_lands_on_grace(self):
+        t = transition(
+            DoorWindowLifecycleState.PAUSED_DURING_GRACE,
+            _ev(DoorWindowFsmEventKind.MANUAL_OVERRIDE_DURING_PAUSE),
+        )
+        assert t.to_state == DoorWindowLifecycleState.GRACE
+
+    def test_sensor_opened_noop(self):
+        t = transition(DoorWindowLifecycleState.PAUSED_DURING_GRACE, _ev(DoorWindowFsmEventKind.SENSOR_OPENED))
+        assert t.to_state == DoorWindowLifecycleState.PAUSED_DURING_GRACE

--- a/tests/test_door_window_fsm_shadow_wiring.py
+++ b/tests/test_door_window_fsm_shadow_wiring.py
@@ -1,0 +1,157 @@
+"""Tests for Issue #637's wiring increment: running the unified door/window
+pause/grace FSM live against production's real readings, tracked as a third
+comparison point alongside the existing production/shadow mirror comparison.
+
+v1 scope, deliberately narrow (see ``coordinator._evaluate_door_window_fsm()``'s
+own docstring and ``_DOOR_WINDOW_FSM_EVENT_KINDS``): only triggered from the 3
+mirrored methods with an unambiguous door/window FSM event-kind correspondence.
+Mirrors ``tests/test_nat_vent_fsm_shadow_wiring.py``'s structure.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from custom_components.climate_advisor.door_window_lifecycle import DoorWindowLifecycleState
+from tools.sim_harness._loop import run_coro
+from tools.sim_harness.build_coordinator import build_headless_coordinator
+
+
+def _run(coro):
+    return run_coro(coro)
+
+
+def _noop_shadow_methods(coordinator, *names: str) -> None:
+    async def _noop(*args, **kwargs):
+        return None
+
+    for name in names:
+        setattr(coordinator.shadow_automation_engine, name, _noop)
+
+
+class TestFsmEvaluationScoping:
+    def test_not_triggered_by_unrelated_mirrored_call(self) -> None:
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        called: list[str] = []
+        coordinator._evaluate_door_window_fsm = lambda method_name: called.append(method_name)  # type: ignore[method-assign]
+
+        _noop_shadow_methods(coordinator, "apply_classification")
+        _run(coordinator._mirror_to_shadow("apply_classification", None))
+        assert called == []
+
+    def test_triggered_by_handle_door_window_open(self) -> None:
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        called: list[str] = []
+        coordinator._evaluate_door_window_fsm = lambda method_name: called.append(method_name)  # type: ignore[method-assign]
+
+        _noop_shadow_methods(coordinator, "handle_door_window_open")
+        _run(coordinator._mirror_to_shadow("handle_door_window_open", "binary_sensor.test"))
+        assert called == ["handle_door_window_open"]
+
+    def test_triggered_by_handle_all_doors_windows_closed(self) -> None:
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        called: list[str] = []
+        coordinator._evaluate_door_window_fsm = lambda method_name: called.append(method_name)  # type: ignore[method-assign]
+
+        _noop_shadow_methods(coordinator, "handle_all_doors_windows_closed")
+        _run(coordinator._mirror_to_shadow("handle_all_doors_windows_closed"))
+        assert called == ["handle_all_doors_windows_closed"]
+
+    def test_triggered_by_handle_manual_override_during_pause(self) -> None:
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        called: list[str] = []
+        coordinator._evaluate_door_window_fsm = lambda method_name: called.append(method_name)  # type: ignore[method-assign]
+
+        _noop_shadow_methods(coordinator, "handle_manual_override_during_pause")
+        _run(coordinator._mirror_to_shadow("handle_manual_override_during_pause"))
+        assert called == ["handle_manual_override_during_pause"]
+
+
+class TestFsmStateTracking:
+    def test_starts_normal(self) -> None:
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        assert coordinator._door_window_fsm_state == DoorWindowLifecycleState.NORMAL
+
+    def test_pauses_when_sensor_opens_and_hvac_active(self) -> None:
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator(
+            climate_state="cool", climate_attributes={"current_temperature": 76.0}
+        )
+        coordinator.automation_engine.update_outdoor_temp(90.0)  # too warm for nat-vent
+        coordinator.config["comfort_cool"] = 78.0
+
+        _noop_shadow_methods(coordinator, "handle_door_window_open")
+        _run(coordinator._mirror_to_shadow("handle_door_window_open", "binary_sensor.test"))
+
+        assert coordinator._door_window_fsm_state == DoorWindowLifecycleState.PAUSED_ACTIVE
+
+
+class TestDiagnosticIntegration:
+    def test_diagnostic_includes_door_window_fsm_state(self) -> None:
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+
+        _noop_shadow_methods(coordinator, "handle_door_window_open")
+        _run(coordinator._mirror_to_shadow("handle_door_window_open", "binary_sensor.test"))
+
+        diag = coordinator.shadow_engine_diagnostic
+        assert diag is not None
+        assert "door_window_fsm_state" in diag
+        assert "door_window_production_state" in diag
+        assert "door_window_fsm_agrees" in diag
+
+    def test_positive_control_fsm_disagreement_is_detected(self) -> None:
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator(
+            climate_state="cool", climate_attributes={"current_temperature": 76.0}
+        )
+        coordinator.automation_engine.update_outdoor_temp(90.0)
+        coordinator.config["comfort_cool"] = 78.0
+        # Force a disagreement: FSM will compute PAUSED_ACTIVE, production stays NORMAL.
+        coordinator.automation_engine._paused_by_door = False
+
+        _noop_shadow_methods(coordinator, "handle_door_window_open")
+        _run(coordinator._mirror_to_shadow("handle_door_window_open", "binary_sensor.test"))
+
+        diag = coordinator.shadow_engine_diagnostic
+        assert diag is not None
+        assert diag["agrees"] is False
+        assert diag["door_window_fsm_agrees"] is False
+        assert diag["door_window_fsm_state"] == DoorWindowLifecycleState.PAUSED_ACTIVE.value
+        assert diag["door_window_production_state"] == DoorWindowLifecycleState.NORMAL.value
+
+    def test_disagreement_logs_distinct_warning(self, caplog) -> None:
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator(
+            climate_state="cool", climate_attributes={"current_temperature": 76.0}
+        )
+        coordinator.automation_engine.update_outdoor_temp(90.0)
+        coordinator.config["comfort_cool"] = 78.0
+        coordinator.automation_engine._paused_by_door = False
+
+        _noop_shadow_methods(coordinator, "handle_door_window_open")
+        with caplog.at_level(logging.WARNING, logger="custom_components.climate_advisor.coordinator"):
+            _run(coordinator._mirror_to_shadow("handle_door_window_open", "binary_sensor.test"))
+        assert any("Door/window FSM disagreement" in r.message for r in caplog.records)
+
+
+class TestIsolation:
+    def test_fsm_exception_does_not_propagate(self) -> None:
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+
+        def _boom(method_name: str) -> None:
+            raise RuntimeError("door/window fsm blew up")
+
+        coordinator._evaluate_door_window_fsm = _boom  # type: ignore[method-assign]
+
+        _noop_shadow_methods(coordinator, "handle_door_window_open")
+        _run(coordinator._mirror_to_shadow("handle_door_window_open", "binary_sensor.test"))
+
+    def test_fsm_exception_logs_warning(self, caplog) -> None:
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+
+        def _boom(method_name: str) -> None:
+            raise RuntimeError("door/window fsm blew up")
+
+        coordinator._evaluate_door_window_fsm = _boom  # type: ignore[method-assign]
+
+        _noop_shadow_methods(coordinator, "handle_door_window_open")
+        with caplog.at_level(logging.WARNING, logger="custom_components.climate_advisor.coordinator"):
+            _run(coordinator._mirror_to_shadow("handle_door_window_open", "binary_sensor.test"))
+        assert any("door/window fsm blew up" in r.message for r in caplog.records)

--- a/tests/test_door_window_pure_modules.py
+++ b/tests/test_door_window_pure_modules.py
@@ -1,0 +1,194 @@
+"""Unit tests for the 5 pure building blocks of Issue #637 (Block 5 Phase 2:
+door/window pause FSM). Each function's input space is small enough for
+exhaustive coverage — mirrors the direct-unit-test layer of
+``tests/test_nat_vent_lifecycle_state.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.climate_advisor.door_window_close_response import (
+    DoorCloseResponseInputs,
+    DoorCloseResponseOutcome,
+    decide_door_close_response,
+)
+from custom_components.climate_advisor.door_window_grace_expiry import (
+    GraceExpiryInputs,
+    GraceExpiryOutcome,
+    decide_grace_expiry_outcome,
+)
+from custom_components.climate_advisor.door_window_lifecycle import (
+    DoorWindowLifecycleInputs,
+    DoorWindowLifecycleState,
+    derive_door_window_lifecycle_state,
+)
+from custom_components.climate_advisor.door_window_open_response import (
+    DoorOpenResponse,
+    DoorOpenResponseInputs,
+    decide_door_open_response,
+)
+from custom_components.climate_advisor.door_window_pause_entry import (
+    PauseEntryInputs,
+    PauseEntryOutcome,
+    decide_pause_entry,
+)
+
+
+class TestDeriveDoorWindowLifecycleState:
+    @pytest.mark.parametrize(
+        ("paused_by_door", "already_off", "grace_active", "expected"),
+        [
+            (False, False, False, DoorWindowLifecycleState.NORMAL),
+            (False, True, False, DoorWindowLifecycleState.NORMAL),  # already_off irrelevant unless paused
+            (False, False, True, DoorWindowLifecycleState.GRACE),
+            (False, True, True, DoorWindowLifecycleState.GRACE),
+            (True, False, False, DoorWindowLifecycleState.PAUSED_ACTIVE),
+            (True, True, False, DoorWindowLifecycleState.PAUSED_IDLE),
+            (True, False, True, DoorWindowLifecycleState.PAUSED_DURING_GRACE),
+            (True, True, True, DoorWindowLifecycleState.PAUSED_DURING_GRACE),
+        ],
+    )
+    def test_exhaustive_flag_space(self, paused_by_door, already_off, grace_active, expected):
+        result = derive_door_window_lifecycle_state(
+            DoorWindowLifecycleInputs(
+                paused_by_door=paused_by_door,
+                paused_with_hvac_already_off=already_off,
+                grace_active=grace_active,
+            )
+        )
+        assert result == expected
+
+
+class TestDecidePauseEntry:
+    @pytest.mark.parametrize(
+        ("hvac_mode", "expected"),
+        [
+            ("heat", PauseEntryOutcome.PAUSE_ACTIVE),
+            ("cool", PauseEntryOutcome.PAUSE_ACTIVE),
+            ("heat_cool", PauseEntryOutcome.PAUSE_ACTIVE),
+            ("off", PauseEntryOutcome.PAUSE_IDLE),
+            ("unavailable", PauseEntryOutcome.NOOP_NOT_APPLICABLE),
+            ("unknown", PauseEntryOutcome.NOOP_NOT_APPLICABLE),
+            (None, PauseEntryOutcome.NOOP_NOT_APPLICABLE),
+        ],
+    )
+    def test_mode_branches(self, hvac_mode, expected):
+        assert decide_pause_entry(PauseEntryInputs(hvac_mode=hvac_mode)) == expected
+
+
+class TestDecideDoorOpenResponse:
+    def _inputs(self, **overrides):
+        base = dict(
+            paused_by_door=False,
+            grace_active=False,
+            outdoor=70.0,
+            comfort_cool=78.0,
+            nat_vent_delta=2.0,
+            within_planned_window=False,
+            nat_vent_gate_entered=False,
+        )
+        base.update(overrides)
+        return DoorOpenResponseInputs(**base)
+
+    def test_already_paused_noop(self):
+        result = decide_door_open_response(self._inputs(paused_by_door=True))
+        assert result == DoorOpenResponse.ALREADY_PAUSED_NOOP
+
+    def test_grace_active_outdoor_too_warm_suppressed(self):
+        result = decide_door_open_response(self._inputs(grace_active=True, outdoor=85.0))
+        assert result == DoorOpenResponse.GRACE_SUPPRESSED
+
+    def test_grace_active_outdoor_unavailable_suppressed(self):
+        result = decide_door_open_response(self._inputs(grace_active=True, outdoor=None))
+        assert result == DoorOpenResponse.GRACE_SUPPRESSED
+
+    def test_grace_active_outdoor_cool_falls_through_to_pause(self):
+        result = decide_door_open_response(self._inputs(grace_active=True, outdoor=65.0))
+        assert result == DoorOpenResponse.PAUSE
+
+    def test_grace_active_outdoor_cool_falls_through_to_nat_vent(self):
+        result = decide_door_open_response(self._inputs(grace_active=True, outdoor=65.0, nat_vent_gate_entered=True))
+        assert result == DoorOpenResponse.NAT_VENT_ELIGIBLE
+
+    def test_planned_window_noop(self):
+        result = decide_door_open_response(self._inputs(within_planned_window=True))
+        assert result == DoorOpenResponse.PLANNED_WINDOW_NOOP
+
+    def test_nat_vent_eligible(self):
+        result = decide_door_open_response(self._inputs(nat_vent_gate_entered=True))
+        assert result == DoorOpenResponse.NAT_VENT_ELIGIBLE
+
+    def test_default_pause(self):
+        result = decide_door_open_response(self._inputs())
+        assert result == DoorOpenResponse.PAUSE
+
+    def test_precedence_already_paused_beats_everything(self):
+        result = decide_door_open_response(
+            self._inputs(paused_by_door=True, grace_active=True, within_planned_window=True, nat_vent_gate_entered=True)
+        )
+        assert result == DoorOpenResponse.ALREADY_PAUSED_NOOP
+
+    def test_precedence_planned_window_beats_nat_vent(self):
+        result = decide_door_open_response(self._inputs(within_planned_window=True, nat_vent_gate_entered=True))
+        assert result == DoorOpenResponse.PLANNED_WINDOW_NOOP
+
+
+class TestDecideDoorCloseResponse:
+    def test_not_paused_noop(self):
+        result = decide_door_close_response(DoorCloseResponseInputs(paused_by_door=False, pre_pause_mode=None))
+        assert result == DoorCloseResponseOutcome.NOOP_NOT_PAUSED
+
+    def test_not_paused_noop_even_with_stale_pre_pause_mode(self):
+        result = decide_door_close_response(DoorCloseResponseInputs(paused_by_door=False, pre_pause_mode="heat"))
+        assert result == DoorCloseResponseOutcome.NOOP_NOT_PAUSED
+
+    def test_paused_with_pre_pause_mode_restores_and_graces(self):
+        result = decide_door_close_response(DoorCloseResponseInputs(paused_by_door=True, pre_pause_mode="cool"))
+        assert result == DoorCloseResponseOutcome.RESTORE_AND_GRACE
+
+    def test_paused_idle_no_pre_pause_mode_clears_without_grace(self):
+        result = decide_door_close_response(DoorCloseResponseInputs(paused_by_door=True, pre_pause_mode=None))
+        assert result == DoorCloseResponseOutcome.CLEAR_NO_GRACE
+
+
+class TestDecideGraceExpiryOutcome:
+    def _inputs(self, **overrides):
+        base = dict(
+            within_planned_window=False,
+            any_sensor_open=False,
+            source="manual",
+            override_matches_current_decision=False,
+        )
+        base.update(overrides)
+        return GraceExpiryInputs(**base)
+
+    def test_planned_window_clears(self):
+        result = decide_grace_expiry_outcome(self._inputs(within_planned_window=True))
+        assert result == GraceExpiryOutcome.CLEAR_PLANNED_WINDOW
+
+    def test_sensor_still_open_re_pauses(self):
+        result = decide_grace_expiry_outcome(self._inputs(any_sensor_open=True))
+        assert result == GraceExpiryOutcome.RE_PAUSE
+
+    def test_planned_window_beats_sensor_open(self):
+        result = decide_grace_expiry_outcome(self._inputs(within_planned_window=True, any_sensor_open=True))
+        assert result == GraceExpiryOutcome.CLEAR_PLANNED_WINDOW
+
+    def test_manual_source_matching_decision_adopts(self):
+        result = decide_grace_expiry_outcome(self._inputs(source="manual", override_matches_current_decision=True))
+        assert result == GraceExpiryOutcome.ADOPT_OVERRIDE
+
+    def test_automation_source_never_adopts(self):
+        result = decide_grace_expiry_outcome(self._inputs(source="automation", override_matches_current_decision=True))
+        assert result == GraceExpiryOutcome.CLEAR_NORMAL
+
+    def test_manual_source_not_matching_clears_normal(self):
+        result = decide_grace_expiry_outcome(self._inputs(source="manual", override_matches_current_decision=False))
+        assert result == GraceExpiryOutcome.CLEAR_NORMAL
+
+    def test_sensor_open_beats_adopt(self):
+        result = decide_grace_expiry_outcome(
+            self._inputs(any_sensor_open=True, source="manual", override_matches_current_decision=True)
+        )
+        assert result == GraceExpiryOutcome.RE_PAUSE

--- a/tools/sim_harness/outcomes.py
+++ b/tools/sim_harness/outcomes.py
@@ -592,6 +592,16 @@ def check_assertion(
             return "paused_by_door"
         return False
 
+    # Issue #637 (Block 5 Phase 2, door/window pause FSM): reads the production
+    # engine's final `_paused_by_door`/`_grace_active` flags directly, same
+    # pattern as `paused_by_door` above. Confirms the composite
+    # PAUSED_DURING_GRACE state (both flags True simultaneously) is genuinely
+    # reachable in production — not just theorized from a static code trace.
+    if expect == "paused_during_grace":
+        if engine_state.get("_paused_by_door") is True and engine_state.get("_grace_active") is True:
+            return "paused_during_grace"
+        return False
+
     # --- ODE ceiling guard (Issue #236 D) ---
     # Production emits "ceiling_guard_fired" when it pre-cools.  The legacy scenarios use
     # bespoke labels; map them to the production decision at the asserted time.  "fires"/

--- a/tools/simulations/golden/MANIFEST.json
+++ b/tools/simulations/golden/MANIFEST.json
@@ -392,5 +392,15 @@
     "sha256": "3739757b54a4e3125df5fb49db3fae6911964f587c22631981009e8402e26eb2",
     "signed": "2026-08-13",
     "issue": 629
+  },
+  "issue_637_paused_during_grace_open_fallthrough": {
+    "sha256": "c06e3dbb0aa583fc182954702f5a936e4206c280f3f2587be0ffc60c26af9f75",
+    "signed": "2026-08-14",
+    "issue": 637
+  },
+  "issue_637_paused_during_grace_nat_vent_exit": {
+    "sha256": "f5230d28191b77e554719d33b3fbfa9587741a9cfafc9ad17b0f06ac71208d85",
+    "signed": "2026-08-14",
+    "issue": 637
   }
 }

--- a/tools/simulations/golden/issue_637_paused_during_grace_nat_vent_exit.json
+++ b/tools/simulations/golden/issue_637_paused_during_grace_nat_vent_exit.json
@@ -1,0 +1,100 @@
+{
+  "name": "issue_637_paused_during_grace_nat_vent_exit",
+  "description": "Confirms the SECOND independently-evidenced path into the door/window pause FSM's new PAUSED_DURING_GRACE composite state (Issue #637, Block 5 Phase 2): _exit_nat_vent()'s sensor-still-open branch sets _paused_by_door=True unconditionally, without ever checking or clearing _grace_active. A door pauses HVAC, closes (starting a grace period), then reopens while grace is still active and outdoor has turned nat-vent-favorable -- handle_door_window_open() hands off to nat-vent WITHOUT clearing grace (production never has clearing grace be nat-vent's job). Outdoor then swings back warm, nat-vent exits via the outdoor-rise reversal check, and since the same door is still open, _exit_nat_vent() re-pauses -- landing on paused+grace simultaneously a second, structurally distinct way. Occupant impact: the same as the first path -- HVAC correctly stays off while a door is open, but the underlying flag combination this scenario proves reachable is exactly what the pre-FSM code had no name for.",
+  "source": "synthetic",
+  "issue": 637,
+  "notes": [
+    "Exercises violation path #2 from the Phase 2 plan's five-whys analysis: _exit_nat_vent()'s sensor-still-open branch (automation.py ~L5325-5347) sets _paused_by_door=True directly, with no read or write of _grace_active at all -- if a nat-vent session was entered while an earlier grace period was still running (a real, separately-evidenced path in its own right: handle_door_window_open()'s SENSOR_OPENED-during-GRACE case can hand off to nat-vent without clearing grace, matching this scenario's own 13:07 event), grace survives the whole nat-vent session and is still active when nat-vent later exits.",
+    "use_coordinator=true for the same reason as the sibling scenario (issue_637_paused_during_grace_open_fallthrough.json) -- real debounce/pause/resume/grace/listener wiring, not an approximation.",
+    "The 13:09 coordinator_refresh event is required to drive check_natural_vent_conditions() (the real periodic gate/exit re-evaluation point) against the 13:08 outdoor spike -- temp_update alone only updates the cached reading, it does not itself trigger a new decision cycle.",
+    "automation_grace_seconds=600 (10 min, grace starts 13:00, expires 13:10) is sized so the 13:09 nat-vent exit lands just before natural expiry -- confirms this is a genuine race between the grace timer and the outdoor-swing/nat-vent-exit sequence, not an artifact of an unrealistically long grace window.",
+    "Assertion at 13:09 uses the same 'paused_during_grace' custom assertion type introduced for the sibling scenario."
+  ],
+  "use_coordinator": true,
+  "skip_startup_coalesce": true,
+  "config": {
+    "comfort_heat": 68,
+    "comfort_cool": 74,
+    "setback_heat": 62,
+    "setback_cool": 80,
+    "natural_vent_delta": 3.0,
+    "automation_grace_seconds": 600,
+    "fan_mode": "whole_house_fan",
+    "fan_entity": "fan.whf",
+    "door_window_sensors": ["binary_sensor.back_door"]
+  },
+  "events": [
+    {
+      "time": "2026-08-14T12:30:00",
+      "type": "temp_update",
+      "indoor_f": 76.0,
+      "outdoor_f": 88.0,
+      "note": "Hot afternoon. Indoor above comfort_cool=74F. Outdoor too warm for nat vent."
+    },
+    {
+      "time": "2026-08-14T12:31:00",
+      "type": "classification",
+      "day_type": "warm",
+      "hvac_mode": "cool",
+      "windows_recommended": false,
+      "note": "Warm-day classification: HVAC cool at 74F."
+    },
+    {
+      "time": "2026-08-14T12:45:00",
+      "type": "sensor_open",
+      "entity": "binary_sensor.back_door",
+      "note": "Back door opens. Outdoor 88F > threshold 77F -- nat vent ineligible. Automation pauses (HVAC was actively cooling)."
+    },
+    {
+      "time": "2026-08-14T13:00:00",
+      "type": "sensor_close",
+      "entity": "binary_sensor.back_door",
+      "note": "Door closes. All sensors closed -- automation resumes (restores cool mode) and a 10-min automation grace period begins (expires 13:10)."
+    },
+    {
+      "time": "2026-08-14T13:05:00",
+      "type": "temp_update",
+      "indoor_f": 76.0,
+      "outdoor_f": 60.0,
+      "note": "A cool front moves in. Outdoor drops to 60F -- now nat-vent-favorable (below indoor, below the 77F threshold, indoor still above comfort_heat=68F)."
+    },
+    {
+      "time": "2026-08-14T13:07:00",
+      "type": "sensor_open",
+      "entity": "binary_sensor.back_door",
+      "note": "Door reopens at 13:07, while the 13:00 grace period is still active (expires 13:10). Grace's outdoor-too-warm guard does not suppress (60F < 77F threshold) -- falls through. The nat-vent gate now passes (indoor 76F > comfort_heat 68F), so handle_door_window_open() hands off to nat-vent (fan on, band armed) WITHOUT clearing the still-active grace period."
+    },
+    {
+      "time": "2026-08-14T13:08:00",
+      "type": "temp_update",
+      "indoor_f": 76.0,
+      "outdoor_f": 85.0,
+      "note": "Outdoor swings back warm (85F), reversing the airflow direction nat-vent depends on (outdoor now above indoor)."
+    },
+    {
+      "time": "2026-08-14T13:09:00",
+      "type": "coordinator_refresh",
+      "note": "Drives the real periodic cycle, which calls check_natural_vent_conditions() while nat-vent is active. The outdoor-rise exit check fires (outdoor 85F > indoor 76F) -- _exit_nat_vent() runs, sees the back door sensor is STILL open (it was never closed after the 13:07 reopen), and pauses HVAC via its unconditional _paused_by_door=True set. The 13:00 grace period (expires 13:10) has not yet elapsed, so it is still active -- production reaches _paused_by_door=True AND _grace_active=True simultaneously via this second, structurally distinct path."
+    }
+  ],
+  "assertions": [
+    {
+      "at": "2026-08-14T12:45:00",
+      "expect": "paused",
+      "reason": "Sensor opens with outdoor (88F) far above the nat-vent threshold -- automation pauses.",
+      "track": "integration"
+    },
+    {
+      "at": "2026-08-14T13:00:00",
+      "expect": "resumed",
+      "reason": "All sensors closed -- automation resumes and starts a 10-min automation grace period.",
+      "track": "integration"
+    },
+    {
+      "at": "2026-08-14T13:09:00",
+      "expect": "paused_during_grace",
+      "reason": "Nat-vent exits (outdoor-rise reversal) while the monitored sensor is still open and the 13:00 grace period has not yet expired. _exit_nat_vent()'s sensor-still-open branch sets _paused_by_door=True without ever reading or clearing _grace_active, so production genuinely reaches PAUSED_DURING_GRACE a second, structurally distinct way from the sibling scenario.",
+      "track": "integration"
+    }
+  ]
+}

--- a/tools/simulations/golden/issue_637_paused_during_grace_open_fallthrough.json
+++ b/tools/simulations/golden/issue_637_paused_during_grace_open_fallthrough.json
@@ -1,0 +1,95 @@
+{
+  "name": "issue_637_paused_during_grace_open_fallthrough",
+  "description": "Confirms the door/window pause FSM's new PAUSED_DURING_GRACE composite state is genuinely reachable in production, not just a static-trace hypothesis (Issue #637, Block 5 Phase 2). Sensor opens while hot (pauses HVAC), closes (resumes + starts a 10-min automation grace period), a cool front moves in, then the sensor reopens while grace is STILL active. handle_door_window_open()'s grace guard only suppresses when outdoor is too warm to nat-vent — with outdoor now cool, it falls through past the guard, but the nat-vent gate itself fails (indoor has not risen above comfort_heat), so _pause_for_door_window() fires with _grace_active never cleared. Occupant impact: HVAC pauses correctly (a door is genuinely open), but the system is left in an undocumented flag combination (paused + grace both active) that the pre-FSM code has no name for — this scenario proves the FSM's new composite state matches what production actually does here, not a hypothetical.",
+  "source": "synthetic",
+  "issue": 637,
+  "notes": [
+    "Exercises violation path #1 from the Phase 2 plan's five-whys analysis: handle_door_window_open()'s `if self._grace_active:` guard (automation.py ~L2823) only suppresses the pause when outdoor is too warm for nat-vent; when outdoor is cool enough to fall through, execution reaches _pause_for_door_window() with grace still active if the nat-vent gate itself then fails (here: indoor has not risen above comfort_heat).",
+    "use_coordinator=true so the real _async_door_window_changed listener drives debounce/pause/resume/grace exactly as production does (sensor_debounce_seconds default is 0 in the harness, so debounce is effectively instant).",
+    "comfort_heat=72 (unusually high) is deliberate: at the 13:14 reopen, indoor=71 is BELOW comfort_heat=72, so decide_nat_vent_gate()'s floor check (indoor > comfort_heat) fails even though outdoor(60) is otherwise nat-vent-favorable (cool, below threshold) -- this is what forces the fall-through to land on PAUSE instead of nat-vent activation.",
+    "automation_grace_seconds=600 (10 min) gives enough room between the 13:00 resume and the 13:14 reopen for grace to still be active (expires 13:10).",
+    "Assertion at 13:14 uses the new 'paused_during_grace' custom assertion type (tools/sim_harness/outcomes.py), which reads the production engine's final _paused_by_door AND _grace_active flags directly -- the same evidence-based pattern the existing 'paused_by_door' assertion type already uses, extended to check both flags at once."
+  ],
+  "use_coordinator": true,
+  "skip_startup_coalesce": true,
+  "config": {
+    "comfort_heat": 72,
+    "comfort_cool": 74,
+    "setback_heat": 62,
+    "setback_cool": 80,
+    "natural_vent_delta": 3.0,
+    "automation_grace_seconds": 600,
+    "fan_mode": "whole_house_fan",
+    "fan_entity": "fan.whf",
+    "door_window_sensors": ["binary_sensor.back_door"]
+  },
+  "events": [
+    {
+      "time": "2026-08-14T12:30:00",
+      "type": "temp_update",
+      "indoor_f": 76.0,
+      "outdoor_f": 88.0,
+      "note": "Hot afternoon. Indoor above comfort_cool=74F. Outdoor too warm for nat vent."
+    },
+    {
+      "time": "2026-08-14T12:31:00",
+      "type": "classification",
+      "day_type": "warm",
+      "hvac_mode": "cool",
+      "windows_recommended": false,
+      "note": "Warm-day classification: HVAC cool at 74F."
+    },
+    {
+      "time": "2026-08-14T12:45:00",
+      "type": "sensor_open",
+      "entity": "binary_sensor.back_door",
+      "note": "Back door opens. Outdoor 88F > threshold 77F -- nat vent ineligible. Automation pauses (HVAC was actively cooling)."
+    },
+    {
+      "time": "2026-08-14T13:00:00",
+      "type": "sensor_close",
+      "entity": "binary_sensor.back_door",
+      "note": "Door closes. All sensors closed -- automation resumes (restores cool mode) and a 10-min automation grace period begins (expires 13:10)."
+    },
+    {
+      "time": "2026-08-14T13:05:00",
+      "type": "temp_update",
+      "indoor_f": 71.0,
+      "outdoor_f": 60.0,
+      "note": "A cool front moves in. Outdoor drops to 60F (below the 77F nat-vent threshold), but indoor has also settled to 71F -- just BELOW comfort_heat=72F."
+    },
+    {
+      "time": "2026-08-14T13:07:00",
+      "type": "sensor_open",
+      "entity": "binary_sensor.back_door",
+      "note": "Door reopens at 13:07, while the 13:00 grace period is still active (expires 13:10). Grace's own outdoor-too-warm guard does NOT suppress (60F < 77F threshold) -- falls through. Nat-vent gate then fails (indoor 71F is not > comfort_heat 72F), so the fall-through lands on a pause with grace still active: PAUSED_DURING_GRACE."
+    },
+    {
+      "time": "2026-08-14T13:08:00",
+      "type": "temp_update",
+      "indoor_f": 71.0,
+      "outdoor_f": 60.0,
+      "note": "No-op re-assertion of the same readings -- purely to advance the fake scheduler past 13:07 so the debounce-triggered handle_door_window_open() dispatch from the reopen above has actually settled before the assertion below reads final state (same pattern as the sibling grace_full_lifecycle_sensor_still_open.json golden's trailing no-op dispatch)."
+    }
+  ],
+  "assertions": [
+    {
+      "at": "2026-08-14T12:45:00",
+      "expect": "paused",
+      "reason": "Sensor opens with outdoor (88F) far above the nat-vent threshold -- automation pauses.",
+      "track": "integration"
+    },
+    {
+      "at": "2026-08-14T13:00:00",
+      "expect": "resumed",
+      "reason": "All sensors closed -- automation resumes and starts a 10-min automation grace period.",
+      "track": "integration"
+    },
+    {
+      "at": "2026-08-14T13:08:00",
+      "expect": "paused_during_grace",
+      "reason": "Sensor reopens while grace is still active. Outdoor is cool enough to fall through the grace guard, but the nat-vent gate fails on the indoor-vs-comfort_heat floor check, so the fall-through pauses HVAC without ever clearing the still-active grace period -- production genuinely reaches _paused_by_door=True AND _grace_active=True simultaneously (Issue #637's confirmed-reachable PAUSED_DURING_GRACE state).",
+      "track": "integration"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Phase 2 of Block 5 epic #594. Builds `door_window_fsm.py` — the unified door/window pause/grace/nat-vent-handoff transition table — following the exact pattern `nat_vent_fsm.py` established in Phase 1 (#633).

- 5 new pure functions extracted from `automation.py`'s pause/resume/grace logic (`door_window_lifecycle.py`, `door_window_pause_entry.py`, `door_window_open_response.py`, `door_window_close_response.py`, `door_window_grace_expiry.py`), each independently unit-tested.
- `door_window_fsm.py` assembles them into an explicit `(state, event) -> Transition` table with a 5-state model (`NORMAL`, `PAUSED_ACTIVE`, `PAUSED_IDLE`, `GRACE`, `PAUSED_DURING_GRACE`).
- Wired into the coordinator's existing shadow-engine diagnostic (`_evaluate_door_window_fsm()`) as a third comparison point, for 3 mirrored methods with an unambiguous event-kind correspondence. Purely observational — `dry_run=True` throughout, isolated (any FSM exception is logged and swallowed, never reaches production), never wired into any decision path that can act.

### Key finding: `PAUSED_DURING_GRACE`

The naive assumption going in was that `_paused_by_door` and `_grace_active` are mutually exclusive. That's false — two independently reachable production code paths set one without ever clearing the other:

1. `handle_door_window_open()`'s grace guard only suppresses when outdoor is too warm for nat-vent; when outdoor is cool enough to fall through but the nat-vent gate itself then fails, execution reaches `_pause_for_door_window()` with grace still active.
2. `_exit_nat_vent()`'s sensor-still-open branch sets `_paused_by_door = True` unconditionally, with no read or write of `_grace_active` at all.

Both are now confirmed reachable via real scenario replay (not just static tracing) — see the two new golden scenarios below.

## New golden scenarios

- `issue_637_paused_during_grace_open_fallthrough.json` — exercises path 1.
- `issue_637_paused_during_grace_nat_vent_exit.json` — exercises path 2.

Both use a new `paused_during_grace` custom assertion type (`tools/sim_harness/outcomes.py`) that reads `_paused_by_door`/`_grace_active` directly off the production engine, same pattern as the existing `paused_by_door` assertion. Reviewed and signed off by the project owner before promotion from `pending/` to `golden/`.

## Descoped (with reasoning)

`tools/door_window_fsm_diff.py` (a differential-replay CLI tool) was in the original plan but not built — checked and confirmed nat-vent's own Phase 1 (#633) never built an equivalent tool either; its actual validation mechanism was unit tests + coordinator wiring tests, which this phase has (105 pure-module/FSM tests + 11 wiring tests).

## Version

0.6.13 → 0.6.14. `RELEASE_NOTES`/`KNOWN_FIXES`/`CHANGELOG.md` updated.

## Test plan

- [x] 36/36 pure-module unit tests pass
- [x] 69/69 FSM wiring tests pass (pure modules + assembly)
- [x] 11/11 coordinator shadow-wiring tests pass
- [x] Full suite: 4329 passed, 6 skipped, 0 warnings (`-W error::RuntimeWarning`)
- [x] Golden suite: 80/80 passed (78 existing + 2 new)
- [x] `ruff check`/`ruff format` clean
- [x] `test_version_sync.py`, `test_shadow_engine_coverage.py` pass unchanged (no new tracked fields introduced)