### PR TITLE
Fix #643: mirror handle_fan_manual_override to the shadow FSM diagnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.17] — 2026-08-15
+
+- Fix #643: internal refactor only, no user-visible behavior change — the diagnostic-only shadow comparison from the Block 5 series (0.6.13–0.6.15) wasn't seeing manual fan overrides, the most common override trigger, so it couldn't confirm its own consistency after one occurred. Now mirrored like every other tracked automation decision. Purely observational — nothing it computes is ever acted on.
+
 ## [0.6.16] — 2026-08-15
 
 - Fix #641: the whole-house fan could rapidly cycle on and off (roughly once a minute) when a predicted-floor or ceiling-threshold exit fired while a window was still open — the very next check immediately turned it back on, repeating indefinitely. Two nat-vent exit conditions now correctly hold off reactivation for 5 minutes after exiting, matching how the outdoor-air-reversal exit already behaved. As a second layer of protection, CA will never toggle the fan faster than once every 5 minutes going forward, regardless of cause — any future situation that would have caused rapid cycling is now blocked outright and logged as an incident instead of hitting the fan.

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,17 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.16"
+VERSION = "0.6.17"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.17": [
+        "Fix #643: an internal diagnostic that shadows automation decisions to verify"
+        " an in-progress refactor wasn't seeing manual fan overrides (the most common"
+        " kind of override), so it could not confirm its own consistency after one"
+        " occurred. No occupant-visible behavior change — this only affects an"
+        " internal diagnostic used to validate the automation-engine refactor before"
+        " any of it goes live.",
+    ],
     "0.6.16": [
         "Fix #641: the whole-house fan could rapidly cycle on and off (roughly once a"
         " minute) when a predicted-floor or ceiling-threshold exit fired while a window"
@@ -1771,6 +1779,23 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    643: {
+        "version_fixed": "0.6.17",
+        "title": "Override/grace shadow FSM never saw handle_fan_manual_override (Block 5 diagnostic gap)",
+        "scope_covered": (
+            "coordinator.py: added await self._mirror_to_shadow('handle_fan_manual_override', ...)"
+            " at all 3 production call sites (_async_thermostat_changed, _async_fan_entity_changed,"
+            " _flush_fan_remote_burst) and added 'handle_fan_manual_override': 'override_detected' to"
+            " _OVERRIDE_GRACE_FSM_EVENT_KINDS. The override_grace_fsm.py OVERRIDE_DETECTED transition"
+            " was already fully implemented and input-driven generically from live automation_engine"
+            " state (Issue #639) — no new pure module, event kind, or transition logic was needed,"
+            " only the mirror wiring. tests/test_shadow_engine_coverage.py's registry reclassified"
+            " handle_fan_manual_override from 'exempted' to 'mirrored'. Shadow-only, dry_run=True,"
+            " zero production behavior change — same isolation posture as the rest of Block 5 (#594)."
+            " Root-caused from a live 06:39:08 WARNING-level disagreement on both the door/window"
+            " (#637) and override/grace (#639) shadow FSMs that never self-corrected."
+        ),
+    },
     641: {
         "version_fixed": "0.6.16",
         "title": (

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -362,23 +362,29 @@ _DOOR_WINDOW_FSM_EVENT_KINDS: dict[str, str] = {
     "handle_manual_override_during_pause": "manual_override_during_pause",
 }
 
-# Issue #639: which mirrored automation.py methods correspond to which override/grace
-# FSM event kind. Narrower still than door/window's own v1 scope above — of the 7
-# OverrideGraceFsmEventKind members, only 2 have an actual _mirror_to_shadow() call
-# site in coordinator.py/api.py today. OVERRIDE_DETECTED/OVERRIDE_CONFIRM_EXPIRED/
-# OVERRIDE_SUPERSEDED/OVERRIDE_CANCELLED all correspond to AutomationEngine methods
-# (start_override_confirmation, _confirm_override, cancel_override,
-# clear_manual_override) that are called directly from coordinator.py/api.py or from
-# internal async_call_later timer closures with no _mirror_to_shadow(...) call site at
-# all (see _sync_shadow_inputs()'s own docstring and
-# tests/test_shadow_engine_coverage.py's registry, which classifies every one of them
-# "exempted" rather than "mirrored") — same "raw copy, not a new mirror call site"
-# reasoning as Issue #631. Confirmed by grepping every _mirror_to_shadow( call site in
-# both files. GRACE_TIMER_EXPIRED also has no mirror call site (the grace-expiry timer
-# closures are internal-only, same as door/window's own GRACE_TIMER_EXPIRED omission).
+# Issue #639/#643: which mirrored automation.py methods correspond to which
+# override/grace FSM event kind. Of the 7 OverrideGraceFsmEventKind members,
+# 3 have an actual _mirror_to_shadow() call site in coordinator.py/api.py today
+# (handle_fan_manual_override added in #643 — the FSM's OVERRIDE_DETECTED
+# transition was already fully built and generically input-driven; the only
+# gap was this dict entry plus the 3 mirror call sites in
+# _async_thermostat_changed/_async_fan_entity_changed/_flush_fan_remote_burst).
+# OVERRIDE_CONFIRM_EXPIRED/OVERRIDE_SUPERSEDED/OVERRIDE_CANCELLED still
+# correspond to AutomationEngine methods (start_override_confirmation,
+# _confirm_override, cancel_override, clear_manual_override) that are called
+# directly from coordinator.py/api.py or from internal async_call_later timer
+# closures with no _mirror_to_shadow(...) call site at all (see
+# _sync_shadow_inputs()'s own docstring and tests/test_shadow_engine_coverage.py's
+# registry, which classifies every one of them "exempted" rather than
+# "mirrored") — same "raw copy, not a new mirror call site" reasoning as Issue
+# #631. GRACE_TIMER_EXPIRED also has no mirror call site (the grace-expiry
+# timer closures are internal-only, same as door/window's own
+# GRACE_TIMER_EXPIRED omission). Confirmed by grepping every
+# _mirror_to_shadow( call site in both files as of #643.
 _OVERRIDE_GRACE_FSM_EVENT_KINDS: dict[str, str] = {
     "handle_manual_override_during_pause": "manual_override_during_pause",
     "resume_from_pause": "dashboard_resume",
+    "handle_fan_manual_override": "override_detected",
 }
 
 
@@ -4683,6 +4689,9 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 self.automation_engine.handle_fan_manual_override(
                     fan_before=str(old_fan_mode), fan_after=str(new_fan_mode)
                 )
+                await self._mirror_to_shadow(
+                    "handle_fan_manual_override", fan_before=str(old_fan_mode), fan_after=str(new_fan_mode)
+                )
 
     async def _async_command_fan_entity(self, *, on: bool) -> bool:
         """Issue a turn_on or turn_off service call to the configured WHF fan entity (Issue #361).
@@ -4848,6 +4857,12 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             )
             self.automation_engine.handle_fan_manual_override(
                 fan_before=str(old_state.state), fan_after=str(new_state.state), event_context_id=event_context_id
+            )
+            await self._mirror_to_shadow(
+                "handle_fan_manual_override",
+                fan_before=str(old_state.state),
+                fan_after=str(new_state.state),
+                event_context_id=event_context_id,
             )
         elif not is_on and self.automation_engine._fan_active:
             # Fan turned off externally — route to on_fan_turned_off() to clear fan state and
@@ -5038,6 +5053,15 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         if is_override:
             duration_seconds = burst.timer_hours * 3600 if burst.timer_hours is not None else None
             self.automation_engine.handle_fan_manual_override(
+                fan_before="?",
+                fan_after="on",
+                duration_override=duration_seconds,
+                remote_timer_hours=burst.timer_hours if burst.has_timer else None,
+                remote_speed=burst.speed,
+                is_remote_event=True,
+            )
+            await self._mirror_to_shadow(
+                "handle_fan_manual_override",
                 fan_before="?",
                 fan_after="on",
                 duration_override=duration_seconds,

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.16"
+  "version": "0.6.17"
 }

--- a/tests/test_fan_remote.py
+++ b/tests/test_fan_remote.py
@@ -156,6 +156,10 @@ def _make_coordinator_stub(config: dict | None = None, *, physical_on: bool | No
     coord._fan_remote_burst = None
     coord._fan_remote_burst_cancel = None
     coord._get_fan_physical_state = MagicMock(return_value=physical_on)
+    # Issue #643: _flush_fan_remote_burst now mirrors handle_fan_manual_override to the
+    # shadow FSM diagnostic — must be an AsyncMock, not the bare MagicMock auto-attr, or
+    # awaiting it raises TypeError.
+    coord._mirror_to_shadow = AsyncMock()
 
     mod = importlib.import_module("custom_components.climate_advisor.coordinator")
     coord._async_fan_remote_changed = types.MethodType(mod.ClimateAdvisorCoordinator._async_fan_remote_changed, coord)

--- a/tests/test_shadow_engine_coverage.py
+++ b/tests/test_shadow_engine_coverage.py
@@ -109,10 +109,7 @@ _COVERAGE_REGISTRY: dict[str, str] = {
         "cancel_override()/_on_grace_expired(); _manual_override_active/_override_confirm_* covered "
         "by _sync_shadow_inputs() raw copy (Issue #631)"
     ),
-    "handle_fan_manual_override": (
-        "exempted: called directly from 3 coordinator.py sites (unmirrored); _fan_override_active/"
-        "_grace_active covered by _sync_shadow_inputs() raw copy (Issue #631)"
-    ),
+    "handle_fan_manual_override": "mirrored",
     "clear_fan_override": (
         "exempted: called from clear_manual_override (exempted) and internal cascades; "
         "_fan_override_active covered by _sync_shadow_inputs() raw copy (Issue #631)"
@@ -129,11 +126,11 @@ _COVERAGE_REGISTRY: dict[str, str] = {
         "_sync_shadow_inputs() raw copy (Issue #631)"
     ),
     "_start_grace_period": (
-        "exempted: called from both mirrored (handle_all_doors_windows_closed, "
-        "check_natural_vent_conditions, resume_from_pause, handle_manual_override_during_pause) and "
-        "unmirrored/internal (handle_fan_manual_override, _confirm_override) paths; _grace_active and "
-        "_grace_protects_override covered by _sync_shadow_inputs() raw copy regardless of caller "
-        "(Issue #631, #639)"
+        "exempted: called from mirrored (handle_all_doors_windows_closed, "
+        "check_natural_vent_conditions, resume_from_pause, handle_manual_override_during_pause, "
+        "handle_fan_manual_override) and unmirrored/internal (_confirm_override) paths; _grace_active "
+        "and _grace_protects_override covered by _sync_shadow_inputs() raw copy regardless of caller "
+        "(Issue #631, #639, #643)"
     ),
     "_cancel_grace_timers": (
         "exempted: called from cancel_override() (unmirrored) and the internal grace-expiry timer "

--- a/tests/test_whf_command_only.py
+++ b/tests/test_whf_command_only.py
@@ -104,6 +104,10 @@ def _make_coord_stub(config: dict | None = None) -> MagicMock:
     # Issue #589: explicit, not a truthy-by-default MagicMock attr — _async_command_fan_entity
     # reads this directly to gate the dry-run/automation-disabled check.
     coord._automation_enabled = True
+    # Issue #643: _async_fan_entity_changed now mirrors handle_fan_manual_override/
+    # on_fan_turned_off to the shadow FSM diagnostic — must be an AsyncMock, not the bare
+    # MagicMock auto-attr, or awaiting it raises TypeError.
+    coord._mirror_to_shadow = AsyncMock()
 
     # Bind the real implementation so guards that call self._fan_state_feedback_enabled()
     # get the actual config value rather than a truthy MagicMock.


### PR DESCRIPTION
## Summary
- The Block 5 override/grace shadow FSM (#639) never received an event for manual fan overrides — the most common override trigger — because `handle_fan_manual_override()` had zero `_mirror_to_shadow()` call sites at any of its 3 production call points.
- Root-caused from a live WARNING-level disagreement (2026-08-15 06:39:08) on both the door/window (#637) and override/grace (#639) shadow FSMs that never self-corrected.
- The FSM's `OVERRIDE_DETECTED` transition was already fully implemented and generically input-driven from live `automation_engine` state (Issue #639) — no new pure module, event kind, or transition logic needed. Only the wiring was missing:
  - Added `await self._mirror_to_shadow("handle_fan_manual_override", ...)` at all 3 call sites (`_async_thermostat_changed`, `_async_fan_entity_changed`, `_flush_fan_remote_burst`).
  - Added `"handle_fan_manual_override": "override_detected"` to `_OVERRIDE_GRACE_FSM_EVENT_KINDS`.
  - Reclassified `handle_fan_manual_override` from `"exempted"` to `"mirrored"` in `tests/test_shadow_engine_coverage.py`'s registry.
- Fixed 2 test stubs (`test_fan_remote.py`, `test_whf_command_only.py`) that used a bare `MagicMock` for `coord._mirror_to_shadow` — now actually awaited on this path, so they need `AsyncMock`.
- Version bump 0.6.16 → 0.6.17, `RELEASE_NOTES`/`KNOWN_FIXES`/`CHANGELOG.md` updated.

Shadow-only, `dry_run=True`, zero production behavior change — same isolation posture as the rest of Block 5 (#594).

## Test plan
- [x] `pytest tests/` full suite green (4476 passed, 6 skipped; 3 pre-existing unrelated failures in `test_door_window.py` confirmed to also fail on `main` before this change, unrelated to this fix)
- [x] `ruff check`/`ruff format` clean
- [x] `tools/validate.py` — all checks pass
- [x] `test_version_sync.py`, `test_shadow_engine_coverage.py` pass
- [ ] Live: confirm the class of disagreement observed at 06:39:08 does not recur on the next manual fan override post-deploy

Closes #643