### PR TITLE
Fix #670: nat-vent/economizer regular-cycle checks fired during startup coalescing window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.32] — 2026-08-17
+
+- Fix #670: right after an HA restart, if a door or window was already open, the whole-house fan could switch on before the startup-reconciliation logic had a chance to check the fan's actual state — occasionally causing a fan on/off flap in the minutes after restart. The regular-cycle nat-vent and window-cooling checks now wait for startup reconciliation to finish before acting, same fix already applied to a sibling check in #627.
+
 ## [0.6.31] — 2026-08-17
 
 - Fix #668: no user-visible change. The shadow-diagnostic door/window FSM was being wrongly reset every automation cycle whenever a door/window was left open with no imminent free-cooling opportunity — a diagnostic-only bug (real HVAC pause behavior was always correct). The periodic nat-vent re-check was unconditionally signalling "nat-vent just reactivated while paused" on every call, regardless of whether that actually happened. Made the signal event-driven instead, so it only fires when nat-vent genuinely reactivates.

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,17 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.31"
+VERSION = "0.6.32"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.32": [
+        "Fix #670: right after an HA restart, if a door or window was already open, the"
+        " whole-house fan could switch on before the startup-reconciliation logic had a"
+        " chance to check the fan's actual state — occasionally causing a fan on/off"
+        " flap in the minutes after restart. The regular-cycle nat-vent and window-"
+        " cooling checks now wait for startup reconciliation to finish before acting,"
+        " same fix already applied to a sibling check in #627.",
+    ],
     "0.6.31": [
         "Fix #668: no user-visible change. The shadow-diagnostic door/window FSM was"
         " being wrongly reset every automation cycle whenever a door/window was left"
@@ -1933,6 +1941,30 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    670: {
+        "version_fixed": "0.6.32",
+        "title": (
+            "Regular-cycle nat-vent/economizer checks fired during the startup-coalescing"
+            " window, before startup reconciliation ran (same bug class as #627)"
+        ),
+        "scope_covered": (
+            "coordinator.py: the regular _async_update_data() cycle's"
+            " check_natural_vent_conditions() and check_window_cooling_opportunity() calls"
+            " had no _startup_coalesce_active gate, unlike every sibling override-detection"
+            " check in this file. HA-restart-triggered extra coordinator refreshes (fan-"
+            " state listener churn) gave the ungated nat-vent check multiple chances to"
+            " activate the whole-house fan for real before _do_startup_coalesce()'s"
+            " reconcile_fan_on_startup() — the single-shot startup-reconciliation mechanism"
+            " (#321/#327) — had run, so reconciliation's own decision arrived minutes late"
+            " and against a fan state it never actually chose (traced live via HA log"
+            " timestamps, 2026-08-17: fan activated at t+66s post-restart, reconcile ran at"
+            " t+5min and read back the self-caused state). This is the same gap #627 fixed"
+            " for the backstop_30min untracked-fan reconcile, in two call sites #627 didn't"
+            " cover. Extracted _should_run_regular_cycle_nat_vent_check() and"
+            " _should_run_regular_cycle_window_cooling_check() gating both behind the"
+            " existing shared _suppress_during_startup_coalescing() helper."
+        ),
+    },
     668: {
         "version_fixed": "0.6.31",
         "title": (

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -3118,7 +3118,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                         self._today_record.comfort_violations_minutes += elapsed_minutes
 
             # Check economizer opportunity (window cooling on hot days)
-            if self._today_record:
+            if self._should_run_regular_cycle_window_cooling_check():
                 windows_open = self._today_record.windows_physically_opened and (
                     self._today_record.window_physical_close_time is None
                 )
@@ -3130,7 +3130,7 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 )
 
             # Re-evaluate natural vent conditions while any sensor is open
-            if self._any_sensor_open():
+            if self._should_run_regular_cycle_nat_vent_check():
                 _LOGGER.debug("[coalesce-diag] before check_natural_vent_conditions()")
                 await self.automation_engine.check_natural_vent_conditions()
                 await self._mirror_to_shadow("check_natural_vent_conditions")
@@ -5777,6 +5777,36 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
             and not self._startup_coalesce_active
             and not self.automation_engine._fan_override_active
             and not self.automation_engine._grace_active
+        )
+
+    def _should_run_regular_cycle_nat_vent_check(self) -> bool:
+        """Whether the regular-cycle ``check_natural_vent_conditions()`` call should fire now.
+
+        Issue #670: same bug class as #627 above, a different call site. This check can
+        activate real hardware (the WHF) and had no ``_startup_coalesce_active`` gate at
+        all — unlike every sibling override-detection check in this file. HA-restart-
+        triggered extra coordinator refreshes (fan-state listener churn) gave this
+        ungated call multiple chances to activate nat-vent for real before
+        ``_do_startup_coalesce()``'s ``reconcile_fan_on_startup()`` — the single-shot,
+        purpose-built startup-reconciliation mechanism (#321/#327) — had run, so the
+        reconciliation's own decision arrived minutes late and against a fan state it
+        never actually chose. Extracted to its own method so this exact predicate can be
+        unit tested directly, matching ``_should_run_untracked_fan_backstop``'s pattern.
+        """
+        return self._any_sensor_open() and not self._suppress_during_startup_coalescing(
+            "check_natural_vent_conditions (regular cycle)"
+        )
+
+    def _should_run_regular_cycle_window_cooling_check(self) -> bool:
+        """Whether the regular-cycle ``check_window_cooling_opportunity()`` call should fire now.
+
+        Issue #670: sibling gap to ``_should_run_regular_cycle_nat_vent_check`` above, same
+        file, same missing gate, same fix. This check can command real AC and was never
+        observed live only because it's independently gated to ``day_type == "hot"`` — the
+        gap is real, just not yet triggered on a warm day.
+        """
+        return bool(self._today_record) and not self._suppress_during_startup_coalescing(
+            "check_window_cooling_opportunity (regular cycle)"
         )
 
     def _derive_thermostat_fan_running_for_reconcile(self, *, fan_mode_attr: str, hvac_action_attr: str) -> bool:

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.31"
+  "version": "0.6.32"
 }

