### PR TITLE
Fix #649: accurate reporting for rate-limited WHF toggles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.20] — 2026-08-16
+
+- Fix #649: follow-up to #641's whole-house-fan rapid-cycling protection. The 5-minute floor itself was already working correctly, but the Activity Report and HA logs made a blocked toggle look like it had actually happened, and repeated the same misleading row every time the system re-checked while still blocked. A blocked-then-later-applied fan toggle now shows as a single accurate "deferred" entry followed by one real "applied" entry once the floor clears, and is no longer mislabeled as an incident — it's the protection working as intended.
+
 ## [0.6.19] — 2026-08-16
 
 - Fix #647: internal refactor only, no user-visible behavior change — the diagnostic-only shadow/FSM comparisons from the Block 5 series (0.6.13–0.6.17) were disagreeing with production on nearly every automation cycle, not just occasionally. A wiring gap left each FSM's tracked state stuck once a real manual override, grace period, or certain nat-vent exits occurred, instead of resetting once each finished. Fixed by feeding each FSM from every real production transition, not just the ones already replayed to the shadow engine. Purely observational — nothing it computes is ever acted on.

--- a/custom_components/climate_advisor/ai_skills_context.py
+++ b/custom_components/climate_advisor/ai_skills_context.py
@@ -1762,14 +1762,20 @@ def _render_fan_activated(p: dict, unit: str) -> tuple[str, str]:
     reason = str(p.get("reason", "")).strip()
     fan_device = p.get("fan_device", "fan")
     label = f"Fan activated -- {reason}" if reason else "Fan activated"
-    return label, f"{fan_device}: off->on"
+    # Issue #649: fan_mode_change, when present, overrides the default "device: off->on"
+    # claim -- set by _exit_nat_vent() to a "deferred (...)" description when the Issue
+    # #641 rate limiter blocked the toggle, so this row doesn't claim a state transition
+    # that hasn't happened yet.
+    settings = p.get("fan_mode_change") or f"{fan_device}: off->on"
+    return label, settings
 
 
 def _render_fan_deactivated(p: dict, unit: str) -> tuple[str, str]:
     reason = str(p.get("reason", "")).strip()
     fan_device = p.get("fan_device", "fan")
     label = f"Fan deactivated -- {reason}" if reason else "Fan deactivated"
-    return label, f"{fan_device}: on->off"
+    settings = p.get("fan_mode_change") or f"{fan_device}: on->off"
+    return label, settings
 
 
 def _render_hvac_write_blocked_whf_active(p: dict, unit: str) -> tuple[str, str]:
@@ -1899,7 +1905,10 @@ def _render_nat_vent_outdoor_rise_exit(p: dict, unit: str) -> tuple[str, str]:
                 f"Nat-vent exit -- outdoor {format_temp(float(outdoor), unit)}"
                 f" > indoor {format_temp(float(indoor), unit)}"
             )
-    return label, ""
+    # Issue #649: fan_mode_change is only present when _exit_nat_vent() overrode it to a
+    # "deferred (...)" description (the Issue #641 rate limiter blocked the toggle).
+    fan_change = p.get("fan_mode_change", "")
+    return label, f"fan: {fan_change}" if fan_change else ""
 
 
 def _render_nat_vent_comfort_floor_exit(p: dict, unit: str) -> tuple[str, str]:
@@ -1937,7 +1946,8 @@ def _render_nat_vent_away_ceiling_exit(p: dict, unit: str) -> tuple[str, str]:
                 f"Nat-vent exit (away) -- indoor {format_temp(float(indoor), unit)}"
                 f" >= ceiling {format_temp(float(cool), unit)}"
             )
-    return label, ""
+    fan_change = p.get("fan_mode_change", "")
+    return label, f"fan: {fan_change}" if fan_change else ""
 
 
 def _render_nat_vent_predicted_floor_exit(p: dict, unit: str) -> tuple[str, str]:

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -12,6 +12,7 @@ import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
+from enum import Enum
 from typing import Any
 
 from homeassistant.core import Context, HomeAssistant, callback
@@ -136,6 +137,26 @@ from .temperature import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class FanCommandResult(Enum):
+    """Outcome of an `_activate_fan()`/`_deactivate_fan()` call (Issue #649).
+
+    Every early-return guard inside those two functions previously returned bare
+    `None`, giving callers no way to tell "a real command was issued" apart from any
+    of the several no-op reasons. That distinction matters once a command can be
+    silently deferred by the Issue #641 rate limiter for up to 5 minutes: callers that
+    build their own Activity Report event (the nat-vent exit branches) need it to avoid
+    reporting a state transition that hasn't happened yet.
+    """
+
+    EXECUTED = "executed"
+    ALREADY_IN_STATE = "already_in_state"
+    RATE_LIMITED_NEW = "rate_limited_new"
+    RATE_LIMITED_DUP = "rate_limited_dup"
+    OVERRIDDEN = "overridden"
+    DISABLED = "disabled"
+
 
 # Issue #530: the ONLY two `_start_grace_period(trigger=...)` values that mean "this grace
 # exists to protect an active manual/fan override" — read by `_start_grace_period()` to set
@@ -693,6 +714,11 @@ class AutomationEngine:
         # no toggle is currently suppressed. Status-tab surfacing only, not read by any
         # decision path — mirrors the pattern of other diagnostic-only fields.
         self._fan_rate_limited_until: datetime | None = None
+        # Issue #649: the direction ("activate"/"deactivate") the pending deferral above
+        # is for — lets the status card and dedup guard describe what's actually pending
+        # instead of just "something is rate-limited". None whenever
+        # _fan_rate_limited_until is None.
+        self._fan_rate_limited_direction: str | None = None
         # Issue #482: id of the HA Context CA attached to its most recent outgoing WHF
         # fan-entity service call (see _command_whf_control_entity). When the resulting
         # state-changed Event's own event.context.id (or parent_id) matches this value,
@@ -3368,9 +3394,13 @@ class AutomationEngine:
                     )
                     self._natural_vent_active = False
                     self._nat_vent_soft_start = False
-                    await self._deactivate_fan(reason="nat-vent ceiling exit (away mode)")
+                    _away_ceiling_result = await self._deactivate_fan(reason="nat-vent ceiling exit (away mode)")
                     # Do NOT pause -- just let away setback handle HVAC
-                    if self._emit_event_callback:
+                    # Issue #649: skip emitting a duplicate report for a repeat block within
+                    # an already-reported deferral window (same reasoning as _exit_nat_vent()'s
+                    # centralized handling — this branch doesn't route through that function,
+                    # since away-mode ceiling exit intentionally has no pause/grace machinery).
+                    if self._emit_event_callback and _away_ceiling_result is not FanCommandResult.RATE_LIMITED_DUP:
                         self._emit_event_callback(
                             "nat_vent_away_ceiling_exit",
                             {
@@ -3391,23 +3421,6 @@ class AutomationEngine:
                         time_to_floor,
                         MIN_VIABLE_NAT_VENT_HOURS,
                     )
-                    if self._emit_event_callback:
-                        self._emit_event_callback(
-                            "nat_vent_predicted_floor_exit",
-                            {
-                                "time_to_floor_hr": round(time_to_floor, 2),
-                                "indoor_temp": round(indoor, 1),
-                                "comfort_heat": round(comfort_heat_now, 1),
-                                "k_passive": round(k_passive, 4),
-                                "fan_mode_change": "on→auto",
-                                "fan_device": _fan_device_label(self.config),
-                                "hvac_mode_restored": (
-                                    self._current_classification.hvac_mode
-                                    if self._current_classification
-                                    else "unknown"
-                                ),
-                            },
-                        )
                     # Issue #641: set_outdoor_exit_time=True — without this, a monitored
                     # sensor left open hands this exit straight into the _paused_by_door
                     # reactivation block below with no lockout armed. Since the instant
@@ -3418,6 +3431,12 @@ class AutomationEngine:
                     # immediate reactivation, another proactive exit, and a repeating
                     # on/off flip-flop (the WHF fast-cycling incident). Arming the same
                     # lockout the outdoor-rise exit already uses closes this gap.
+                    #
+                    # Issue #649: event emission moved into _exit_nat_vent() itself (via
+                    # event_type/event_payload) instead of firing here unconditionally —
+                    # centralizes the "was this actually executed or deferred by the #641
+                    # rate limiter" check in one place instead of repeating it at every
+                    # exit-reason branch.
                     await self._exit_nat_vent(
                         reason=(
                             f"nat-vent proactive floor exit: indoor {indoor:.1f}°F"
@@ -3425,6 +3444,18 @@ class AutomationEngine:
                             f" in {time_to_floor:.2f}h"
                         ),
                         set_outdoor_exit_time=True,
+                        event_type="nat_vent_predicted_floor_exit",
+                        event_payload={
+                            "time_to_floor_hr": round(time_to_floor, 2),
+                            "indoor_temp": round(indoor, 1),
+                            "comfort_heat": round(comfort_heat_now, 1),
+                            "k_passive": round(k_passive, 4),
+                            "fan_mode_change": "on→auto",
+                            "fan_device": _fan_device_label(self.config),
+                            "hvac_mode_restored": (
+                                self._current_classification.hvac_mode if self._current_classification else "unknown"
+                            ),
+                        },
                     )
                     return
 
@@ -3434,11 +3465,6 @@ class AutomationEngine:
                         outdoor,
                         indoor,
                     )
