### PR TITLE
Fix #668: door/window shadow FSM unconditionally reset by check_natural_vent_conditions() re-check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.31] — 2026-08-17
+
+- Fix #668: no user-visible change. The shadow-diagnostic door/window FSM was being wrongly reset every automation cycle whenever a door/window was left open with no imminent free-cooling opportunity — a diagnostic-only bug (real HVAC pause behavior was always correct). The periodic nat-vent re-check was unconditionally signalling "nat-vent just reactivated while paused" on every call, regardless of whether that actually happened. Made the signal event-driven instead, so it only fires when nat-vent genuinely reactivates.
+
 ## [0.6.30] — 2026-08-17
 
 - Fix #666: no user-visible change. The coordinator test harness silently dropped the shadow-diagnostic FSM feed for every nat-vent/door-window exit event — a test-infrastructure bug, not a production one (real HVAC pause behavior was always correct). Fixed the harness wiring, closed a matching coverage gap where one specific nat-vent exit reason never emitted its Activity Report event at all, and added a regression test proven load-bearing against a real revert.

--- a/custom_components/climate_advisor/ai_skills_context.py
+++ b/custom_components/climate_advisor/ai_skills_context.py
@@ -2001,6 +2001,24 @@ def _render_nat_vent_soft_start_entered(p: dict, unit: str) -> tuple[str, str]:
     return label, ", ".join(parts)
 
 
+def _render_nat_vent_reactivated_while_paused(p: dict, unit: str) -> tuple[str, str]:
+    outdoor = p.get("outdoor")
+    indoor = p.get("indoor")
+    threshold = p.get("threshold")
+    label = "Nat-vent reactivated while paused by an open door/window"
+    if outdoor is not None and indoor is not None:
+        with contextlib.suppress(TypeError, ValueError):
+            label = (
+                f"Nat-vent reactivated while paused -- outdoor {format_temp(float(outdoor), unit)}"
+                f" cooled below indoor {format_temp(float(indoor), unit)}"
+            )
+    settings = ""
+    if threshold is not None:
+        with contextlib.suppress(TypeError, ValueError):
+            settings = f"threshold: {format_temp(float(threshold), unit)}"
+    return label, settings
+
+
 def _render_nat_vent_ceiling_escalation(p: dict, unit: str) -> tuple[str, str]:
     indoor = p.get("indoor")
     cool = p.get("comfort_cool")
@@ -2373,6 +2391,7 @@ EVENT_RENDERERS: dict[str, Callable[[dict, str], tuple[str, str]]] = {
     "nat_vent_comfort_floor_exit": _render_nat_vent_comfort_floor_exit,
     "nat_vent_away_ceiling_exit": _render_nat_vent_away_ceiling_exit,
     "nat_vent_soft_start_entered": _render_nat_vent_soft_start_entered,
+    "nat_vent_reactivated_while_paused": _render_nat_vent_reactivated_while_paused,
     "nat_vent_predicted_floor_exit": _render_nat_vent_predicted_floor_exit,
     "nat_vent_ceiling_escalation": _render_nat_vent_ceiling_escalation,
     "nat_vent_ac_assist_armed": _render_nat_vent_ac_assist_armed,

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -3889,6 +3889,17 @@ class AutomationEngine:
                         kind=DoorWindowFsmEventKind.PAUSED_NAT_VENT_REACTIVATED,
                         legacy=_legacy_clear_pause,
                     )
+                    # Issue #668: explicit event for this exact branch — the coordinator
+                    # previously fed the door/window shadow FSM's PAUSED_NAT_VENT_REACTIVATED
+                    # kind unconditionally on every call to this method (method-name-keyed
+                    # trigger), not just when this deeply-conditional branch actually fired,
+                    # wrongly resetting the shadow FSM to NORMAL on every paused-but-not-
+                    # reactivating cycle. Event-driven, matching nat-vent's own 6 exit events.
+                    if self._emit_event_callback:
+                        self._emit_event_callback(
+                            "nat_vent_reactivated_while_paused",
+                            {"outdoor": outdoor, "indoor": indoor, "threshold": threshold},
+                        )
                     self._paused_entity = None
                     self._paused_since = None
                     _LOGGER.info(
@@ -3930,6 +3941,13 @@ class AutomationEngine:
                         kind=DoorWindowFsmEventKind.PAUSED_NAT_VENT_REACTIVATED,
                         legacy=_legacy_clear_pause,
                     )
