### PR TITLE
Feat #637: Phase R Step 2 (partial) — door/window FSM authoritative for 2 methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.25] — 2026-08-16
+
+- Feat #637 (Phase R Step 2, partial): begins letting the door/window pause/grace lifecycle FSM actually drive production decisions — a new, off-by-default switch lets it take over 2 of the lifecycle's 7 actions (a manual thermostat override detected during a pause, and resuming from a dashboard pause) instead of the older logic. Both were proven behavior-identical to the existing logic before this shipped, across the full scenario library plus dedicated tests. The switch defaults off — no occupant-visible behavior change unless it is explicitly turned on, and even then only for those 2 actions; everything else about door/window pause/grace handling is unchanged.
+
 ## [0.6.24] — 2026-08-16
 
 - Feat #637 (Phase R Step 1b): internal refactor only, no user-visible behavior change — closes the last coverage gap in the door/window pause/grace lifecycle's diagnostic-only shadow FSM (Block 5 series, epic #594). 3 of its 7 tracked event kinds (grace-timer expiry, dashboard resume, and a sensor-state reconcile check) were never fed to it, deferred as future work when the FSM was first built. All 7 are now fed. Purely observational — nothing it computes is ever acted on.

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -101,6 +101,11 @@ from .desired_state import (
     decide_scheduled_write_seq_current,
     decide_setpoint_retry_action,
 )
+from .door_window_lifecycle import (
+    DoorWindowLifecycleInputs,
+    DoorWindowLifecycleState,
+    derive_door_window_lifecycle_state,
+)
 from .fan_drift_reconciliation import FanDriftInputs, FanDriftOutcome, decide_fan_drift_reconciliation
 from .fan_thermostat_decision import (
     FanThermostatInputs,
@@ -773,6 +778,17 @@ class AutomationEngine:
         # Default False — zero behavior change until a future per-lifecycle
         # switch (Phase R, Step 4) flips it. Not yet exposed to config/switch.py.
         self._natvent_fsm_authoritative: bool = False
+        # Issue #594 Phase R, Step 2 (door/window): PARTIAL authority only —
+        # governs handle_all_doors_windows_closed()/handle_manual_override_during_pause()/
+        # resume_from_pause() alone. The other 4 door/window methods
+        # (handle_door_window_open, _re_pause_for_open_sensor, _on_grace_expired,
+        # _exit_nat_vent's sensor-still-open branch) stay on the legacy path
+        # regardless of this flag's value — each has its own documented blocker
+        # (#655, an origin-state plumbing gap, a missing shadow-FSM feed, and a
+        # write-shape divergence, respectively) that must resolve before it can
+        # join. Default False — zero behavior change until the switch (Step 4)
+        # flips it, and even then only for the 3 methods above.
+        self._doorwindow_fsm_authoritative: bool = False
 
         # Override confirmation period (Issue #76) — pending window before override is formally accepted
         self._override_confirm_pending: bool = False
@@ -4356,8 +4372,29 @@ class AutomationEngine:
         if not self._paused_by_door:
             return
         _LOGGER.info("Manual HVAC override detected during door/window pause")
-        self._paused_by_door = False
-        self._paused_with_hvac_already_off = False
+        if self._doorwindow_fsm_authoritative:
+            # Issue #594 Phase R, Step 2: door_window_fsm.transition() decides the
+            # resulting pause/grace state instead of the unconditional inline clear
+            # below. MANUAL_OVERRIDE_DURING_PAUSE lands on NORMAL from PAUSED_ACTIVE/
+            # PAUSED_IDLE, or GRACE from PAUSED_DURING_GRACE (grace left running,
+            # matching the legacy path's own silence on _grace_active here) —
+            # unconditional on origin state either way, so this produces the same
+            # flag values the legacy branch below always wrote; only the source of
+            # truth changes.
+            from .door_window_fsm import DoorWindowFsmEvent, DoorWindowFsmEventKind
+            from .door_window_fsm import transition as _door_window_transition
+
+            _dw_result = _door_window_transition(
+                self.door_window_lifecycle_state,
+                DoorWindowFsmEvent(
+                    kind=DoorWindowFsmEventKind.MANUAL_OVERRIDE_DURING_PAUSE,
+                    inputs=self._build_door_window_fsm_inputs(now=dt_util.now()),
+                ),
+            )
+            self._apply_door_window_fsm_state(_dw_result.to_state)
+        else:
+            self._paused_by_door = False
+            self._paused_with_hvac_already_off = False
         self._paused_entity = None
         self._paused_since = None
         self._pre_pause_mode = None
@@ -4382,8 +4419,26 @@ class AutomationEngine:
             return None
 
         _LOGGER.info("User resumed HVAC from door/window pause via dashboard")
-        self._paused_by_door = False
-        self._paused_with_hvac_already_off = False
+        if self._doorwindow_fsm_authoritative:
+            # Issue #594 Phase R, Step 2: same shape as
+            # handle_manual_override_during_pause()'s FSM-authoritative branch.
+            # DASHBOARD_RESUME lands unconditionally on GRACE from either origin
+            # state, matching the legacy path's own unconditional
+            # _start_grace_period() call below regardless of origin.
+            from .door_window_fsm import DoorWindowFsmEvent, DoorWindowFsmEventKind
+            from .door_window_fsm import transition as _door_window_transition
+
+            _dw_result = _door_window_transition(
+                self.door_window_lifecycle_state,
+                DoorWindowFsmEvent(
+                    kind=DoorWindowFsmEventKind.DASHBOARD_RESUME,
+                    inputs=self._build_door_window_fsm_inputs(now=dt_util.now()),
+                ),
+            )
+            self._apply_door_window_fsm_state(_dw_result.to_state)
+        else:
+            self._paused_by_door = False
+            self._paused_with_hvac_already_off = False
         self._paused_entity = None
         self._paused_since = None
         self._pre_pause_mode = None
@@ -5601,6 +5656,87 @@ class AutomationEngine:
                 lockout_seconds=lockout_s,
             )
         )
