### PR TITLE
Fix #637: re-pause nat-vent reactivation clears stale _paused_by_door

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.23] — 2026-08-16
+
+- Fix #637: after a grace period expires with a door/window still open, if natural ventilation now takes over cooling, the system was still privately marking itself as "paused by door" — which could suppress the away/vacation energy setback later, and made the dashboard/API misreport the reason HVAC was off. Now clears correctly the moment nat-vent takes over, matching how every other nat-vent-activation path already behaves.
+
 ## [0.6.22] — 2026-08-16
 
 - Feat #633 (Phase R prep): begins the cutover work for the nat-vent lifecycle FSM (Block 5 series, epic #594) — modeled the one remaining gap in its transition table (soft-start escalating to full free-cooling mid-session), and added an opt-in, off-by-default switch that lets the FSM's decision drive the real whole-house-fan/HVAC calls for nat-vent instead of the legacy inline computation. Proven behavior-identical to the legacy path across the full scenario library before this shipped. The switch defaults off and does not persist across a restart — no occupant-visible behavior change unless it is explicitly turned on.

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -4665,6 +4665,15 @@ class AutomationEngine:
                 )
                 await self._activate_fan(reason=nat_vent_reason)
                 self._natural_vent_active = True
+                # Issue #637 (Phase R Step 1, violation #3): clear the stale pause flag,
+                # matching the structurally identical branch in
+                # check_natural_vent_conditions() (see _exit_nat_vent()'s callers around
+                # automation.py:3486/3518). Without this, _paused_by_door stays True even
+                # though nat-vent has taken over control, which incorrectly suppresses the
+                # away/vacation setback band (handle_occupancy_away/vacation both early-return
+                # on _paused_by_door=True) and misreports "paused by door" on the
+                # dashboard/API while nat-vent is actually running.
+                self._paused_by_door = False
                 await self._apply_nat_vent_hvac_state()
                 _LOGGER.info(
                     "Re-check after grace: nat-vent conditions met — outdoor %.1f°F < indoor %.1f°F,"

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,17 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.22"
+VERSION = "0.6.23"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.23": [
+        "Fix #637: after a grace period expires with a door/window still open, if"
+        " natural ventilation now takes over cooling, the system was still privately"
+        ' marking itself as "paused by door" — which could suppress the away/vacation'
+        " energy setback later, and made the dashboard/API misreport the reason HVAC"
+        " was off. Now clears correctly the moment nat-vent takes over, matching how"
+        " every other nat-vent-activation path already behaves.",
+    ],
     "0.6.22": [
         "Feat #633 (Phase R prep): begins the cutover work for the nat-vent lifecycle"
         " FSM — modeled the one remaining gap in its transition table (soft-start"
@@ -2070,7 +2078,7 @@ KNOWN_FIXES: dict[int, dict] = {
         ),
     },
     637: {
-        "version_fixed": "0.6.14",
+        "version_fixed": "0.6.23",
         "title": (
             "Block 5 epic #594 Phase 2: builds the unified door/window pause/grace"
             " transition table (5 new pure functions + door_window_fsm.py assembly),"
@@ -2081,6 +2089,16 @@ KNOWN_FIXES: dict[int, dict] = {
             " assumed unreachable. Wired into the shadow engine's existing diagnostic"
             " as a third comparison point, purely observational — never wired into any"
             " decision path that can act."
+            " Phase R Step 1 (0.6.23): reading the FSM's own docstring against production"
+            " surfaced 3 `_paused_by_door` inconsistencies that must be resolved before the"
+            " lifecycle can become FSM-authoritative. Fixed the narrowest, unambiguous one:"
+            " `_re_pause_for_open_sensor()`'s nat-vent-reactivation branch never cleared"
+            " `_paused_by_door`, unlike the identical branch in"
+            " `check_natural_vent_conditions()`. The other two (`handle_door_window_open()`'s"
+            " grace-fallthrough, `_exit_nat_vent()`'s unconditional sensor-still-open pause)"
+            " are longer-standing production behavior with unclear intent from code alone —"
+            " posted to #637 for an explicit owner decision (model faithfully vs. fix first)"
+            " before Step 2's read-authority swap can close out."
         ),
         "scope_covered": (
             "New: door_window_lifecycle.py (5-state derivation), door_window_pause_entry.py, "
@@ -2097,6 +2115,10 @@ KNOWN_FIXES: dict[int, dict] = {
             "issue_637_paused_during_grace_nat_vent_exit.json confirm PAUSED_DURING_GRACE "
             "is reachable via 2 structurally distinct production paths, pending user "
             "review before promotion to golden/."
+            " 0.6.23: automation.py `_re_pause_for_open_sensor()` now clears `_paused_by_door`"
+            " in its nat-vent-reactivation branch; new test"
+            " test_resume_from_pause.py::TestGraceExpiryRecheck::"
+            "test_repause_clears_paused_by_door_on_nat_vent_reactivation."
         ),
     },
     633: {

--- a/custom_components/climate_advisor/door_window_fsm.py
+++ b/custom_components/climate_advisor/door_window_fsm.py
@@ -51,20 +51,29 @@ violation paths already documented in the Phase 2 plan
 (``handle_door_window_open()``'s grace-fallthrough,
 ``_exit_nat_vent()``'s sensor-still-open branch), reading
 ``_re_pause_for_open_sensor()`` in full during implementation found a THIRD,
-narrower case: when grace expires from ``PAUSED_DURING_GRACE`` with a sensor
+narrower case: when grace expires from plain ``GRACE`` with a sensor
 still open (``RE_PAUSE``), and the nested nat-vent reactivation recheck inside
-``_re_pause_for_open_sensor()`` then succeeds, ``_paused_by_door`` is NOT
-cleared by that nat-vent-activation branch — unlike the structurally similar
-branch in ``check_natural_vent_conditions()`` (automation.py:3486/3518), which
-DOES clear it. This is a genuine inconsistency between two nat-vent entry
-paths, not a bug this shadow-only phase fixes (would be a production behavior
-change) — noted here so it isn't silently modeled as clean. Net effect on
-THIS module: from ``PAUSED_DURING_GRACE``, the ``RE_PAUSE`` outcome always
-lands on a plain paused state regardless of whether the nested nat-vent recheck
-succeeds, since neither of its sub-branches clears ``_paused_by_door`` — so
-(unlike the same recheck from plain ``GRACE``, where it genuinely decides
-paused-vs-normal) this module does not need to evaluate the nested gate at all
-for that specific origin state. See ``_transition_from_paused_during_grace()``.
+``_re_pause_for_open_sensor()`` then succeeds, ``_paused_by_door`` was NOT
+being cleared by that nat-vent-activation branch — unlike the structurally
+similar branch in ``check_natural_vent_conditions()`` (automation.py:3486/3518),
+which DOES clear it. **Fixed in production as of Issue #637 Phase R Step 1
+(v0.6.23)** — ``_re_pause_for_open_sensor()`` now clears ``_paused_by_door`` on
+that branch too, so this module's mirrored behavior below is no longer a
+documented inconsistency, it's simply correct. The origin-state distinction
+still matters for a different reason: from ``PAUSED_DURING_GRACE`` specifically
+(see ``_transition_from_paused_during_grace()``), the ``RE_PAUSE`` outcome
+still always lands on a plain paused state regardless of the nested nat-vent
+recheck, because pause was already separately active there and grace clearing
+doesn't touch it — unlike from plain ``GRACE``, where the recheck genuinely
+decides paused-vs-normal (now correctly reflected in production, per the fix
+above).
+
+**Still open (owner decision requested on #637, not yet resolved):**
+``handle_door_window_open()``'s grace-fallthrough and ``_exit_nat_vent()``'s
+unconditional sensor-still-open pause remain long-standing production behavior
+of unclear intent — this module continues to mirror both faithfully as-is
+until the owner decides whether to fix them or keep them, so Step 2's
+read-authority swap does not silently ship a behavior change.
 
 **Cross-lifecycle inputs.** ``natural_vent_active`` and ``whf_owns_hvac`` are
 state *reads* from other lifecycles (Issue #631's "communicating automata"

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.22"
+  "version": "0.6.23"
 }

--- a/docs/08-COMPUTATION-REFERENCE.md
+++ b/docs/08-COMPUTATION-REFERENCE.md
@@ -2023,7 +2023,7 @@ proving the real gate's formula is used, not the cycling-band midpoint), `TestWa
 
 Only one grace timer of each type is active at a time; starting a new one cancels the previous.
 
-**Grace expiry sensor re-check:** When either grace period expires, the system re-checks whether any monitored contact sensor is currently open. If one or more sensors are still open, HVAC is re-paused immediately (`_paused_by_door = True`, HVAC set to `off`) rather than restoring normal automation. This prevents the safety issue of running HVAC with a door or window open after the grace window closes.
+**Grace expiry sensor re-check:** When either grace period expires, the system re-checks whether any monitored contact sensor is currently open. If one or more sensors are still open, HVAC is re-paused immediately (`_paused_by_door = True`, HVAC set to `off`) rather than restoring normal automation. This prevents the safety issue of running HVAC with a door or window open after the grace window closes. If instead the nat-vent reactivation gate is satisfied (sensor open but outdoor conditions now favor free cooling), `_re_pause_for_open_sensor()` activates nat-vent and clears `_paused_by_door` (Issue #637, v0.6.23) — matching every other nat-vent-activation call site, so the away/vacation setback guard and dashboard/API status don't keep reporting "paused by door" once nat-vent has taken over.
 
 ### Clean-Slate Override State on HA Restart (Issue #282 / #306)
 

--- a/tests/test_resume_from_pause.py
+++ b/tests/test_resume_from_pause.py
@@ -18,8 +18,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from custom_components.climate_advisor.automation import AutomationEngine
 from custom_components.climate_advisor.classifier import DayClassification
 from custom_components.climate_advisor.const import (
+    CONF_FAN_MODE,
     CONF_MANUAL_GRACE_NOTIFY,
     CONF_MANUAL_GRACE_PERIOD,
+    FAN_MODE_WHOLE_HOUSE,
 )
 
 # Patch dt_util.now to return a real datetime (needed for isoformat() calls in the engine)
@@ -404,6 +406,36 @@ class TestGraceExpiryRecheck:
         ]
         assert len(hvac_calls) >= 1
         assert hvac_calls[0].args[2]["hvac_mode"] == "off"
+
+    def test_repause_clears_paused_by_door_on_nat_vent_reactivation(self):
+        """Issue #637 (Phase R Step 1, violation #3): when grace expires with a sensor
+        still open but nat-vent conditions are now favorable, _re_pause_for_open_sensor()
+        must clear _paused_by_door — matching the structurally identical branch in
+        check_natural_vent_conditions() (automation.py:3486/3518). Before this fix,
+        _paused_by_door stayed stale=True even though nat-vent took over, which incorrectly
+        suppresses the away/vacation setback band (handle_occupancy_away/vacation both
+        early-return on _paused_by_door=True) and misreports "paused by door" on the
+        dashboard/API while nat-vent is actually running.
+        """
+        engine = _make_automation_engine(
+            {
+                CONF_MANUAL_GRACE_PERIOD: 300,
+                CONF_MANUAL_GRACE_NOTIFY: False,
+                CONF_FAN_MODE: FAN_MODE_WHOLE_HOUSE,
+            }
+        )
+        engine._paused_by_door = True
+        engine._last_outdoor_temp = 65.0
+        climate_state = MagicMock()
+        climate_state.state = "off"
+        climate_state.attributes.get.return_value = 78.0
+        engine.hass.states.get.return_value = climate_state
+        engine._hourly_forecast_temps = []
+
+        asyncio.run(engine._re_pause_for_open_sensor())
+
+        assert engine._natural_vent_active is True
+        assert engine._paused_by_door is False
 
     def test_grace_expiry_clears_normally_when_closed(self):
         """If all sensors are closed at grace expiry, grace clears normally."""


### PR DESCRIPTION
## Summary
- Phase R Step 1 for door/window (epic #594): `_re_pause_for_open_sensor()`'s nat-vent-reactivation branch now clears `_paused_by_door`, matching the identical branch in `check_natural_vent_conditions()`.
- Before this fix, the flag stayed stale=True after nat-vent took over cooling on grace-expiry re-check, which could suppress the away/vacation setback band and misreported "paused by door" on the dashboard/API while nat-vent was actually running.
- Confirmed original design gap, not a regression (`git log -S`).
- Two related, longer-standing inconsistencies (`handle_door_window_open()`'s grace-fallthrough, `_exit_nat_vent()`'s unconditional sensor-still-open pause) are posted to #637 for an explicit owner decision — not touched in this PR.

## Test plan
- [x] New regression test: `test_resume_from_pause.py::TestGraceExpiryRecheck::test_repause_clears_paused_by_door_on_nat_vent_reactivation` — red before fix, green after
- [x] Full suite: 4595 passed, 6 skipped, zero regressions
- [x] `python tools/simulate.py`: 81/81 golden scenarios pass
- [x] `ruff check` / `ruff format` clean
- [x] `test_version_sync.py` passes (0.6.23)
