### PR TITLE
Feat #664: override/grace FSM full authoritative migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.29] — 2026-08-17
+
+- Feat #664: the override/grace lifecycle FSM (whole-house-fan and thermostat manual overrides, and the grace period that protects them from being undone) can now optionally drive real production decisions instead of only observing them — a new, off-by-default, non-persisted switch, matching the same pattern nat-vent and door/window already have. Unlike door/window's staged rollout, this ships full authority for all 8 real trigger sites at once, since investigation proved the FSM and the existing logic always compute identical results, confirmed across the full scenario library with the switch turned on. Also fixes a config edge case found during this work: a manual grace period disabled via configuration (0 seconds) could have been reported as active with no way to ever clear it, had the switch been turned on before this fix. The switch defaults off — no occupant-visible behavior change from this release alone.
+
 ## [0.6.28] — 2026-08-16
 
 - Fix #661: the override/grace shadow FSM's diagnostic accuracy for fan overrides (whole-house-fan remote timers, physical fan-on detection) is now correct — it previously modeled a confirmation delay that fan overrides never actually go through in production, causing a spurious disagreement reading on the most common override path. No occupant-visible change: override/grace has no authoritative switch and never drove real decisions — this only fixes what the diagnostic sensor reports.

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -70,6 +70,7 @@ from .const import (
     FAN_MODE_DISABLED,
     FAN_MODE_HVAC,
     FAN_MODE_WHOLE_HOUSE,
+    GRACE_TRIGGERS_PROTECTING_OVERRIDE,
     HOT_DAY_PRE_COOL_MODIFIER,
     MIN_VIABLE_NAT_VENT_HOURS,
     NAT_VENT_HYSTERESIS_F,
@@ -104,6 +105,7 @@ from .desired_state import (
 
 if TYPE_CHECKING:
     from .door_window_fsm import DoorWindowFsmEventKind
+    from .override_grace_fsm import OverrideGraceFsmEventKind
 
 from .door_window_lifecycle import (
     DoorWindowLifecycleInputs,
@@ -135,6 +137,11 @@ from .nat_vent_lifecycle import (
     derive_nat_vent_lifecycle_state,
 )
 from .nat_vent_reactivation_lockout import is_reactivation_locked_out
+from .override_grace_lifecycle import (
+    GraceState,
+    OverrideConfirmState,
+    OverrideGraceLifecycleState,
+)
 from .setpoint_verify_decision import SetpointVerifyOutcome, decide_setpoint_verify
 from .temperature import (
     convert_delta,
@@ -167,18 +174,10 @@ class FanCommandResult(Enum):
     DISABLED = "disabled"
 
 
-# Issue #530: the ONLY two `_start_grace_period(trigger=...)` values that mean "this grace
-# exists to protect an active manual/fan override" — read by `_start_grace_period()` to set
-# `_grace_protects_override`, which `coordinator._check_orphaned_grace()` uses to scope its
-# self-heal to grace types that can actually BE orphaned (an override was cleared without its
-# grace being cancelled alongside it). Every other grace trigger (fan-off cooldown, physical-
-# drift correction, window-close resume, nat-vent-exit resume, dashboard resume) never sets
-# `_manual_override_active`/`_fan_override_active` in the first place by design — treating
-# their absence as "orphaned" was the root cause of #530's fan-off grace being killed within
-# ~1ms of starting. A future grace-starting call site is automatically excluded here unless
-# its trigger string is deliberately added to this set — if it's meant to protect a real
-# override, add it; if not, leave it out.
-_GRACE_TRIGGERS_PROTECTING_OVERRIDE = frozenset({"fan_manual_override", "override_confirmed"})
+# Issue #664: moved to const.py (GRACE_TRIGGERS_PROTECTING_OVERRIDE) as the single source of
+# truth — override_grace_start.py's decide_grace_protects_override() previously hand-duplicated
+# this same frozenset as its own default, with no import connecting the two.
+_GRACE_TRIGGERS_PROTECTING_OVERRIDE = GRACE_TRIGGERS_PROTECTING_OVERRIDE
 
 
 @dataclass(frozen=True)
@@ -796,6 +795,15 @@ class AutomationEngine:
         # flips it; deployed OFF, live switch-flip is a separate verification step.
         self._doorwindow_fsm_authoritative: bool = False
 
+        # Issue #664 (Block 5 Phase 3, epic #594): whether the override/grace lifecycle FSM
+        # (override_grace_fsm.py, Issue #639) is authoritative for _override_confirm_pending/
+        # _grace_active/_grace_protects_override, instead of each real call site's own inline
+        # flag write. Default False — zero behavior change until the switch (switch.py) flips
+        # it; deployed OFF, live switch-flip is a separate verification step. See
+        # _resolve_override_grace_fsm_state()'s docstring for why full authority ships in one
+        # PR rather than the staged partial-scope rollout door/window used.
+        self._override_grace_fsm_authoritative: bool = False
+
         # Override confirmation period (Issue #76) — pending window before override is formally accepted
         self._override_confirm_pending: bool = False
         self._override_confirm_cancel: Any | None = None
@@ -1012,16 +1020,56 @@ class AutomationEngine:
 
         self._revisit_cancel = async_call_later(self.hass, REVISIT_DELAY_SECONDS, _revisit_fired)
 
+    def _legacy_clear_confirm_flag(self) -> None:
+        """The 1-line flag-clear ``clear_manual_override()`` always used to perform
+        inline (Issue #664) — extracted so it can be composed into the ``legacy``
+        closure passed to ``_resolve_override_grace_fsm_state()`` at the real
+        override/grace call sites (``cancel_override()``, ``_on_grace_expired()``'s 3
+        branches, coordinator's OVERRIDE_SUPERSEDED "Fix D" branch), and reused
+        unchanged by ``clear_manual_override()`` itself for every other caller
+        (``handle_occupancy_away/vacation``, ``handle_bedtime``,
+        ``handle_morning_wakeup``, the stuck-grace-recovery watchdog) — none of those
+        are override/grace FSM-modeled events.
+        """
+        self._override_confirm_pending = False
+
+    def _clear_override_confirm_action(self) -> None:
+        """Real side effect only: cancel the confirm-expiry timer handle (if any) and
+        clear the non-FSM-derived confirm bookkeeping (Issue #664). Deliberately does
+        NOT write ``_override_confirm_pending`` — see ``_legacy_clear_confirm_flag()``.
+        """
+        if self._override_confirm_cancel:
+            self._override_confirm_cancel()
+            self._override_confirm_cancel = None
+        self._override_confirm_time = None
+        self._override_confirm_mode = None
+        self._override_confirm_source = None
+
     def clear_manual_override(self, reason: str = "grace_expired") -> None:
-        """Clear the manual override flag (called at transition points)."""
+        """Clear the manual override flag (called at transition points).
+
+        Issue #664: the confirm-clear half is a thin wrapper over
+        ``_clear_override_confirm_action()`` + ``_legacy_clear_confirm_flag()`` —
+        real work / flag-write split, same shape as ``_start_grace_period()``'s split.
+        Used unconditionally by every caller except the 3 real override/grace call
+        sites named in ``_legacy_clear_confirm_flag()``'s docstring, which call the
+        action directly and route the flag-write through the dispatcher instead,
+        atomically alongside the grace flags for the SAME event (see
+        ``cancel_override()``).
+        """
         if self._override_confirm_pending:
-            if self._override_confirm_cancel:
-                self._override_confirm_cancel()
-                self._override_confirm_cancel = None
-            self._override_confirm_pending = False
-            self._override_confirm_time = None
-            self._override_confirm_mode = None
-            self._override_confirm_source = None
+            self._clear_override_confirm_action()
+            self._legacy_clear_confirm_flag()
+        self._clear_manual_override_active(reason)
+
+    def _clear_manual_override_active(self, reason: str) -> None:
+        """The ``_manual_override_active``-and-below half of ``clear_manual_override()``
+        (Issue #664, extracted for reuse). None of these fields are part of the
+        override/grace FSM's ``(OverrideConfirmState, GraceState)`` 2-tuple derivation
+        (same exclusion list ``_apply_override_grace_fsm_state()``'s docstring
+        documents) — always runs directly, unconditionally, regardless of which
+        computation determined the confirm/grace flags for this event.
+        """
         if self._manual_override_active:
             if self._emit_event_callback:
                 _cs = self.hass.states.get(self.climate_entity) if self.hass else None
@@ -1056,6 +1104,12 @@ class AutomationEngine:
         method is the entry point for both dashboard "Cancel..." buttons — there is no separate
         "kind" of cancellation, just one operation with two entry points.
 
+        Issue #664: the confirm/grace flag write is a SINGLE atomic dispatch call for the
+        OVERRIDE_CANCELLED event (not two separate calls into ``clear_manual_override()``'s
+        and ``_cancel_grace_timers()``'s own dispatch — the FSM's ``transition()`` computes
+        both flags from one ``(confirm, grace)`` state pair per event, so this must be one
+        dispatcher call, not two racing against each other's ``origin_state`` read).
+
         Returns:
             True if an override and/or grace period was actually cancelled; False if there was
             nothing active (safe no-op — callers can use this to choose their response message).
@@ -1066,8 +1120,18 @@ class AutomationEngine:
         if not (had_manual or had_fan or had_grace):
             return False
 
-        self.clear_manual_override(reason=reason)
-        self._cancel_grace_timers()
+        from .override_grace_fsm import OverrideGraceFsmEventKind as _OGFEventKind
+
+        if self._override_confirm_pending:
+            self._clear_override_confirm_action()
+        self._cancel_grace_timers_action()
+
+        def _legacy_clear() -> None:
+            self._legacy_clear_confirm_flag()
+            self._legacy_clear_grace_flags()
+
+        self._resolve_override_grace_fsm_state(kind=_OGFEventKind.OVERRIDE_CANCELLED, legacy=_legacy_clear)
+        self._clear_manual_override_active(reason)
 
         # clear_manual_override() only emits "override_cleared" when a thermostat-mode override
         # was active (guarded on _manual_override_active); a fan-only override cleared here would
@@ -1194,7 +1258,14 @@ class AutomationEngine:
                     "remote_speed": remote_speed,
                 },
             )
-        self._start_grace_period("manual", trigger="fan_manual_override", duration_override=duration_override)
+        from .override_grace_fsm import OverrideGraceFsmEventKind as _OGFEventKind
+
+        _trigger = "fan_manual_override"
+        if self._start_grace_period_action("manual", trigger=_trigger, duration_override=duration_override):
+            self._resolve_override_grace_fsm_state(
+                kind=_OGFEventKind.FAN_OVERRIDE_DETECTED,
+                legacy=lambda: self._legacy_set_grace_flags(_trigger),
+            )
 
         # Issue #495: whole-house fan and HVAC are mutually exclusive — this was previously
         # only enforced for CA-initiated activation (_activate_fan()). A manually/remotely
@@ -1532,8 +1603,11 @@ class AutomationEngine:
             old_setpoint_f: Previous thermostat setpoint in degrees F (setpoint overrides only).
             new_setpoint_f: New thermostat setpoint in degrees F (setpoint overrides only).
         """
+        from .override_grace_fsm import OverrideGraceFsmEventKind as _OGFEventKind
+
         self.start_override_confirmation(
             source=source,
+            event_kind=_OGFEventKind.OVERRIDE_DETECTED,
             old_mode=old_mode,
             new_mode=new_mode,
             classification_mode=classification_mode,
@@ -1545,6 +1619,7 @@ class AutomationEngine:
         self,
         source: str,
         *,
+        event_kind: OverrideGraceFsmEventKind,
         old_mode: str | None = None,
         new_mode: str | None = None,
         classification_mode: str | None = None,
@@ -1556,6 +1631,11 @@ class AutomationEngine:
         Args:
             source: "normal" for regular operation overrides,
                     "pause" for overrides detected during a door/window pause.
+            event_kind: Issue #664 — which ``OverrideGraceFsmEventKind`` this call
+                corresponds to (``OVERRIDE_DETECTED`` for ``handle_manual_override()``,
+                ``MANUAL_OVERRIDE_DURING_PAUSE`` for
+                ``handle_manual_override_during_pause()``) — the two callers land on the
+                same shape of transition but are distinct real production entry points.
             old_mode: Previous hvac_mode (for enriched event payload).
             new_mode: New hvac_mode detected.
             classification_mode: What classification expects (for event payload).
@@ -1569,12 +1649,25 @@ class AutomationEngine:
         # Architecture-reset Step 2 (session state machine slice): the disabled-vs-pending
         # branch now lives in desired_state.decide_override_confirm() — this method still
         # owns the immediate-accept side effect and the real async_call_later scheduling.
+        # Issue #664: this decision itself is never dispatcher-branched — it's the exact
+        # same decide_override_confirm() call override_grace_fsm.py's _land_after_detection()
+        # makes, so legacy and FSM can never disagree on which branch to take.
         _override_pending = decide_override_confirm(
             confirm_seconds=confirm_seconds, detected_mode=detected_mode, now=dt_util.now()
         )
         if _override_pending is None:
             # Confirmation disabled — accept override immediately (legacy behaviour)
-            self._confirm_override(detected_mode, source=source)
+            _grace_started = self._confirm_override_action(detected_mode, source=source)
+
+            def _legacy_immediate_accept() -> None:
+                # Manual grace can itself be disabled by config (manual_grace_seconds=0)
+                # — in that case _confirm_override_action() returned False and no grace
+                # timer actually started, so the flags must stay at NONE, not be forced
+                # to ACTIVE_PROTECTING_OVERRIDE (Issue #664).
+                if _grace_started:
+                    self._legacy_set_grace_flags("override_confirmed")
+
+            self._resolve_override_grace_fsm_state(kind=event_kind, legacy=_legacy_immediate_accept)
             return
 
         # Cancel any existing pending confirmation (restart the window)
@@ -1582,10 +1675,13 @@ class AutomationEngine:
             self._override_confirm_cancel()
             self._override_confirm_cancel = None
 
-        self._override_confirm_pending = True
         self._override_confirm_time = dt_util.now().isoformat()
         self._override_confirm_mode = detected_mode
         self._override_confirm_source = source
+        self._resolve_override_grace_fsm_state(
+            kind=event_kind,
+            legacy=lambda: setattr(self, "_override_confirm_pending", True),
+        )
         _LOGGER.info(
             "Potential %s override detected (mode=%s) — confirming in %d minutes",
             source,
@@ -1618,6 +1714,8 @@ class AutomationEngine:
                 self._last_override_detected_time.isoformat(),
             )
 
+        from .override_grace_fsm import OverrideGraceFsmEventKind as _OGFEventKind
+
         @callback
         def _confirm_override_expired(_now: Any) -> None:
             self._override_confirm_cancel = None
@@ -1637,11 +1735,20 @@ class AutomationEngine:
                     current_mode,
                     cls_mode,
                 )
-                self._override_confirm_pending = False
-                self._override_confirm_time = None
-                self._override_confirm_mode = None
-                self._override_confirm_source = None
-                self._confirm_override(current_mode, source=source)
+                self._clear_override_confirm_action()
+                _grace_started = self._confirm_override_action(current_mode, source=source)
+
+                def _legacy_path_a() -> None:
+                    self._legacy_clear_confirm_flag()
+                    # Issue #664: manual grace can be disabled by config — don't force
+                    # ACTIVE_PROTECTING_OVERRIDE when no grace timer actually started.
+                    if _grace_started:
+                        self._legacy_set_grace_flags("override_confirmed")
+
+                self._resolve_override_grace_fsm_state(
+                    kind=_OGFEventKind.OVERRIDE_CONFIRM_EXPIRED,
+                    legacy=_legacy_path_a,
+                )
                 if self._emit_event_callback:
                     self._emit_event_callback(
                         "override_confirmed",
@@ -1659,10 +1766,11 @@ class AutomationEngine:
                     self._override_confirm_mode,
                     current_mode,
                 )
-                self._override_confirm_pending = False
-                self._override_confirm_time = None
-                self._override_confirm_mode = None
-                self._override_confirm_source = None
+                self._clear_override_confirm_action()
+                self._resolve_override_grace_fsm_state(
+                    kind=_OGFEventKind.OVERRIDE_CONFIRM_EXPIRED,
+                    legacy=self._legacy_clear_confirm_flag,
+                )
                 if self._emit_event_callback:
                     self._emit_event_callback(
                         "override_self_resolved",
@@ -1751,14 +1859,26 @@ class AutomationEngine:
             return True
         return abs(current_f - target_f) <= OVERRIDE_ADOPT_SETPOINT_TOLERANCE_F
 
-    def _confirm_override(self, mode: str, source: str | None = None) -> None:
-        """Formally accept a manual override and start the grace period.
+    def _confirm_override_action(self, mode: str, source: str | None = None) -> bool:
+        """Real side effect only (Issue #664): the non-FSM-derived manual-override
+        fields (always direct writes, outside the 2-tuple derivation) plus the
+        grace-start action. Deliberately does NOT write
+        ``_grace_active``/``_grace_protects_override`` — callers
+        (``start_override_confirmation()``, the confirm-expiry timer closure) must
+        follow with exactly one ``_resolve_override_grace_fsm_state()`` call, and MUST
+        only claim ``ACTIVE_PROTECTING_OVERRIDE`` in their ``legacy`` closure when this
+        method's return value is True — manual grace can be disabled by config
+        (``manual_grace_seconds=0``), in which case no grace timer actually starts.
 
         Args:
             mode: The confirmed HVAC mode string.
             source: The originating ``_override_confirm_source`` ("normal", "pause",
                 or "setpoint"), carried forward so later adopt-on-match logic
                 (Issue #483) can exclude setpoint-only overrides from adoption.
+
+        Returns:
+            True if grace actually started (a real timer now exists), False if manual
+            grace is disabled by config.
         """
         self._manual_override_active = True
         self._manual_override_mode = mode
@@ -1769,7 +1889,19 @@ class AutomationEngine:
             self._manual_override_mode,
             self._manual_override_source or "unknown",
         )
-        self._start_grace_period("manual", trigger="override_confirmed")
+        return self._start_grace_period_action("manual", trigger="override_confirmed")
+
+    def _confirm_override(self, mode: str, source: str | None = None) -> None:
+        """Formally accept a manual override and start the grace period.
+
+        Issue #664: thin wrapper — real work lives in ``_confirm_override_action()``.
+        Not called from anywhere post-refactor (both former call sites now call the
+        action directly and route the flag-write through the dispatcher instead — see
+        ``start_override_confirmation()`` and its internal confirm-expiry closure), kept
+        as the reference "legacy" flag computation and for any future direct caller.
+        """
+        if self._confirm_override_action(mode, source=source):
+            self._legacy_set_grace_flags("override_confirmed")
 
     @contextlib.asynccontextmanager
     async def _decision_pass(self, method_name: str):
@@ -4531,9 +4663,12 @@ class AutomationEngine:
         self._paused_entity = None
         self._paused_since = None
         self._pre_pause_mode = None
+        from .override_grace_fsm import OverrideGraceFsmEventKind as _OGFEventKind
+
         # Start confirmation period — wait before formally accepting the override
         self.start_override_confirmation(
             source="pause",
+            event_kind=_OGFEventKind.MANUAL_OVERRIDE_DURING_PAUSE,
             old_mode=old_mode,
             new_mode=new_mode,
             classification_mode=classification_mode,
@@ -4586,8 +4721,93 @@ class AutomationEngine:
                     reason="user resumed from door/window pause",
                 )
 
-        self._start_grace_period("manual", trigger="dashboard_resume")
+        from .override_grace_fsm import OverrideGraceFsmEventKind as _OGFEventKind
+
+        _trigger = "dashboard_resume"
+        if self._start_grace_period_action("manual", trigger=_trigger):
+            self._resolve_override_grace_fsm_state(
+                kind=_OGFEventKind.DASHBOARD_RESUME,
+                legacy=lambda: self._legacy_set_grace_flags(_trigger),
+            )
         return restore_mode
+
+    def _legacy_set_grace_flags(self, trigger: str) -> None:
+        """The 2-line flag computation ``_start_grace_period()`` always used to perform
+        inline (Issue #664) — extracted so it can be passed as the ``legacy`` closure to
+        ``_resolve_override_grace_fsm_state()`` at the real override/grace call sites,
+        and reused unchanged by ``_start_grace_period()`` itself for every other trigger
+        (fan-off, window-close, nat-vent-exit, drift-correction) that isn't a modeled
+        ``OverrideGraceFsmEventKind`` at all — those callers never touch the dispatcher,
+        by design (there is nothing for the FSM to arbitrate; only this flag-write runs).
+        """
+        self._grace_active = True
+        self._grace_protects_override = trigger in _GRACE_TRIGGERS_PROTECTING_OVERRIDE
+
+    def _start_grace_period_action(
+        self, source: str, trigger: str = "", duration_override: float | None = None
+    ) -> bool:
+        """Real side effect only: cancel any prior timer, resolve duration/should_notify,
+        schedule the real grace-expiry ``async_call_later``, and write every
+        non-FSM-derived bookkeeping field (Issue #664). Deliberately does NOT write
+        ``_grace_active``/``_grace_protects_override`` — the two flags
+        ``override_grace_fsm.py`` models — so a caller can genuinely choose which
+        computation determines those two, exclusively, via
+        ``_resolve_override_grace_fsm_state()``, instead of this method silently
+        overwriting whatever the dispatcher just decided.
+
+        Returns True if grace actually started (a real timer now exists), False if grace
+        is disabled (``decide_grace_start()`` returned None) — callers must only proceed
+        to write the 2 derived flags (via legacy or the dispatcher) when this is True;
+        a disabled grace period must never claim ``_grace_active=True``.
+        """
+        self._cancel_grace_timers()
+
+        now = dt_util.now()
+        manual_duration = (
+            duration_override
+            if (source == "manual" and duration_override is not None)
+            else self.config.get(CONF_MANUAL_GRACE_PERIOD, DEFAULT_MANUAL_GRACE_SECONDS)
+        )
+        grace = decide_grace_start(
+            source=source,
+            manual_duration_seconds=manual_duration,
+            manual_should_notify=self.config.get(CONF_MANUAL_GRACE_NOTIFY, True),
+            automation_duration_seconds=self.config.get(CONF_AUTOMATION_GRACE_PERIOD, DEFAULT_AUTOMATION_GRACE_SECONDS),
+            automation_should_notify=self.config.get(CONF_AUTOMATION_GRACE_NOTIFY, True),
+            now=now,
+        )
+        if grace is None:
+            return False  # Grace period disabled
+
+        duration = int((grace.at - now).total_seconds())
+        should_notify = grace.should_notify
+
+        self._last_resume_source = source
+        self._last_grace_trigger = trigger
+        self._grace_duration_seconds = duration
+        self._grace_end_time = grace.at.isoformat()
+
+        @callback
+        def _grace_expired(_now: Any) -> None:
+            """Grace period has elapsed — re-check sensors before clearing."""
+            self._on_grace_expired(source, duration, should_notify)
+
+            # Converge to correct scheduled state (bedtime setback or current classification)
+            self.hass.async_create_task(self._apply_current_scheduled_state())
+
+        cancel = async_call_later(self.hass, duration, _grace_expired)
+        if source == "manual":
+            self._manual_grace_cancel = cancel
+        else:
+            self._automation_grace_cancel = cancel
+
+        _LOGGER.info("Started %s grace period (%d seconds)", source, duration)
+        if self._emit_event_callback:
+            self._emit_event_callback(
+                "grace_started",
+                {"source": source, "duration_seconds": duration, "trigger": trigger},
+            )
+        return True
 
     def _start_grace_period(self, source: str, trigger: str = "", duration_override: float | None = None) -> None:
         """Start a grace period after HVAC is resumed.
@@ -4610,63 +4830,18 @@ class AutomationEngine:
                 long as the user asked at the physical remote. Only meaningful when
                 source == "manual"; ignored otherwise.
 
-        Architecture-reset Step 2 (session state machine slice): the
-        duration/should_notify RESOLUTION now lives in
-        ``desired_state.decide_grace_start()`` — the first real production
-        wiring of a DesiredState type, not just a schema. This method still
-        owns everything decide_grace_start() doesn't cover: cancelling prior
-        timers, scheduling the real ``async_call_later``, setting instance
-        flags, and emitting the ``grace_started`` event.
+        Issue #664: thin wrapper — real work lives in ``_start_grace_period_action()``.
+        This wrapper is for every caller whose ``trigger`` is NOT a modeled
+        ``OverrideGraceFsmEventKind`` (fan-off, window-close, nat-vent-exit,
+        drift-correction, etc.) — those callers keep this exact unconditional
+        action-then-flags shape, unchanged. The ~3 callers whose trigger IS modeled
+        (``fan_manual_override``, ``dashboard_resume``, ``override_confirmed``) call
+        ``_start_grace_period_action()`` directly instead and route the flag-write
+        through ``_resolve_override_grace_fsm_state()`` — see ``handle_fan_manual_override()``,
+        ``resume_from_pause()``, ``_confirm_override()``.
         """
-        self._cancel_grace_timers()
-
-        now = dt_util.now()
-        manual_duration = (
-            duration_override
-            if (source == "manual" and duration_override is not None)
-            else self.config.get(CONF_MANUAL_GRACE_PERIOD, DEFAULT_MANUAL_GRACE_SECONDS)
-        )
-        grace = decide_grace_start(
-            source=source,
-            manual_duration_seconds=manual_duration,
-            manual_should_notify=self.config.get(CONF_MANUAL_GRACE_NOTIFY, True),
-            automation_duration_seconds=self.config.get(CONF_AUTOMATION_GRACE_PERIOD, DEFAULT_AUTOMATION_GRACE_SECONDS),
-            automation_should_notify=self.config.get(CONF_AUTOMATION_GRACE_NOTIFY, True),
-            now=now,
-        )
-        if grace is None:
-            return  # Grace period disabled
-
-        duration = int((grace.at - now).total_seconds())
-        should_notify = grace.should_notify
-
-        self._grace_active = True
-        self._last_resume_source = source
-        self._last_grace_trigger = trigger
-        self._grace_duration_seconds = duration
-        self._grace_end_time = grace.at.isoformat()
-        self._grace_protects_override = trigger in _GRACE_TRIGGERS_PROTECTING_OVERRIDE
-
-        @callback
-        def _grace_expired(_now: Any) -> None:
-            """Grace period has elapsed — re-check sensors before clearing."""
-            self._on_grace_expired(source, duration, should_notify)
-
-            # Converge to correct scheduled state (bedtime setback or current classification)
-            self.hass.async_create_task(self._apply_current_scheduled_state())
-
-        cancel = async_call_later(self.hass, duration, _grace_expired)
-        if source == "manual":
-            self._manual_grace_cancel = cancel
-        else:
-            self._automation_grace_cancel = cancel
-
-        _LOGGER.info("Started %s grace period (%d seconds)", source, duration)
-        if self._emit_event_callback:
-            self._emit_event_callback(
-                "grace_started",
-                {"source": source, "duration_seconds": duration, "trigger": trigger},
-            )
+        if self._start_grace_period_action(source, trigger, duration_override):
+            self._legacy_set_grace_flags(trigger)
 
     def _on_grace_expired(self, source: str, duration: int, should_notify: bool) -> None:
         """Handle grace period expiry — re-check sensors then clear state.
@@ -4705,19 +4880,40 @@ class AutomationEngine:
             # open" branch defers that to the scheduled _re_pause_for_open_sensor() task.
             pass
 
+        from .override_grace_fsm import OverrideGraceFsmEventKind as _OGFEventKind
+
+        def _dispatch_override_grace_expired() -> None:
+            """Real action + single dispatcher call for GRACE_TIMER_EXPIRED (Issue #664),
+            shared by all 3 branches below. Origin state doesn't need explicit capture
+            (unlike the door/window dispatcher above) — the action calls never touch
+            _override_confirm_pending/_grace_active/_grace_protects_override themselves,
+            so a live read after them still reflects the correct pre-transition state.
+            """
+            _was_confirm_pending = self._override_confirm_pending
+            if _was_confirm_pending:
+                self._clear_override_confirm_action()
+            self._cancel_grace_timers_action()
+
+            def _legacy_clear() -> None:
+                if _was_confirm_pending:
+                    self._legacy_clear_confirm_flag()
+                self._legacy_clear_grace_flags()
+
+            self._resolve_override_grace_fsm_state(kind=_OGFEventKind.GRACE_TIMER_EXPIRED, legacy=_legacy_clear)
+
         # If within planned window period, sensors open is expected — just clear grace
         if self._is_within_planned_window_period():
             _LOGGER.info(
                 "%s grace expired during planned window period — sensors open as expected, clearing grace",
                 source,
             )
-            self._cancel_grace_timers()
+            _dispatch_override_grace_expired()
             self._resolve_door_window_pause_flags(
                 kind=DoorWindowFsmEventKind.GRACE_TIMER_EXPIRED,
                 legacy=_legacy_noop,
                 origin_state=_origin_state,
             )
-            self.clear_manual_override(reason="grace_expired")
+            self._clear_manual_override_active("grace_expired")
             if self._request_refresh_callback:
                 self._request_refresh_callback()
             if self._post_grace_fan_check_callback:
@@ -4740,7 +4936,7 @@ class AutomationEngine:
                 "%s grace expired but sensor(s) still open — re-pausing HVAC",
                 source,
             )
-            self._cancel_grace_timers()
+            _dispatch_override_grace_expired()
             # Issue #660 Step 8: when authoritative, this applies the FSM's RE_PAUSE
             # outcome (including its own nested nat-vent reactivation gate check) to
             # _paused_by_door/_paused_with_hvac_already_off/_grace_active BEFORE
@@ -4753,7 +4949,7 @@ class AutomationEngine:
                 legacy=_legacy_noop,
                 origin_state=_origin_state,
             )
-            self.clear_manual_override(reason="grace_expired")
+            self._clear_manual_override_active("grace_expired")
             if self._request_refresh_callback:
                 self._request_refresh_callback()
             if self._post_grace_fan_check_callback:
@@ -4789,13 +4985,13 @@ class AutomationEngine:
                 duration,
             )
 
-        self._cancel_grace_timers()
+        _dispatch_override_grace_expired()
         self._resolve_door_window_pause_flags(
             kind=DoorWindowFsmEventKind.GRACE_TIMER_EXPIRED,
             legacy=_legacy_noop,
             origin_state=_origin_state,
         )
-        self.clear_manual_override(reason="adopted_matching_decision" if _adopted else "grace_expired")
+        self._clear_manual_override_active("adopted_matching_decision" if _adopted else "grace_expired")
         if self._request_refresh_callback:
             self._request_refresh_callback()
         if self._post_grace_fan_check_callback:
@@ -4854,19 +5050,48 @@ class AutomationEngine:
             remaining_seconds,
         )
 
-    def _cancel_grace_timers(self) -> None:
-        """Cancel any active grace period timers."""
+    def _legacy_clear_grace_flags(self) -> None:
+        """The 2-line flag-clear ``_cancel_grace_timers()`` always used to perform inline
+        (Issue #664) — extracted so it can be passed as the ``legacy`` closure to
+        ``_resolve_override_grace_fsm_state()`` at the 4 real call sites
+        (``_on_grace_expired()``'s 3 branches, ``_check_orphaned_grace()``), and reused
+        unchanged by ``_cancel_grace_timers()`` itself for every other caller (``cleanup()``,
+        the internal cancel-prior-timer call inside ``_start_grace_period_action()``, and
+        every door/window call site — none of those are override/grace FSM-modeled events;
+        door/window's own dispatcher independently derives and writes ``_grace_active`` from
+        its own FSM/legacy branch regardless of this method, same redundant-but-harmless
+        coexistence already proven safe for door/window's shipped authoritative switch).
+        """
+        self._grace_active = False
+        self._grace_protects_override = False
+
+    def _cancel_grace_timers_action(self) -> None:
+        """Real side effect only: cancel any pending timer handles and clear the
+        non-FSM-derived bookkeeping fields (Issue #664). Deliberately does NOT write
+        ``_grace_active``/``_grace_protects_override`` — see ``_legacy_clear_grace_flags()``.
+        """
         if self._manual_grace_cancel:
             self._manual_grace_cancel()
             self._manual_grace_cancel = None
         if self._automation_grace_cancel:
             self._automation_grace_cancel()
             self._automation_grace_cancel = None
-        self._grace_active = False
         self._grace_end_time = None  # Bug 2 fix (Issue #321): prevent stuck-at-0 display
         self._last_resume_source = None
         self._last_grace_trigger = None
-        self._grace_protects_override = False
+
+    def _cancel_grace_timers(self) -> None:
+        """Cancel any active grace period timers.
+
+        Issue #664: thin wrapper — real work lives in ``_cancel_grace_timers_action()``.
+        Used unconditionally by every caller EXCEPT the 4 real override/grace
+        GRACE_TIMER_EXPIRED/OVERRIDE_CANCELLED call sites, which call
+        ``_cancel_grace_timers_action()`` directly and route the flag-clear through
+        ``_resolve_override_grace_fsm_state()`` instead — see ``_on_grace_expired()``,
+        ``coordinator._check_orphaned_grace()``.
+        """
+        self._cancel_grace_timers_action()
+        self._legacy_clear_grace_flags()
 
     async def _re_pause_for_open_sensor(self) -> None:
         """Re-pause HVAC because a sensor is still open when grace expired."""
@@ -6019,6 +6244,190 @@ class AutomationEngine:
                 DoorWindowFsmEvent(kind=kind, inputs=self._build_door_window_fsm_inputs(now=dt_util.now())),
             )
             self._apply_door_window_fsm_state(result.to_state)
+        else:
+            legacy()
+
+    def _build_override_grace_fsm_inputs(self):
+        """Build the override/grace FSM's input snapshot from current engine state
+        (Issue #664).
+
+        Sole builder for ``OverrideGraceFsmInputs`` — mirrors
+        ``coordinator._evaluate_override_grace_fsm()``'s pre-existing computation
+        exactly (same ``current_setpoint_f``/``target_setpoint_f`` resolution via
+        ``select_comfort_band()`` + ``to_fahrenheit()``, wrapped in the same
+        defensive try/except a missing/unparseable live setpoint tolerates), now
+        called from inside ``AutomationEngine`` itself so the dispatcher can build
+        the same snapshot the shadow-mirror path already builds, without a second,
+        coordinator-side copy of this computation.
+        """
+        from .override_grace_fsm import OverrideGraceFsmInputs
+
+        now = dt_util.now()
+        classification = self._current_classification
+        classification_mode = classification.hvac_mode if classification else None
+
+        current_setpoint_f: float | None = None
+        target_setpoint_f: float | None = None
+        try:
+            if classification is not None and classification_mode in ("heat", "cool"):
+                band = select_comfort_band(
+                    classification,
+                    self.config,
+                    occupancy_mode=self._occupancy_mode,
+                    in_sleep_window=_in_sleep_window(now, self.config),
+                    aggressive_savings=bool(self.config.get("aggressive_savings", False)),
+                )
+                target_setpoint_f = band.floor if classification_mode == "heat" else band.ceiling
+                state = self.hass.states.get(self.climate_entity)
+                raw_setpoint = state.attributes.get("temperature") if state else None
+                if raw_setpoint is not None:
+                    unit = self.config.get("temp_unit", "fahrenheit")
+                    current_setpoint_f = to_fahrenheit(float(raw_setpoint), unit)
+        except (TypeError, ValueError, AttributeError):
+            current_setpoint_f = None
+            target_setpoint_f = None
+
+        current_mode_state = self.hass.states.get(self.climate_entity)
+        return OverrideGraceFsmInputs(
+            confirm_seconds=float(self.config.get(CONF_OVERRIDE_CONFIRM_PERIOD, DEFAULT_OVERRIDE_CONFIRM_SECONDS)),
+            setpoint_override=bool(self._override_confirm_source == "setpoint"),
+            current_mode=current_mode_state.state if current_mode_state else None,
+            classification_mode=classification_mode,
+            manual_override_active=bool(self._manual_override_active),
+            manual_override_mode=self._manual_override_mode,
+            manual_override_source=self._manual_override_source,
+            fan_override_active=bool(self._fan_override_active),
+            current_setpoint_f=current_setpoint_f,
+            target_setpoint_f=target_setpoint_f,
+            tolerance_f=OVERRIDE_ADOPT_SETPOINT_TOLERANCE_F,
+            within_planned_window=self._is_within_planned_window_period(),
+            any_sensor_open=self._any_monitored_sensor_open(),
+            grace_source=self._last_resume_source or "automation",
+            now=now,
+            grace_would_start=self._manual_grace_would_start(now),
+        )
+
+    def _manual_grace_would_start(self, now: datetime) -> bool:
+        """Whether manual grace is currently enabled (``CONF_MANUAL_GRACE_PERIOD`` > 0)
+        (Issue #664). Same ``decide_grace_start()`` call ``_start_grace_period_action()``
+        itself makes — every override/grace-modeled event that starts grace uses
+        ``source="manual"``, so this is always resolved against the manual duration,
+        never the automation one.
+        """
+        manual_duration = self.config.get(CONF_MANUAL_GRACE_PERIOD, DEFAULT_MANUAL_GRACE_SECONDS)
+        return (
+            decide_grace_start(
+                source="manual",
+                manual_duration_seconds=manual_duration,
+                manual_should_notify=self.config.get(CONF_MANUAL_GRACE_NOTIFY, True),
+                automation_duration_seconds=self.config.get(
+                    CONF_AUTOMATION_GRACE_PERIOD, DEFAULT_AUTOMATION_GRACE_SECONDS
+                ),
+                automation_should_notify=self.config.get(CONF_AUTOMATION_GRACE_NOTIFY, True),
+                now=now,
+            )
+            is not None
+        )
+
+    @property
+    def override_grace_lifecycle_state(self) -> OverrideGraceLifecycleState:
+        """Current override/grace session state, derived from existing flags
+        (Issue #639, promoted from shadow-only to authoritative-capable in #664).
+
+        Read-only observability by default — the value this property computes is
+        also fed as the ``current_state`` argument to ``override_grace_fsm.transition()``
+        by ``AutomationEngine._resolve_override_grace_fsm_state()``, the shared
+        dispatcher every real override/grace trigger site calls under
+        ``_override_grace_fsm_authoritative``. Purely a computed view of
+        ``_override_confirm_pending``/``_grace_active``/``_grace_protects_override``,
+        so it cannot desync from the flags it reads. See ``override_grace_lifecycle.py``
+        for the pure derivation.
+        """
+        from .override_grace_lifecycle import (
+            OverrideGraceLifecycleInputs,
+            derive_override_grace_lifecycle_state,
+        )
+
+        return derive_override_grace_lifecycle_state(
+            OverrideGraceLifecycleInputs(
+                override_confirm_pending=bool(self._override_confirm_pending),
+                grace_active=bool(self._grace_active),
+                grace_protects_override=bool(self._grace_protects_override),
+            )
+        )
+
+    def _apply_override_grace_fsm_state(self, state: OverrideGraceLifecycleState) -> None:
+        """Write ``_override_confirm_pending``/``_grace_active``/``_grace_protects_override``
+        from an ``override_grace_fsm.transition()`` result (Issue #664).
+
+        The inverse of ``override_grace_lifecycle_state``'s derivation. Deliberately does
+        NOT touch ``_override_confirm_time``/``_mode``/``_source``, ``_grace_end_time``,
+        ``_last_resume_source``, ``_last_grace_trigger``, ``_grace_duration_seconds``, or
+        any ``_manual_override_*``/``_fan_override_active`` field — none of those are part
+        of the 2-tuple's derivation (same "outside the N-field derivation stays a direct
+        per-caller write" rule ``_apply_door_window_fsm_state()``'s own docstring
+        documents).
+
+        Called only from the authoritative branch of ``_resolve_override_grace_fsm_state()``
+        — the real timer/confirm-window primitives (``_start_grace_period_action()``,
+        ``_start_override_confirmation_action()``, ``_cancel_grace_timers_action()``) never
+        write these 3 flags themselves; only this method (FSM path) or the paired legacy
+        closure (non-authoritative path) does, exclusively, so the switch genuinely governs
+        which computation determines these flags rather than one silently overwriting the
+        other. Proven behaviorally equivalent to the legacy closures by construction (see
+        the approved plan's H1) — that equivalence is what makes it safe to flip live, not
+        a reason the split is unnecessary.
+        """
+        confirm, grace = state
+        self._override_confirm_pending = confirm == OverrideConfirmState.PENDING
+        self._grace_active = grace != GraceState.NONE
+        self._grace_protects_override = grace == GraceState.ACTIVE_PROTECTING_OVERRIDE
+
+    def _resolve_override_grace_fsm_state(
+        self,
+        *,
+        kind: OverrideGraceFsmEventKind,
+        legacy: Callable[[], None],
+        origin_state: OverrideGraceLifecycleState | None = None,
+    ) -> None:
+        """Single dispatch point for every override/grace flag-derivation call site
+        (Issue #664, full authority in one PR — see the approved plan's H1-H4 for why
+        this does not need door/window's staged partial-scope rollout).
+
+        **Genuinely mutually exclusive — exactly one of the FSM path or ``legacy()``
+        ever writes `_override_confirm_pending`/`_grace_active`/`_grace_protects_override`
+        for a given call, never both.** An earlier draft of this dispatcher called
+        ``legacy()`` unconditionally after the FSM write "for the real timer side
+        effects," mirroring what looked like door/window's own pattern — but door/window's
+        ``_grace_active`` write is the ONLY one of its 3 flags with that shape, and even
+        there it means the switch has zero real effect on that specific flag (the
+        unconditional real timer call always overwrites it right after). Doing that for
+        ALL THREE of override/grace's flags would make this switch behaviorally inert in
+        every case — not a genuine A/B mechanism, just a decorative toggle. Real timer/
+        confirm-window scheduling is NOT owned here or by ``legacy()`` — callers must
+        already have run the real side-effecting "_action" half of whichever primitive
+        (``_start_grace_period_action()``, ``_start_override_confirmation_action()``,
+        ``_cancel_grace_timers_action()``) *before* calling this dispatcher; both branches
+        below only ever decide the 3 flags, never timers.
+
+        ``legacy`` is the SAME flag-computation the removed inline code used to perform
+        (e.g. ``lambda: self._legacy_set_grace_flags(trigger)``) — called only when NOT
+        authoritative. ``origin_state`` defaults to a live read of
+        ``self.override_grace_lifecycle_state`` — correct for every site except
+        ``_on_grace_expired()``'s branches and ``_check_orphaned_grace()``, both of which
+        must capture state *before* the real cancel action clears the flags being
+        transitioned, and pass it explicitly here.
+        """
+        if self._override_grace_fsm_authoritative:
+            from .override_grace_fsm import OverrideGraceFsmEvent
+            from .override_grace_fsm import transition as _override_grace_transition
+
+            state = origin_state if origin_state is not None else self.override_grace_lifecycle_state
+            result = _override_grace_transition(
+                state,
+                OverrideGraceFsmEvent(kind=kind, inputs=self._build_override_grace_fsm_inputs()),
+            )
+            self._apply_override_grace_fsm_state(result.to_state)
         else:
             legacy()
 

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,20 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.28"
+VERSION = "0.6.29"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.29": [
+        "Feat #664: the override/grace lifecycle FSM (whole-house-fan and thermostat"
+        " manual overrides, and the grace period that protects them from being"
+        " undone) can now optionally drive real production decisions instead of only"
+        " observing them, matching the same opt-in switch nat-vent and door/window"
+        " already have. Off by default and not persisted across a restart — nothing"
+        " changes for any occupant unless this switch is explicitly turned on. Also"
+        " fixes a config edge case found during this work: a manual grace period"
+        " disabled via configuration (0 seconds) could have been reported as active"
+        " with no way to ever clear it, had the switch been turned on before this fix.",
+    ],
     "0.6.28": [
         "Fix #661: the override/grace shadow FSM's diagnostic accuracy for fan"
         " overrides (whole-house-fan remote timers, physical fan-on detection)"
@@ -1947,6 +1958,51 @@ KNOWN_FIXES: dict[int, dict] = {
             " automatically gained FSM-authoritative capability through that one shared"
             " wrapper rather than needing individual treatment — noted here since it's a"
             " correction to the investigation's own site count, not a new gap."
+        ),
+    },
+    664: {
+        "version_fixed": "0.6.29",
+        "title": "Override/grace FSM: full authoritative migration (switch, no partial-scope staging)",
+        "scope_covered": (
+            "override_grace_fsm.py/override_grace_lifecycle.py/automation.py/coordinator.py/"
+            "switch.py/const.py: adds override_grace_fsm_authoritative (default OFF, not"
+            " persisted across restart, same convention as natvent_fsm_authoritative/"
+            " doorwindow_fsm_authoritative), governing _override_confirm_pending/"
+            " _grace_active/_grace_protects_override for all 8 real OverrideGraceFsmEventKind"
+            " call sites in one increment — full authority shipped directly rather than"
+            " door/window's staged partial-scope rollout, because investigation proved every"
+            " flag value these primitives compute is a pure function of their own call"
+            " arguments (never of prior engine state), so the FSM and the legacy inline"
+            " computation are provably equivalent at every site (confirmed by a"
+            " corpus-wide decision-equivalence comparator, switch flipped True, across all"
+            " 81 golden + 7 pending scenarios). Split the 4 timer/flag-owning primitives"
+            " (_start_grace_period(), _cancel_grace_timers(), start_override_confirmation(),"
+            " clear_manual_override()) into an action half (real async_call_later"
+            " scheduling + non-derived bookkeeping, always runs unconditionally — timer"
+            " ownership never transfers to the FSM, same rule door/window's own switch"
+            " already established) and a flags half (dispatcher-owned, genuinely mutually"
+            " exclusive between the FSM and legacy computation — an earlier draft called"
+            " both unconditionally, which would have made the switch behaviorally inert;"
+            " fixed before landing). Found and fixed 2 real correctness gaps the shadow-only"
+            " phase's own tests never exercised: (1) override_grace_fsm.py's landing"
+            " branches (_land_after_detection, DASHBOARD_RESUME, FAN_OVERRIDE_DETECTED)"
+            " never checked whether manual grace is disabled via config"
+            " (manual_grace_seconds=0), which would have made an authoritative FSM claim"
+            " grace_active=True with no real timer behind it — a stuck-forever phantom"
+            " grace, a worse bug class than #661; (2) coordinator.py's 'new_override_during_"
+            " grace' Fix D branch was mis-modeled as OVERRIDE_CANCELLED (Issue #647,"
+            " shadow-only) when its real production behavior never touches grace at all"
+            " (Issue #282's 'Fix D' deliberately leaves the still-running grace protecting"
+            " the new override about to be redetected) — re-classified as OVERRIDE_SUPERSEDED,"
+            " the previously-unreachable 8th event kind, whose own transition already"
+            " correctly preserves grace. Also fixed 2 pre-existing DRY violations found"
+            " during investigation: GRACE_TRIGGERS_PROTECTING_OVERRIDE and"
+            " OVERRIDE_ADOPT_SETPOINT_TOLERANCE_F were each hand-duplicated (override_grace_"
+            "start.py/override_match.py vs automation.py) with no import connecting the"
+            " copies — consolidated into single const.py definitions. Default OFF — zero"
+            " occupant-visible behavior change from this release alone; a live switch-flip"
+            " verification is a separate follow-up step, same as door/window's and"
+            " nat-vent's own switches."
         ),
     },
     661: {
@@ -8198,6 +8254,21 @@ CEILING_ESCALATION_SAVINGS_MARGIN_F: float = 2.0
 # automation.py). Deliberately tight -- this only exists to catch minor floating-point/
 # rounding noise, not to treat a genuinely different user-chosen temperature as a match.
 OVERRIDE_ADOPT_SETPOINT_TOLERANCE_F: float = 1.0
+
+# Issue #664: the ONLY two `_start_grace_period(trigger=...)` values that mean "this grace
+# exists to protect an active manual/fan override" — read by `_start_grace_period()` to set
+# `_grace_protects_override`, which `coordinator._check_orphaned_grace()` uses to scope its
+# self-heal to grace types that can actually BE orphaned (an override was cleared without its
+# grace being cancelled alongside it). Every other grace trigger (fan-off cooldown, physical-
+# drift correction, window-close resume, nat-vent-exit resume, dashboard resume) never sets
+# `_manual_override_active`/`_fan_override_active` in the first place by design — treating
+# their absence as "orphaned" was the root cause of #530's fan-off grace being killed within
+# ~1ms of starting. A future grace-starting call site is automatically excluded here unless
+# its trigger string is deliberately added to this set — if it's meant to protect a real
+# override, add it; if not, leave it out. Single source of truth (Issue #664) — previously
+# also hand-duplicated in override_grace_start.py's own module-level default, which risked
+# silent drift since override_grace_fsm.py's call site never passed the real set explicitly.
+GRACE_TRIGGERS_PROTECTING_OVERRIDE: frozenset[str] = frozenset({"fan_manual_override", "override_confirmed"})
 
 # Issue #249 — thermostat capability detection. Home Assistant's
 # ClimateEntityFeature.TARGET_TEMPERATURE_RANGE bit: when set in a climate entity's

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -1496,6 +1496,25 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             "made authoritative" if enabled else "reverted to legacy computation",
         )
 
+    @property
+    def override_grace_fsm_authoritative(self) -> bool:
+        """Whether the override/grace lifecycle FSM (Issue #639) is authoritative for
+        ``_override_confirm_pending``/``_grace_active``/``_grace_protects_override``
+        (Issue #664 — full authority for all 8 real call sites, no partial-scope caveat
+        unlike ``doorwindow_fsm_authoritative`` above). False = legacy inline flag
+        writes (default)."""
+        return bool(self.automation_engine._override_grace_fsm_authoritative)
+
+    def set_override_grace_fsm_authoritative(self, enabled: bool) -> None:
+        """Flip override/grace FSM authority, live. Same NOT-persisted-across-restart
+        reasoning as ``set_natvent_fsm_authoritative()``'s own docstring.
+        """
+        self.automation_engine._override_grace_fsm_authoritative = enabled
+        _LOGGER.warning(
+            "Override/grace FSM %s for production decisions (full authority — Issue #664)",
+            "made authoritative" if enabled else "reverted to legacy computation",
+        )
+
     async def async_setup(self) -> None:
         """Set up scheduled events and state listeners."""
 
@@ -2693,14 +2712,17 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             "Stuck grace detected: grace_active=True but no override is active — force-cancelling grace (Issue #508)."
         )
         _grace_end = ae._grace_end_time
-        ae._cancel_grace_timers()
-        # Issue #647: this clears `_grace_active` directly via `_cancel_grace_timers()`,
-        # not via `clear_manual_override()`/`_on_grace_expired()` — a distinct mutation
-        # path with no other FSM feed. Closest semantic match is GRACE_TIMER_EXPIRED
-        # (grace ending with nothing left to protect).
-        try:
-            from .override_grace_fsm import OverrideGraceFsmEventKind as _OGFEventKind
+        from .override_grace_fsm import OverrideGraceFsmEventKind as _OGFEventKind
 
+        # Issue #664: this clears `_grace_active` directly, not via `clear_manual_override()`/
+        # `_on_grace_expired()` — confirm was never involved here (Issue #647's own comment:
+        # "not via clear_manual_override()"), so only the grace half is dispatched. Closest
+        # semantic match is GRACE_TIMER_EXPIRED (grace ending with nothing left to protect).
+        ae._cancel_grace_timers_action()
+        ae._resolve_override_grace_fsm_state(
+            kind=_OGFEventKind.GRACE_TIMER_EXPIRED, legacy=ae._legacy_clear_grace_flags
+        )
+        try:
             self._evaluate_override_grace_fsm(_OGFEventKind.GRACE_TIMER_EXPIRED)
         except Exception as fsm_exc:  # noqa: BLE001 — FSM errors must never affect production
             _LOGGER.warning(
@@ -4604,10 +4626,35 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 new_state.state,
                 self.automation_engine._manual_override_mode,
             )
-            self.automation_engine.clear_manual_override(reason="new_override_during_grace")
-            # Issue #647: feeds OVERRIDE_CANCELLED for the clear half of this
-            # clear-then-reopen sequence; Issue #651 wires the reopen half below.
-            self._feed_override_grace_fsm_cancelled()
+            # Issue #664: this is the real production trigger for OVERRIDE_SUPERSEDED,
+            # not OVERRIDE_CANCELLED — clear_manual_override() here never calls
+            # _cancel_grace_timers() (Issue #282's "Fix D" deliberately leaves the
+            # still-running grace protecting the NEW override handle_manual_override()
+            # is about to (re)detect below), unlike cancel_override()'s real
+            # OVERRIDE_CANCELLED behavior which clears both confirm AND grace. Feeding
+            # this as OVERRIDE_CANCELLED (as Issue #647 originally did, shadow-only)
+            # would have made an authoritative FSM wrongly force grace to NONE here.
+            ae = self.automation_engine
+            _was_confirm_pending = ae._override_confirm_pending
+            if _was_confirm_pending:
+                ae._clear_override_confirm_action()
+
+            def _legacy_supersede() -> None:
+                if _was_confirm_pending:
+                    ae._legacy_clear_confirm_flag()
+                # Grace intentionally left untouched — see comment above.
+
+            from .override_grace_fsm import OverrideGraceFsmEventKind as _OGFEventKind
+
+            ae._resolve_override_grace_fsm_state(kind=_OGFEventKind.OVERRIDE_SUPERSEDED, legacy=_legacy_supersede)
+            ae._clear_manual_override_active("new_override_during_grace")
+            try:
+                self._evaluate_override_grace_fsm(_OGFEventKind.OVERRIDE_SUPERSEDED)
+            except Exception as fsm_exc:  # noqa: BLE001 — FSM errors must never affect production
+                _LOGGER.warning(
+                    "Override/grace FSM evaluation (supersession-driven) failed (isolated, no production impact): %s",
+                    fsm_exc,
+                )
             self.automation_engine.handle_manual_override(
                 old_mode=old_state.state,
                 new_mode=new_state.state,

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.28"
+  "version": "0.6.29"
 }

--- a/custom_components/climate_advisor/override_grace_fsm.py
+++ b/custom_components/climate_advisor/override_grace_fsm.py
@@ -137,6 +137,15 @@ class OverrideGraceFsmInputs:
       any_sensor_open            -> self._any_monitored_sensor_open()
       grace_source               -> self._last_resume_source of the EXPIRING grace
                                     ("manual" | "automation")
+      grace_would_start           -> desired_state.decide_grace_start(source="manual", ...)
+                                    is not None for the config values live right now — i.e.
+                                    whether CONF_MANUAL_GRACE_PERIOD is currently > 0
+                                    (Issue #664: manual_grace_seconds=0 is a valid, documented
+                                    way to disable manual grace entirely — every real
+                                    manual-grace-starting transition below must land on
+                                    GraceState.NONE in that case instead of unconditionally
+                                    assuming grace starts, matching what
+                                    ``_start_grace_period_action()`` actually does)
       now                        -> caller-resolved wall-clock time
     """
 
@@ -155,6 +164,7 @@ class OverrideGraceFsmInputs:
     any_sensor_open: bool
     grace_source: str
     now: datetime
+    grace_would_start: bool = True
 
 
 @dataclass(frozen=True)
@@ -187,8 +197,11 @@ def _land_after_detection(inputs: OverrideGraceFsmInputs, current_grace: GraceSt
     )
     if pending is not None:
         return (OverrideConfirmState.PENDING, current_grace)
-    # Confirmation disabled — _confirm_override() fires immediately, which always
-    # (re)starts a manual grace with trigger="override_confirmed" (protects).
+    # Confirmation disabled — _confirm_override() fires immediately, which (re)starts a
+    # manual grace with trigger="override_confirmed" (protects) UNLESS manual grace is
+    # itself disabled via config (Issue #664 — manual_grace_seconds=0 is valid).
+    if not inputs.grace_would_start:
+        return (OverrideConfirmState.IDLE, GraceState.NONE)
     return (OverrideConfirmState.IDLE, GraceState.ACTIVE_PROTECTING_OVERRIDE)
 
 
@@ -232,7 +245,7 @@ def _transition_from_no_grace(
             current_mode=inputs.current_mode or "unknown",
             classification_mode=inputs.classification_mode,
         )
-        if path == OverrideConfirmPathOutcome.CONFIRM:
+        if path == OverrideConfirmPathOutcome.CONFIRM and inputs.grace_would_start:
             next_state = (OverrideConfirmState.IDLE, GraceState.ACTIVE_PROTECTING_OVERRIDE)
         else:
             next_state = (OverrideConfirmState.IDLE, GraceState.NONE)
@@ -243,10 +256,12 @@ def _transition_from_no_grace(
         return OverrideGraceTransition(current_state, next_state, kind, "override_confirmation_started", inputs.now)
 
     if kind == OverrideGraceFsmEventKind.DASHBOARD_RESUME:
-        # resume_from_pause() unconditionally (re)starts grace with
-        # trigger="dashboard_resume" — not in GRACE_TRIGGERS_PROTECTING_OVERRIDE.
+        # resume_from_pause() unconditionally attempts to (re)start grace with
+        # trigger="dashboard_resume" — not in GRACE_TRIGGERS_PROTECTING_OVERRIDE — but
+        # (Issue #664) only actually starts it if manual grace isn't disabled by config.
         assert not decide_grace_protects_override(_TRIGGER_DASHBOARD_RESUME)
-        next_state = (confirm, GraceState.ACTIVE_UNPROTECTED)
+        grace_next = GraceState.ACTIVE_UNPROTECTED if inputs.grace_would_start else GraceState.NONE
+        next_state = (confirm, grace_next)
         return OverrideGraceTransition(current_state, next_state, kind, "resumed", inputs.now)
 
     if kind == OverrideGraceFsmEventKind.OVERRIDE_CANCELLED:
@@ -337,10 +352,19 @@ def _transition_from_grace_unprotected(
             classification_mode=inputs.classification_mode,
         )
         if path == OverrideConfirmPathOutcome.CONFIRM:
-            # _confirm_override() cancels the unprotected grace and starts a
-            # fresh protecting one.
-            next_state = (OverrideConfirmState.IDLE, GraceState.ACTIVE_PROTECTING_OVERRIDE)
+            # _confirm_override() cancels the unprotected grace and starts a fresh
+            # protecting one — unless manual grace is disabled by config (Issue #664),
+            # in which case _start_grace_period_action() itself no-ops and the prior
+            # unprotected grace (cancelled by the same call regardless) does not get
+            # replaced by anything.
+            next_state = (
+                OverrideConfirmState.IDLE,
+                GraceState.ACTIVE_PROTECTING_OVERRIDE if inputs.grace_would_start else GraceState.NONE,
+            )
         else:
+            # PATH B (self-resolve): production never touches grace at all here — the
+            # pre-existing, independent unprotected grace (fan-off/window-close/
+            # dashboard-resume) is left running untouched.
             next_state = (OverrideConfirmState.IDLE, GraceState.ACTIVE_UNPROTECTED)
         return OverrideGraceTransition(current_state, next_state, kind, path.value, inputs.now)
 
@@ -384,7 +408,11 @@ def transition(current_state: OverrideGraceLifecycleState, event: OverrideGraceF
     untouched by the fan path's different contract.
     """
     if event.kind == OverrideGraceFsmEventKind.FAN_OVERRIDE_DETECTED:
-        next_state = (OverrideConfirmState.IDLE, GraceState.ACTIVE_PROTECTING_OVERRIDE)
+        # Issue #664: "unconditional" means unconditional on ORIGIN STATE — it does not
+        # mean grace is guaranteed to actually start; manual_grace_seconds=0 still
+        # disables it, same as every other manual-grace-starting transition.
+        grace_next = GraceState.ACTIVE_PROTECTING_OVERRIDE if event.inputs.grace_would_start else GraceState.NONE
+        next_state = (OverrideConfirmState.IDLE, grace_next)
         return OverrideGraceTransition(
             current_state, next_state, event.kind, "fan_override_immediate", event.inputs.now
         )

--- a/custom_components/climate_advisor/override_grace_start.py
+++ b/custom_components/climate_advisor/override_grace_start.py
@@ -14,11 +14,13 @@ resolves duration/should_notify; this module resolves the one remaining branch
 
 from __future__ import annotations
 
-GRACE_TRIGGERS_PROTECTING_OVERRIDE = frozenset({"fan_manual_override", "override_confirmed"})
-"""Mirrors automation.py's _GRACE_TRIGGERS_PROTECTING_OVERRIDE. Callers should pass the
-real frozenset explicitly via ``protecting_triggers`` rather than relying on this
-duplicate staying in sync — this default exists only so the function is usable
-standalone in tests."""
+from .const import GRACE_TRIGGERS_PROTECTING_OVERRIDE
+
+# Issue #664: previously a hand-duplicated frozenset literal here, independent of
+# automation.py's own copy — override_grace_fsm.py's call site never passed
+# `protecting_triggers=` explicitly, so it silently depended on this duplicate staying
+# in sync by hand. Both automation.py and this module now import the same const.py
+# definition; there is exactly one frozenset, not two kept manually consistent.
 
 
 def decide_grace_protects_override(

--- a/custom_components/climate_advisor/override_match.py
+++ b/custom_components/climate_advisor/override_match.py
@@ -18,10 +18,11 @@ its own caller-resolved boolean.
 
 from __future__ import annotations
 
-OVERRIDE_ADOPT_SETPOINT_TOLERANCE_F = 1.0
-"""Mirrors automation.py's OVERRIDE_ADOPT_SETPOINT_TOLERANCE_F — duplicated as a default
-only; callers should pass the real constant explicitly via ``tolerance_f`` rather than
-relying on this value drifting in sync."""
+from .const import OVERRIDE_ADOPT_SETPOINT_TOLERANCE_F
+
+# Issue #664: previously a hand-duplicated literal (1.0) here, independent of
+# const.py's real OVERRIDE_ADOPT_SETPOINT_TOLERANCE_F that automation.py itself
+# imports. Now the same single definition both modules import.
 
 
 def decide_override_matches_decision(

--- a/custom_components/climate_advisor/switch.py
+++ b/custom_components/climate_advisor/switch.py
@@ -39,6 +39,7 @@ async def async_setup_entry(
             ClimateAdvisorAutomationSwitch(coordinator, entry),
             ClimateAdvisorNatVentFsmAuthoritativeSwitch(coordinator, entry),
             ClimateAdvisorDoorWindowFsmAuthoritativeSwitch(coordinator, entry),
+            ClimateAdvisorOverrideGraceFsmAuthoritativeSwitch(coordinator, entry),
         ]
     )
 
@@ -172,4 +173,55 @@ class ClimateAdvisorDoorWindowFsmAuthoritativeSwitch(CoordinatorEntity, SwitchEn
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Revert to the legacy inline door/window flag writes."""
         self.coordinator.set_doorwindow_fsm_authoritative(False)
+        self.async_write_ha_state()
+
+
+class ClimateAdvisorOverrideGraceFsmAuthoritativeSwitch(CoordinatorEntity, SwitchEntity):
+    """Switch to make the override/grace lifecycle FSM (Issue #639) authoritative for
+    ``_override_confirm_pending``/``_grace_active``/``_grace_protects_override``,
+    instead of each real call site's own inline flag write (Issue #664).
+
+    **Full authority for all 8 real call sites, shipped in one increment** — unlike
+    door/window's staged partial-authority rollout, this switch does not need one.
+    Investigation for Issue #664 proved every flag value these primitives compute is a
+    pure function of their own call arguments (never of prior engine state), so the FSM
+    and the legacy inline computation are provably equivalent at every site — there was
+    no latent derivation ambiguity to discover and fix incrementally the way door/window's
+    11-step rollout did. The real timer-owning primitives (``_start_grace_period_action()``/
+    ``_cancel_grace_timers_action()``/etc.) are never gated by this switch — they always
+    run, unconditionally, exactly like ``_start_grace_period()``/``_cancel_grace_timers()``
+    are never gated by the door/window switch either; only which computation decides the
+    3 flag values is what this switch genuinely governs.
+
+    Default OFF, NOT persisted across a Home Assistant restart — same reasoning as the
+    nat-vent/door-window switches' own docstrings: a restart always comes back up on the
+    proven legacy path, and the owner must explicitly re-enable this each time.
+    """
+
+    _attr_icon = "mdi:state-machine"
+    _attr_entity_category = None
+
+    def __init__(
+        self,
+        coordinator: ClimateAdvisorCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize the override/grace FSM-authoritative switch."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{entry.entry_id}_override_grace_fsm_authoritative"
+        self._attr_name = "Climate Advisor Override/Grace FSM Authoritative"
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if the override/grace FSM is authoritative for production decisions."""
+        return self.coordinator.override_grace_fsm_authoritative
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Make the override/grace FSM authoritative."""
+        self.coordinator.set_override_grace_fsm_authoritative(True)
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Revert to the legacy inline override/grace flag writes."""
+        self.coordinator.set_override_grace_fsm_authoritative(False)
         self.async_write_ha_state()

--- a/tests/test_grace_refresh_and_band_call.py
+++ b/tests/test_grace_refresh_and_band_call.py
@@ -63,6 +63,8 @@ def _minimal_engine() -> AutomationEngine:
             "_paused_with_hvac_already_off": False,
             "_pre_pause_mode": None,
             "_doorwindow_fsm_authoritative": False,
+            "_override_grace_fsm_authoritative": False,
+            "_grace_protects_override": False,
             "_manual_grace_cancel": None,
             "_automation_grace_cancel": None,
             "_grace_active": True,  # grace is active when expiry fires

--- a/tests/test_grace_restart_behavior.py
+++ b/tests/test_grace_restart_behavior.py
@@ -366,7 +366,13 @@ class TestNewOverrideDuringGrace:
 
         asyncio.run(coord._async_thermostat_changed(event))
 
-        coord.automation_engine.clear_manual_override.assert_called_once()
+        # Issue #664: clear_manual_override() itself is no longer called directly here —
+        # the confirm-clear half is dispatched via _resolve_override_grace_fsm_state()
+        # (OVERRIDE_SUPERSEDED), and _clear_manual_override_active() performs the rest
+        # (was clear_manual_override()'s own second half). See coordinator.py's
+        # 'new_override_during_grace' branch docstring for why this is OVERRIDE_SUPERSEDED,
+        # not OVERRIDE_CANCELLED (grace must stay untouched here).
+        coord.automation_engine._clear_manual_override_active.assert_called_once()
         coord.automation_engine.handle_manual_override.assert_called_once()
 
     def test_same_mode_during_grace_not_refired(self):

--- a/tests/test_grace_stuck.py
+++ b/tests/test_grace_stuck.py
@@ -402,11 +402,11 @@ class TestOrphanedGraceDetection:
             grace_end_time="2026-06-12T21:53:00+00:00",
         )
         coord.automation_engine._fan_override_active = False
-        coord.automation_engine._cancel_grace_timers = MagicMock()
+        coord.automation_engine._cancel_grace_timers_action = MagicMock()
 
         coord._check_orphaned_grace()
 
-        coord.automation_engine._cancel_grace_timers.assert_called_once()
+        coord.automation_engine._cancel_grace_timers_action.assert_called_once()
         coord._emit_event.assert_called_once()
         event_name, event_data = coord._emit_event.call_args[0]
         assert event_name == "stuck_grace_recovered"
@@ -424,11 +424,11 @@ class TestOrphanedGraceDetection:
             grace_end_time="2026-06-12T21:53:00+00:00",
         )
         coord.automation_engine._fan_override_active = False
-        coord.automation_engine._cancel_grace_timers = MagicMock()
+        coord.automation_engine._cancel_grace_timers_action = MagicMock()
 
         coord._check_orphaned_grace()
 
-        coord.automation_engine._cancel_grace_timers.assert_not_called()
+        coord.automation_engine._cancel_grace_timers_action.assert_not_called()
         coord._emit_event.assert_not_called()
 
     def test_orphaned_grace_not_cancelled_when_fan_override_active(self):
@@ -443,11 +443,11 @@ class TestOrphanedGraceDetection:
             grace_end_time="2026-06-12T21:53:00+00:00",
         )
         coord.automation_engine._fan_override_active = True
-        coord.automation_engine._cancel_grace_timers = MagicMock()
+        coord.automation_engine._cancel_grace_timers_action = MagicMock()
 
         coord._check_orphaned_grace()
 
-        coord.automation_engine._cancel_grace_timers.assert_not_called()
+        coord.automation_engine._cancel_grace_timers_action.assert_not_called()
         coord._emit_event.assert_not_called()
 
     def test_no_orphaned_grace_when_grace_inactive(self):
@@ -458,11 +458,11 @@ class TestOrphanedGraceDetection:
             grace_end_time=None,
         )
         coord.automation_engine._fan_override_active = False
-        coord.automation_engine._cancel_grace_timers = MagicMock()
+        coord.automation_engine._cancel_grace_timers_action = MagicMock()
 
         coord._check_orphaned_grace()
 
-        coord.automation_engine._cancel_grace_timers.assert_not_called()
+        coord.automation_engine._cancel_grace_timers_action.assert_not_called()
         coord._emit_event.assert_not_called()
 
     def test_orphaned_grace_not_cancelled_when_grace_does_not_protect_override(self):
@@ -481,11 +481,11 @@ class TestOrphanedGraceDetection:
         )
         coord.automation_engine._fan_override_active = False
         coord.automation_engine._grace_protects_override = False
-        coord.automation_engine._cancel_grace_timers = MagicMock()
+        coord.automation_engine._cancel_grace_timers_action = MagicMock()
 
         coord._check_orphaned_grace()
 
-        coord.automation_engine._cancel_grace_timers.assert_not_called()
+        coord.automation_engine._cancel_grace_timers_action.assert_not_called()
         coord._emit_event.assert_not_called()
 
     def test_orphaned_grace_still_cancelled_when_protects_override_and_flags_gone(self):
@@ -500,11 +500,11 @@ class TestOrphanedGraceDetection:
         )
         coord.automation_engine._fan_override_active = False
         coord.automation_engine._grace_protects_override = True
-        coord.automation_engine._cancel_grace_timers = MagicMock()
+        coord.automation_engine._cancel_grace_timers_action = MagicMock()
 
         coord._check_orphaned_grace()
 
-        coord.automation_engine._cancel_grace_timers.assert_called_once()
+        coord.automation_engine._cancel_grace_timers_action.assert_called_once()
         coord._emit_event.assert_called_once()
 
 

--- a/tests/test_override_confirmation.py
+++ b/tests/test_override_confirmation.py
@@ -20,6 +20,7 @@ from custom_components.climate_advisor.classifier import DayClassification
 from custom_components.climate_advisor.const import (
     CONF_OVERRIDE_CONFIRM_PERIOD,
 )
+from custom_components.climate_advisor.override_grace_fsm import OverrideGraceFsmEventKind
 
 # Patch dt_util.now to return a real datetime (needed for isoformat() calls)
 sys.modules["homeassistant.util.dt"].now = lambda: datetime(2026, 3, 19, 14, 30, 0)
@@ -111,7 +112,7 @@ def _start_confirmation_and_capture(engine, source="normal"):
         patch("custom_components.climate_advisor.automation.callback", side_effect=lambda fn: fn),
         patch("custom_components.climate_advisor.automation.async_call_later", side_effect=_fake_async_call_later),
     ):
-        engine.start_override_confirmation(source=source)
+        engine.start_override_confirmation(source=source, event_kind=OverrideGraceFsmEventKind.OVERRIDE_DETECTED)
 
     return captured[0] if captured else None
 
@@ -132,7 +133,7 @@ class TestConfirmationBypass:
         state.state = "cool"
         engine.hass.states.get.return_value = state
 
-        engine.start_override_confirmation(source="normal")
+        engine.start_override_confirmation(source="normal", event_kind=OverrideGraceFsmEventKind.OVERRIDE_DETECTED)
 
         assert engine._manual_override_active is True
         assert engine._manual_override_mode == "cool"

--- a/tests/test_override_dedup.py
+++ b/tests/test_override_dedup.py
@@ -32,6 +32,7 @@ sys.modules["homeassistant.util.dt"].now = lambda: _NOW_BASE
 
 from custom_components.climate_advisor.automation import AutomationEngine  # noqa: E402
 from custom_components.climate_advisor.classifier import DayClassification  # noqa: E402
+from custom_components.climate_advisor.override_grace_fsm import OverrideGraceFsmEventKind  # noqa: E402
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -258,7 +259,7 @@ class TestOverrideEventDeduplication:
         engine._emit_event_callback = lambda name, payload: emitted.append((name, payload))
 
         with patch("custom_components.climate_advisor.automation.async_call_later"):
-            engine.start_override_confirmation("normal")
+            engine.start_override_confirmation("normal", event_kind=OverrideGraceFsmEventKind.OVERRIDE_DETECTED)
 
         override_events = [e for e in emitted if e[0] == "override_detected"]
         assert len(override_events) == 1, f"Expected exactly 1 override_detected, got {len(override_events)}: {emitted}"
@@ -277,10 +278,10 @@ class TestOverrideEventDeduplication:
             patch("custom_components.climate_advisor.automation.dt_util") as mock_dt,
         ):
             mock_dt.now.return_value = t0
-            engine.start_override_confirmation("normal")
+            engine.start_override_confirmation("normal", event_kind=OverrideGraceFsmEventKind.OVERRIDE_DETECTED)
 
             mock_dt.now.return_value = t1
-            engine.start_override_confirmation("normal")
+            engine.start_override_confirmation("normal", event_kind=OverrideGraceFsmEventKind.OVERRIDE_DETECTED)
 
         override_events = [e for e in emitted if e[0] == "override_detected"]
         assert len(override_events) == 1, (
@@ -303,10 +304,10 @@ class TestOverrideEventDeduplication:
             patch("custom_components.climate_advisor.automation.dt_util") as mock_dt,
         ):
             mock_dt.now.return_value = t0
-            engine.start_override_confirmation("normal")
+            engine.start_override_confirmation("normal", event_kind=OverrideGraceFsmEventKind.OVERRIDE_DETECTED)
 
             mock_dt.now.return_value = t1
-            engine.start_override_confirmation("normal")
+            engine.start_override_confirmation("normal", event_kind=OverrideGraceFsmEventKind.OVERRIDE_DETECTED)
 
         override_events = [e for e in emitted if e[0] == "override_detected"]
         assert len(override_events) == 2, (
@@ -332,13 +333,13 @@ class TestOverrideEventDeduplication:
 
             with patch("custom_components.climate_advisor.automation.dt_util") as mock_dt:
                 mock_dt.now.return_value = t0
-                engine.start_override_confirmation("normal")
+                engine.start_override_confirmation("normal", event_kind=OverrideGraceFsmEventKind.OVERRIDE_DETECTED)
 
                 # After first call, _override_confirm_cancel should be set
                 first_cancel = engine._override_confirm_cancel
 
                 mock_dt.now.return_value = t1
-                engine.start_override_confirmation("normal")
+                engine.start_override_confirmation("normal", event_kind=OverrideGraceFsmEventKind.OVERRIDE_DETECTED)
 
         # The first cancel function should have been called (timer restarted)
         assert cancel_mock.called or first_cancel is None or first_cancel.called, (
@@ -366,6 +367,7 @@ class TestOverrideEventDeduplication:
             with patch("custom_components.climate_advisor.automation.async_call_later"):
                 engine.start_override_confirmation(
                     "normal",
+                    event_kind=OverrideGraceFsmEventKind.OVERRIDE_DETECTED,
                     old_mode="off",
                     new_mode="heat",
                     classification_mode="off",

--- a/tests/test_override_grace_fsm_authoritative_compare.py
+++ b/tests/test_override_grace_fsm_authoritative_compare.py
@@ -1,0 +1,170 @@
+"""Tests for Issue #664: decision-equivalence for the override/grace FSM-authoritative
+full-authority swap.
+
+Prior coverage (``test_shadow_engine_coverage.py``, ``test_override_grace_fsm_shadow_
+wiring.py``) only proved *state-label* agreement in shadow mode. This file proves the
+stronger claim full authority needs before any live switch is considered: flipping
+``AutomationEngine._override_grace_fsm_authoritative`` from its default ``False`` to
+``True`` produces a byte-for-byte identical ``event_log``/``action_log`` across the
+full golden + pending scenario corpus.
+
+**Corpus coverage confirmed, not assumed**: FAN_OVERRIDE_DETECTED (RF-remote/manual
+fan-on) and DASHBOARD_RESUME (dashboard "Resume HVAC" button) both have no scenario-
+event mapping in ``tools/sim_harness/run_production.py`` — same "narrower than it
+looks" finding door/window's and nat-vent's own comparators already flagged. Both get
+direct-engine-construction positive controls below.
+
+**The manual_grace_seconds=0 edge case (Issue #664's own finding)**: investigation for
+this migration found the FSM's landing branches originally never checked whether manual
+grace was disabled by config, which would have made an authoritative FSM claim
+``_grace_active=True`` with no real timer behind it — a worse bug class than #661. Fixed
+in ``override_grace_fsm.py`` before this switch was added; ``TestGraceDisabledPositive
+Control`` below is the regression guard proving it stays fixed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.sim_harness.differential import diff_runs
+from tools.sim_harness.override_grace_fsm_authoritative_compare import fsm_authoritative_mutation
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_GOLDEN_DIR = _REPO_ROOT / "tools" / "simulations" / "golden"
+_PENDING_DIR = _REPO_ROOT / "tools" / "simulations" / "pending"
+
+
+def _load_scenario(path: Path) -> dict:
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _all_golden_and_pending_scenarios() -> list[Path]:
+    paths = [p for p in _GOLDEN_DIR.glob("*.json") if p.name != "MANIFEST.json"]
+    paths += [p for p in _PENDING_DIR.glob("*.json") if p.name != "MANIFEST.json"]
+    return sorted(paths)
+
+
+class TestFsmAuthoritativeEquivalence:
+    @pytest.mark.parametrize("scenario_path", _all_golden_and_pending_scenarios(), ids=lambda p: p.stem)
+    def test_flag_on_produces_identical_outcome(self, scenario_path: Path) -> None:
+        scenario = _load_scenario(scenario_path)
+        diff = diff_runs(scenario, mutate_b=fsm_authoritative_mutation, scenario_name=scenario_path.stem)
+        assert not diff.a_error and not diff.b_error, (
+            f"{scenario_path.stem}: a_error={diff.a_error!r} b_error={diff.b_error!r}"
+        )
+        assert diff.is_clean, (
+            f"{scenario_path.stem}: FSM-authoritative diverged from baseline — "
+            f"{len(diff.event_divergences)} event, {len(diff.action_divergences)} action divergences — "
+            f"full authority must be a behavioral no-op (Issue #664 H1)"
+        )
+
+
+def _make_engine(**overrides):
+    from unittest.mock import AsyncMock, MagicMock
+
+    from custom_components.climate_advisor.automation import AutomationEngine
+
+    hass = MagicMock()
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+    hass.async_create_task = MagicMock(side_effect=lambda coro: coro.close())
+    climate_state = MagicMock()
+    climate_state.state = "cool"
+    climate_state.attributes = {"temperature": 74.0}
+    hass.states = MagicMock()
+    hass.states.get = MagicMock(return_value=climate_state)
+
+    engine = AutomationEngine(
+        hass=hass,
+        climate_entity="climate.thermostat",
+        weather_entity="weather.forecast_home",
+        door_window_sensors=["binary_sensor.front_door"],
+        notify_service="notify.notify",
+        config={
+            "comfort_heat": 70.0,
+            "comfort_cool": 76.0,
+            "manual_grace_seconds": 1800,
+            "automation_grace_seconds": 300,
+        },
+    )
+    engine._override_grace_fsm_authoritative = True
+    for key, value in overrides.items():
+        setattr(engine, key, value)
+    return engine
+
+
+class TestFanOverrideDetectedPositiveControl:
+    """FAN_OVERRIDE_DETECTED has no scenario-event mapping in run_production.py
+    (fan manual-override detection isn't simulated) — direct construction needed."""
+
+    def test_broken_transition_detected(self) -> None:
+        from unittest.mock import patch
+
+        from custom_components.climate_advisor.override_grace_lifecycle import GraceState, OverrideConfirmState
+
+        engine = _make_engine()
+        with patch(
+            "custom_components.climate_advisor.override_grace_fsm.transition",
+            side_effect=lambda *a, **k: type(
+                "T",
+                (),
+                {"to_state": (OverrideConfirmState.IDLE, GraceState.NONE), "outcome": "broken", "at": None},
+            )(),
+        ):
+            engine.handle_fan_manual_override(fan_before="auto", fan_after="on")
+
+        assert engine._grace_active is False, (
+            "positive control FAILED: forcing override_grace_fsm.transition() to return grace=NONE "
+            "was not reflected in engine._grace_active — the mock wasn't actually exercised (real "
+            "outcome should be grace=ACTIVE_PROTECTING_OVERRIDE, so an undetected broken swap would "
+            "incorrectly show _grace_active=True instead)"
+        )
+
+    def test_unbroken_transition_activates_grace_normally(self) -> None:
+        engine = _make_engine()
+        engine.handle_fan_manual_override(fan_before="auto", fan_after="on")
+        assert engine._grace_active is True
+        assert engine._grace_protects_override is True
+
+
+class TestDashboardResumePositiveControl:
+    """DASHBOARD_RESUME has no scenario-event mapping — the sim harness doesn't
+    simulate the dashboard 'Resume HVAC' endpoint. Direct construction needed,
+    same finding door/window's own comparator already established for this method."""
+
+    def test_unbroken_transition_starts_unprotected_grace(self) -> None:
+        import asyncio
+
+        engine = _make_engine(_paused_by_door=True, _current_classification=None)
+        asyncio.run(engine.resume_from_pause())
+        assert engine._grace_active is True
+        assert engine._grace_protects_override is False
+
+
+class TestGraceDisabledPositiveControl:
+    """Issue #664's own core finding: manual_grace_seconds=0 must land on
+    GraceState.NONE, not be forced to an active state regardless of config. This is
+    a regression guard for the fix in override_grace_fsm.py's landing branches."""
+
+    def test_fan_override_with_grace_disabled_does_not_claim_active(self) -> None:
+        engine = _make_engine(config={"comfort_heat": 70.0, "comfort_cool": 76.0, "manual_grace_seconds": 0})
+        engine.handle_fan_manual_override(fan_before="auto", fan_after="on")
+        assert engine._grace_active is False, (
+            "manual_grace_seconds=0 must never result in _grace_active=True — no real timer exists "
+            "to ever clear it, which would be a stuck-forever phantom grace"
+        )
+
+    def test_dashboard_resume_with_grace_disabled_does_not_claim_active(self) -> None:
+        import asyncio
+
+        engine = _make_engine(
+            config={"comfort_heat": 70.0, "comfort_cool": 76.0, "manual_grace_seconds": 0},
+            _paused_by_door=True,
+            _current_classification=None,
+        )
+        asyncio.run(engine.resume_from_pause())
+        assert engine._grace_active is False

--- a/tests/test_override_grace_fsm_authoritative_switch.py
+++ b/tests/test_override_grace_fsm_authoritative_switch.py
@@ -1,0 +1,63 @@
+"""Tests for Issue #664: the override/grace FSM-authoritative cutover switch's
+coordinator-level plumbing.
+
+Binds the REAL ``ClimateAdvisorCoordinator.override_grace_fsm_authoritative``/
+``set_override_grace_fsm_authoritative()`` (object.__new__() + types.MethodType(),
+the established partial-instantiation pattern — see test_contact_status.py)
+rather than re-implementing the toggle logic in the test body, per this
+project's doctrine against mirror tests.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+if "homeassistant" not in sys.modules:
+    from conftest import _install_ha_stubs
+
+    _install_ha_stubs()
+
+from custom_components.climate_advisor.coordinator import ClimateAdvisorCoordinator
+
+
+def _make_coordinator() -> ClimateAdvisorCoordinator:
+    # object.__new__() preserves the real class, so the real
+    # `override_grace_fsm_authoritative` property (a class-level descriptor) already
+    # resolves without manual binding — only the plain method needs explicit
+    # types.MethodType() binding.
+    coord = object.__new__(ClimateAdvisorCoordinator)
+    coord.automation_engine = MagicMock()
+    coord.automation_engine._override_grace_fsm_authoritative = False
+    coord.set_override_grace_fsm_authoritative = types.MethodType(
+        ClimateAdvisorCoordinator.set_override_grace_fsm_authoritative, coord
+    )
+    return coord
+
+
+class TestOverrideGraceFsmAuthoritativeToggle:
+    def test_defaults_reflect_engine_flag(self):
+        coord = _make_coordinator()
+        assert coord.override_grace_fsm_authoritative is False
+
+    def test_enabling_sets_engine_flag(self):
+        coord = _make_coordinator()
+        coord.set_override_grace_fsm_authoritative(True)
+        assert coord.automation_engine._override_grace_fsm_authoritative is True
+        assert coord.override_grace_fsm_authoritative is True
+
+    def test_disabling_clears_engine_flag(self):
+        coord = _make_coordinator()
+        coord.set_override_grace_fsm_authoritative(True)
+        coord.set_override_grace_fsm_authoritative(False)
+        assert coord.automation_engine._override_grace_fsm_authoritative is False
+        assert coord.override_grace_fsm_authoritative is False
+
+    def test_not_persisted_no_save_state_call(self):
+        """Deliberately does not call _async_save_state — see the method's own
+        docstring: a restart must always come back up on the legacy path."""
+        coord = _make_coordinator()
+        coord.hass = MagicMock()
+        coord.set_override_grace_fsm_authoritative(True)
+        coord.hass.async_create_task.assert_not_called()

--- a/tests/test_setpoint_override.py
+++ b/tests/test_setpoint_override.py
@@ -22,6 +22,7 @@ from custom_components.climate_advisor.classifier import DayClassification
 from custom_components.climate_advisor.const import (
     CONF_OVERRIDE_CONFIRM_PERIOD,
 )
+from custom_components.climate_advisor.override_grace_fsm import OverrideGraceFsmEventKind
 
 # Patch dt_util.now to return a real datetime (needed for isoformat() calls)
 sys.modules["homeassistant.util.dt"].now = lambda: datetime(2026, 6, 1, 17, 0, 0)
@@ -105,7 +106,7 @@ def _start_confirmation_and_capture(engine, source="normal"):
         patch("custom_components.climate_advisor.automation.callback", side_effect=lambda fn: fn),
         patch("custom_components.climate_advisor.automation.async_call_later", side_effect=_fake_async_call_later),
     ):
-        engine.start_override_confirmation(source=source)
+        engine.start_override_confirmation(source=source, event_kind=OverrideGraceFsmEventKind.OVERRIDE_DETECTED)
 
     return captured[0] if captured else None
 

--- a/tests/test_shadow_engine_coverage.py
+++ b/tests/test_shadow_engine_coverage.py
@@ -166,6 +166,47 @@ _COVERAGE_REGISTRY: dict[str, str] = {
         "(2 unmirrored sites); all fields it clears are covered by _sync_shadow_inputs() raw copy "
         "(Issue #631)"
     ),
+    # Issue #664: override/grace full authoritative migration. The action/flags split
+    # (mirroring door/window's own _pause_for_door_window_action() precedent) introduced
+    # several small internal helpers — none are new entry points, all are called only
+    # from the real call sites already classified above (now routed through
+    # _resolve_override_grace_fsm_state() instead of writing flags inline).
+    "_apply_override_grace_fsm_state": (
+        "internal: Issue #664 helper, called only from the FSM-authoritative branch of "
+        "_resolve_override_grace_fsm_state() — the inverse of override_grace_lifecycle_state's "
+        "derivation, same role as _apply_door_window_fsm_state above"
+    ),
+    "_confirm_override_action": (
+        "internal: Issue #664 action half of _confirm_override (exempted above) — called from "
+        "start_override_confirmation()'s immediate-accept branch and the internal "
+        "_confirm_override_expired timer closure's PATH A, both already covered by "
+        "start_override_confirmation's own exemption"
+    ),
+    "_clear_override_confirm_action": (
+        "internal: Issue #664 action half of clear_manual_override's confirm-clear branch — "
+        "called from cancel_override() (exempted), _on_grace_expired() (internal), and "
+        "clear_manual_override() itself (exempted)"
+    ),
+    "_clear_manual_override_active": (
+        "internal: Issue #664 helper extracted from clear_manual_override's second half — "
+        "called from clear_manual_override() (exempted) and cancel_override() (exempted)"
+    ),
+    "_legacy_set_grace_flags": (
+        "internal: Issue #664 trivial 2-line flag-set, passed as the non-authoritative "
+        "'legacy' closure to _resolve_override_grace_fsm_state() at every real grace-starting "
+        "call site, and reused by _start_grace_period()'s own thin wrapper for every "
+        "non-FSM-modeled trigger (fan-off, window-close, nat-vent-exit)"
+    ),
+    "_legacy_clear_grace_flags": (
+        "internal: Issue #664 trivial 2-line flag-clear, passed as the non-authoritative "
+        "'legacy' closure to _resolve_override_grace_fsm_state() at the GRACE_TIMER_EXPIRED/"
+        "OVERRIDE_CANCELLED call sites, and reused by _cancel_grace_timers()'s own thin wrapper"
+    ),
+    "_legacy_clear_confirm_flag": (
+        "internal: Issue #664 trivial 1-line flag-clear, passed as the non-authoritative "
+        "'legacy' closure to _resolve_override_grace_fsm_state() wherever confirm is cleared, "
+        "and reused by clear_manual_override()'s own thin wrapper"
+    ),
 }
 
 
@@ -269,14 +310,17 @@ _OVERRIDE_GRACE_EVENT_KIND_REGISTRY: dict[str, str] = {
     "OVERRIDE_CONFIRM_EXPIRED": "reachable",
     "OVERRIDE_CANCELLED": "reachable",
     "GRACE_TIMER_EXPIRED": "reachable",
-    "OVERRIDE_SUPERSEDED": (
-        "unreachable: no production code path emits this distinct kind today — the "
-        "closest real case (a mode change arriving during an active override grace, "
-        "coordinator.py's 'new_override_during_grace' branch) still feeds OVERRIDE_CANCELLED "
-        "for the clear half then OVERRIDE_DETECTED (via the now-mirrored "
-        "handle_manual_override(), Issue #651) for the reopen half, rather than a single "
-        "distinct SUPERSEDED transition"
-    ),
+    # Issue #664: re-classified reachable. Investigation for the full-authority migration
+    # found the OVERRIDE_CANCELLED classification above was a real, dangerous mismatch —
+    # coordinator.py's 'new_override_during_grace' branch (clear_manual_override() call)
+    # never touches grace (Issue #282's "Fix D" deliberately leaves the still-running
+    # grace protecting the NEW override handle_manual_override() immediately re-detects),
+    # but OVERRIDE_CANCELLED's own transition unconditionally forces grace to NONE. Feeding
+    # this real site as OVERRIDE_CANCELLED would have made an authoritative FSM wrongly
+    # clear a grace period production intentionally preserves. OVERRIDE_SUPERSEDED's own
+    # transition (_land_after_detection with grace fixed at ACTIVE_PROTECTING_OVERRIDE)
+    # correctly matches production's real "confirm re-evaluated, grace untouched" behavior.
+    "OVERRIDE_SUPERSEDED": "reachable",
 }
 
 

--- a/tests/test_window_hvac_interaction.py
+++ b/tests/test_window_hvac_interaction.py
@@ -95,7 +95,10 @@ def _make_ae_stub(**overrides) -> AutomationEngine:
     ae._paused_with_hvac_already_off = False
     ae._pre_pause_mode = None
     ae._doorwindow_fsm_authoritative = False
+    ae._override_grace_fsm_authoritative = False
     ae._grace_active = False
+    ae._grace_protects_override = False
+    ae._override_confirm_pending = False
     ae._grace_end_time = None
     ae._last_resume_source = None
     ae._last_outdoor_temp = 65.0
@@ -132,6 +135,7 @@ def _make_ae_stub(**overrides) -> AutomationEngine:
     ae._start_grace_period = types.MethodType(_ae_mod.AutomationEngine._start_grace_period, ae)
     ae._cancel_grace_timers = types.MethodType(_ae_mod.AutomationEngine._cancel_grace_timers, ae)
     ae.clear_manual_override = MagicMock()
+    ae._clear_manual_override_active = MagicMock()
 
     return ae
 

--- a/tools/sim_harness/override_grace_fsm_authoritative_compare.py
+++ b/tools/sim_harness/override_grace_fsm_authoritative_compare.py
@@ -1,0 +1,48 @@
+"""override_grace_fsm_authoritative_compare — full-authority equivalence proof
+(Issue #664), override/grace lifecycle.
+
+Same shape and purpose as ``doorwindow_fsm_authoritative_compare.py``/
+``nat_vent_fsm_authoritative_compare.py`` — proves that flipping
+``AutomationEngine._override_grace_fsm_authoritative`` from its default ``False``
+to ``True`` produces a byte-for-byte identical ``event_log``/``action_log`` across
+the full golden + pending scenario corpus.
+
+**Full authority, no partial-scope caveat** (unlike door/window's own comparator,
+which only covers 2 of 7 methods for its increment) — this flag governs all 8 real
+``OverrideGraceFsmEventKind`` call sites simultaneously; see
+``AutomationEngine._resolve_override_grace_fsm_state()``'s docstring and the
+approved Issue #664 plan's H1-H4 for why full authority was safe to ship in one
+increment rather than staged.
+
+Use via ``tools.sim_harness.differential.diff_runs(scenario,
+mutate_b=fsm_authoritative_mutation)`` — run A is untouched production (flag
+default False), run B forces the flag True on every engine instance constructed
+during that run. ``diff.is_clean`` must be True for every scenario in the
+golden/pending corpus.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+
+@contextmanager
+def fsm_authoritative_mutation() -> Iterator[None]:
+    """Force ``_override_grace_fsm_authoritative = True`` on every engine
+    constructed while this context is active — the "run B" side of a diff_runs
+    comparison.
+    """
+    from unittest.mock import patch
+
+    from custom_components.climate_advisor.automation import AutomationEngine
+
+    original_init = AutomationEngine.__init__
+
+    def _wrapped_init(self: Any, *args: Any, **kwargs: Any) -> None:
+        original_init(self, *args, **kwargs)
+        self._override_grace_fsm_authoritative = True
+
+    with patch.object(AutomationEngine, "__init__", _wrapped_init):
+        yield


### PR DESCRIPTION
## Summary

- Adds `override_grace_fsm_authoritative` switch (default OFF, not persisted across
  restart, same convention as `natvent_fsm_authoritative`/`doorwindow_fsm_authoritative`),
  governing `_override_confirm_pending`/`_grace_active`/`_grace_protects_override` for
  all 8 real `OverrideGraceFsmEventKind` call sites in one increment.
- Unlike door/window's staged partial-authority rollout (#660, 11 steps), this ships
  full authority directly — investigation (scientific-method hypothesis testing, see
  the approved plan) proved every flag value these primitives compute is a pure
  function of their own call arguments, never of prior engine state, so the FSM and
  legacy computation are provably equivalent everywhere. Confirmed by a corpus-wide
  decision-equivalence comparator (switch flipped True) across all 81 golden + 7
  pending scenarios — zero divergence.
- Splits the 4 timer/flag-owning primitives (`_start_grace_period()`,
  `_cancel_grace_timers()`, `start_override_confirmation()`, `clear_manual_override()`)
  into an action half (real `async_call_later` scheduling + non-derived bookkeeping,
  always runs unconditionally — timer ownership never transfers to the FSM, same rule
  door/window's own switch already established) and a flags half (genuinely
  dispatcher-owned, mutually exclusive between FSM and legacy — an earlier draft called
  both unconditionally, which would have made the switch behaviorally inert; caught
  and fixed before landing, per explicit user direction to build a genuine A/B
  mechanism rather than a decorative one).

## Real correctness gaps found and fixed during investigation

1. `override_grace_fsm.py`'s landing branches (`_land_after_detection`,
   `DASHBOARD_RESUME`, `FAN_OVERRIDE_DETECTED`) never checked whether manual grace is
   disabled via config (`manual_grace_seconds=0`) — an authoritative FSM would have
   claimed `_grace_active=True` with no real timer behind it, a stuck-forever phantom
   grace (worse bug class than #661). Fixed via a new `grace_would_start` input,
   computed from the same `decide_grace_start()` the real primitive already calls.
2. `coordinator.py`'s `"new_override_during_grace"` Fix D branch was mis-modeled as
   `OVERRIDE_CANCELLED` (shadow-only, Issue #647) when its real production behavior
   never touches grace at all (Issue #282's "Fix D" deliberately leaves the
   still-running grace protecting the new override about to be redetected) —
   re-classified as `OVERRIDE_SUPERSEDED`, the previously "unreachable" 8th event
   kind, whose own transition already correctly preserves grace.

## DRY cleanup

Two pre-existing duplicated constants (`GRACE_TRIGGERS_PROTECTING_OVERRIDE` in
`override_grace_start.py`, `OVERRIDE_ADOPT_SETPOINT_TOLERANCE_F` in `override_match.py`
— both hand-copied from `automation.py` with no import connecting them) consolidated
into single `const.py` definitions.

## Test plan

- [x] Full test suite (4858 passed, 6 skipped), warnings-as-errors
- [x] `ruff check` + `ruff format` clean
- [x] Golden corpus: 81/81 passed (switch OFF, default — zero behavior change)
- [x] Pending corpus: 7/7 passed
- [x] Golden integrity check clean
- [x] New decision-equivalence comparator: switch ON, full golden+pending corpus,
      zero divergence (`test_override_grace_fsm_authoritative_compare.py`)
- [x] Positive controls proving a broken FSM transition would be caught (fan-override,
      dashboard-resume, and the grace-disabled edge case specifically)
- [x] New switch plumbing tests (`test_override_grace_fsm_authoritative_switch.py`)
- [x] Version bump 0.6.28 → 0.6.29, `RELEASE_NOTES`/`KNOWN_FIXES[664]`/`CHANGELOG.md`
      all updated, `test_version_sync.py` passes

**Not merged/deployed** — switch defaults OFF, zero occupant-visible behavior change
from this PR alone. Per standing instruction, awaiting explicit go-ahead before
merge/deploy.