+                    # Issue #668: see the sibling emit in the activate-fan branch above for
+                    # rationale — same explicit, branch-gated event for the soft-start case.
+                    if self._emit_event_callback:
+                        self._emit_event_callback(
+                            "nat_vent_reactivated_while_paused",
+                            {"outdoor": outdoor, "indoor": indoor, "threshold": threshold},
+                        )
                     self._paused_entity = None
                     self._paused_since = None
                     _LOGGER.info(

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,18 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.30"
+VERSION = "0.6.31"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.31": [
+        "Fix #668: no user-visible change. The shadow-diagnostic door/window FSM was"
+        " being wrongly reset every automation cycle whenever a door/window was left"
+        " open with no imminent free-cooling opportunity (a diagnostic-only bug — real"
+        " HVAC pause behavior was always correct). The periodic nat-vent re-check was"
+        " unconditionally signalling 'nat-vent just reactivated while paused' on every"
+        " call, regardless of whether that actually happened. Made the signal"
+        " event-driven instead, so it only fires when nat-vent genuinely reactivates.",
+    ],
     "0.6.30": [
         "Fix #666: no user-visible change. The coordinator test harness silently"
         " dropped the shadow-diagnostic FSM feed for every nat-vent/door-window exit"
@@ -1924,6 +1933,41 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    668: {
+        "version_fixed": "0.6.31",
+        "title": (
+            "Door/window shadow FSM unconditionally reset by check_natural_vent_conditions()"
+            " re-check (4th occurrence of #613/#647/#666, opposite failure mode)"
+        ),
+        "scope_covered": (
+            "coordinator.py: _DOOR_WINDOW_FSM_EVENT_KINDS['check_natural_vent_conditions']"
+            " = 'paused_nat_vent_reactivated' was a method-name-keyed, UNCONDITIONAL"
+            " trigger (added by #660 Step 3) — every call to check_natural_vent_conditions()"
+            " fired DoorWindowFsmEventKind.PAUSED_NAT_VENT_REACTIVATED regardless of which"
+            " internal branch it took, and door_window_fsm.py's _transition_from_paused()"
+            " handles that kind unconditionally by landing on NORMAL. Production only"
+            " actually reactivates nat-vent while paused in 2 deeply conditional branches"
+            " (automation.py's activate-fan and soft-start branches); every other cycle"
+            " with a door left open and no imminent reactivation wrongly reset the shadow"
+            " FSM to NORMAL moments after apply_classification()'s SYNC_RECONCILE dispatch"
+            " correctly restored PAUSED_IDLE — a permanent live disagreement surviving"
+            " deploys and restarts (traced live via HA log timestamps, 2026-08-17;"
+            " occupant impact: none — production's own pause state was always correct;"
+            " this is shadow-diagnostic-only, unrelated to and independent of #666's"
+            " harness fix earlier the same day). Fix: emit an explicit"
+            " nat_vent_reactivated_while_paused event at the 2 real branch call sites,"
+            " removed the unconditional method-name mapping, added an event-type-keyed"
+            " feed instead (matching nat-vent's own 6-exit-event convention) so the shadow"
+            " FSM only reacts when a reactivation genuinely happened. New renderer added"
+            " to ai_skills_context.py's EVENT_RENDERERS for the new event type (Activity"
+            " Report coverage guardrail, Issue #330). Regression tests in"
+            " tests/test_shadow_fsm_harness_event_coverage.py cover both directions (no"
+            " reactivation leaves the FSM alone; a real reactivation still clears it) plus"
+            " a positive control reproducing the old unconditional trigger; the now-stale"
+            " assertion in tests/test_door_window_fsm_shadow_wiring.py that pinned the old"
+            " unconditional behavior as correct was rewritten to assert the opposite."
+        ),
+    },
     666: {
         "version_fixed": "0.6.30",
         "title": "Test harness silently broke event-driven shadow-FSM feed coverage (3rd occurrence of #613/#647)",

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -365,17 +365,19 @@ _DOOR_WINDOW_FSM_EVENT_KINDS: dict[str, str] = {
     "handle_all_doors_windows_closed": "all_sensors_closed",
     "handle_manual_override_during_pause": "manual_override_during_pause",
     "resume_from_pause": "dashboard_resume",
-    # Issue #660: check_natural_vent_conditions()'s two reactivation branches clear
-    # all 4 door/window pause fields directly when nat-vent may reactivate while
-    # paused -- previously this method had NO door/window FSM event feed at all (it
-    # was only registered in _NAT_VENT_FSM_TRIGGER_METHODS, feeding the *nat-vent*
-    # FSM). It already has a _mirror_to_shadow("check_natural_vent_conditions") call
-    # site (coordinator.py), so adding this entry is enough to reach
-    # _evaluate_door_window_fsm() via _dispatch_fsm_evaluators() -- no new call site
-    # needed. Most invocations of this periodic method aren't a reactivation-while-
-    # paused at all; PAUSED_NAT_VENT_REACTIVATED is a defensive no-op from any
-    # non-paused origin state, same convention SENSOR_OPENED already uses.
-    "check_natural_vent_conditions": "paused_nat_vent_reactivated",
+    # Issue #668: "check_natural_vent_conditions": "paused_nat_vent_reactivated" used to
+    # live here (added by #660) as a method-name-keyed, UNCONDITIONAL trigger — every
+    # call to check_natural_vent_conditions() fed PAUSED_NAT_VENT_REACTIVATED regardless
+    # of which internal branch it took. #660's own comment claimed this kind is "a
+    # defensive no-op from any non-paused origin state" — true for NORMAL, but silently
+    # FALSE from a PAUSED_* origin: _transition_from_paused() lands unconditionally on
+    # NORMAL for this kind, so every paused-but-not-actually-reactivating cycle wrongly
+    # reset the shadow FSM, producing a permanent live disagreement (confirmed via HA log
+    # timestamps: SYNC_RECONCILE correctly restores PAUSED_IDLE, then this unconditional
+    # trigger immediately clobbers it back to NORMAL moments later, every cycle). Removed
+    # in favor of the event-driven feed below (_DOOR_WINDOW_NAT_VENT_REACTIVATED_EVENT_TYPES),
+    # matching nat-vent's own 6-exit-event convention — only fires when one of the 2 real,
+    # deeply-conditional reactivation branches (automation.py) actually runs.
 }
 
 # Issue #594 Phase R Step 1b: door/window's SYNC_RECONCILE event kind has no natural
@@ -546,6 +548,15 @@ _DOOR_WINDOW_NAT_VENT_EXIT_EVENT_TYPES: frozenset[str] = frozenset(
         "nat_vent_reconcile_exit",
     }
 )
+
+# Issue #668: event-driven replacement for the removed method-name-keyed
+# "check_natural_vent_conditions" entry in _DOOR_WINDOW_FSM_EVENT_KINDS above. Fed only
+# from the 2 real, deeply-conditional reactivation-while-paused branches in
+# check_natural_vent_conditions() (automation.py's activate-fan and soft-start branches),
+# each of which now emits this event type explicitly, right alongside the existing
+# _resolve_door_window_pause_flags(kind=PAUSED_NAT_VENT_REACTIVATED, ...) call — unlike
+# the old trigger, this only fires when one of those branches actually runs.
+_DOOR_WINDOW_NAT_VENT_REACTIVATED_EVENT_TYPES: frozenset[str] = frozenset({"nat_vent_reactivated_while_paused"})
 
 
 class ClimateAdvisorCoordinator(DataUpdateCoordinator):
@@ -7775,6 +7786,13 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                         "_on_grace_expired", event_kind=_DWFEventKind.GRACE_TIMER_EXPIRED
                     ),
                     "Door/window FSM evaluation (grace-expiry)",
