### PR TITLE
Fix #651: override/grace shadow FSM — handle_manual_override entry gap + bedtime/wakeup exit gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.21] — 2026-08-16
+
+- Fix #651: internal refactor only, no user-visible behavior change — two more gaps in the diagnostic-only shadow/FSM comparisons (Block 5 series, 0.6.13–0.6.20). A manual override made directly at the thermostat wasn't registering with the diagnostic at all (fan overrides already worked, since #643). A fan-only override cleared by the bedtime or morning-wakeup schedule now reflects immediately instead of self-correcting a cycle later. Purely observational — nothing it computes is ever acted on.
+
 ## [0.6.20] — 2026-08-16
 
 - Fix #649: follow-up to #641's whole-house-fan rapid-cycling protection. The 5-minute floor itself was already working correctly, but the Activity Report and HA logs made a blocked toggle look like it had actually happened, and repeated the same misleading row every time the system re-checked while still blocked. A blocked-then-later-applied fan toggle now shows as a single accurate "deferred" entry followed by one real "applied" entry once the floor clears, and is no longer mislabeled as an incident — it's the protection working as intended.

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,19 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.20"
+VERSION = "0.6.21"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.21": [
+        "Fix #651: closed two more gaps in the internal diagnostic that shadows"
+        " automation decisions to verify an in-progress refactor (#613/#633/#637/#639,"
+        " most recently #643/#647). A manual override made directly at the thermostat"
+        " now correctly registers with the diagnostic (it was invisible before); and a"
+        " fan-only override cleared by the bedtime or morning-wakeup schedule now"
+        " reflects immediately instead of a brief delayed self-correction. No"
+        " occupant-visible behavior change — this only affects an internal diagnostic"
+        " used to validate the automation-engine refactor before any of it goes live.",
+    ],
     "0.6.20": [
         "Fix #649: follow-up to #641's whole-house-fan rapid-cycling protection. The"
         " 5-minute floor itself was already working correctly, but the Activity Report"
@@ -1810,6 +1820,38 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    651: {
+        "version_fixed": "0.6.21",
+        "title": "Override/grace shadow FSM: handle_manual_override entry gap + bedtime/wakeup exit gap",
+        "scope_covered": (
+            "coordinator.py: two remaining gaps in the override/grace lifecycle FSM diagnostic"
+            " (#613/#633/#637/#639, most recently #643/#647), same root-cause class (FSM"
+            " event-coverage narrower than the real production state-mutation surface)."
+            " Gap 1: handle_manual_override() (the thermostat-level override path, distinct"
+            " from handle_fan_manual_override which #643 already wired) was never mirrored to"
+            " the shadow FSM at any of its 3 real coordinator.py call sites"
+            " (_async_thermostat_changed's new-override-during-grace, mode-changed-outside-"
+            "pause, and setpoint-only branches) — added to _OVERRIDE_GRACE_FSM_EVENT_KINDS"
+            " and _mirror_to_shadow('handle_manual_override', ...) calls at all 3 sites,"
+            " mapping to the same OVERRIDE_DETECTED kind #643 used for the fan path. Gap 2:"
+            " handle_bedtime()/handle_morning_wakeup() can silently clear a fan-only override"
+            " via clear_manual_override() with no adjacent event emission (the emit is gated"
+            " on _manual_override_active, false for a fan-only override) — this was not"
+            " permanently stuck (the pre-existing _check_orphaned_grace() self-heal, run every"
+            " ~30s cycle, catches it as an orphaned grace within one cycle since"
+            " 'fan_manual_override' is in _GRACE_TRIGGERS_PROTECTING_OVERRIDE) but produced a"
+            " transient shadow-disagreement blip until then. Fixed via a before/after"
+            " _any_override_active() diff around both _async_bedtime()/_async_morning_wakeup()"
+            " calls, feeding _feed_override_grace_fsm_cancelled() immediately on a detected"
+            " clear rather than waiting on the backstop — coordinator.py only, no automation.py"
+            " changes, avoids duplicating either handler's own gate logic."
+            " tests/test_shadow_engine_coverage.py gained a new TestPerCallerFsmFeedCoverage"
+            " class asserting per-call-site (not just per-event-kind) reachability, the"
+            " specific gap in test coverage that let #643 ship asymmetric wiring undetected."
+            " Zero production HVAC impact: shadow engine/FSM state reaches nothing but the"
+            " Shadow Engine Status diagnostic sensor."
+        ),
+    },
     647: {
         "version_fixed": "0.6.19",
         "title": "Shadow-engine/FSM diagnostics (#613/#633/#637/#639) disagreed with production on nearly every cycle",

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -385,6 +385,11 @@ _OVERRIDE_GRACE_FSM_EVENT_KINDS: dict[str, str] = {
     "handle_manual_override_during_pause": "manual_override_during_pause",
     "resume_from_pause": "dashboard_resume",
     "handle_fan_manual_override": "override_detected",
+    # Issue #651: same entry-wiring gap #643 fixed for handle_fan_manual_override,
+    # never done for the thermostat-level override path. Maps to the same
+    # OVERRIDE_DETECTED kind — OverrideGraceFsmInputs.setpoint_override already
+    # differentiates a setpoint-only override from a mode-change override.
+    "handle_manual_override": "override_detected",
 }
 
 # Issue #647: the mirror-name-keyed dicts above only ever covered FSM *entry* paths —
@@ -850,13 +855,18 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         method — gates nat-vent reactivation on ``not self._grace_active``, and the
         shadow's copy never reflected production's active manual-override grace period.
         Deliberately NOT adding new ``_mirror_to_shadow(...)`` call sites for the setters
-        of these fields (``handle_fan_manual_override``, ``handle_manual_override``,
-        ``clear_manual_override``, ``cancel_override``) — that would reintroduce the
+        of ``clear_manual_override``/``cancel_override`` — that would reintroduce the
         "duplicate each write at its call site" pattern this function exists to replace,
         and would start real ``async_call_later`` timers against the shared ``hass``
         event loop on the shadow engine for no benefit over a raw copy refreshed every
-        cycle. See ``tests/test_shadow_engine_coverage.py`` for the registry entries
-        documenting why each setter is exempted rather than mirrored.
+        cycle. ``handle_fan_manual_override`` (#643) and ``handle_manual_override``
+        (#651) are the sole exceptions — both are mirrored anyway, but only to serve as
+        the FSM entry-event trigger hook in ``_mirror_to_shadow()``'s finally block (see
+        ``_OVERRIDE_GRACE_FSM_EVENT_KINDS``); the shadow-engine replay side-effect of
+        that call is redundant with this function's raw copy and intentionally
+        tolerated, not the reason the mirror call exists. See
+        ``tests/test_shadow_engine_coverage.py`` for the registry entries documenting
+        why each setter is exempted or mirrored.
         """
         se = self.shadow_automation_engine
         ae = self.automation_engine
@@ -1190,6 +1200,32 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 "Override/grace FSM evaluation (cancel-driven) failed (isolated, no production impact): %s",
                 fsm_exc,
             )
+
+    def _any_override_active(self) -> bool:
+        """True if either a thermostat-level or fan-only override is currently active.
+
+        Used to detect a same-cycle clear across ``handle_bedtime()``/
+        ``handle_morning_wakeup()`` (Issue #651) — see
+        ``_feed_override_grace_fsm_if_cleared()``.
+        """
+        ae = self.automation_engine
+        return bool(ae._manual_override_active or ae._fan_override_active)
+
+    def _feed_override_grace_fsm_if_cleared(self, was_active: bool) -> None:
+        """Feed OVERRIDE_CANCELLED if an override that was active before a call is gone after it (Issue #651).
+
+        ``handle_bedtime()``/``handle_morning_wakeup()`` can silently clear a fan-only
+        override via ``clear_manual_override()`` — its ``"override_cleared"`` emit is
+        gated on ``_manual_override_active`` (false for a fan-only override), so no
+        event reaches ``_feed_lifecycle_fsms_from_event()``. Without this, the FSM
+        still self-heals within one update cycle via ``_check_orphaned_grace()``'s
+        orphaned-grace backstop, but produces a transient shadow-disagreement blip
+        until then. Call with the pre-call ``_any_override_active()`` result; this
+        reads state strictly after the real engine call has returned, so no staleness
+        risk (same ordering guarantee as ``_feed_override_grace_fsm_cancelled()``).
+        """
+        if was_active and not self._any_override_active():
+            self._feed_override_grace_fsm_cancelled()
 
     def _current_hvac_mode(self) -> str | None:
         """Live thermostat mode read, shared by the door/window FSM evaluation
@@ -3922,11 +3958,15 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
 
     async def _async_morning_wakeup(self, now: datetime) -> None:
         """Handle morning wake-up."""
+        _was_overridden = self._any_override_active()
         await self.automation_engine.handle_morning_wakeup(indoor_temp=self._get_indoor_temp())
+        self._feed_override_grace_fsm_if_cleared(_was_overridden)
 
     async def _async_bedtime(self, now: datetime) -> None:
         """Handle bedtime setback."""
+        _was_overridden = self._any_override_active()
         await self.automation_engine.handle_bedtime()
+        self._feed_override_grace_fsm_if_cleared(_was_overridden)
         await self._mirror_to_shadow("handle_bedtime")
 
     def _compute_pre_cool_trigger_time(self) -> datetime | None:
@@ -4443,14 +4483,16 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 self.automation_engine._manual_override_mode,
             )
             self.automation_engine.clear_manual_override(reason="new_override_during_grace")
-            # Issue #647: only feeds OVERRIDE_CANCELLED for the clear half of this
-            # clear-then-reopen sequence — `handle_manual_override()` right below has
-            # no FSM entry wiring yet (same follow-up class as #643's
-            # `handle_fan_manual_override`, tracked separately, not this issue's scope).
-            # Still strictly better than leaving the FSM stuck on the just-cleared
-            # override's stale state.
+            # Issue #647: feeds OVERRIDE_CANCELLED for the clear half of this
+            # clear-then-reopen sequence; Issue #651 wires the reopen half below.
             self._feed_override_grace_fsm_cancelled()
             self.automation_engine.handle_manual_override(
+                old_mode=old_state.state,
+                new_mode=new_state.state,
+                classification_mode=(self._current_classification.hvac_mode if self._current_classification else None),
+            )
+            await self._mirror_to_shadow(
+                "handle_manual_override",
                 old_mode=old_state.state,
                 new_mode=new_state.state,
                 classification_mode=(self._current_classification.hvac_mode if self._current_classification else None),
@@ -4529,6 +4571,12 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                     ),
                 )
             self.automation_engine.handle_manual_override(
+                old_mode=old_state.state,
+                new_mode=new_state.state,
+                classification_mode=(self._current_classification.hvac_mode if self._current_classification else None),
+            )
+            await self._mirror_to_shadow(
+                "handle_manual_override",
                 old_mode=old_state.state,
                 new_mode=new_state.state,
                 classification_mode=(self._current_classification.hvac_mode if self._current_classification else None),
@@ -4846,6 +4894,17 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                     new_state.state,
                 )
                 ae.handle_manual_override(
+                    source="setpoint",
+                    old_mode=old_state.state,
+                    new_mode=new_state.state,
+                    classification_mode=(
+                        self._current_classification.hvac_mode if self._current_classification else None
+                    ),
+                    old_setpoint_f=old_temp,
+                    new_setpoint_f=new_temp,
+                )
+                await self._mirror_to_shadow(
+                    "handle_manual_override",
                     source="setpoint",
                     old_mode=old_state.state,
                     new_mode=new_state.state,

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.20"
+  "version": "0.6.21"
 }

--- a/tests/test_shadow_engine_coverage.py
+++ b/tests/test_shadow_engine_coverage.py
@@ -110,13 +110,19 @@ _COVERAGE_REGISTRY: dict[str, str] = {
         "by _sync_shadow_inputs() raw copy (Issue #631)"
     ),
     "handle_fan_manual_override": "mirrored",
+    # Issue #651: not itself an AST-detected direct mutator (delegates to
+    # start_override_confirmation()), but mirrored at all 3 real call sites for the same
+    # reason handle_fan_manual_override is — see TestOverrideGraceFsmEventCoverage for
+    # the FSM-entry-kind check and TestPerCallerFsmFeedCoverage below for the
+    # per-call-site assertion.
+    "handle_manual_override": "mirrored",
     "clear_fan_override": (
         "exempted: called from clear_manual_override (exempted) and internal cascades; "
         "_fan_override_active covered by _sync_shadow_inputs() raw copy (Issue #631)"
     ),
     "start_override_confirmation": (
-        "exempted: called from handle_manual_override() (3 unmirrored coordinator.py sites) and "
-        "handle_manual_override_during_pause() (mirrored); contains the internal "
+        "exempted: called from handle_manual_override() (3 now-mirrored coordinator.py sites, "
+        "Issue #651) and handle_manual_override_during_pause() (mirrored); contains the internal "
         "_confirm_override_expired timer closure. _override_confirm_*/_manual_override_* covered by "
         "_sync_shadow_inputs() raw copy (Issue #631)"
     ),
@@ -249,9 +255,10 @@ _OVERRIDE_GRACE_EVENT_KIND_REGISTRY: dict[str, str] = {
     "OVERRIDE_SUPERSEDED": (
         "unreachable: no production code path emits this distinct kind today — the "
         "closest real case (a mode change arriving during an active override grace, "
-        "coordinator.py's 'new_override_during_grace' branch) is fed OVERRIDE_CANCELLED "
-        "instead, since handle_manual_override()'s own FSM entry wiring is a separate, "
-        "already-tracked follow-up, not this issue's scope"
+        "coordinator.py's 'new_override_during_grace' branch) still feeds OVERRIDE_CANCELLED "
+        "for the clear half then OVERRIDE_DETECTED (via the now-mirrored "
+        "handle_manual_override(), Issue #651) for the reopen half, rather than a single "
+        "distinct SUPERSEDED transition"
     ),
 }
 
@@ -310,3 +317,50 @@ class TestOverrideGraceFsmEventCoverage:
         all_kinds = {"A_TOTALLY_NEW_KIND_NOT_IN_REGISTRY"}
         unregistered = all_kinds - set(_OVERRIDE_GRACE_EVENT_KIND_REGISTRY)
         assert unregistered == {"A_TOTALLY_NEW_KIND_NOT_IN_REGISTRY"}
+
+
+# Issue #651: the existing "reachable from *some* call site" checks above are true but
+# not sufficient — #643 shipping an entry-only wiring for handle_fan_manual_override
+# proved that a kind being reachable overall doesn't mean every real production call
+# site that should feed it actually does. These tests assert PER-CALLER reachability
+# for the two gaps this issue closes, so a future regression that re-wires one call site
+# but not its siblings (or drops the bedtime/morning-wakeup feed) fails loudly instead of
+# passing the coarser kind-level check above.
+class TestPerCallerFsmFeedCoverage:
+    def test_handle_manual_override_mirrored_at_all_three_call_sites(self) -> None:
+        """handle_manual_override() has exactly 3 real production call sites
+        (coordinator.py's _async_thermostat_changed: new-override-during-grace,
+        mode-changed-outside-pause, setpoint-only). Each must mirror, or a future new
+        call site could silently skip FSM feed the way the original gap did."""
+        src = _COORDINATOR_PY.read_text(encoding="utf-8")
+        call_sites = len(re.findall(r"\.handle_manual_override\(", src))
+        mirror_sites = len(re.findall(r'_mirror_to_shadow\(\s*"handle_manual_override"', src))
+        assert call_sites >= 3, (
+            f"Expected at least 3 handle_manual_override() call sites in coordinator.py, "
+            f"found {call_sites} — if call sites were consolidated, lower this bound "
+            f"deliberately rather than letting the test rot."
+        )
+        assert mirror_sites == call_sites, (
+            f"handle_manual_override() has {call_sites} real call site(s) in coordinator.py "
+            f'but only {mirror_sites} have a matching _mirror_to_shadow("handle_manual_override", '
+            f"...) call — every call site must mirror (Issue #651)."
+        )
+
+    def test_bedtime_and_morning_wakeup_feed_fsm_on_override_clear(self) -> None:
+        """_async_bedtime()/_async_morning_wakeup() must call
+        _feed_override_grace_fsm_if_cleared() after the real engine call, so a fan-only
+        override cleared by either handler is fed to the FSM immediately instead of
+        waiting on _check_orphaned_grace()'s one-cycle-later self-heal (Issue #651)."""
+        src = _COORDINATOR_PY.read_text(encoding="utf-8")
+        # Match each method body up to the next method definition (async or sync) at the
+        # same indent level, so the assertion is scoped to that method's own body only.
+        bedtime_match = re.search(r"    async def _async_bedtime\(.*?\n    (?:async )?def ", src, re.DOTALL)
+        wakeup_match = re.search(r"    async def _async_morning_wakeup\(.*?\n    (?:async )?def ", src, re.DOTALL)
+        assert bedtime_match and "_feed_override_grace_fsm_if_cleared" in bedtime_match.group(0), (
+            "_async_bedtime() must call _feed_override_grace_fsm_if_cleared() after "
+            "automation_engine.handle_bedtime() (Issue #651)."
+        )
+        assert wakeup_match and "_feed_override_grace_fsm_if_cleared" in wakeup_match.group(0), (
+            "_async_morning_wakeup() must call _feed_override_grace_fsm_if_cleared() after "
+            "automation_engine.handle_morning_wakeup() (Issue #651)."
+        )


### PR DESCRIPTION
## Summary

Closes #651. Two remaining wiring gaps in the override/grace shadow FSM diagnostic (epic #594), same root-cause class as #643/#647 (FSM event coverage narrower than the real production state-mutation surface). Both fix in this single PR since they're the same class of bug with the same fix shape.

- **Gap 1**: `handle_manual_override()` (thermostat-level override, distinct from `handle_fan_manual_override` which #643 wired) was never mirrored to the shadow FSM at any of its 3 real `coordinator.py` call sites. Now wired to the same `OVERRIDE_DETECTED` kind.
- **Gap 2**: `handle_bedtime()`/`handle_morning_wakeup()` could silently clear a fan-only override with no FSM feed. This was NOT permanently stuck — re-investigation found the existing `_check_orphaned_grace()` self-heal (runs every ~30s cycle) catches it as an orphaned grace within one cycle — but it produced a real, transient shadow-disagreement blip (stray WARNING + brief `disagree` sensor read) until self-correcting. Now fed immediately via a before/after override-state diff around both call sites in `coordinator.py` only — no `automation.py` changes, avoids duplicating either handler's own gate logic.

Extended `tests/test_shadow_engine_coverage.py` with a new `TestPerCallerFsmFeedCoverage` class asserting per-call-site (not just per-event-kind) reachability — the specific gap in test coverage that let #643 ship asymmetric wiring undetected in the first place.

## Blast radius

Zero production impact — shadow engine/FSM state reaches nothing but the Shadow Engine Status diagnostic sensor (unchanged invariant, reconfirmed during investigation). Both fixes are purely additive diagnostic feeds.

## Test plan
- [x] 4494 unit tests pass (`pytest tests/ -W error::pytest.PytestUnraisableExceptionWarning -W error::RuntimeWarning`)
- [x] 81/81 golden scenarios pass (`tools/simulate.py`)
- [x] `tools/validate.py` clean
- [x] `ruff check`/`ruff format` clean
- [x] `test_version_sync.py` confirms const.py/manifest.json version match
- [x] New `TestPerCallerFsmFeedCoverage` tests confirm both gaps are closed at the code level
- [ ] Live: watch `ha_logs.py` for "disagreement" across a real thermostat-override cycle and a real fan-override-through-bedtime/morning-wakeup transition post-deploy

Related: #613, #633, #637, #639, #643, #647