### PR TITLE
Feat #637: Phase R Step 1b — close door/window shadow FSM coverage gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.24] — 2026-08-16
+
+- Feat #637 (Phase R Step 1b): internal refactor only, no user-visible behavior change — closes the last coverage gap in the door/window pause/grace lifecycle's diagnostic-only shadow FSM (Block 5 series, epic #594). 3 of its 7 tracked event kinds (grace-timer expiry, dashboard resume, and a sensor-state reconcile check) were never fed to it, deferred as future work when the FSM was first built. All 7 are now fed. Purely observational — nothing it computes is ever acted on.
+
 ## [0.6.23] — 2026-08-16
 
 - Fix #637: after a grace period expires with a door/window still open, if natural ventilation now takes over cooling, the system was still privately marking itself as "paused by door" — which could suppress the away/vacation energy setback later, and made the dashboard/API misreport the reason HVAC was off. Now clears correctly the moment nat-vent takes over, matching how every other nat-vent-activation path already behaves.

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,18 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.23"
+VERSION = "0.6.24"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.24": [
+        "Feat #637 (Phase R Step 1b): internal refactor only, no user-visible behavior"
+        " change — closes the last coverage gap in the door/window pause/grace"
+        " lifecycle's diagnostic-only shadow FSM (Block 5 series, epic #594). 3 of its"
+        " 7 tracked event kinds (grace-timer expiry, dashboard resume, and a sensor-"
+        " state reconcile check) were never fed to it, deferred as future work when the"
+        " FSM was first built. All 7 are now fed. Purely observational — nothing it"
+        " computes is ever acted on.",
+    ],
     "0.6.23": [
         "Fix #637: after a grace period expires with a door/window still open, if"
         " natural ventilation now takes over cooling, the system was still privately"
@@ -2078,7 +2087,7 @@ KNOWN_FIXES: dict[int, dict] = {
         ),
     },
     637: {
-        "version_fixed": "0.6.23",
+        "version_fixed": "0.6.24",
         "title": (
             "Block 5 epic #594 Phase 2: builds the unified door/window pause/grace"
             " transition table (5 new pure functions + door_window_fsm.py assembly),"
@@ -2094,11 +2103,30 @@ KNOWN_FIXES: dict[int, dict] = {
             " lifecycle can become FSM-authoritative. Fixed the narrowest, unambiguous one:"
             " `_re_pause_for_open_sensor()`'s nat-vent-reactivation branch never cleared"
             " `_paused_by_door`, unlike the identical branch in"
-            " `check_natural_vent_conditions()`. The other two (`handle_door_window_open()`'s"
-            " grace-fallthrough, `_exit_nat_vent()`'s unconditional sensor-still-open pause)"
-            " are longer-standing production behavior with unclear intent from code alone —"
-            " posted to #637 for an explicit owner decision (model faithfully vs. fix first)"
-            " before Step 2's read-authority swap can close out."
+            " `check_natural_vent_conditions()`. The other two — `_exit_nat_vent()`'s"
+            " unconditional sensor-still-open pause (investigated, verified benign, not a"
+            " bug: the flag is accurate when set and `_on_grace_expired()` already"
+            " re-derives from live sensor state rather than reading it) and"
+            " `handle_door_window_open()`'s grace-fallthrough (real gap, five-whys traced"
+            " to Issue #87, no live evidence found of it firing, split to its own"
+            " independent issue #655 per owner steer, not blocking this migration) — are"
+            " resolved. Step 1 for door/window is closed."
+            " Phase R Step 1b (0.6.24): before Step 2's read-authority swap, the shadow"
+            " FSM had to be proven correct against all 7 `DoorWindowFsmEventKind` members,"
+            " not just 4 — `GRACE_TIMER_EXPIRED`/`DASHBOARD_RESUME`/`SYNC_RECONCILE` were"
+            " explicitly deferred as future work when Phase 2 shipped. All 3 now wired:"
+            " `dashboard_resume` reuses `resume_from_pause()`'s existing mirror call site;"
+            " `grace_timer_expired` keys off `_on_grace_expired()`'s own emitted event"
+            " types (`grace_expired`/`override_adopted`) via the existing #647 event-driven"
+            " hook; `sync_reconcile` (no natural emitted event exists for it) uses"
+            " method-name-triggered dispatch instead, the same mechanism"
+            " `_NAT_VENT_FSM_TRIGGER_METHODS` already established for nat-vent's own"
+            " non-event-shaped triggers — 2 new `_mirror_to_shadow()` call sites"
+            " (`handle_pre_cool`, `handle_morning_wakeup`) needed adding first. One"
+            ' accepted residual: `_on_grace_expired()`\'s "within planned window" branch'
+            " emits no event at all, so that one grace-expiry outcome still doesn't feed"
+            " the FSM — documented in door_window_fsm.py's docstring, not silently"
+            " missed."
         ),
         "scope_covered": (
             "New: door_window_lifecycle.py (5-state derivation), door_window_pause_entry.py, "
@@ -2119,6 +2147,16 @@ KNOWN_FIXES: dict[int, dict] = {
             " in its nat-vent-reactivation branch; new test"
             " test_resume_from_pause.py::TestGraceExpiryRecheck::"
             "test_repause_clears_paused_by_door_on_nat_vent_reactivation."
+            " 0.6.24: coordinator.py — `_DOOR_WINDOW_FSM_EVENT_KINDS` gains"
+            " `resume_from_pause`/`dashboard_resume`; new"
+            " `_DOOR_WINDOW_GRACE_EXPIRY_EVENT_TYPES` frozenset + branch in"
+            " `_feed_lifecycle_fsms_from_event()`; new"
+            " `_DOOR_WINDOW_SYNC_RECONCILE_TRIGGER_METHODS` frozenset + branch in"
+            " `_mirror_to_shadow()`'s finally block; `_evaluate_door_window_fsm()` now"
+            " accepts an optional explicit `event_kind`; 2 new `_mirror_to_shadow()` call"
+            " sites in `_async_morning_wakeup()`/`_async_pre_cool_trigger()`. New"
+            " `_DOOR_WINDOW_EVENT_KIND_REGISTRY` + `TestDoorWindowFsmEventCoverage` in"
+            " test_shadow_engine_coverage.py enforces all 7 event kinds stay reachable."
         ),
     },
     633: {

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Any, Final
 if TYPE_CHECKING:
     from .ai_skills import AISkillRegistry
     from .claude_api import ClaudeAPIClient
+    from .door_window_fsm import DoorWindowFsmEventKind
     from .override_grace_fsm import OverrideGraceFsmEventKind
 
 from homeassistant.const import EVENT_CALL_SERVICE, EVENT_HOMEASSISTANT_STOP
@@ -349,18 +350,51 @@ def _pick_daily_line(pool: tuple[str, ...], salt: str) -> str:
 
 
 # Issue #637: which mirrored automation.py methods correspond to which door/window
-# FSM event kind. Narrower than the FSM's own 7-member DoorWindowFsmEventKind enum —
-# GRACE_TIMER_EXPIRED/DASHBOARD_RESUME/NAT_VENT_EXITED_SENSOR_STILL_OPEN/SYNC_RECONCILE
-# have no _mirror_to_shadow() call site today (see _sync_shadow_inputs()'s own
-# docstring on why _on_grace_expired can't be reached that way), same v1-scope-
-# narrowing precedent as #633's nat-vent FSM (only check_natural_vent_conditions is
-# wired, not every gate/exit-adjacent call site). Additional future work, not this
-# increment.
+# FSM event kind. NAT_VENT_EXITED_SENSOR_STILL_OPEN is fed separately via
+# _DOOR_WINDOW_NAT_VENT_EXIT_EVENT_TYPES (event-driven, Issue #647).
+# GRACE_TIMER_EXPIRED is fed separately via _DOOR_WINDOW_GRACE_EXPIRY_EVENT_TYPES
+# (also event-driven). SYNC_RECONCILE is fed separately via
+# _DOOR_WINDOW_SYNC_RECONCILE_TRIGGER_METHODS (method-name-triggered, same shape as
+# _NAT_VENT_FSM_TRIGGER_METHODS — Phase R Step 1b, epic #594, v0.6.24). As of Step 1b
+# all 7 DoorWindowFsmEventKind members have a real feed path; see door_window_fsm.py's
+# own docstring for the one still-accepted residual (the "within planned window" grace
+# expiry branch emits no event at all, so that one outcome doesn't feed the FSM).
 _DOOR_WINDOW_FSM_EVENT_KINDS: dict[str, str] = {
     "handle_door_window_open": "sensor_opened",
     "handle_all_doors_windows_closed": "all_sensors_closed",
     "handle_manual_override_during_pause": "manual_override_during_pause",
+    "resume_from_pause": "dashboard_resume",
 }
+
+# Issue #594 Phase R Step 1b: door/window's SYNC_RECONCILE event kind has no natural
+# emitted event to key off (the only event on this path, "sensor_opened", is already
+# claimed by handle_door_window_open()'s semantically different fresh-open transition
+# — reusing it would silently misroute reconcile-detected pauses through the wrong
+# transition logic). Method-name-triggered dispatch is the correct fit instead — same
+# pattern _NAT_VENT_FSM_TRIGGER_METHODS already uses for nat-vent's own non-event-
+# shaped triggers. Each of these 4 methods calls
+# AutomationEngine._sync_paused_by_door_with_live_sensors() internally; all 4 already
+# have (or, for handle_pre_cool/handle_morning_wakeup, now gain) a _mirror_to_shadow()
+# call site, so this reuses that existing timing hook rather than adding a new
+# coordinator/automation-engine callback. This is a trigger-timing hook, not a data
+# dependency — the FSM still reads fresh self.automation_engine state, matching #647's
+# own stated principle that FSM re-evaluation shouldn't depend on shadow-engine replay.
+_DOOR_WINDOW_SYNC_RECONCILE_TRIGGER_METHODS: frozenset[str] = frozenset(
+    {"apply_classification", "handle_bedtime", "handle_pre_cool", "handle_morning_wakeup"}
+)
+
+# Issue #594 Phase R Step 1b: event types that indicate a door/window grace period just
+# expired, for feeding DoorWindowFsmEventKind.GRACE_TIMER_EXPIRED. _on_grace_expired()
+# (automation.py) is an internal timer callback with no _mirror_to_shadow() call site,
+# but 3 of its 4 branches already emit a distinct event type after mutating state (no
+# staleness risk): "grace_expired" (the re-pause-on-still-open branch and the normal-
+# expiry branch) and "override_adopted" (the adopted-matching-decision branch). The
+# 4th branch ("within planned window") emits nothing at all — an accepted residual, see
+# door_window_fsm.py's docstring. These event-type strings are also consumed by
+# _OVERRIDE_GRACE_FSM_EVENT_TYPE_MAP for a *different* FSM's GRACE_TIMER_EXPIRED
+# concept — one event type can and does feed multiple FSMs, same as every other branch
+# in _feed_lifecycle_fsms_from_event().
+_DOOR_WINDOW_GRACE_EXPIRY_EVENT_TYPES: frozenset[str] = frozenset({"grace_expired", "override_adopted"})
 
 # Issue #639/#643: which mirrored automation.py methods correspond to which
 # override/grace FSM event kind. Of the 7 OverrideGraceFsmEventKind members,
@@ -937,6 +971,16 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                         "Door/window FSM evaluation failed (isolated, no production impact): %s",
                         fsm_exc,
                     )
+            if method_name in _DOOR_WINDOW_SYNC_RECONCILE_TRIGGER_METHODS:
+                try:
+                    from .door_window_fsm import DoorWindowFsmEventKind as _DWFEventKind
+
+                    self._evaluate_door_window_fsm(method_name, event_kind=_DWFEventKind.SYNC_RECONCILE)
+                except Exception as fsm_exc:  # noqa: BLE001 — FSM errors must never affect production
+                    _LOGGER.warning(
+                        "Door/window FSM evaluation (sync-reconcile) failed (isolated, no production impact): %s",
+                        fsm_exc,
+                    )
             if method_name in _OVERRIDE_GRACE_FSM_EVENT_KINDS:
                 try:
                     from .override_grace_fsm import OverrideGraceFsmEventKind as _OGFEventKind
@@ -1056,23 +1100,39 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             now=now,
         )
 
-    def _evaluate_door_window_fsm(self, method_name: str) -> None:
+    def _evaluate_door_window_fsm(self, method_name: str, event_kind: DoorWindowFsmEventKind | None = None) -> None:
         """Run the unified door/window pause/grace FSM (Issue #637) against
         production's current live readings and track its own independently-
         derived state.
 
-        v1 scope, narrowed to the 3 event kinds a mirrored method exists for
-        today (see ``_DOOR_WINDOW_FSM_EVENT_KINDS``) — same precedent as
-        ``_evaluate_nat_vent_fsm()``'s own v1 scope note. The FSM's own tracked
-        state (``self._door_window_fsm_state``) is never written back onto
-        either engine — a third, independent computation, purely for
-        comparison against production's real derived state. Isolated the same
-        way: any exception here is logged and swallowed by the caller, never
-        allowed to affect production.
+        The FSM's own tracked state (``self._door_window_fsm_state``) is never
+        written back onto either engine — a third, independent computation,
+        purely for comparison against production's real derived state.
+        Isolated the same way: any exception here is logged and swallowed by
+        the caller, never allowed to affect production.
 
-        Issue #647 adds a second, event-driven trigger for this same FSM — see
-        ``_feed_lifecycle_fsms_from_event()`` — for the ``NAT_VENT_EXITED_SENSOR_STILL_OPEN``
-        event kind, which no mirrored method name corresponds to.
+        As of Issue #594 Phase R Step 1b, all 7 ``DoorWindowFsmEventKind``
+        members have a real feed path across 3 distinct mechanisms — same
+        precedent ``_evaluate_override_grace_fsm()`` established for taking an
+        explicit event kind rather than always deriving one from
+        ``method_name``:
+          - 4 via ``_DOOR_WINDOW_FSM_EVENT_KINDS`` (method-name lookup, this
+            function's original v1 mechanism) — ``event_kind`` omitted.
+          - ``NAT_VENT_EXITED_SENSOR_STILL_OPEN`` via
+            ``_DOOR_WINDOW_NAT_VENT_EXIT_EVENT_TYPES`` (event-driven, #647).
+          - ``GRACE_TIMER_EXPIRED`` via ``_DOOR_WINDOW_GRACE_EXPIRY_EVENT_TYPES``
+            (event-driven, Step 1b).
+          - ``SYNC_RECONCILE`` via ``_DOOR_WINDOW_SYNC_RECONCILE_TRIGGER_METHODS``
+            (method-name-triggered, Step 1b) — ``event_kind`` passed explicitly
+            rather than added to ``_DOOR_WINDOW_FSM_EVENT_KINDS`` itself, since
+            that dict's method-name keys are disjoint from this trigger set's
+            (``apply_classification``/``handle_bedtime``/``handle_pre_cool``/
+            ``handle_morning_wakeup`` are not door/window "entry point" methods
+            in the same sense as the other 4), but reusing the same dict shape
+            for two different kinds per name would be confusing.
+        All non-method-name-derived kinds are resolved by the caller
+        (``_feed_lifecycle_fsms_from_event()`` or ``_mirror_to_shadow()``'s
+        finally block) and passed via ``event_kind``.
         """
         from .door_window_fsm import DoorWindowFsmEvent, DoorWindowFsmEventKind, transition
 
@@ -1080,8 +1140,11 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         now = dt_util.now()
         config = self.config
 
+        kind = (
+            event_kind if event_kind is not None else DoorWindowFsmEventKind(_DOOR_WINDOW_FSM_EVENT_KINDS[method_name])
+        )
         event = DoorWindowFsmEvent(
-            kind=DoorWindowFsmEventKind(_DOOR_WINDOW_FSM_EVENT_KINDS[method_name]),
+            kind=kind,
             inputs=self._door_window_fsm_inputs(ae, now, config),
         )
         result = transition(self._door_window_fsm_state, event)
@@ -3982,8 +4045,12 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
     async def _async_morning_wakeup(self, now: datetime) -> None:
         """Handle morning wake-up."""
         _was_overridden = self._any_override_active()
-        await self.automation_engine.handle_morning_wakeup(indoor_temp=self._get_indoor_temp())
+        _indoor_temp = self._get_indoor_temp()
+        await self.automation_engine.handle_morning_wakeup(indoor_temp=_indoor_temp)
         self._feed_override_grace_fsm_if_cleared(_was_overridden)
+        # Issue #594 Phase R Step 1b: closes the door/window SYNC_RECONCILE coverage
+        # gap — see _DOOR_WINDOW_SYNC_RECONCILE_TRIGGER_METHODS.
+        await self._mirror_to_shadow("handle_morning_wakeup", indoor_temp=_indoor_temp)
 
     async def _async_bedtime(self, now: datetime) -> None:
         """Handle bedtime setback."""
@@ -4092,6 +4159,11 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         result = await self.automation_engine.handle_pre_cool(
             indoor_temp=indoor_temp,
             nat_vent_just_closed=nat_vent_just_closed,
+        )
+        # Issue #594 Phase R Step 1b: closes the door/window SYNC_RECONCILE coverage
+        # gap — see _DOOR_WINDOW_SYNC_RECONCILE_TRIGGER_METHODS.
+        await self._mirror_to_shadow(
+            "handle_pre_cool", indoor_temp=indoor_temp, nat_vent_just_closed=nat_vent_just_closed
         )
         _LOGGER.info("Pre-cool trigger handler completed: %s", result)
         if "suppressed" in result:
@@ -7648,6 +7720,21 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             except Exception as fsm_exc:  # noqa: BLE001 — FSM errors must never affect production
                 _LOGGER.warning(
                     "Door/window FSM evaluation (event-driven) failed (isolated, no production impact): %s",
+                    fsm_exc,
+                )
+        if event_type in _DOOR_WINDOW_GRACE_EXPIRY_EVENT_TYPES:
+            try:
+                from .door_window_fsm import DoorWindowFsmEventKind as _DWFEventKind
+
+                # "grace_expired"/"override_adopted" are both emitted by
+                # _on_grace_expired() *after* it has already mutated grace/pause state
+                # (self._cancel_grace_timers(), self.clear_manual_override()) — no
+                # staleness risk reading self.automation_engine here, unlike the
+                # NAT_VENT_EXITED_SENSOR_STILL_OPEN block above.
+                self._evaluate_door_window_fsm("_on_grace_expired", event_kind=_DWFEventKind.GRACE_TIMER_EXPIRED)
+            except Exception as fsm_exc:  # noqa: BLE001 — FSM errors must never affect production
+                _LOGGER.warning(
+                    "Door/window FSM evaluation (grace-expiry) failed (isolated, no production impact): %s",
                     fsm_exc,
                 )
         if event_type in _OVERRIDE_GRACE_FSM_EVENT_TYPE_MAP:

--- a/custom_components/climate_advisor/door_window_fsm.py
+++ b/custom_components/climate_advisor/door_window_fsm.py
@@ -68,12 +68,30 @@ doesn't touch it — unlike from plain ``GRACE``, where the recheck genuinely
 decides paused-vs-normal (now correctly reflected in production, per the fix
 above).
 
-**Still open (owner decision requested on #637, not yet resolved):**
-``handle_door_window_open()``'s grace-fallthrough and ``_exit_nat_vent()``'s
-unconditional sensor-still-open pause remain long-standing production behavior
-of unclear intent — this module continues to mirror both faithfully as-is
-until the owner decides whether to fix them or keep them, so Step 2's
-read-authority swap does not silently ship a behavior change.
+**#637 Step 1 closed.** ``_exit_nat_vent()``'s unconditional sensor-still-open pause was
+investigated and verified **benign, not a bug**: the flag is accurate the moment it's
+set, and ``_on_grace_expired()`` already re-derives its decision from live sensor state
+rather than reading ``_paused_by_door``, so it self-corrects regardless of whether grace
+is left running. ``handle_door_window_open()``'s grace-fallthrough (a coarser
+outdoor-only proxy check gating a stricter gate computed later in the same function) is
+a real, independent gap — tracked on its own issue, **#655**, deliberately kept separate
+from this FSM migration since it's unrelated production behavior, not a migration
+blocker. This module continues to mirror both faithfully as-is; #655's resolution (if
+any) will land in production first, same "fix production, then the FSM inherits the fix
+for free" order Step 1's violation #3 already followed.
+
+**Shadow-feed coverage (Issue #594 Phase R Step 1b, v0.6.24).** All 7
+``DoorWindowFsmEventKind`` members now have a real feed path — see
+``coordinator.py``'s ``_DOOR_WINDOW_FSM_EVENT_KINDS``/
+``_DOOR_WINDOW_SYNC_RECONCILE_TRIGGER_METHODS``/``_DOOR_WINDOW_GRACE_EXPIRY_EVENT_TYPES``.
+**One accepted residual**: ``_on_grace_expired()``'s "within planned window" branch
+(automation.py, the first branch — windows recommended, sensor open is expected) emits
+no event at all, so that specific grace-expiry outcome does not feed
+``GRACE_TIMER_EXPIRED`` this increment — the shadow FSM's tracked state simply doesn't
+advance for that one case until the next event that does feed it. Explicit scope
+boundary, not a silent gap: if this needs closing before Step 2, it requires either a
+new emitted event on that branch or a bespoke direct callback (same shape as
+``_feed_override_grace_fsm_cancelled()``'s exception in override_grace_fsm.py).
 
 **Cross-lifecycle inputs.** ``natural_vent_active`` and ``whf_owns_hvac`` are
 state *reads* from other lifecycles (Issue #631's "communicating automata"

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.23"
+  "version": "0.6.24"
 }

--- a/tests/test_shadow_engine_coverage.py
+++ b/tests/test_shadow_engine_coverage.py
@@ -319,6 +319,72 @@ class TestOverrideGraceFsmEventCoverage:
         assert unregistered == {"A_TOTALLY_NEW_KIND_NOT_IN_REGISTRY"}
 
 
+# Issue #594 Phase R Step 1b: same registry-enforcement shape as
+# _OVERRIDE_GRACE_EVENT_KIND_REGISTRY above, for DoorWindowFsmEventKind. Originally only
+# 4 of 7 members had a real feed path (SENSOR_OPENED, ALL_SENSORS_CLOSED,
+# MANUAL_OVERRIDE_DURING_PAUSE via _DOOR_WINDOW_FSM_EVENT_KINDS;
+# NAT_VENT_EXITED_SENSOR_STILL_OPEN via _DOOR_WINDOW_NAT_VENT_EXIT_EVENT_TYPES, #647) —
+# GRACE_TIMER_EXPIRED/DASHBOARD_RESUME/SYNC_RECONCILE were explicitly deferred as
+# "future work" when Phase 2 shipped. Step 1b closes all 3.
+_DOOR_WINDOW_EVENT_KIND_REGISTRY: dict[str, str] = {
+    "SENSOR_OPENED": "reachable",
+    "ALL_SENSORS_CLOSED": "reachable",
+    "GRACE_TIMER_EXPIRED": "reachable",
+    "MANUAL_OVERRIDE_DURING_PAUSE": "reachable",
+    "DASHBOARD_RESUME": "reachable",
+    "NAT_VENT_EXITED_SENSOR_STILL_OPEN": "reachable",
+    "SYNC_RECONCILE": "reachable",
+}
+
+
+class TestDoorWindowFsmEventCoverage:
+    def test_every_event_kind_is_registered(self) -> None:
+        from custom_components.climate_advisor.door_window_fsm import DoorWindowFsmEventKind
+
+        all_kinds = {member.name for member in DoorWindowFsmEventKind}
+        unregistered = all_kinds - set(_DOOR_WINDOW_EVENT_KIND_REGISTRY)
+        assert not unregistered, (
+            f"New DoorWindowFsmEventKind member(s) aren't in "
+            f"_DOOR_WINDOW_EVENT_KIND_REGISTRY: {sorted(unregistered)}. Classify each "
+            f'as "reachable" (and wire a real trigger in coordinator.py) or '
+            f'"unreachable: <reason>" — see Issue #594 Phase R Step 1b.'
+        )
+
+    def test_registry_entries_reference_real_members(self) -> None:
+        from custom_components.climate_advisor.door_window_fsm import DoorWindowFsmEventKind
+
+        all_kinds = {member.name for member in DoorWindowFsmEventKind}
+        unknown = set(_DOOR_WINDOW_EVENT_KIND_REGISTRY) - all_kinds
+        assert not unknown, (
+            f"Registry references DoorWindowFsmEventKind member(s) that no longer exist "
+            f"(renamed or removed?): {sorted(unknown)}. Update the registry."
+        )
+
+    def test_every_reachable_kind_has_a_real_trigger(self) -> None:
+        """Positive control: every 'reachable' entry must appear as a value somewhere
+        coordinator.py actually feeds the FSM from — either _DOOR_WINDOW_FSM_EVENT_KINDS'
+        dict values, _DOOR_WINDOW_NAT_VENT_EXIT_EVENT_TYPES'/
+        _DOOR_WINDOW_GRACE_EXPIRY_EVENT_TYPES' event-type membership, or a direct
+        DoorWindowFsmEventKind.<X>/_DWFEventKind.<X> reference at a real call site."""
+        combined = _COORDINATOR_PY.read_text(encoding="utf-8")
+        for name, classification in _DOOR_WINDOW_EVENT_KIND_REGISTRY.items():
+            if classification != "reachable":
+                continue
+            value_pattern = re.compile(r'"' + re.escape(name.lower()) + r'"')
+            member_pattern = re.compile(r"\b\w*EventKind\." + re.escape(name) + r"\b")
+            assert value_pattern.search(combined) or member_pattern.search(combined), (
+                f'{name} is marked "reachable" but no dict value or direct '
+                f"DoorWindowFsmEventKind.{name} reference was found in coordinator.py"
+            )
+
+    def test_positive_control_unregistered_kind_is_caught(self) -> None:
+        """Proves test_every_event_kind_is_registered actually fails on a genuinely
+        unregistered member, not just passing vacuously."""
+        all_kinds = {"A_TOTALLY_NEW_KIND_NOT_IN_REGISTRY"}
+        unregistered = all_kinds - set(_DOOR_WINDOW_EVENT_KIND_REGISTRY)
+        assert unregistered == {"A_TOTALLY_NEW_KIND_NOT_IN_REGISTRY"}
+
+
 # Issue #651: the existing "reachable from *some* call site" checks above are true but
 # not sufficient — #643 shipping an entry-only wiring for handle_fan_manual_override
 # proved that a kind being reachable overall doesn't mean every real production call


### PR DESCRIPTION
## Summary
- Phase R Step 1b for door/window (epic #594): closes the shadow FSM's coverage gap before Step 2's read-authority swap can proceed.
- All 7 `DoorWindowFsmEventKind` members now have a real feed path (previously 4: `sensor_opened`/`all_sensors_closed`/`manual_override_during_pause`/`nat_vent_exited_sensor_still_open`).
- `dashboard_resume` — reuses `resume_from_pause()`'s existing mirror call site.
- `grace_timer_expired` — event-driven, keys off `_on_grace_expired()`'s own emitted event types, same mechanism #647 established. One accepted residual: the "within planned window" branch emits no event, documented not silently missed.
- `sync_reconcile` — no natural emitted event exists on this path, so uses method-name-triggered dispatch instead (same shape as `_NAT_VENT_FSM_TRIGGER_METHODS`); required 2 new `_mirror_to_shadow()` call sites (`handle_pre_cool`, `handle_morning_wakeup`).
- New `_DOOR_WINDOW_EVENT_KIND_REGISTRY` + `TestDoorWindowFsmEventCoverage` enforces all 7 stay reachable going forward.
- Purely observational — the shadow FSM's derived state still isn't read by anything actionable. Zero occupant-visible behavior change.

## Test plan
- [x] Full suite: 4599 passed, 6 skipped, zero regressions
- [x] `python tools/simulate.py`: 81/81 golden scenarios pass
- [x] New registry tests (`TestDoorWindowFsmEventCoverage`, 4 tests) pass
- [x] `ruff check` / `ruff format` clean
- [x] `test_version_sync.py` passes (0.6.24)