+                ),
+                (
+                    _DOOR_WINDOW_NAT_VENT_REACTIVATED_EVENT_TYPES,
+                    lambda: self._evaluate_door_window_fsm(
+                        "check_natural_vent_conditions", event_kind=_DWFEventKind.PAUSED_NAT_VENT_REACTIVATED
+                    ),
+                    "Door/window FSM evaluation (nat-vent-reactivated-while-paused, event-driven)",
                 ),
                 (
                     _OVERRIDE_GRACE_FSM_EVENT_TYPE_MAP,

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.30"
+  "version": "0.6.31"
 }

--- a/tests/test_door_window_fsm_shadow_wiring.py
+++ b/tests/test_door_window_fsm_shadow_wiring.py
@@ -66,17 +66,24 @@ class TestFsmEvaluationScoping:
         _run(coordinator._mirror_to_shadow("handle_manual_override_during_pause"))
         assert called == ["handle_manual_override_during_pause"]
 
-    def test_triggered_by_check_natural_vent_conditions(self) -> None:
-        """Issue #660 Step 3: the 8th real trigger site. check_natural_vent_conditions()
-        previously had zero door/window FSM event feed at all -- it was only
-        registered in _NAT_VENT_FSM_TRIGGER_METHODS (feeding the nat-vent FSM)."""
+    def test_not_triggered_by_check_natural_vent_conditions_mirror_alone(self) -> None:
+        """Issue #668: check_natural_vent_conditions() was, until now, registered as a
+        method-name-keyed, UNCONDITIONAL trigger for PAUSED_NAT_VENT_REACTIVATED (#660
+        Step 3) -- merely mirroring this method (with no real reactivation-while-paused
+        branch taken) wrongly fired the door/window FSM every single cycle, permanently
+        resetting it to NORMAL moments after SYNC_RECONCILE correctly restored a paused
+        state (confirmed live, Issue #668). The feed is now event-driven instead (see
+        TestFsmEvaluationScoping's sibling test in test_shadow_fsm_harness_event_coverage.py
+        for the positive case where the real branch DOES fire) -- mirroring this method
+        alone, with no emitted "nat_vent_reactivated_while_paused" event, must not call
+        _evaluate_door_window_fsm at all."""
         coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
         called: list[str] = []