+
+    def _build_door_window_fsm_inputs(self, *, now: datetime):
+        """Build the door/window FSM's input snapshot from current engine state
+        (Issue #594 Phase R, Step 2). Same field set
+        ``coordinator._door_window_fsm_inputs()`` already builds for the
+        shadow-diagnostic comparison — kept as a single definition callers on
+        both sides can share rather than two independently maintained copies of
+        the same construction. The one exception is ``hvac_mode``: the
+        coordinator's version reads it via ``self.hass.states.get(...)``
+        against its own ``automation_engine`` reference; this reads the exact
+        same live state directly against ``self``.
+        """
+        from .door_window_fsm import DoorWindowFsmInputs
+
+        state = self.hass.states.get(self.climate_entity)
+        hvac_mode = state.state if state else None
+        return DoorWindowFsmInputs(
+            hvac_mode=hvac_mode,
+            outdoor=self._last_outdoor_temp,
+            indoor=self._get_indoor_temp_f(),
+            comfort_heat=self._nat_vent_reactivation_floor(),
+            comfort_cool=float(self.config.get("comfort_cool", DEFAULT_COMFORT_COOL)),
+            nat_vent_delta=float(self.config.get(CONF_NATURAL_VENT_DELTA, DEFAULT_NATURAL_VENT_DELTA)),
+            fan_mode=str(self.config.get(CONF_FAN_MODE, "whole_house_fan")),
+            aggressive_savings=bool(self.config.get("aggressive_savings", False)),
+            within_planned_window=self._is_within_planned_window_period(),
+            any_sensor_open=self._any_monitored_sensor_open(),
+            sensor_debounce_pending=bool(self._sensor_debounce_pending),
+            override_matches_current_decision=self._override_matches_current_decision(self._current_classification),
+            grace_source=self._last_resume_source or "automation",
+            natural_vent_active=bool(self._natural_vent_active),
+            whf_owns_hvac=bool(self._whf_owns_hvac()),
+            now=now,
+        )
+
+    @property
+    def door_window_lifecycle_state(self) -> DoorWindowLifecycleState:
+        """Current door/window pause/grace session state, derived from existing
+        flags (Issue #637).
+
+        Read-only observability by default — the value this property computes
+        is also fed as the ``current_state`` argument to ``door_window_fsm.transition()``
+        by the 2 methods that are FSM-authoritative as of Phase R Step 2
+        (``handle_manual_override_during_pause``, ``resume_from_pause``); see each
+        method's own FSM-authoritative branch. (``handle_all_doors_windows_closed``
+        was scoped into this increment originally but deferred — its
+        ``ALL_SENSORS_CLOSED`` transition in ``door_window_fsm.py`` infers
+        ``pre_pause_mode`` from state rather than taking the real value as input,
+        which isn't safe to trust for real flag-derivation until fixed.) Purely a
+        computed view of ``_paused_by_door``/``_paused_with_hvac_already_off``/
+        ``_grace_active``, so it cannot desync from the flags it reads. See
+        ``door_window_lifecycle.py`` for the pure derivation.
+        """
+        return derive_door_window_lifecycle_state(
+            DoorWindowLifecycleInputs(
+                paused_by_door=bool(self._paused_by_door),
+                paused_with_hvac_already_off=bool(self._paused_with_hvac_already_off),
+                grace_active=bool(self._grace_active),
+            )
+        )
+
+    def _apply_door_window_fsm_state(self, state: DoorWindowLifecycleState) -> None:
+        """Write ``_paused_by_door``/``_paused_with_hvac_already_off``/``_grace_active``
+        from a ``door_window_fsm.transition()`` result (Issue #594 Phase R, Step 2).
+
+        The inverse of ``door_window_lifecycle_state``'s derivation — see
+        ``door_window_lifecycle.py``'s state-to-flags table. Deliberately does NOT
+        touch ``_paused_entity``/``_paused_since``/``_pre_pause_mode``/
+        ``_last_resume_source``/``_last_grace_trigger``/``_grace_end_time``/
+        ``_grace_protects_override`` — those aren't part of the 5-state derivation
+        (the FSM's ``outcome``/``at`` fields don't carry entity labels or trigger
+        names), so every caller keeps writing those itself, same as before this
+        method existed.
+        """
+        self._paused_by_door = state in (
+            DoorWindowLifecycleState.PAUSED_ACTIVE,
+            DoorWindowLifecycleState.PAUSED_IDLE,
+            DoorWindowLifecycleState.PAUSED_DURING_GRACE,
+        )
+        self._paused_with_hvac_already_off = state == DoorWindowLifecycleState.PAUSED_IDLE
+        self._grace_active = state in (DoorWindowLifecycleState.GRACE, DoorWindowLifecycleState.PAUSED_DURING_GRACE)
 
     def _nat_vent_may_reactivate(
         self,

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,21 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.24"
+VERSION = "0.6.25"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.25": [
+        "Feat #637 (Phase R Step 2, partial): begins letting the door/window"
+        " pause/grace lifecycle FSM actually drive production decisions — a new,"
+        " off-by-default switch lets it take over 2 of the lifecycle's 7 actions"
+        " (a manual thermostat override detected during a pause, and resuming from"
+        " a dashboard pause) instead of the older logic. Both were proven"
+        " behavior-identical to the existing logic before this shipped, across the"
+        " full scenario library plus dedicated tests. The switch defaults off — no"
+        " occupant-visible behavior change unless it is explicitly turned on, and"
+        " even then only for those 2 actions; everything else about door/window"
+        " pause/grace handling is unchanged.",
+    ],
     "0.6.24": [
         "Feat #637 (Phase R Step 1b): internal refactor only, no user-visible behavior"
         " change — closes the last coverage gap in the door/window pause/grace"
@@ -2087,7 +2099,7 @@ KNOWN_FIXES: dict[int, dict] = {
         ),
     },
     637: {
-        "version_fixed": "0.6.24",
+        "version_fixed": "0.6.25",
         "title": (
             "Block 5 epic #594 Phase 2: builds the unified door/window pause/grace"
             " transition table (5 new pure functions + door_window_fsm.py assembly),"
@@ -2127,6 +2139,28 @@ KNOWN_FIXES: dict[int, dict] = {
             " emits no event at all, so that one grace-expiry outcome still doesn't feed"
             " the FSM — documented in door_window_fsm.py's docstring, not silently"
             " missed."
+            " Phase R Step 2 (0.6.25, PARTIAL authority): the nat-vent precedent"
+            " (`_natvent_fsm_authoritative`) swapped one boolean decision point."
+            " Door/window's full scope — deriving all 9 pause/grace flags across 7"
+            " methods from FSM state — turned out qualitatively bigger and not equally"
+            " safe by default. Per-method mapping initially found 3 mechanical/unblocked"
+            " methods and 4 blocked ones (`handle_door_window_open`: #655's gap; "
+            "`_re_pause_for_open_sensor`: needs origin-state plumbing it doesn't have;"
+            ' `_on_grace_expired`: its unfed "within planned window" branch;'
+            " `_exit_nat_vent`'s sensor-still-open branch: write-shape divergence)."
+            " `handle_all_doors_windows_closed()` looked mechanical too but was found"
+            " during implementation to have its own gap: `door_window_fsm.py`'s"
+            " `ALL_SENSORS_CLOSED` transition hardcodes `pre_pause_mode` from state"
+            " rather than taking the real value as input — unsafe to trust for real"
+            " flag-derivation given `_exit_nat_vent()` can leave `_paused_with_hvac_"
+            "already_off` stale. Shipped: `_doorwindow_fsm_authoritative` flag (off by"
+            " default) governs ONLY `handle_manual_override_during_pause`/"
+            "`resume_from_pause` — both land unconditionally on their target state"
+            " regardless of origin state, confirmed by direct code read, no"
+            " placeholder-inference risk. Also found (independent of this migration,"
+            " filed as #657): `_re_pause_for_open_sensor()`'s 0.6.23 fix only cleared"
+            " `_paused_by_door`, not the 3 other stale pause fields the mirrored branch"
+            " in `check_natural_vent_conditions()` clears together."
         ),
         "scope_covered": (
             "New: door_window_lifecycle.py (5-state derivation), door_window_pause_entry.py, "
@@ -2138,11 +2172,13 @@ KNOWN_FIXES: dict[int, dict] = {
             "door_window_fsm_agrees, wired into _mirror_to_shadow() for "
             "handle_door_window_open/handle_all_doors_windows_closed/"
             "handle_manual_override_during_pause (the 3 mirrored methods with an "
-            "unambiguous door/window FSM event-kind correspondence). New pending "
-            "scenarios issue_637_paused_during_grace_open_fallthrough.json and "
+            "unambiguous door/window FSM event-kind correspondence). New scenarios "
+            "issue_637_paused_during_grace_open_fallthrough.json and "
             "issue_637_paused_during_grace_nat_vent_exit.json confirm PAUSED_DURING_GRACE "
-            "is reachable via 2 structurally distinct production paths, pending user "
-            "review before promotion to golden/."
+            "is reachable via 2 structurally distinct production paths — both landed "
+            "directly in golden/ (this text previously said 'pending user review before "
+            "promotion to golden/', which was stale/aspirational and never updated after "
+            "that promotion actually happened; corrected during Phase R Step 2 scoping)."
             " 0.6.23: automation.py `_re_pause_for_open_sensor()` now clears `_paused_by_door`"
             " in its nat-vent-reactivation branch; new test"
             " test_resume_from_pause.py::TestGraceExpiryRecheck::"

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -1469,6 +1469,27 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             "made authoritative" if enabled else "reverted to legacy computation",
         )
 
+    @property
+    def doorwindow_fsm_authoritative(self) -> bool:
+        """Whether the door/window lifecycle FSM (Issue #637) is authoritative
+        for ``handle_manual_override_during_pause``/``resume_from_pause`` (Issue
+        #594 Phase R, Step 4 — partial scope, see
+        ``AutomationEngine._doorwindow_fsm_authoritative``'s docstring for which
+        methods this does and doesn't cover). False = legacy inline flag writes
+        (default)."""
+        return bool(self.automation_engine._doorwindow_fsm_authoritative)
+
+    def set_doorwindow_fsm_authoritative(self, enabled: bool) -> None:
+        """Flip door/window FSM authority — Step 2's partial read-authority
+        swap, live. Same NOT-persisted-across-restart reasoning as
+        ``set_natvent_fsm_authoritative()``'s own docstring.
+        """
+        self.automation_engine._doorwindow_fsm_authoritative = enabled
+        _LOGGER.warning(
+            "Door/window FSM %s for production decisions (partial scope — Issue #594 Phase R)",
+            "made authoritative" if enabled else "reverted to legacy computation",
+        )
+
     async def async_setup(self) -> None:
         """Set up scheduled events and state listeners."""
 

--- a/custom_components/climate_advisor/door_window_fsm.py
+++ b/custom_components/climate_advisor/door_window_fsm.py
@@ -97,6 +97,36 @@ new emitted event on that branch or a bespoke direct callback (same shape as
 state *reads* from other lifecycles (Issue #631's "communicating automata"
 design) — legacy flag-derived today, same convention as ``nat_vent_fsm.py``'s
 own ``paused_by_door`` read.
+
+**Authoritative for production, as of Step 2 (v0.6.25) — PARTIAL scope.** This
+module's ``transition()`` is no longer purely a shadow diagnostic: when
+``AutomationEngine._doorwindow_fsm_authoritative`` is True,
+``handle_manual_override_during_pause()``/``resume_from_pause()`` call it for
+real and derive their resulting flags from ``result.to_state`` (via
+``AutomationEngine._apply_door_window_fsm_state()``). Both transitions
+(``MANUAL_OVERRIDE_DURING_PAUSE``, ``DASHBOARD_RESUME``) land unconditionally on
+their target state regardless of origin state — no placeholder-inference risk,
+unlike ``_transition_from_paused()``'s ``ALL_SENSORS_CLOSED`` branch below. The
+other 5 event kinds/methods stay shadow-only, each blocked on its own documented
+gap (see automation.py's ``_doorwindow_fsm_authoritative`` docstring) — this
+module's transition table is faithful to production for all 7, but "faithful"
+and "safe to read authoritatively" are different bars, and only 2 have cleared
+the second one so far.
+
+**Known non-mechanical transition — do not swap without fixing first.**
+``_transition_from_paused()``'s ``ALL_SENSORS_CLOSED`` branch infers
+``pre_pause_mode`` from ``current_state == PAUSED_ACTIVE`` rather than taking the
+real ``AutomationEngine._pre_pause_mode`` value as an input — a placeholder, not
+the actual field ``door_window_close_response.DoorCloseResponseInputs`` was
+designed to take. Found while attempting to swap
+``handle_all_doors_windows_closed()`` in this same increment: since
+``PAUSED_ACTIVE`` vs. ``PAUSED_IDLE`` depends on ``_paused_with_hvac_already_off``,
+which the still-shadow-only ``_exit_nat_vent()`` branch can leave stale (it never
+writes that field), trusting this transition's resulting state for real
+flag-derivation risks a genuine divergence in that reachable edge case. Needs
+either a real ``pre_pause_mode``-truthiness input added to this branch, or
+another safe path, before ``handle_all_doors_windows_closed()`` can join a future
+increment.
 """
 
 from __future__ import annotations

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.24"
+  "version": "0.6.25"
 }

--- a/custom_components/climate_advisor/sensor.py
+++ b/custom_components/climate_advisor/sensor.py
@@ -506,4 +506,8 @@ class ClimateAdvisorShadowEngineStatusSensor(ClimateAdvisorBaseSensor):
             # computation). Surfaced here rather than a new card/sensor, same
             # "extend an existing diagnostic" rule this sensor itself follows.
             "natvent_fsm_authoritative": self.coordinator.natvent_fsm_authoritative,
+            # Issue #594 Phase R, Step 4: same rationale as natvent_fsm_authoritative
+            # above — partial scope, see AutomationEngine._doorwindow_fsm_authoritative's
+            # docstring for exactly which methods this does and doesn't cover.
+            "doorwindow_fsm_authoritative": self.coordinator.doorwindow_fsm_authoritative,
         }

--- a/custom_components/climate_advisor/switch.py
+++ b/custom_components/climate_advisor/switch.py
@@ -6,8 +6,8 @@ service calls are skipped and logged with a [DRY RUN] prefix.
 
 See: GitHub Issue #19
 
-Issue #594 Phase R, Step 4: also provides the per-lifecycle nat-vent
-FSM-authoritative toggle.
+Issue #594 Phase R, Step 4: also provides the per-lifecycle nat-vent and
+door/window FSM-authoritative toggles.
 """
 
 from __future__ import annotations
@@ -38,6 +38,7 @@ async def async_setup_entry(
         [
             ClimateAdvisorAutomationSwitch(coordinator, entry),
             ClimateAdvisorNatVentFsmAuthoritativeSwitch(coordinator, entry),
+            ClimateAdvisorDoorWindowFsmAuthoritativeSwitch(coordinator, entry),
         ]
     )
 
@@ -120,4 +121,55 @@ class ClimateAdvisorNatVentFsmAuthoritativeSwitch(CoordinatorEntity, SwitchEntit
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Revert to the legacy inline nat-vent computation."""
         self.coordinator.set_natvent_fsm_authoritative(False)
+        self.async_write_ha_state()
+
+
+class ClimateAdvisorDoorWindowFsmAuthoritativeSwitch(CoordinatorEntity, SwitchEntity):
+    """Switch to make the door/window lifecycle FSM (Issue #637) authoritative,
+    instead of the legacy inline flag writes (Issue #594 Phase R, Step 4).
+
+    **Partial authority** — unlike the nat-vent switch above, this one increment
+    only governs 2 of the door/window lifecycle's 7 methods
+    (``handle_manual_override_during_pause``, ``resume_from_pause``). The other 5
+    (``handle_door_window_open``, ``handle_all_doors_windows_closed``,
+    ``_re_pause_for_open_sensor``, ``_on_grace_expired``, ``_exit_nat_vent``'s
+    sensor-still-open branch) stay on the legacy path regardless of this switch's
+    position — each has its own documented blocker (see
+    ``AutomationEngine._doorwindow_fsm_authoritative``'s docstring in
+    automation.py) that must resolve before it can join a future increment.
+    Flipping this switch on does NOT mean "the FSM fully controls door/window."
+
+    Default OFF, NOT persisted across a Home Assistant restart — same reasoning
+    as the nat-vent switch's own docstring: a restart always comes back up on
+    the proven legacy path, and the owner must explicitly re-enable this each
+    time.
+    """
+
+    _attr_icon = "mdi:state-machine"
+    _attr_entity_category = None
+
+    def __init__(
+        self,
+        coordinator: ClimateAdvisorCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize the door/window FSM-authoritative switch."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{entry.entry_id}_doorwindow_fsm_authoritative"
+        self._attr_name = "Climate Advisor Door/Window FSM Authoritative"
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if the door/window FSM is authoritative for the 2
+        methods this increment covers."""
+        return self.coordinator.doorwindow_fsm_authoritative
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Make the door/window FSM authoritative (partial scope — see class docstring)."""
+        self.coordinator.set_doorwindow_fsm_authoritative(True)
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Revert to the legacy inline door/window flag writes."""
+        self.coordinator.set_doorwindow_fsm_authoritative(False)
         self.async_write_ha_state()

--- a/tests/test_door_window.py
+++ b/tests/test_door_window.py
@@ -470,6 +470,59 @@ class TestManualOverrideDuringPause:
         assert engine._grace_active is False
 
 
+class TestManualOverrideDuringPauseFsmAuthoritative:
+    """Issue #594 Phase R Step 2: with _doorwindow_fsm_authoritative=True,
+    handle_manual_override_during_pause() derives its resulting flags from
+    door_window_fsm.transition() instead of the unconditional inline clear —
+    same outcome, different source of truth. Mirrors TestManualOverrideDuringPause
+    above with the flag on.
+    """
+
+    def test_clears_pause_and_starts_confirmation_from_paused_active(self):
+        engine = _make_automation_engine()
+        engine._doorwindow_fsm_authoritative = True
+        engine._paused_by_door = True
+        engine._pre_pause_mode = "heat"
+
+        with patch(
+            "custom_components.climate_advisor.automation.async_call_later",
+            return_value=MagicMock(),
+        ):
+            asyncio.run(engine.handle_manual_override_during_pause())
+
+        assert engine._paused_by_door is False
+        assert engine._paused_with_hvac_already_off is False
+        assert engine._pre_pause_mode is None
+        # CONF_OVERRIDE_CONFIRM_PERIOD=0 in this file's engine fixture — override
+        # confirmation is immediate (_confirm_override()), not pending.
+        assert engine._manual_override_active is True
+
+    def test_leaves_grace_running_from_paused_during_grace(self):
+        """From PAUSED_DURING_GRACE, MANUAL_OVERRIDE_DURING_PAUSE lands on GRACE —
+        pause clears but the already-running grace timer is left untouched,
+        matching the legacy path's own silence on _grace_active here."""
+        engine = _make_automation_engine()
+        engine._doorwindow_fsm_authoritative = True
+        engine._paused_by_door = True
+        engine._grace_active = True
+        engine._pre_pause_mode = "heat"
+
+        asyncio.run(engine.handle_manual_override_during_pause())
+
+        assert engine._paused_by_door is False
+        assert engine._grace_active is True
+
+    def test_noop_when_not_paused(self):
+        engine = _make_automation_engine()
+        engine._doorwindow_fsm_authoritative = True
+        engine._paused_by_door = False
+
+        asyncio.run(engine.handle_manual_override_during_pause())
+
+        assert engine._grace_active is False
+        assert engine._override_confirm_pending is False
+
+
 class TestGracePeriodDuration:
     """Tests for configurable grace period durations."""
 

--- a/tests/test_doorwindow_fsm_authoritative_compare.py
+++ b/tests/test_doorwindow_fsm_authoritative_compare.py
@@ -1,0 +1,162 @@
+"""Tests for Issue #594 Phase R, Step 3: decision-equivalence for the door/window
+FSM-authoritative swap (Step 2, partial-authority increment).
+
+Prior coverage (``test_shadow_engine_coverage.py``, ``test_shadow_engine_pair.py``)
+only proved *state-label* agreement. This file proves the stronger claim Phase R
+needs before any live switch is considered: flipping
+``AutomationEngine._doorwindow_fsm_authoritative`` from its default ``False`` to
+``True`` produces a byte-for-byte identical ``event_log``/``action_log`` — for the
+2 methods this increment actually swaps
+(``handle_manual_override_during_pause``/``resume_from_pause``) — across the full
+golden + pending scenario corpus.
+
+**Corpus coverage confirmed insufficient before writing this, not assumed.**
+``resume_from_pause()`` has NO scenario-event mapping at all in
+``tools/sim_harness/run_production.py`` — it's only reachable via ``api.py``'s
+dashboard "Resume HVAC" endpoint, which the sim harness doesn't simulate (no HTTP
+layer). So the corpus-wide test below is an inert no-op for DASHBOARD_RESUME by
+construction, same "narrower than it looks" finding nat-vent's own comparator
+already flagged for soft-start. ``handle_manual_override_during_pause()`` *is*
+reachable in principle (``thermostat_state_changed`` scenario events, when
+``is_paused_by_door`` is True at the time — see coordinator.py's
+``_async_thermostat_changed``), but whether any current scenario actually lands in
+that exact state is not assumed here either. Both get a direct-engine-construction
+positive control below, same style as
+``test_nat_vent_fsm_authoritative_compare.py``'s soft-start probe.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.sim_harness.differential import diff_runs
+from tools.sim_harness.doorwindow_fsm_authoritative_compare import fsm_authoritative_mutation
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_GOLDEN_DIR = _REPO_ROOT / "tools" / "simulations" / "golden"
+_PENDING_DIR = _REPO_ROOT / "tools" / "simulations" / "pending"
+
+
+def _load_scenario(path: Path) -> dict:
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _all_golden_and_pending_scenarios() -> list[Path]:
+    paths = [p for p in _GOLDEN_DIR.glob("*.json") if p.name != "MANIFEST.json"]
+    paths += [p for p in _PENDING_DIR.glob("*.json") if p.name != "MANIFEST.json"]
+    return sorted(paths)
+
+
+class TestFsmAuthoritativeEquivalence:
+    @pytest.mark.parametrize("scenario_path", _all_golden_and_pending_scenarios(), ids=lambda p: p.stem)
+    def test_flag_on_produces_identical_outcome(self, scenario_path: Path) -> None:
+        scenario = _load_scenario(scenario_path)
+        diff = diff_runs(scenario, mutate_b=fsm_authoritative_mutation, scenario_name=scenario_path.stem)
+        assert not diff.a_error and not diff.b_error, (
+            f"{scenario_path.stem}: a_error={diff.a_error!r} b_error={diff.b_error!r}"
+        )
+        assert diff.is_clean, (
+            f"{scenario_path.stem}: FSM-authoritative diverged from baseline — "
+            f"{len(diff.event_divergences)} event, {len(diff.action_divergences)} action divergences — "
+            f"Step 2's read-authority swap must be a behavioral no-op"
+        )
+
+
+class TestFsmAuthoritativePositiveControl:
+    """A deliberately broken FSM transition MUST produce a real, detectable
+    divergence from the direct-engine tests below — proves this style of
+    comparison can actually catch a bug in the swapped path, not just always
+    report clean. Reuses the same direct-construction pattern
+    ``tests/test_door_window.py``'s/``tests/test_resume_from_pause.py``'s own
+    ``TestManualOverrideDuringPauseFsmAuthoritative``/
+    ``TestResumeFromPauseFsmAuthoritative`` classes already establish — this
+    class instead patches the FSM's own ``transition()`` to prove a broken
+    swap is detectable, not just that the swap produces the expected output.
+    """
+
+    def _make_paused_engine(self, *, fsm_authoritative: bool, grace_active: bool = False):
+        import sys
+        from datetime import datetime
+        from unittest.mock import AsyncMock, MagicMock
+
+        from custom_components.climate_advisor.automation import AutomationEngine
+
+        sys.modules["homeassistant.util.dt"].now = lambda: datetime(2026, 7, 29, 18, 0, 0)
+
+        hass = MagicMock()
+        hass.services = MagicMock()
+        hass.services.async_call = AsyncMock()
+        hass.async_create_task = MagicMock(side_effect=lambda coro: coro.close())
+        climate_state = MagicMock()
+        climate_state.state = "cool"
+        climate_state.attributes = {"current_temperature": 74.0}
+        hass.states = MagicMock()
+        hass.states.get = MagicMock(return_value=climate_state)
+
+        engine = AutomationEngine(
+            hass=hass,
+            climate_entity="climate.thermostat",
+            weather_entity="weather.forecast_home",
+            door_window_sensors=["binary_sensor.front_door"],
+            notify_service="notify.notify",
+            config={
+                "comfort_heat": 70.0,
+                "comfort_cool": 76.0,
+                "setback_heat": 60,
+                "setback_cool": 80,
+                "notify_service": "notify.notify",
+            },
+        )
+        engine._doorwindow_fsm_authoritative = fsm_authoritative
+        engine._paused_by_door = True
+        engine._grace_active = grace_active
+        engine._pre_pause_mode = "cool"
+        return engine
+
+    def test_positive_control_detects_a_broken_fsm_transition(self) -> None:
+        import asyncio
+        from unittest.mock import patch
+
+        from custom_components.climate_advisor.door_window_lifecycle import DoorWindowLifecycleState
+
+        engine = self._make_paused_engine(fsm_authoritative=True)
+        with patch(
+            "custom_components.climate_advisor.door_window_fsm.transition",
+            side_effect=lambda *a, **k: type(
+                "T", (), {"to_state": DoorWindowLifecycleState.PAUSED_ACTIVE, "outcome": "broken", "at": None}
+            )(),
+        ):
+            asyncio.run(engine.handle_manual_override_during_pause())
+
+        # Real behavior: MANUAL_OVERRIDE_DURING_PAUSE always clears the pause.
+        # Forcing transition() to instead return PAUSED_ACTIVE (pause never
+        # clears) must show up as a detectable divergence — proves a broken
+        # FSM-authoritative swap wouldn't silently pass.
+        assert engine._paused_by_door is True, (
+            "positive control FAILED: forcing door_window_fsm.transition() to return the wrong "
+            "state did not change engine._paused_by_door — a broken FSM-authoritative swap would "
+            "go undetected"
+        )
+
+    def test_unbroken_transition_clears_pause_normally(self) -> None:
+        import asyncio
+
+        engine = self._make_paused_engine(fsm_authoritative=True)
+        asyncio.run(engine.handle_manual_override_during_pause())
+        assert engine._paused_by_door is False
+
+    def test_resume_from_pause_unreachable_via_scenario_corpus_uses_direct_construction(self) -> None:
+        """Documents (and asserts, not just claims) why DASHBOARD_RESUME needs this
+        direct-construction control: resume_from_pause() has no scenario-event
+        mapping in run_production.py at all."""
+        import asyncio
+
+        engine = self._make_paused_engine(fsm_authoritative=True)
+        engine._current_classification = None  # no HVAC call needed for this assertion
+        asyncio.run(engine.resume_from_pause())
+        assert engine._paused_by_door is False
+        assert engine._grace_active is True

--- a/tests/test_doorwindow_fsm_authoritative_switch.py
+++ b/tests/test_doorwindow_fsm_authoritative_switch.py
@@ -1,0 +1,63 @@
+"""Tests for Issue #594 Phase R, Step 4: the door/window FSM-authoritative
+cutover switch's coordinator-level plumbing.
+
+Binds the REAL ``ClimateAdvisorCoordinator.doorwindow_fsm_authoritative``/
+``set_doorwindow_fsm_authoritative()`` (object.__new__() + types.MethodType(),
+the established partial-instantiation pattern — see test_contact_status.py)
+rather than re-implementing the toggle logic in the test body, per this
+project's doctrine against mirror tests.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+if "homeassistant" not in sys.modules:
+    from conftest import _install_ha_stubs
+
+    _install_ha_stubs()
+
+from custom_components.climate_advisor.coordinator import ClimateAdvisorCoordinator
+
+
+def _make_coordinator() -> ClimateAdvisorCoordinator:
+    # object.__new__() preserves the real class, so the real
+    # `doorwindow_fsm_authoritative` property (a class-level descriptor) already
+    # resolves without manual binding — only the plain method needs explicit
+    # types.MethodType() binding.
+    coord = object.__new__(ClimateAdvisorCoordinator)
+    coord.automation_engine = MagicMock()
+    coord.automation_engine._doorwindow_fsm_authoritative = False
+    coord.set_doorwindow_fsm_authoritative = types.MethodType(
+        ClimateAdvisorCoordinator.set_doorwindow_fsm_authoritative, coord
+    )
+    return coord
+
+
+class TestDoorWindowFsmAuthoritativeToggle:
+    def test_defaults_reflect_engine_flag(self):
+        coord = _make_coordinator()
+        assert coord.doorwindow_fsm_authoritative is False
+
+    def test_enabling_sets_engine_flag(self):
+        coord = _make_coordinator()
+        coord.set_doorwindow_fsm_authoritative(True)
+        assert coord.automation_engine._doorwindow_fsm_authoritative is True
+        assert coord.doorwindow_fsm_authoritative is True
+
+    def test_disabling_clears_engine_flag(self):
+        coord = _make_coordinator()
+        coord.set_doorwindow_fsm_authoritative(True)
+        coord.set_doorwindow_fsm_authoritative(False)
+        assert coord.automation_engine._doorwindow_fsm_authoritative is False
+        assert coord.doorwindow_fsm_authoritative is False
+
+    def test_not_persisted_no_save_state_call(self):
+        """Deliberately does not call _async_save_state — see the method's own
+        docstring: a restart must always come back up on the legacy path."""
+        coord = _make_coordinator()
+        coord.hass = MagicMock()
+        coord.set_doorwindow_fsm_authoritative(True)
+        coord.hass.async_create_task.assert_not_called()

--- a/tests/test_resume_from_pause.py
+++ b/tests/test_resume_from_pause.py
@@ -360,6 +360,75 @@ class TestResumeFromPause:
         assert engine._last_resume_source == "manual"
 
 
+class TestResumeFromPauseFsmAuthoritative:
+    """Issue #594 Phase R Step 2: with _doorwindow_fsm_authoritative=True,
+    resume_from_pause() derives its resulting flags from
+    door_window_fsm.transition() instead of the unconditional inline clear —
+    same outcome, different source of truth. Mirrors TestResumeFromPause above
+    with the flag on.
+    """
+
+    def test_restores_mode_and_starts_grace_from_paused_active(self):
+        engine = _make_automation_engine(
+            {
+                CONF_MANUAL_GRACE_PERIOD: 300,
+                CONF_MANUAL_GRACE_NOTIFY: False,
+            }
+        )
+        engine._doorwindow_fsm_authoritative = True
+        engine._paused_by_door = True
+        engine._pre_pause_mode = "cool"
+        engine._current_classification = _make_classification(hvac_mode="cool")
+
+        with patch(_PATCH_CALL_LATER) as mock_call_later, patch(_PATCH_CALLBACK, side_effect=lambda f: f):
+            mock_call_later.return_value = MagicMock()
+            result = asyncio.run(engine.resume_from_pause())
+
+        assert engine._paused_by_door is False
+        assert engine._paused_with_hvac_already_off is False
+        assert engine._pre_pause_mode is None
+        assert engine._resumed_from_pause is True
+        assert engine._grace_active is True
+        assert result == "cool"
+
+        calls = engine.hass.services.async_call.call_args_list
+        hvac_calls = [c for c in calls if c.args[0] == "climate" and c.args[1] == "set_hvac_mode"]
+        assert len(hvac_calls) >= 1
+        assert hvac_calls[0].args[2]["hvac_mode"] == "cool"
+
+    def test_leaves_grace_running_from_paused_during_grace(self):
+        """From PAUSED_DURING_GRACE, DASHBOARD_RESUME lands unconditionally on
+        GRACE, same as from a plain paused state — matching the legacy path's
+        own unconditional _start_grace_period() call regardless of origin."""
+        engine = _make_automation_engine(
+            {
+                CONF_MANUAL_GRACE_PERIOD: 300,
+                CONF_MANUAL_GRACE_NOTIFY: False,
+            }
+        )
+        engine._doorwindow_fsm_authoritative = True
+        engine._paused_by_door = True
+        engine._grace_active = True
+        engine._current_classification = _make_classification(hvac_mode="cool")
+
+        with patch(_PATCH_CALL_LATER) as mock_call_later, patch(_PATCH_CALLBACK, side_effect=lambda f: f):
+            mock_call_later.return_value = MagicMock()
+            asyncio.run(engine.resume_from_pause())
+
+        assert engine._paused_by_door is False
+        assert engine._grace_active is True
+
+    def test_noop_when_not_paused(self):
+        engine = _make_automation_engine()
+        engine._doorwindow_fsm_authoritative = True
+        engine._paused_by_door = False
+
+        result = asyncio.run(engine.resume_from_pause())
+
+        assert result is None
+        engine.hass.services.async_call.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # TestGraceExpiryRecheck
 # ---------------------------------------------------------------------------

--- a/tests/test_shadow_engine_coverage.py
+++ b/tests/test_shadow_engine_coverage.py
@@ -89,6 +89,11 @@ _COVERAGE_REGISTRY: dict[str, str] = {
     "_pause_for_door_window": (
         "internal: called only from handle_door_window_open (mirrored) and _re_pause_for_open_sensor (internal)"
     ),
+    "_apply_door_window_fsm_state": (
+        "internal: Issue #594 Phase R Step 2 helper, called only from the FSM-authoritative "
+        "branches of handle_manual_override_during_pause (mirrored) and resume_from_pause "
+        "(mirrored) — the inverse of door_window_lifecycle_state's derivation"
+    ),
     "_clear_fan_flags_and_start_grace": (
         "internal: called only from on_fan_turned_off (mirrored) and _reconcile_fan_physical_drift (internal)"
     ),

--- a/tools/sim_harness/doorwindow_fsm_authoritative_compare.py
+++ b/tools/sim_harness/doorwindow_fsm_authoritative_compare.py
@@ -1,0 +1,48 @@
+"""doorwindow_fsm_authoritative_compare — Step 2/Step 3 equivalence proof (Issue #594
+Phase R), door/window lifecycle.
+
+Same shape and purpose as ``nat_vent_fsm_authoritative_compare.py`` — proves that
+flipping ``AutomationEngine._doorwindow_fsm_authoritative`` from its default
+``False`` to ``True`` produces a byte-for-byte identical ``event_log``/``action_log``
+across the full golden + pending scenario corpus.
+
+**Partial-authority scope (unlike nat-vent's comparator, which covers the whole
+lifecycle)**: this increment's flag only governs
+``handle_manual_override_during_pause()``/``resume_from_pause()`` — see each
+method's own FSM-authoritative branch in ``automation.py`` and
+``door_window_fsm.py``'s docstring for why the other 5 door/window methods stay on
+the legacy path regardless of this flag. A clean corpus diff here proves those 2
+methods are behavior-identical when authoritative; it says nothing about the other
+5, which don't read this flag at all.
+
+Use via ``tools.sim_harness.differential.diff_runs(scenario,
+mutate_b=fsm_authoritative_mutation)`` — run A is untouched production (flag
+default False), run B forces the flag True on every engine instance constructed
+during that run. ``diff.is_clean`` must be True for every scenario in the
+golden/pending corpus.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+
+@contextmanager
+def fsm_authoritative_mutation() -> Iterator[None]:
+    """Force ``_doorwindow_fsm_authoritative = True`` on every engine constructed
+    while this context is active — the "run B" side of a diff_runs comparison.
+    """
+    from unittest.mock import patch
+
+    from custom_components.climate_advisor.automation import AutomationEngine
+
+    original_init = AutomationEngine.__init__
+
+    def _wrapped_init(self: Any, *args: Any, **kwargs: Any) -> None:
+        original_init(self, *args, **kwargs)
+        self._doorwindow_fsm_authoritative = True
+
+    with patch.object(AutomationEngine, "__init__", _wrapped_init):
+        yield


### PR DESCRIPTION
## Summary
- Phase R Step 2 for door/window (epic #594) — **right-sized after scoping investigation**, not the originally-planned full 7-method swap.
- Nat-vent's shipped Step 2 precedent swapped exactly one boolean decision point. Door/window's full scope (9 flags across 7 methods) turned out qualitatively bigger and not equally safe by default — 4 methods have real blockers (#655's gap, missing origin-state plumbing, an unfed shadow event, a write-shape divergence), and a 5th (`handle_all_doors_windows_closed`) was found *during implementation* to have its own: `door_window_fsm.py`'s `ALL_SENSORS_CLOSED` transition infers `pre_pause_mode` from state rather than the real value, unsafe given `_exit_nat_vent()` can leave a dependent flag stale.
- **Ships the 2 genuinely mechanical methods**: `handle_manual_override_during_pause()` and `resume_from_pause()` — both land unconditionally on their target state regardless of origin state (confirmed by direct code read of the FSM's transition branches), no placeholder-inference risk.
- New `_doorwindow_fsm_authoritative` flag (off by default, explicit partial-scope docstring), `door_window_lifecycle_state` property, `_apply_door_window_fsm_state()` derivation helper.
- New decision-equivalence comparator proves the swap is a behavioral no-op across the full corpus — **verified corpus coverage was insufficient before trusting it**: `resume_from_pause()` has zero scenario-event mapping in the sim harness at all (dashboard-API-only), so both swapped methods get a direct-engine-construction positive control proving the comparator can actually detect a broken swap, not just report clean by construction.
- New `switch.climate_advisor_doorwindow_fsm_authoritative` (off by default, not persisted across restart), wired into the existing shadow diagnostic sensor.
- Fixes a stale "pending review" note in `KNOWN_FIXES[637]` (the two `issue_637_paused_during_grace_*.json` scenarios were promoted to `golden/` long ago).
- Files #657 for a related-but-independent finding surfaced during scoping: `_re_pause_for_open_sensor()`'s Step 1 fix (#637 v0.6.23) only cleared `_paused_by_door`, not 3 other stale pause fields the mirrored branch in `check_natural_vent_conditions()` clears together.

## Test plan
- [x] New unit tests for both FSM-authoritative branches (6 tests, covering both origin states + the not-paused no-op)
- [x] New decision-equivalence comparator: 91 tests (88 corpus scenarios + 3 positive-control) — all pass, corpus is a behavioral no-op, positive control proves real divergences are detectable
- [x] New switch/coordinator plumbing tests (4 tests)
- [x] Full suite: 4700 passed, 6 skipped, zero regressions
- [x] `python tools/simulate.py`: 81/81 golden scenarios pass
- [x] `ruff check` / `ruff format` clean
- [x] `test_version_sync.py` passes (0.6.25)