-                    if self._emit_event_callback:
-                        self._emit_event_callback(
-                            "nat_vent_outdoor_rise_exit",
-                            {"outdoor": outdoor, "indoor": indoor, "fan_device": _fan_device_label(self.config)},
-                        )
                     # set_outdoor_exit_time=True: the original exit reason this lockout was
                     # built for (Issue #115/#411). Issue #641 later extended the same
                     # treatment to PROACTIVE_FLOOR and CEILING_THRESHOLD above/below, once
@@ -3446,6 +3472,12 @@ class AutomationEngine:
                     await self._exit_nat_vent(
                         reason=(f"nat vent exit: outdoor {outdoor:.1f}°F > indoor {indoor:.1f}°F — airflow reversed"),
                         set_outdoor_exit_time=True,
+                        event_type="nat_vent_outdoor_rise_exit",
+                        event_payload={
+                            "outdoor": outdoor,
+                            "indoor": indoor,
+                            "fan_device": _fan_device_label(self.config),
+                        },
                     )
                     return
 
@@ -3669,25 +3701,22 @@ class AutomationEngine:
                     current_temp,
                     _hard_floor,
                 )
-                if self._emit_event_callback:
-                    self._emit_event_callback(
-                        "nat_vent_comfort_floor_exit",
-                        {
-                            "indoor_temp": current_temp,
-                            "comfort_heat": _hard_floor,
-                            "source": "temp_check",
-                            "fan_device": _fan_device_label(self.config),
-                            "fan_mode_change": "on→auto",
-                            "hvac_mode_restored": (
-                                self._current_classification.hvac_mode if self._current_classification else "unknown"
-                            ),
-                        },
-                    )
                 await self._exit_nat_vent(
                     reason=(
                         f"nat-vent hard floor exit [{_context}]: indoor {current_temp:.1f}°F"
                         f" ≤ floor {_hard_floor:.1f}°F"
-                    )
+                    ),
+                    event_type="nat_vent_comfort_floor_exit",
+                    event_payload={
+                        "indoor_temp": current_temp,
+                        "comfort_heat": _hard_floor,
+                        "source": "temp_check",
+                        "fan_device": _fan_device_label(self.config),
+                        "fan_mode_change": "on→auto",
+                        "hvac_mode_restored": (
+                            self._current_classification.hvac_mode if self._current_classification else "unknown"
+                        ),
+                    },
                 )
                 return
 
@@ -3875,14 +3904,11 @@ class AutomationEngine:
                 True,
                 f"stop:{stop_reason}",
             )
-            if self._emit_event_callback:
-                self._emit_event_callback(
-                    "nat_vent_outdoor_rise_exit",
-                    {"outdoor": outdoor, "indoor": indoor, "fan_device": _fan_device_label(self.config)},
-                )
             await self._exit_nat_vent(
                 reason=f"nat vent exit (fast loop): {stop_reason}",
                 set_outdoor_exit_time=True,
+                event_type="nat_vent_outdoor_rise_exit",
+                event_payload={"outdoor": outdoor, "indoor": indoor, "fan_device": _fan_device_label(self.config)},
             )
             return
 
@@ -3913,21 +3939,20 @@ class AutomationEngine:
             # genuinely was; otherwise emit the same generic event _deactivate_fan() itself
             # would have (test_stops_non_natvent_fan_without_natvent_event).
             _was_nat_vent = self._natural_vent_active
-            if self._emit_event_callback:
-                if _was_nat_vent:
-                    self._emit_event_callback(
-                        "nat_vent_outdoor_rise_exit",
-                        {"outdoor": outdoor, "indoor": indoor, "fan_device": _fan_device_label(self.config)},
-                    )
-                else:
-                    self._emit_event_callback(
-                        "fan_deactivated",
-                        {
-                            "reason": f"fan thermostat check — {stop_reason}",
-                            "fan_mode": self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED),
-                            "fan_device": _fan_device_label(self.config),
-                        },
-                    )
+            if _was_nat_vent:
+                _event_type = "nat_vent_outdoor_rise_exit"
+                _event_payload: dict[str, Any] = {
+                    "outdoor": outdoor,
+                    "indoor": indoor,
+                    "fan_device": _fan_device_label(self.config),
+                }
+            else:
+                _event_type = "fan_deactivated"
+                _event_payload = {
+                    "reason": f"fan thermostat check — {stop_reason}",
+                    "fan_mode": self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED),
+                    "fan_device": _fan_device_label(self.config),
+                }
             # Issue #641: same treatment as STOP_VIA_NAT_VENT_EXIT above and
             # check_natural_vent_conditions()'s OUTDOOR_RISE exit — this branch's own
             # docstring already documents it as "the exact same boundary condition,"
@@ -3937,6 +3962,8 @@ class AutomationEngine:
             await self._exit_nat_vent(
                 reason=f"fan thermostat check — {stop_reason}",
                 set_outdoor_exit_time=True,
+                event_type=_event_type,
+                event_payload=_event_payload,
             )
             return
 
@@ -3975,30 +4002,29 @@ class AutomationEngine:
         # cycling) — only label the event nat-vent-specific when one genuinely was active,
         # mirroring the same distinction made for STOP_DEACTIVATE above.
         _was_nat_vent_floor = self._natural_vent_active