-        coordinator._evaluate_door_window_fsm = lambda method_name: called.append(method_name)  # type: ignore[method-assign]
+        coordinator._evaluate_door_window_fsm = lambda method_name, event_kind=None: called.append(method_name)  # type: ignore[method-assign]
 
         _noop_shadow_methods(coordinator, "check_natural_vent_conditions")
         _run(coordinator._mirror_to_shadow("check_natural_vent_conditions"))
-        assert called == ["check_natural_vent_conditions"]
+        assert called == []
 
 
 class TestFsmStateTracking:

--- a/tests/test_shadow_fsm_harness_event_coverage.py
+++ b/tests/test_shadow_fsm_harness_event_coverage.py
@@ -151,3 +151,154 @@ class TestHarnessEventFeedPositiveControl:
         assert any(evt[0] == "nat_vent_comfort_floor_exit" for evt in captured), (
             "sanity check: the event really was emitted, just not routed to the FSM feed"
         )
+
+
+def _build_paused_by_door_coordinator(*, outdoor: float, indoor: float, hvac_already_off: bool):
+    """Builds a coordinator already paused by an open door/window (PAUSED_IDLE), for
+    exercising ``check_natural_vent_conditions()`` (Issue #668).
+
+    ``hvac_already_off`` selects which of the two structurally-distinct reactivation
+    code paths inside ``check_natural_vent_conditions()`` is reachable:
+      - ``True`` (``_paused_with_hvac_already_off=True``, matching the actual live
+        incident — HVAC was already off when the door was noticed open) makes
+        ``_actively_paused`` False, which routes into the "idle_open" re-evaluation
+        branch (Issue #244/#402/#504, automation.py ~3459-3546) — that branch never
+        calls ``_resolve_door_window_pause_flags()`` at all (by design: nat-vent can
+        legitimately re-engage through an open door without clearing the pause) and
+        unconditionally ``return``s afterward, so the paused-by-door block below it
+        (~3830) is never reached this call.
+      - ``False`` makes ``_actively_paused`` True, skipping the idle_open branch
+        entirely and reaching the paused-by-door reactivation block (~3830-3934) —
+        the 2 real call sites this fix's new event emit was added to.
+    """
+    config = {
+        "door_window_sensors": ["binary_sensor.front_door"],
+        "comfort_heat": 68.0,
+        "comfort_cool": 76.0,
+        "fan_mode": "whole_house_fan",
+    }
+    coordinator, fake_hass, scheduler, event_log = build_headless_coordinator(
+        config=config,
+        climate_state="off",
+        climate_attributes={"current_temperature": indoor},
+        skip_startup_coalesce=True,
+    )
+    ae = coordinator.automation_engine
+
+    fake_hass.states.set_simple("binary_sensor.front_door", "on")
+    coordinator._resolved_sensors = ["binary_sensor.front_door"]
+    ae.update_outdoor_temp(outdoor)
+    ae._natural_vent_active = False
+    ae._nat_vent_soft_start = False
+    ae._paused_by_door = True
+    ae._paused_with_hvac_already_off = hvac_already_off
+    ae._paused_entity = "monitored door/window"
+
+    from custom_components.climate_advisor.door_window_lifecycle import (
+        DoorWindowLifecycleState as _DWLState,
+    )
+
+    coordinator._door_window_fsm_state = _DWLState.PAUSED_IDLE
+
+    return coordinator, fake_hass, scheduler, event_log, ae
+
+
+class TestPausedNatVentReactivatedEventCoverage:
+    """Issue #668: check_natural_vent_conditions() was, until now, registered as a
+    method-name-keyed, UNCONDITIONAL door/window FSM trigger (#660 Step 3) — every
+    call, regardless of which internal branch it took, fired
+    ``DoorWindowFsmEventKind.PAUSED_NAT_VENT_REACTIVATED``, which
+    ``_transition_from_paused()`` handles unconditionally by resetting to ``NORMAL``.
+    On a hot day with a door left open and no imminent nat-vent reactivation, this
+    wrongly reset the shadow FSM to ``NORMAL`` every single cycle, moments after
+    ``SYNC_RECONCILE`` correctly restored ``PAUSED_IDLE`` — a permanent live
+    disagreement (confirmed via HA log timestamps, 2026-08-17). The feed is now
+    event-driven: only fired when one of the 2 real, deeply-conditional reactivation
+    branches in ``automation.py`` actually runs.
+    """
+
+    def test_no_reactivation_leaves_shadow_fsm_paused(self) -> None:
+        """The exact live-incident shape: HVAC already off, door open, outdoor far
+        above the reactivation threshold — the idle_open branch runs but doesn't
+        reactivate, and never touches the paused-by-door block at all. Calls
+        production's real ``ae.check_natural_vent_conditions()`` directly (not
+        ``_mirror_to_shadow``, which replays on the *shadow* engine and can never
+        reach the new event-driven feed — that's fed only from production's own
+        ``_emit_event_callback``, wired to ``coordinator._emit_event``). The shadow
+        FSM must stay PAUSED_IDLE, not get reset to NORMAL."""
+        coordinator, _fake_hass, scheduler, _event_log, ae = _build_paused_by_door_coordinator(
+            outdoor=85.0, indoor=73.0, hvac_already_off=True
+        )
+
+        with scheduler.installed():
+            run_coro(ae.check_natural_vent_conditions())
+            # Settle any fire-and-forget hass.async_create_task() calls queued by a
+            # real HVAC-mode/state change, same pattern build_headless_coordinator()
+            # itself uses (Issue #476) — otherwise an unawaited-coroutine warning
+            # surfaces at interpreter shutdown, unrelated to this test's assertions.
+            scheduler.advance_to(scheduler.now())
+
+        assert ae._paused_by_door is True, "production's own pause flag must be unaffected — sanity check"
+        assert coordinator._door_window_fsm_state == DoorWindowLifecycleState.PAUSED_IDLE, (
+            f"shadow door/window FSM ({coordinator._door_window_fsm_state}) was wrongly reset — "
+            "check_natural_vent_conditions() ran but did not actually reactivate nat-vent, so "
+            "the FSM must not have received a PAUSED_NAT_VENT_REACTIVATED event (Issue #668)"
+        )
+
+    def test_real_reactivation_still_clears_shadow_fsm(self) -> None:
+        """The mirror-image, correctness-preserving direction: HVAC was actively
+        paused (not already off) and outdoor is genuinely cool enough to reactivate
+        nat-vent while paused — reaching the paused-by-door block's real
+        ``_resolve_door_window_pause_flags(kind=PAUSED_NAT_VENT_REACTIVATED, ...)``
+        call site this fix's new event emit sits beside. Calls production's real
+        engine directly, same reasoning as the sibling test above. The shadow FSM
+        must still correctly reach NORMAL, proving the fix isn't just a blanket
+        suppression."""
+        coordinator, _fake_hass, scheduler, _event_log, ae = _build_paused_by_door_coordinator(
+            outdoor=58.5, indoor=73.0, hvac_already_off=False
+        )
+
+        with scheduler.installed():
+            run_coro(ae.check_natural_vent_conditions())
+            # Settle any fire-and-forget hass.async_create_task() calls queued by a
+            # real HVAC-mode/state change, same pattern build_headless_coordinator()
+            # itself uses (Issue #476) — otherwise an unawaited-coroutine warning
+            # surfaces at interpreter shutdown, unrelated to this test's assertions.
+            scheduler.advance_to(scheduler.now())
+
+        assert ae._paused_by_door is False, "production must have actually reactivated — sanity check"
+        assert ae._natural_vent_active is True, "production must have actually reactivated — sanity check"
+        assert coordinator._door_window_fsm_state == DoorWindowLifecycleState.NORMAL, (
+            f"shadow door/window FSM ({coordinator._door_window_fsm_state}) disagreed with "
+            "production's real reactivation — the new event-driven feed must still fire when "
+            "the real branch actually runs (Issue #668)"
+        )
+
+
+class TestPausedNatVentReactivatedPositiveControl:
+    """Proves the two tests above are load-bearing: reintroducing the old
+    unconditional method-name trigger must make the no-reactivation test fail."""
+
+    def test_reintroducing_unconditional_trigger_reproduces_the_bug(self) -> None:
+        import custom_components.climate_advisor.coordinator as _coordinator_mod
+
+        coordinator, _fake_hass, scheduler, _event_log, ae = _build_paused_by_door_coordinator(
+            outdoor=85.0, indoor=73.0, hvac_already_off=True
+        )
+
+        # Reintroduce the Issue #660/#668 bug: method-name-keyed, unconditional trigger.
+        original_kinds = dict(_coordinator_mod._DOOR_WINDOW_FSM_EVENT_KINDS)
+        _coordinator_mod._DOOR_WINDOW_FSM_EVENT_KINDS["check_natural_vent_conditions"] = "paused_nat_vent_reactivated"
+        try:
+            with scheduler.installed():
+                run_coro(coordinator._mirror_to_shadow("check_natural_vent_conditions"))
+        finally:
+            _coordinator_mod._DOOR_WINDOW_FSM_EVENT_KINDS.clear()
+            _coordinator_mod._DOOR_WINDOW_FSM_EVENT_KINDS.update(original_kinds)
+
+        assert ae._paused_by_door is True, "production's own flag is unaffected by the dispatch-table bug"
+        assert coordinator._door_window_fsm_state == DoorWindowLifecycleState.NORMAL, (
+            "positive control FAILED: reintroducing the unconditional method-name trigger should "
+            "reproduce the live bug (shadow FSM wrongly reset to NORMAL) — if this assertion "
+            "fails, the tests above are not actually exercising the dispatch table they claim to"
+        )