--- a/tests/test_startup_coalesce.py
+++ b/tests/test_startup_coalesce.py
@@ -572,3 +572,81 @@ class TestStartupCoalesceDoCoalesce:
 
         _, event_data = coord._emit_event.call_args[0]
         assert event_data["sensors_open_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# TestRegularCycleCoalesceGating: Issue #670 — regular-cycle nat-vent/economizer
+# checks must not act during the startup-coalescing window
+# ---------------------------------------------------------------------------
+
+
+class TestRegularCycleCoalesceGating:
+    """Issue #670: coordinator._should_run_regular_cycle_nat_vent_check() and
+    _should_run_regular_cycle_window_cooling_check() gate the regular-cycle
+    check_natural_vent_conditions()/check_window_cooling_opportunity() calls behind
+    the startup-coalescing window — the same idiom #627 already established for
+    _should_run_untracked_fan_backstop().
+
+    Before this fix, the regular _async_update_data() cycle's nat-vent check had no
+    _startup_coalesce_active gate at all. Live incident 2026-08-17: an HA-restart-
+    triggered extra coordinator refresh (fan-state listener churn) let this check
+    activate the whole-house fan for real ~65s after restart, before
+    _do_startup_coalesce()'s reconcile_fan_on_startup() — the single-shot startup-
+    reconciliation mechanism (#321/#327) — ever ran. reconcile_fan_on_startup() then
+    read back the self-caused fan state 4 minutes later and decided "turn-off" against
+    a decision it never actually made.
+    """
+
+    def _make_coord(self, *, startup_coalesce_active: bool, any_sensor_open: bool, today_record):
+        mod = importlib.import_module("custom_components.climate_advisor.coordinator")
+        coord = MagicMock()
+        coord._should_run_regular_cycle_nat_vent_check = types.MethodType(
+            mod.ClimateAdvisorCoordinator._should_run_regular_cycle_nat_vent_check, coord
+        )
+        coord._should_run_regular_cycle_window_cooling_check = types.MethodType(
+            mod.ClimateAdvisorCoordinator._should_run_regular_cycle_window_cooling_check, coord
+        )
+        coord._suppress_during_startup_coalescing = types.MethodType(
+            mod.ClimateAdvisorCoordinator._suppress_during_startup_coalescing, coord
+        )
+        coord._startup_coalesce_active = startup_coalesce_active
+        coord._any_sensor_open = MagicMock(return_value=any_sensor_open)
+        coord._today_record = today_record
+        return coord
+
+    def test_nat_vent_check_suppressed_during_startup_coalescing_window(self):
+        """REGRESSION GUARD: a sensor open while _startup_coalesce_active is True (the
+        exact post-restart state from the live incident) must NOT trigger the regular-
+        cycle nat-vent check."""
+        coord = self._make_coord(startup_coalesce_active=True, any_sensor_open=True, today_record=_make_today_record())
+        assert coord._should_run_regular_cycle_nat_vent_check() is False
+
+    def test_nat_vent_check_fires_once_coalescing_window_closes(self):
+        """The exact same open-sensor state must fire normally once
+        _startup_coalesce_active flips False — the fix delays the decision, it doesn't
+        remove it."""
+        coord = self._make_coord(startup_coalesce_active=False, any_sensor_open=True, today_record=_make_today_record())
+        assert coord._should_run_regular_cycle_nat_vent_check() is True
+
+    def test_nat_vent_check_never_fires_with_no_sensor_open_regardless_of_window(self):
+        coord = self._make_coord(
+            startup_coalesce_active=False, any_sensor_open=False, today_record=_make_today_record()
+        )
+        assert coord._should_run_regular_cycle_nat_vent_check() is False
+
+    def test_window_cooling_check_suppressed_during_startup_coalescing_window(self):
+        """Sibling gap: check_window_cooling_opportunity() can command real AC and had
+        the same missing gate — never observed live only because it's independently
+        restricted to hot days."""
+        coord = self._make_coord(startup_coalesce_active=True, any_sensor_open=False, today_record=_make_today_record())
+        assert coord._should_run_regular_cycle_window_cooling_check() is False
+
+    def test_window_cooling_check_fires_once_coalescing_window_closes(self):
+        coord = self._make_coord(
+            startup_coalesce_active=False, any_sensor_open=False, today_record=_make_today_record()
+        )
+        assert coord._should_run_regular_cycle_window_cooling_check() is True
+
+    def test_window_cooling_check_never_fires_with_no_today_record_regardless_of_window(self):
+        coord = self._make_coord(startup_coalesce_active=False, any_sensor_open=False, today_record=None)
+        assert coord._should_run_regular_cycle_window_cooling_check() is False


### PR DESCRIPTION
## Summary
- Right after an HA restart, if a door/window was already open, the regular-cycle `check_natural_vent_conditions()` call could activate the whole-house fan for real before `_do_startup_coalesce()`'s `reconcile_fan_on_startup()` had run — jumping the purpose-built, single-shot startup-reconciliation mechanism (#321/#327). Confirmed live via HA logs from the 2026-08-17 restart: fan activated at t+66s post-restart, reconciliation read back the self-caused state and decided "turn-off" 4 minutes later.
- Same bug class already fixed once for a sibling call site in #627 (`_should_run_untracked_fan_backstop()`). This PR closes the same gap in `check_natural_vent_conditions()` and its sibling `check_window_cooling_opportunity()` (same missing gate, not yet observed live only because it's hot-day-gated).
- Reuses the existing shared `_suppress_during_startup_coalescing()` helper (already used by 3 sibling override-detection listeners) rather than inventing a new mechanism, extracted into two unit-testable predicates matching #627's own precedent.

## Test plan
- [x] `python -m pytest tests/test_startup_coalesce.py -v` — 19 passed, including 6 new positive/negative-control tests for the two new gates
- [x] Full suite: `pytest tests/ -W error::pytest.PytestUnraisableExceptionWarning -W error::RuntimeWarning` — 4870 passed, 6 skipped, zero warnings
- [x] `python tools/simulate.py --check-integrity` — 81 scenarios verified
- [x] `python tools/simulate.py` — 81/81 golden scenarios passed
- [x] `ruff check` / `ruff format` clean on all modified files

Closes #670