-        if self._emit_event_callback:
-            if _was_nat_vent_floor:
-                self._emit_event_callback(
-                    "nat_vent_comfort_floor_exit",
-                    {
-                        "indoor_temp": indoor,
-                        "comfort_heat": vent_floor_ftc,
-                        "fan_mode_change": "on→auto",
-                        "fan_device": _fan_device_label(self.config),
-                        "hvac_mode_restored": (
-                            self._current_classification.hvac_mode if self._current_classification else "unknown"
-                        ),
-                    },
-                )
-            else:
-                self._emit_event_callback(
-                    "fan_deactivated",
-                    {
-                        "reason": f"fan thermostat check — {stop_reason}",
-                        "fan_mode": self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED),
-                        "fan_device": _fan_device_label(self.config),
-                    },
-                )
-        await self._exit_nat_vent(reason=f"fan thermostat check — {stop_reason}")
+        if _was_nat_vent_floor:
+            _event_type = "nat_vent_comfort_floor_exit"
+            _event_payload: dict[str, Any] = {
+                "indoor_temp": indoor,
+                "comfort_heat": vent_floor_ftc,
+                "fan_mode_change": "on→auto",
+                "fan_device": _fan_device_label(self.config),
+                "hvac_mode_restored": (
+                    self._current_classification.hvac_mode if self._current_classification else "unknown"
+                ),
+            }
+        else:
+            _event_type = "fan_deactivated"
+            _event_payload = {
+                "reason": f"fan thermostat check — {stop_reason}",
+                "fan_mode": self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED),
+                "fan_device": _fan_device_label(self.config),
+            }
+        await self._exit_nat_vent(
+            reason=f"fan thermostat check — {stop_reason}",
+            event_type=_event_type,
+            event_payload=_event_payload,
+        )
 
     async def reconcile_fan_on_startup(
         self,
@@ -5337,7 +5363,14 @@ class AutomationEngine:
         """
         return bool(self._sensor_check_callback and self._sensor_check_callback())
 
-    async def _exit_nat_vent(self, *, reason: str, set_outdoor_exit_time: bool = False) -> None:
+    async def _exit_nat_vent(
+        self,
+        *,
+        reason: str,
+        set_outdoor_exit_time: bool = False,
+        event_type: str | None = None,
+        event_payload: dict[str, Any] | None = None,
+    ) -> FanCommandResult:
         """Single choke point for ending a nat-vent session (Issue #411).
 
         Unifies the handoff previously hand-rolled at 4 separate call sites (Phase 2
@@ -5360,18 +5393,34 @@ class AutomationEngine:
                 it's independently proven immune to immediate re-satisfaction by the
                 instant gate (comfort-floor and away-ceiling exits don't route through
                 this function at all, so they're exempt by construction, not by omission).
+            event_type: Issue #649 — the caller's own specific Activity Report event type
+                (e.g. ``nat_vent_predicted_floor_exit``). Centralizing emission here (instead
+                of each of the 7+ call sites emitting before calling this method, as before
+                #649) lets the payload accurately reflect whether the underlying fan command
+                actually executed or was deferred by the Issue #641 rate limiter, in exactly
+                one place. None (the historical default) skips event emission entirely,
+                preserving the small number of call sites that build their own event some
+                other way.
+            event_payload: Payload for ``event_type``. Its ``fan_mode_change`` key is
+                overwritten based on the real outcome — left as given when the toggle
+                executed, replaced with a "deferred" description when newly rate-limited.
+                Ignored if ``event_type`` is None.
+
+        Returns:
+            The ``FanCommandResult`` from the underlying ``_deactivate_fan()`` call.
         """
         self._natural_vent_active = False
         self._nat_vent_soft_start = False
         if set_outdoor_exit_time:
             self._nat_vent_outdoor_exit_time = dt_util.now()
         sensor_open = self._any_monitored_sensor_open()
-        # emit_event=False on both branches: every call site already emits its own more
-        # specific exit event (nat_vent_predicted_floor_exit, nat_vent_comfort_floor_exit,
-        # nat_vent_outdoor_rise_exit, etc.) before calling this method. Letting
-        # _deactivate_fan() also emit a generic fan_deactivated event here would land at
-        # the same timestamp and shadow the specific event in outcome-ordering consumers
-        # (Issue #411 — found during test verification).
+        # emit_event=False on both branches: the caller's own specific exit event
+        # (nat_vent_predicted_floor_exit, nat_vent_comfort_floor_exit,
+        # nat_vent_outdoor_rise_exit, etc.) is emitted below, by this method, once the
+        # real outcome is known (Issue #649) — letting _deactivate_fan() also emit a
+        # generic fan_deactivated event here would land at the same timestamp and shadow
+        # the specific event in outcome-ordering consumers (Issue #411 — found during
+        # test verification).
         if sensor_open:
             # Don't restore active HVAC into an open window — pause instead. The
             # existing pause/grace machinery (_re_pause_for_open_sensor) re-evaluates
@@ -5386,19 +5435,42 @@ class AutomationEngine:
             # handle_all_doors_windows_closed() ran, but apply_classification()'s DEFER_NAT_VENT
             # gate kept deferring the HVAC-mode restore for hours because this flag was never
             # released.
-            await self._deactivate_fan(reason=reason, restore_hvac=False, release_suppression=True, emit_event=False)
+            result = await self._deactivate_fan(
+                reason=reason, restore_hvac=False, release_suppression=True, emit_event=False
+            )
             self._paused_by_door = True
             state = self.hass.states.get(self.climate_entity)
             self._pre_pause_mode = state.state if state and state.state != "off" else None
-            _LOGGER.info(
+            # Issue #649: a repeat of an already-reported deferral logs at DEBUG, not INFO —
+            # this is the exact "one retry tick after another while still blocked" pattern
+            # that produced unbounded duplicate INFO lines before this fix.
+            _log = _LOGGER.debug if result is FanCommandResult.RATE_LIMITED_DUP else _LOGGER.info
+            _log(
                 "Nat-vent exit (%s): monitored sensor still open — pausing HVAC (pre_pause_mode=%s)",
                 reason,
                 self._pre_pause_mode,
             )
         else:
-            await self._deactivate_fan(reason=reason, emit_event=False)
+            result = await self._deactivate_fan(reason=reason, emit_event=False)
             self._start_grace_period("automation", trigger="nat_vent_exit_resume")
-            _LOGGER.info("Nat-vent exit (%s): sensors closed — restoring HVAC and starting grace period", reason)
+            _log = _LOGGER.debug if result is FanCommandResult.RATE_LIMITED_DUP else _LOGGER.info
+            _log("Nat-vent exit (%s): sensors closed — restoring HVAC and starting grace period", reason)
+
+        if event_type and self._emit_event_callback and result is not FanCommandResult.RATE_LIMITED_DUP:
+            payload = dict(event_payload or {})
+            if result is FanCommandResult.RATE_LIMITED_NEW:
+                applies_at = self._fan_rate_limited_until
+                payload["fan_mode_change"] = (
+                    f"deferred (5-min floor, applies {applies_at.strftime('%H:%M:%S')})"
+                    if isinstance(applies_at, datetime)
+                    else "deferred (5-min floor)"
+                )
+            # EXECUTED / ALREADY_IN_STATE / OVERRIDDEN / DISABLED: payload's own
+            # fan_mode_change (if any) is left exactly as the caller built it — matches
+            # pre-#649 behavior for every outcome that isn't a fresh deferral.
+            self._emit_event_callback(event_type, payload)
+
+        return result
 
     def _nat_vent_reactivation_floor(self) -> float:
         """Sleep-aware comfort floor for nat-vent reactivation/eligibility gates (Issue #417).
@@ -5860,11 +5932,21 @@ class AutomationEngine:
             for cid, ts in self._recent_fan_command_context_ids
         )
 
-    def _fan_toggle_rate_limited(self, *, action: str, reason: str) -> bool:
+    def _fan_toggle_rate_limited(self, *, action: str, reason: str) -> FanCommandResult | None:
         """Hard safety backstop against rapid fan on/off/on cycling (Issue #641).
 
-        Returns True (and suppresses the caller's command) if this toggle would reverse
-        the fan's state within ``FAN_MIN_TOGGLE_INTERVAL_S`` of CA's own last command.
+        Returns ``None`` if this toggle is NOT rate-limited (caller should proceed).
+        Otherwise returns ``FanCommandResult.RATE_LIMITED_NEW`` the first time a given
+        deferral window is reported, or ``RATE_LIMITED_DUP`` for every later call that
+        lands in the *same* window (Issue #649) — e.g. two independent decision paths
+        noticing the same condition in one tick, or `fan_thermostat_check()` re-running
+        on every subsequent temperature-change tick while still blocked. Before #649
+        every such call logged its own WARNING and fired its own
+        ``incident_detected``/``fan_rapid_cycling`` event, producing an unbounded string
+        of duplicate, misleadingly-framed Activity Report rows for what is physically
+        one ongoing blocked state — the floor doing its job, not an anomaly, so it is no
+        longer reported as an incident at all.
+
         Defense-in-depth: independent of any specific root cause, protects the physical
         WHF/HVAC-fan relay from rapid cycling regardless of which upstream decision logic
         produced the reversal (the WHF fast-cycling incident that motivated this — a
@@ -5889,35 +5971,37 @@ class AutomationEngine:
         as "no prior command", never raise.
         """
         if not isinstance(self._fan_toggle_command_time, datetime):
-            return False
+            return None
         elapsed = (dt_util.now() - self._fan_toggle_command_time).total_seconds()
         if elapsed >= FAN_MIN_TOGGLE_INTERVAL_S:
-            return False
+            return None
 
-        _LOGGER.warning(
-            "Fan toggle suppressed: rate limit (%.0fs since last change, min %ds) — %s (%s)",
+        applies_at = self._fan_toggle_command_time + timedelta(seconds=FAN_MIN_TOGGLE_INTERVAL_S)
+        # Issue #649: a deferral window already has a WARNING/report on record if
+        # _fan_rate_limited_until already points at this exact applies_at moment for the
+        # same direction — every later call in that same window is a silent duplicate of
+        # already-known information.
+        if self._fan_rate_limited_until == applies_at and self._fan_rate_limited_direction == action:
+            _LOGGER.debug(
+                "Fan toggle already deferred until %s — skipping duplicate report (%s)",
+                applies_at.strftime("%H:%M:%S"),
+                reason,
+            )
+            return FanCommandResult.RATE_LIMITED_DUP
+
+        _LOGGER.info(
+            "Fan toggle deferred: rate limit (%.0fs since last change, min %ds) — %s (%s) — applies at %s",
             elapsed,
             FAN_MIN_TOGGLE_INTERVAL_S,
             action,
             reason,
+            applies_at.strftime("%H:%M:%S"),
         )
-        self._fan_rate_limited_until = self._fan_toggle_command_time + timedelta(seconds=FAN_MIN_TOGGLE_INTERVAL_S)
-        if self._emit_event_callback:
-            self._emit_event_callback(
-                "incident_detected",
-                {
-                    "incident_class": "fan_rapid_cycling",
-                    "incident_id": dt_util.now().isoformat(),
-                    "attempted_action": action,
-                    "attempted_reason": reason,
-                    "seconds_since_last_command": round(elapsed, 1),
-                    "min_interval_s": FAN_MIN_TOGGLE_INTERVAL_S,
-                    "fan_device": _fan_device_label(self.config),
-                },
-            )
-        return True
+        self._fan_rate_limited_until = applies_at
+        self._fan_rate_limited_direction = action
+        return FanCommandResult.RATE_LIMITED_NEW
 
-    async def _activate_fan(self, *, reason: str, emit_event: bool = True) -> None:
+    async def _activate_fan(self, *, reason: str, emit_event: bool = True) -> FanCommandResult:
         """Activate fan based on configured fan_mode.
 
         Args:
@@ -5926,27 +6010,45 @@ class AutomationEngine:
                 so the Activity Report shows every CA fan command with its source. Callers
                 that already emit a more specific event for the same transition (the nat-vent
                 cycler / exit paths) pass False to avoid a duplicate row (Issue #331 follow-up).
+
+        Returns:
+            A ``FanCommandResult`` describing what actually happened (Issue #649) — callers
+            that build their own Activity Report event for this same transition use this to
+            avoid reporting a state change that didn't happen (rate-limited) or reporting the
+            same deferral twice (a duplicate block within the same window).
         """
         fan_mode = self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED)
         if fan_mode == FAN_MODE_DISABLED:
-            return
+            return FanCommandResult.DISABLED
 
         if self._fan_override_active:
             _LOGGER.info("Fan override active — skipping fan activation")
-            return
+            return FanCommandResult.OVERRIDDEN
 
         # Issue #392 Fix 1c: idempotency guard — collapse redundant re-decisions from
         # multiple gate sites into a single real state transition.
         if self._fan_active:
             _LOGGER.debug("_activate_fan: already active — no-op (%s)", reason)
-            return
+            return FanCommandResult.ALREADY_IN_STATE
 
-        if self._fan_toggle_rate_limited(action="activate", reason=reason):
-            return
+        _rate_limit_result = self._fan_toggle_rate_limited(action="activate", reason=reason)
+        if _rate_limit_result is not None:
+            return _rate_limit_result
 
         if self.dry_run:
             _LOGGER.info("[DRY RUN] Would activate fan — %s", reason)
-            return
+            return FanCommandResult.EXECUTED
+
+        _was_deferred = (
+            isinstance(self._fan_rate_limited_until, datetime) and self._fan_rate_limited_direction == "activate"
+        )
+        if _was_deferred:
+            _LOGGER.info(
+                "5-minute floor expired — applying deferred activation (original reason: %s)",
+                reason,
+            )
+            self._fan_rate_limited_until = None
+            self._fan_rate_limited_direction = None
 
         self._fan_command_time = dt_util.now()
         self._fan_toggle_command_time = self._fan_command_time
@@ -6041,6 +6143,7 @@ class AutomationEngine:
             self._start_fan_thermo_backstop()
         finally:
             self._fan_command_pending = False
+        return FanCommandResult.EXECUTED
 
     def _start_fan_thermo_backstop(self) -> None:
         """Start (or restart) the 5-minute thermostatic backstop timer (Issue #327).
@@ -6272,7 +6375,7 @@ class AutomationEngine:
         restore_hvac: bool = True,
         release_suppression: bool | None = None,
         emit_event: bool = True,
-    ) -> None:
+    ) -> FanCommandResult:
         """Deactivate fan based on configured fan_mode.
 
         Args:
@@ -6295,12 +6398,16 @@ class AutomationEngine:
                 Report shows every CA fan-off with its source. Callers that already emit a
                 more specific event for the same transition (nat-vent cycler / exit paths)
                 pass False to avoid a duplicate row (Issue #331 follow-up).
+
+        Returns:
+            A ``FanCommandResult`` describing what actually happened (Issue #649) — see
+            ``_activate_fan()``'s matching docstring note.
         """
         if release_suppression is None:
             release_suppression = restore_hvac
         fan_mode = self.config.get(CONF_FAN_MODE, FAN_MODE_DISABLED)
         if fan_mode == FAN_MODE_DISABLED:
-            return
+            return FanCommandResult.DISABLED
 
         if self._fan_override_active:
             if self._fan_remote_timer_hours is not None:
@@ -6315,7 +6422,7 @@ class AutomationEngine:
                 )
             else:
                 _LOGGER.info("Fan override active — skipping fan deactivation")
-            return
+            return FanCommandResult.OVERRIDDEN
 
         # Issue #392 Fix 1c: idempotency guard — collapse redundant re-decisions from
         # multiple gate sites into a single real state transition.
@@ -6371,14 +6478,26 @@ class AutomationEngine:
                     )
             else:
                 _LOGGER.debug("_deactivate_fan: already inactive — no-op (%s)", reason)
-            return
+            return FanCommandResult.ALREADY_IN_STATE
 
-        if self._fan_toggle_rate_limited(action="deactivate", reason=reason):
-            return
+        _rate_limit_result = self._fan_toggle_rate_limited(action="deactivate", reason=reason)
+        if _rate_limit_result is not None:
+            return _rate_limit_result
 
         if self.dry_run:
             _LOGGER.info("[DRY RUN] Would deactivate fan — %s", reason)
-            return
+            return FanCommandResult.EXECUTED
+
+        _was_deferred = (
+            isinstance(self._fan_rate_limited_until, datetime) and self._fan_rate_limited_direction == "deactivate"
+        )
+        if _was_deferred:
+            _LOGGER.info(
+                "5-minute floor expired — applying deferred exit (original reason: %s)",
+                reason,
+            )
+            self._fan_rate_limited_until = None
+            self._fan_rate_limited_direction = None
 
         self._fan_command_time = dt_util.now()
         self._fan_toggle_command_time = self._fan_command_time
@@ -6488,6 +6607,7 @@ class AutomationEngine:
             async_call_later(self.hass, 30.0, _verify_setpoint_after_fan_off)
         finally:
             self._fan_command_pending = False
+        return FanCommandResult.EXECUTED
 
     async def check_window_cooling_opportunity(
         self,

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,19 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.19"
+VERSION = "0.6.20"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.20": [
+        "Fix #649: follow-up to #641's whole-house-fan rapid-cycling protection. The"
+        " 5-minute floor itself was already working correctly, but the Activity Report"
+        " and HA logs made a blocked toggle look like it had actually happened, and"
+        " repeated the same misleading row every time the system re-checked while still"
+        " blocked. A blocked-then-later-applied fan toggle now shows as a single"
+        " accurate 'deferred' entry followed by one real 'applied' entry once the floor"
+        " clears, and is no longer mislabeled as an incident — it's the protection"
+        " working as intended.",
+    ],
     "0.6.19": [
         "Fix #647: the internal diagnostic that shadows automation decisions to verify"
         " an in-progress refactor (added in #613/#633/#637/#639, most recently touched"
@@ -1930,6 +1940,48 @@ KNOWN_FIXES: dict[int, dict] = {
             " fan_min_runtime_per_hour feature) now floor their computed on/off phase"
             " durations at the same 300s minimum so a configured value outside ~[5, 55]"
             " minutes can't schedule its own off/on command inside the rate-limit window."
+        ),
+    },
+    649: {
+        "version_fixed": "0.6.20",
+        "title": "WHF rate-limit reporting was misleading and mis-framed as an incident (follow-up to #641)",
+        "scope_covered": (
+            "automation.py: _activate_fan()/_deactivate_fan() now return a FanCommandResult"
+            " (EXECUTED / ALREADY_IN_STATE / RATE_LIMITED_NEW / RATE_LIMITED_DUP / OVERRIDDEN /"
+            " DISABLED) instead of None, so callers can tell whether a fan command actually"
+            " executed. _exit_nat_vent() gained event_type/event_payload kwargs and now"
+            " centralizes emission for its 7 call sites (check_natural_vent_conditions()'s"
+            " PROACTIVE_FLOOR/OUTDOOR_RISE/CEILING_THRESHOLD-adjacent branches,"
+            " fan_thermostat_check()'s STOP_VIA_NAT_VENT_EXIT/STOP_DEACTIVATE/STOP_COOLED_TO_FLOOR,"
+            " and nat_vent_temperature_check()'s hard-floor exit) — the caller's own"
+            " nat_vent_predicted_floor_exit/nat_vent_comfort_floor_exit/nat_vent_outdoor_rise_exit/"
+            " fan_deactivated event now fires with an accurate fan_mode_change field ('on→auto'"
+            " when the toggle executed, a 'deferred (5-min floor, applies HH:MM:SS)' description"
+            " when newly rate-limited) instead of unconditionally claiming a state transition"
+            " that may not have happened. _fan_toggle_rate_limited() gained a dedup guard"
+            " (_fan_rate_limited_direction + comparing against the already-armed"
+            " _fan_rate_limited_until) so a repeat block within the same deferral window —"
+            " either two decision paths racing in one tick, or fan_thermostat_check() re-"
+            " deciding on every retry tick while still blocked — logs at DEBUG and reports"
+            " nothing new, instead of an unbounded WARNING/incident per tick. The"
+            " incident_detected/fan_rapid_cycling emission (added in #641) was removed entirely"
+            " and its docs/incident-classes.md rows deleted — a blocked-and-deferred toggle is"
+            " the #641 floor working correctly, not an anomaly; the first block in a window now"
+            " logs at INFO (was WARNING). When a deferred toggle finally executes,"
+            " _activate_fan()/_deactivate_fan() log a new INFO '5-minute floor expired — applying"
+            " deferred ...' line ahead of the pre-existing (unchanged, WARNING) 'Activated/"
+            " Deactivated fan' line, so the completion is visible without inflating its severity."
+            " ai_skills_context.py: _render_fan_activated()/_render_fan_deactivated() now honor an"
+            " optional fan_mode_change payload override (falling back to the historical"
+            " 'device: off->on'/'on->off' when absent) — needed because those two renderers,"
+            " unlike the nat_vent_* renderers, previously hardcoded the state-transition text"
+            " regardless of payload; _render_nat_vent_outdoor_rise_exit()/"
+            " _render_nat_vent_away_ceiling_exit() also extended to surface fan_mode_change when"
+            " present, matching the pattern the comfort-floor/predicted-floor renderers already"
+            " used. coordinator.py: _whf_rate_limit_suffix() reworded from '(rate-limited Xs ago)'"
+            " to '(<on/off> pending — 5-min floor, applies at HH:MM:SS)', naming the pending"
+            " direction (via the new _fan_rate_limited_direction field) and the exact clock time"
+            " the deferred toggle will apply. No change to the #641 floor/lockout mechanism itself."
         ),
     },
     639: {

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -131,7 +131,6 @@ from .const import (
     ECONOMIZER_MORNING_END_HOUR,
     ECONOMIZER_TEMP_DELTA,
     EVENT_LOG_CAP,
-    FAN_MIN_TOGGLE_INTERVAL_S,
     FAN_MODE_BOTH,
     FAN_MODE_DISABLED,
     FAN_MODE_HVAC,
@@ -8073,19 +8072,27 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         return status + self._whf_rate_limit_suffix(ae)
 
     def _whf_rate_limit_suffix(self, ae: AutomationEngine) -> str:
-        """Append '(rate-limited Xs ago)' to the WHF status while a toggle is still
-        within the Issue #641 cooldown window — Status Card Ontology rule: extend the
-        existing card's value string, don't add a new one. Returns "" once the cooldown
-        has elapsed; never raises on a mocked/partial engine (isinstance guard, matching
-        _format_grace_remaining()'s existing defensive pattern for the same reason)."""
+        """Append '(<direction> pending — 5-min floor, applies at HH:MM:SS)' to the WHF
+        status while a toggle is still deferred by the Issue #641 cooldown — Status Card
+        Ontology rule: extend the existing card's value string, don't add a new one.
+        Returns "" once the cooldown has elapsed; never raises on a mocked/partial engine
+        (isinstance guard, matching _format_grace_remaining()'s existing defensive pattern
+        for the same reason).
+
+        Issue #649: reworded from the original "(rate-limited Xs ago)", which didn't say
+        what was pending or when it would resolve — this names the direction (using the
+        same "activate"/"deactivate" strings _fan_toggle_rate_limited() already tracks)
+        and the exact clock time the deferred toggle will apply.
+        """
         until = getattr(ae, "_fan_rate_limited_until", None)
         if not isinstance(until, datetime):
             return ""
         remaining = (until - dt_util.now()).total_seconds()
         if remaining <= 0:
             return ""
-        suppressed_ago = FAN_MIN_TOGGLE_INTERVAL_S - remaining
-        return f" (rate-limited {suppressed_ago:.0f}s ago)"
+        direction = getattr(ae, "_fan_rate_limited_direction", None)
+        pending = "on" if direction == "activate" else "off"
+        return f" ({pending} pending — 5-min floor, applies at {until.strftime('%H:%M:%S')})"
 
     def _compute_hvac_fan_status(self) -> str | None:
         """Return HVAC-fan-blower-specific status, or None when HVAC fan is not configured.

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.19"
+  "version": "0.6.20"
 }

--- a/docs/incident-classes.md
+++ b/docs/incident-classes.md
@@ -6,7 +6,7 @@
 
 | Question | Short answer (<= 2 sentences) | -> Full answer |
 |---|---|---|
-| Which incident classes are proactive (fire at command time)? | Two: `setpoint_mode_inconsistency` -- fires inside automation.py _set_temperature() before the HA service call; and `fan_rapid_cycling` (Issue #641) -- fires inside automation.py _activate_fan()/_deactivate_fan() when the rate-limit backstop suppresses a command. All other classes are reactive and fire post-cycle in coordinator._detect_and_emit_incidents. | [Proactive vs. Reactive column below](#incident-class-reference) |
+| Which incident classes are proactive (fire at command time)? | One: `setpoint_mode_inconsistency` -- fires inside automation.py _set_temperature() before the HA service call. All other classes are reactive and fire post-cycle in coordinator._detect_and_emit_incidents. (Issue #641 briefly added a proactive `fan_rapid_cycling` class when the rate-limit backstop suppressed a command; removed in #649 -- a suppressed-and-deferred toggle is the backstop working correctly, not an anomaly, and is now surfaced as a `fan_toggle_deferred`-flavored event payload plus a WHF status-card suffix instead of an incident.) | [Proactive vs. Reactive column below](#incident-class-reference) |
 | What is the `incident_detected` event payload schema? | `type`, `time`, `incident_class`, `incident_id`, `indoor_f`, `outdoor_f`, `hvac_mode`, `comfort_cool`, `comfort_heat`, plus class-specific fields (`nat_vent_active`, `manual_override_active`, `occupancy_mode`, `setpoint_f`). | [Event Payload](#event-payload) |
 | Does `comfort_violation`/`comfort_undertemp` require a sustained 15-min deviation? | No -- both are a **point-in-time** check (>0.5 F past the comfort band edge) with a 30-min incident-dedup window, not a duration tracker; as of Issue #411 they also skip emission when the deviation is within nat-vent-cycling tolerance (`coordinator._is_nat_vent_tolerated_deviation()`). | [Incident Class Reference below](#incident-class-reference) |
 | Which classes were added for bugs #220-222? | Four new classes: `setpoint_mode_inconsistency` (#222 -- silent wrong setpoint), `rapid_override_after_automation` (#221 -- false override detection), `occupancy_transition` (#220 -- coverage gap), `override_active_on_occupancy` (compound condition at occupancy change). | [Bug Motivation column below](#incident-class-reference) |
@@ -28,7 +28,6 @@
 | `rapid_override_after_automation` | `override_detected` event within 60s of any automation decision event in event_log | Reactive | Integration | **HIGH** | #221 -- automation-driven setpoint change falsely flagged as manual override |
 | `occupancy_transition` | Any `occupancy_change` event in event_log during the last cycle | Reactive | Both | Medium | #220 -- near-zero occupancy transition coverage in golden suite |
 | `override_active_on_occupancy` | `manual_override_active=True` at the time of an `occupancy_change` event | Reactive | Integration | Medium | Compound condition exposed by #220 investigation |
-| `fan_rapid_cycling` | `_fan_toggle_rate_limited()` suppresses a CA-issued fan activate/deactivate within `FAN_MIN_TOGGLE_INTERVAL_S` (300s) of CA's own last fan command | **Proactive** | Integration | **HIGH** | #641 -- WHF cycled on/off ~every minute (proactive-floor exit vs. instant reactivation-gate flip-flop); a suppressed command silently diverges commanded vs. physical fan state |
 
 ---
 
@@ -75,7 +74,6 @@ All numeric fields are in Fahrenheit regardless of the user's display unit setti
 | Class | Where it fires | Code location |
 |---|---|---|
 | `setpoint_mode_inconsistency` | Before HA service call | `automation.py _set_temperature()` |
-| `fan_rapid_cycling` | At the suppressed command, before any HA service call | `automation.py _fan_toggle_rate_limited()`, called from `_activate_fan()`/`_deactivate_fan()` |
 | All others | Post-cycle | `coordinator.py _detect_and_emit_incidents()` |
 
 The `incident_detected` event is appended to `coordinator._event_log` in both cases. It is visible in the event log API at `GET /api/climate_advisor/event_log`.

--- a/docs/nat-vent-lifecycle-spec.md
+++ b/docs/nat-vent-lifecycle-spec.md
@@ -13,7 +13,7 @@
 | What happens when nat-vent exits and the sensor is still open — pause or grace? | `_exit_nat_vent()` forks: sensor still open → hands off into the pause lifecycle; sensors closed → hands off into the grace lifecycle. See `grace-periods-spec.md` for what happens next in either lifecycle. | [Handoff to Pause/Grace](#handoff-to-pausegrace) |
 | How was this spec's accuracy verified? | Differential replay: `derive_nat_vent_lifecycle_state()` run against the real final engine flags from all 74 golden + 4 pending scenarios (Issue #606), plus 3 hand-reasoned ground-truth scenarios. | [Verification](#verification) |
 | Is every `_exit_nat_vent()` call site's lockout-arming decision enforced, not just documented? | Yes — `tests/test_nat_vent_exit_lockout_coverage.py` AST-scans every call site and requires each to be explicitly classified `"arms lockout"` / `"exempted: <reason>"`, with a positive control that checks the claim against the actual `set_outdoor_exit_time=True` argument (Issue #641). | [Incident: WHF fast-cycling](#incident-whf-fast-cycling-proactive-floor-exit-vs-instant-reactivation-issue-641) |
-| Is there a hard floor on how fast CA can physically toggle the fan, independent of any exit/reactivation logic? | Yes — `AutomationEngine._fan_toggle_rate_limited()` (Issue #641), a defense-in-depth backstop inside `_activate_fan()`/`_deactivate_fan()`: any reversal within `FAN_MIN_TOGGLE_INTERVAL_S` (300s) of CA's own last real toggle command is suppressed, logged at WARNING, and raised as a proactive `fan_rapid_cycling` incident (`docs/incident-classes.md`). Never affects genuine user/RF-remote fan actions. | [Incident: WHF fast-cycling](#incident-whf-fast-cycling-proactive-floor-exit-vs-instant-reactivation-issue-641) |
+| Is there a hard floor on how fast CA can physically toggle the fan, independent of any exit/reactivation logic? | Yes — `AutomationEngine._fan_toggle_rate_limited()` (Issue #641), a defense-in-depth backstop inside `_activate_fan()`/`_deactivate_fan()`: any reversal within `FAN_MIN_TOGGLE_INTERVAL_S` (300s) of CA's own last real toggle command is suppressed and logged at INFO (a repeat block within the same deferral window logs at DEBUG only, Issue #649). No longer raised as an incident — Issue #649 removed `fan_rapid_cycling`, since a blocked-and-deferred toggle is the floor working correctly, not an anomaly; it's surfaced via an accurate Activity Report event payload and a WHF status-card suffix instead. Never affects genuine user/RF-remote fan actions. | [Follow-up: rate-limit reporting](#follow-up-rate-limit-reporting-was-misleading-and-mis-framed-as-an-incident-issue-649) |
 | Does `check_natural_vent_conditions()`'s exit chain always decide WHY a session ends? | No — confirmed by direct experiment (Issue #608): `nat_vent_temperature_check()` and `fan_thermostat_check()` (both dispatched from the same `temp_update`/thermostat-attribute-change trigger, both already pure-extracted by Issue #441) run FIRST and independently implement equivalent comfort-floor and outdoor-rise-style stops — they win the race and exit the session before `check_natural_vent_conditions()`'s chain ever evaluates, for every golden scenario tested. | [Known Duplicate-Logic Race](#known-duplicate-logic-race-issue-608-finding) |
 | Has a shadow engine instance been proven safe to construct alongside production, offline? | Yes — `tools/sim_harness/shadow_engine_pair.py` (Issue #611) proves, across 60 offline-eligible golden+pending scenarios, that a dry_run=True shadow instance never issues a real action AND never changes what production itself does. | [Offline Whole-Engine Shadow-Pair Validation](#offline-whole-engine-shadow-pair-validation-issue-611-subtask-o) |
 | Is there a real, live shadow engine running inside the coordinator today, and is its coverage complete? | Yes to both — `coordinator.shadow_automation_engine` (Issue #613), permanently `dry_run=True`, mirrors all 13 real nat-vent entry points, the 3 input-data attributes they depend on (Issue #615), and the 7 grace/override lifecycle-gate fields plus companions (Issue #631) — enforced by an AST-based coverage registry test so new gaps can't ship silently. Zero occupant/HVAC impact; surfaced via a diagnostic sensor, not any Status-tab card. | [Live Shadow Engine](#live-shadow-engine-issue-613-subtask-q) |
@@ -218,6 +218,57 @@ exit reason added later without a classification fails immediately. Separately,
 durations at the same 300s minimum — a configured value outside roughly [5, 55]
 minutes would otherwise schedule its own off/on command inside the rate-limit window,
 stranding the fan far longer than the configured cycle intended.
+
+### Follow-up: rate-limit reporting was misleading and mis-framed as an incident (Issue #649)
+
+Live logs confirmed the #641 floor itself works correctly — a real production window
+showed a clean, unbroken 5-min-on/5-min-off cadence. But reviewing the Activity Report
+for one of those blocked toggles surfaced three reporting defects, all pre-existing
+architecture exposed (not caused) by #641's rate limiter:
+
+1. **A blocked toggle was reported as if it physically happened.** Every nat-vent exit
+   branch (`nat_vent_predicted_floor_exit`, `nat_vent_comfort_floor_exit`,
+   `fan_deactivated`, etc.) built its Activity Report event **before** calling
+   `_exit_nat_vent()` → `_deactivate_fan()`/`_activate_fan()`, with no way to know
+   whether the toggle actually executed or was silently swallowed by
+   `_fan_toggle_rate_limited()`. This pattern predates #641 — before the rate limiter
+   existed, "decided" and "physically executed" were always the same instant, so no
+   caller needed to distinguish them.
+2. **The same blocked moment produced multiple rows.** Two independent mechanisms: (a)
+   two decision paths (e.g. `check_natural_vent_conditions()`'s `PROACTIVE_FLOOR` and
+   `fan_thermostat_check()`'s comfort-floor check) can notice the same condition in the
+   same tick, and (b) `fan_thermostat_check()` re-runs on every subsequent
+   temperature-change tick while the fan is still physically on but blocked — each
+   retry independently re-decided and re-triggered the limiter.
+3. **`incident_detected`/`fan_rapid_cycling` mischaracterized correct behavior** — the
+   floor blocking a too-soon toggle is the protection working, not an anomaly.
+
+**Fix, centralized rather than repeated per call site**: `_exit_nat_vent()` gained
+`event_type`/`event_payload` kwargs and now performs the toggle first, then emits the
+caller's event itself with `fan_mode_change` reflecting the real
+`FanCommandResult` — unchanged when executed, a `"deferred (5-min floor, applies
+HH:MM:SS)"` description when newly rate-limited, and not emitted at all for a
+duplicate block within an already-reported deferral window.
+`_fan_toggle_rate_limited()` now tracks `_fan_rate_limited_direction` alongside
+`_fan_rate_limited_until` so it can recognize "this is the same pending window as
+last time" — the single change that fixes both duplicate-report mechanisms above,
+since both funnel through this one function. `_activate_fan()`/`_deactivate_fan()`
+log an INFO "5-minute floor expired — applying deferred exit/activation" line when a
+previously-blocked command finally lands, ahead of the pre-existing (unchanged,
+WARNING) "Activated/Deactivated fan" line — deferred completion is normal operation,
+not a fault, so it doesn't get an elevated severity. `incident_detected`/
+`fan_rapid_cycling` was removed entirely (`docs/incident-classes.md`); the first block
+in a deferral window now logs at INFO instead of WARNING. `_whf_rate_limit_suffix()`
+was reworded from the vague `"(rate-limited Xs ago)"` to `"(<on/off> pending — 5-min
+floor, applies at HH:MM:SS)"`.
+
+No change to the #641 floor/lockout mechanism itself, no change to any event *type*
+(only payload content — the shadow-FSM re-evaluation triggers keyed on these event
+types in `coordinator.py` are unaffected), and no frontend changes (the renderers in
+`ai_skills_context.py` were already payload-driven for the nat-vent-specific event
+types; `_render_fan_activated`/`_render_fan_deactivated` gained a small
+`fan_mode_change`-override fallback since, unlike their nat-vent-specific siblings,
+they previously hardcoded the state-transition text unconditionally).
 
 ## Code Reference
 

--- a/tests/test_activity_renderers.py
+++ b/tests/test_activity_renderers.py
@@ -554,9 +554,16 @@ class TestEventRenderersCoverage:
     )
 
     def _extract_emitted_types(self) -> set[str]:
-        """Read automation.py and coordinator.py; return all emitted event type literals."""
+        """Read automation.py and coordinator.py; return all emitted event type literals.
+
+        Issue #649: `_exit_nat_vent()` centralizes emission for its callers' nat-vent
+        exit events — callers now pass the type as an `event_type="..."` keyword
+        literal instead of calling `_emit_event_callback("...", ...)` directly, so the
+        extraction regex covers both call shapes.
+        """
         emitted: set[str] = set()
         pattern = re.compile(r'_emit_event(?:_callback)?\s*\(\s*["\'](\w+)["\']')
+        event_type_kwarg_pattern = re.compile(r'event_type\s*=\s*["\'](\w+)["\']')
         for fname in (
             "custom_components/climate_advisor/automation.py",
             "custom_components/climate_advisor/coordinator.py",
@@ -564,6 +571,7 @@ class TestEventRenderersCoverage:
             with open(fname, encoding="utf-8") as f:
                 content = f.read()
             emitted.update(pattern.findall(content))
+            emitted.update(event_type_kwarg_pattern.findall(content))
         return emitted
 
     def test_all_emitted_types_have_renderer(self):

--- a/tests/test_fan_control.py
+++ b/tests/test_fan_control.py
@@ -3460,10 +3460,12 @@ class TestWhfStatusRateLimitSuffix:
             physical_state=False,
         )
         now = datetime(2026, 8, 15, 6, 41, 0)
-        coord.automation_engine._fan_rate_limited_until = now + timedelta(seconds=120)
+        applies_at = now + timedelta(seconds=120)
+        coord.automation_engine._fan_rate_limited_until = applies_at
+        coord.automation_engine._fan_rate_limited_direction = "deactivate"
         with patch("custom_components.climate_advisor.coordinator.dt_util.now", return_value=now):
             result = coord._compute_whf_status()
-        assert result == "inactive (rate-limited 180s ago)"
+        assert result == f"inactive (off pending — 5-min floor, applies at {applies_at.strftime('%H:%M:%S')})"
 
     def test_suffix_absent_once_cooldown_elapses(self):
         coord = _make_coordinator_for_fan_status(

--- a/tests/test_fan_rate_limit.py
+++ b/tests/test_fan_rate_limit.py
@@ -13,7 +13,7 @@ import asyncio
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from custom_components.climate_advisor.automation import AutomationEngine
+from custom_components.climate_advisor.automation import AutomationEngine, FanCommandResult
 from custom_components.climate_advisor.const import (
     CONF_FAN_ENTITY,
     CONF_FAN_MODE,
@@ -60,8 +60,9 @@ def _get_service_calls(engine, domain: str, service: str) -> list:
 
 
 class TestFanToggleRateLimitSuppression:
-    """A reversal within the cooldown window must be suppressed, logged, and
-    flagged as a fan_rapid_cycling incident — never silent."""
+    """A reversal within the cooldown window must be suppressed and logged at INFO —
+    never silent, but also never framed as an incident (Issue #649: a blocked-and-
+    deferred toggle is the backstop working correctly, not an anomaly)."""
 
     def test_reactivate_within_window_is_suppressed(self):
         """Fan turned on, legitimately deactivated after the cooldown has elapsed
@@ -89,18 +90,19 @@ class TestFanToggleRateLimitSuppression:
         events: list[tuple] = []
         engine._emit_event_callback = lambda name, payload: events.append((name, payload))
         with patch(_DT_NOW_PATH, return_value=t2), patch("custom_components.climate_advisor.automation._LOGGER") as log:
-            asyncio.run(engine._activate_fan(reason="reactivation attempt"))
+            result = asyncio.run(engine._activate_fan(reason="reactivation attempt"))
 
         assert engine._fan_active is False, "rate limit must suppress the reactivation"
         assert len(_get_service_calls(engine, "fan", "turn_on")) == 1, "no second turn_on call issued"
-        log.warning.assert_called_once()
-        assert "rate limit" in log.warning.call_args.args[0].lower()
+        assert result is FanCommandResult.RATE_LIMITED_NEW
+        log.info.assert_called_once()
+        assert "rate limit" in log.info.call_args.args[0].lower()
+        log.warning.assert_not_called()
 
-        incidents = [e for e in events if e[0] == "incident_detected"]
-        assert len(incidents) == 1
-        assert incidents[0][1]["incident_class"] == "fan_rapid_cycling"
-        assert incidents[0][1]["attempted_action"] == "activate"
-        assert incidents[0][1]["min_interval_s"] == FAN_MIN_TOGGLE_INTERVAL_S
+        assert not any(e[0] == "incident_detected" for e in events), (
+            "a blocked-and-deferred toggle must never be reported as an incident (Issue #649)"
+        )
+        assert engine._fan_rate_limited_direction == "activate"
 
     def test_deactivate_within_window_is_suppressed(self):
         """Symmetric case: activate, then a too-soon deactivate attempt is suppressed."""
@@ -114,12 +116,13 @@ class TestFanToggleRateLimitSuppression:
         events: list[tuple] = []
         engine._emit_event_callback = lambda name, payload: events.append((name, payload))
         with patch(_DT_NOW_PATH, return_value=t1):
-            asyncio.run(engine._deactivate_fan(reason="too-soon exit attempt"))
+            result = asyncio.run(engine._deactivate_fan(reason="too-soon exit attempt"))
 
         assert engine._fan_active is True, "rate limit must suppress the too-soon deactivation"
         assert len(_get_service_calls(engine, "fan", "turn_off")) == 0
-        incidents = [e for e in events if e[0] == "incident_detected"]
-        assert incidents[0][1]["attempted_action"] == "deactivate"
+        assert result is FanCommandResult.RATE_LIMITED_NEW
+        assert not any(e[0] == "incident_detected" for e in events)
+        assert engine._fan_rate_limited_direction == "deactivate"
 
     def test_suppression_sets_fan_rate_limited_until(self):
         """_fan_rate_limited_until is set to command_time + interval — the field the
@@ -134,6 +137,77 @@ class TestFanToggleRateLimitSuppression:
             asyncio.run(engine._deactivate_fan(reason="suppressed"))
 
         assert engine._fan_rate_limited_until == t0 + timedelta(seconds=FAN_MIN_TOGGLE_INTERVAL_S)
+
+
+class TestFanToggleRateLimitDedup:
+    """A repeat block within the same already-reported deferral window must be a
+    silent (DEBUG-only) duplicate — the two duplicate-report mechanisms Issue #649
+    found: two decision paths racing in the same tick, and fan_thermostat_check()
+    re-deciding on every subsequent retry tick while still blocked."""
+
+    def test_second_block_in_same_window_is_a_silent_duplicate(self):
+        engine = _make_engine()
+        t0 = datetime(2026, 8, 15, 9, 29, 0)
+        with patch(_DT_NOW_PATH, return_value=t0):
+            asyncio.run(engine._activate_fan(reason="initial activation"))
+
+        t1 = t0 + timedelta(seconds=180)
+        with (
+            patch(_DT_NOW_PATH, return_value=t1),
+            patch("custom_components.climate_advisor.automation._LOGGER") as log1,
+        ):
+            first_result = asyncio.run(engine._deactivate_fan(reason="first decision path"))
+        assert first_result is FanCommandResult.RATE_LIMITED_NEW
+        log1.info.assert_called_once()
+
+        # A second, independent decision path re-evaluates 5s later (matches the
+        # observed same-tick race) — must be recognized as the same pending window.
+        t2 = t1 + timedelta(seconds=5)
+        with (
+            patch(_DT_NOW_PATH, return_value=t2),
+            patch("custom_components.climate_advisor.automation._LOGGER") as log2,
+        ):
+            second_result = asyncio.run(engine._deactivate_fan(reason="second decision path, same tick"))
+        assert second_result is FanCommandResult.RATE_LIMITED_DUP
+        log2.info.assert_not_called()
+        log2.debug.assert_called_once()
+        assert "already deferred" in log2.debug.call_args.args[0].lower()
+
+        # A further retry tick, still within the window, is also a silent duplicate.
+        t3 = t1 + timedelta(seconds=90)
+        with (
+            patch(_DT_NOW_PATH, return_value=t3),
+            patch("custom_components.climate_advisor.automation._LOGGER") as log3,
+        ):
+            third_result = asyncio.run(engine._deactivate_fan(reason="retry tick"))
+        assert third_result is FanCommandResult.RATE_LIMITED_DUP
+        log3.info.assert_not_called()
+
+    def test_completion_logs_deferred_application_at_info_not_warning(self):
+        """Once the floor clears, the real toggle applies — Issue #649: this is normal,
+        expected operation, so it gets an INFO context line, not an elevated severity."""
+        engine = _make_engine()
+        t0 = datetime(2026, 8, 15, 9, 29, 0)
+        with patch(_DT_NOW_PATH, return_value=t0):
+            asyncio.run(engine._activate_fan(reason="initial activation"))
+
+        t1 = t0 + timedelta(seconds=180)
+        with patch(_DT_NOW_PATH, return_value=t1):
+            asyncio.run(engine._deactivate_fan(reason="blocked"))
+        assert engine._fan_active is True
+
+        t2 = t0 + timedelta(seconds=FAN_MIN_TOGGLE_INTERVAL_S + 1)
+        with patch(_DT_NOW_PATH, return_value=t2), patch("custom_components.climate_advisor.automation._LOGGER") as log:
+            result = asyncio.run(engine._deactivate_fan(reason="floor cleared"))
+
+        assert result is FanCommandResult.EXECUTED
+        assert engine._fan_active is False
+        assert engine._fan_rate_limited_until is None
+        info_messages = [c.args[0] for c in log.info.call_args_list]
+        assert any("floor expired" in m.lower() for m in info_messages), (
+            "the deferred-completion context must be its own INFO line, not folded into"
+            " the pre-existing (unchanged) WARNING 'Deactivated fan' line"
+        )
 
 
 class TestFanToggleRateLimitAllowsSpacedToggles:


### PR DESCRIPTION
## Summary
Follow-up to #641. The 300s rate-limit floor genuinely works (confirmed via live logs: clean 5-min-on/5-min-off cadence for hours) — this PR fixes the *reporting* around a blocked toggle, which was misleading in three ways:

- A blocked toggle claimed a physical state change (`whf: on->off`) that hadn't happened yet
- The same blocked moment produced duplicate rows (two decision paths racing in one tick, plus every retry tick while still blocked)
- `incident_detected: fan_rapid_cycling` mischaracterized the floor doing its job as an anomaly

## Changes
- `_activate_fan()`/`_deactivate_fan()` return a `FanCommandResult` (EXECUTED/RATE_LIMITED_NEW/RATE_LIMITED_DUP/etc.) instead of `None`
- `_exit_nat_vent()` centralizes event emission via new `event_type`/`event_payload` kwargs — 8 call sites now report an accurate `fan_mode_change` based on the real outcome instead of unconditionally emitting before the toggle is attempted
- `_fan_toggle_rate_limited()` dedups repeat blocks within the same deferral window and no longer emits `incident_detected`
- Deferred-toggle completion gets a new INFO line ahead of the existing (unchanged) WARNING action line
- WHF status card suffix reworded to show pending direction + ETA instead of vague "rate-limited Xs ago"
- `docs/incident-classes.md` / `docs/nat-vent-lifecycle-spec.md` updated

No change to the #641 floor/lockout mechanism itself, no event-type renames (shadow-FSM wiring unaffected), no new frontend plumbing (renderers already payload-driven, with a small fallback added to two that weren't).

## Test plan
- [x] `ruff check` / `ruff format` clean
- [x] Full unit suite: 4492 passed, 6 skipped
- [x] `python tools/simulate.py` — 81/81 golden scenarios
- [x] `python tools/simulate.py --pending` — 7/7 pending scenarios
- [x] `test_version_sync.py` passes (0.6.20)