### PR DESCRIPTION
## Summary

Closes #668. Fresh five-whys investigation triggered by the user observing the
`Door/window FSM disagreement (Issue #637)` shadow-diagnostic WARNING still firing
continuously, unchanged, after the #666 deploy earlier today — same "brief agreement
blip at restart, then permanent disagreement" pattern seen at the previous deploy too.

**Occupant impact: none.** Production's real pause/HVAC behavior was correct
throughout; this is a diagnostic-only bug in the shadow-tracking FSM used to validate
a future authoritative-mode migration.

## Root cause (4th occurrence of the #613/#647/#666 bug class — opposite failure mode)

`coordinator.py`'s `_DOOR_WINDOW_FSM_EVENT_KINDS["check_natural_vent_conditions"] =
"paused_nat_vent_reactivated"` was a method-name-keyed, **unconditional** trigger
(added by #660 Step 3). Every call to `check_natural_vent_conditions()` fired
`DoorWindowFsmEventKind.PAUSED_NAT_VENT_REACTIVATED` regardless of which internal
branch actually ran, and `door_window_fsm.py`'s handler for that kind unconditionally
lands on `NORMAL`. But production only actually reactivates nat-vent while paused in
2 deeply conditional branches — so on any day with a door left open and no imminent
reactivation, the shadow FSM was wrongly reset to `NORMAL` every single cycle, moments
after `apply_classification()`'s `SYNC_RECONCILE` dispatch correctly restored
`PAUSED_IDLE`. Confirmed via live HA log timestamps, line-by-line against the
dispatch code.

Where #666 (same day, unrelated) was events *not* reaching the FSM feed, this is
events reaching it when they shouldn't.

## Fix

- `automation.py`: explicit `nat_vent_reactivated_while_paused` event emitted at the
  2 real reactivation-while-paused call sites, matching nat-vent's own 6-exit-event
  pattern.
- `coordinator.py`: removed the unconditional method-name mapping; added an
  event-type-keyed feed instead, wired into `_feed_lifecycle_fsms_from_event()`.
- `ai_skills_context.py`: added an Activity Report renderer for the new event type
  (Issue #330's coverage guardrail caught the gap during the full test run).
- Rewrote the one existing test that pinned the old unconditional behavior as
  correct (`test_door_window_fsm_shadow_wiring.py`).
- New regression tests (`test_shadow_fsm_harness_event_coverage.py`) covering both
  directions — no reactivation leaves the FSM alone; a real reactivation still
  correctly clears it — plus a positive control proving the tests are load-bearing.

Zero change to `_doorwindow_fsm_authoritative=True` production behavior (different,
untouched code path — verified by reading `test_doorwindow_fsm_authoritative_compare.py`
directly) and no double-firing risk from the shadow engine's own isolated event sink
(verified by reading `_build_shadow_automation_callbacks()`).

## Test plan
- [x] Full test suite green with warnings-as-errors (4864 passed, 6 skipped)
- [x] `python tools/simulate.py` — 81/81 golden scenarios pass
- [x] `python tools/simulate.py --check-integrity` — clean
- [x] `ruff check` / `ruff format` clean
- [x] `test_version_sync.py` — VERSION/manifest.json in sync
- [ ] Live: watch `ha_logs.py --filter "FSM disagreement"` after deploy through a
      full cycle with a door left open — should stop firing within one 30-min cycle