### PR TITLE
Fix #672: door/window, nat-vent, override/grace shadow-FSM diagnostics never self-heal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.33] — 2026-08-17
+
+- Fix #672: no user-visible change. Three shadow-diagnostic state machines (door/window, nat-vent, override/grace) each had their own reason for getting permanently stuck out of sync with real production state after a restart or a specific state transition — real HVAC/fan behavior was always correct throughout. Fixed all three.
+
 ## [0.6.32] — 2026-08-17
 
 - Fix #670: right after an HA restart, if a door or window was already open, the whole-house fan could switch on before the startup-reconciliation logic had a chance to check the fan's actual state — occasionally causing a fan on/off flap in the minutes after restart. The regular-cycle nat-vent and window-cooling checks now wait for startup reconciliation to finish before acting, same fix already applied to a sibling check in #627.

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -4766,11 +4766,11 @@ class AutomationEngine:
     def _legacy_set_grace_flags(self, trigger: str) -> None:
         """The 2-line flag computation ``_start_grace_period()`` always used to perform
         inline (Issue #664) — extracted so it can be passed as the ``legacy`` closure to
-        ``_resolve_override_grace_fsm_state()`` at the real override/grace call sites,
-        and reused unchanged by ``_start_grace_period()`` itself for every other trigger
-        (fan-off, window-close, nat-vent-exit, drift-correction) that isn't a modeled
-        ``OverrideGraceFsmEventKind`` at all — those callers never touch the dispatcher,
-        by design (there is nothing for the FSM to arbitrate; only this flag-write runs).
+        ``_resolve_override_grace_fsm_state()`` at every real override/grace call site,
+        including (as of Issue #672) ``_start_grace_period()``'s own "every other
+        trigger" callers (fan-off, window-close, nat-vent-exit, drift-correction),
+        under the ``UNPROTECTED_GRACE_STARTED`` kind — this is the non-authoritative
+        branch's flag computation for all of them now, not a legacy-only path.
         """
         self._grace_active = True
         self._grace_protects_override = trigger in _GRACE_TRIGGERS_PROTECTING_OVERRIDE
@@ -4863,17 +4863,42 @@ class AutomationEngine:
                 source == "manual"; ignored otherwise.
 
         Issue #664: thin wrapper — real work lives in ``_start_grace_period_action()``.
-        This wrapper is for every caller whose ``trigger`` is NOT a modeled
+        This wrapper is for every caller whose ``trigger`` was historically NOT a modeled
         ``OverrideGraceFsmEventKind`` (fan-off, window-close, nat-vent-exit,
-        drift-correction, etc.) — those callers keep this exact unconditional
-        action-then-flags shape, unchanged. The ~3 callers whose trigger IS modeled
+        drift-correction, etc.). The ~3 callers whose trigger IS modeled
         (``fan_manual_override``, ``dashboard_resume``, ``override_confirmed``) call
         ``_start_grace_period_action()`` directly instead and route the flag-write
         through ``_resolve_override_grace_fsm_state()`` — see ``handle_fan_manual_override()``,
         ``resume_from_pause()``, ``_confirm_override()``.
+
+        Issue #672: this wrapper's own "every other trigger" callers now ALSO route
+        through the dispatcher, under ``UNPROTECTED_GRACE_STARTED`` — closing the gap
+        where those triggers set real production state (``_grace_active=True``,
+        never protecting) but the FSM had no way to ever find out. One shared edit here
+        covers all of them (fan-off, window-close, nat-vent-exit, drift-correction),
+        instead of touching each of their individual call sites.
         """
         if self._start_grace_period_action(source, trigger, duration_override):
-            self._legacy_set_grace_flags(trigger)
+            from .override_grace_fsm import OverrideGraceFsmEventKind as _OGFEventKind
+
+            self._resolve_override_grace_fsm_state(
+                kind=_OGFEventKind.UNPROTECTED_GRACE_STARTED,
+                legacy=lambda: self._legacy_set_grace_flags(trigger),
+            )
+            # Issue #672: a second, DISTINCT event from _start_grace_period_action()'s own
+            # "grace_started" (which also fires for the 3 protecting triggers, via their
+            # own direct dispatcher call sites — reusing it here would wrongly feed
+            # UNPROTECTED_GRACE_STARTED for those too). This wrapper is, by construction
+            # per its own docstring, called only for the non-protecting triggers, so this
+            # event type is exactly and only ever "an unprotected grace genuinely started"
+            # — feeds coordinator.py's diagnostic FSM tracker via
+            # _OVERRIDE_GRACE_FSM_EVENT_TYPE_MAP, closing the live production=idle/
+            # active_unprotected vs fsm=idle/none gap this whole fix targets.
+            if self._emit_event_callback:
+                self._emit_event_callback(
+                    "unprotected_grace_started",
+                    {"source": source, "trigger": trigger},
+                )
 
     def _on_grace_expired(self, source: str, duration: int, should_notify: bool) -> None:
         """Handle grace period expiry — re-check sensors then clear state.

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,20 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.32"
+VERSION = "0.6.33"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.33": [
+        "Fix #672: no user-visible change. Three shadow-diagnostic state machines"
+        " (door/window, nat-vent, override/grace) each had their own reason for"
+        " getting permanently stuck out of sync with real production state after a"
+        " restart or a specific state transition — real HVAC/fan behavior was"
+        " always correct throughout. Fixed all three: door/window now notices a"
+        " grace period that starts for an unrelated reason, nat-vent can recognize"
+        " a door-pause condition even after wrongly staying active, and"
+        " override/grace now tracks fan-off/window-close/nat-vent-exit/drift-"
+        " correction grace periods it previously never modeled at all.",
+    ],
     "0.6.32": [
         "Fix #670: right after an HA restart, if a door or window was already open, the"
         " whole-house fan could switch on before the startup-reconciliation logic had a"
@@ -1941,6 +1952,35 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    672: {
+        "version_fixed": "0.6.33",
+        "title": (
+            "Door/window, nat-vent, and override/grace shadow-FSM diagnostics each had a"
+            " different, previously-unexamined reason for staying permanently stuck"
+            " out of sync with production"
+        ),
+        "scope_covered": (
+            "door_window_fsm.py: _sync_reconcile_next_state() never checked grace_active"
+            " from a NORMAL origin, so a grace period started for a reason unrelated to any"
+            " door/window pause (override grace, fan-off grace) was invisible forever"
+            " (production=grace fsm=normal, confirmed live for 90+ minutes 2026-08-17)."
+            " nat_vent_fsm.py: _transition_from_active() only checked the thermal/comfort"
+            " exit chain, never a door-pause/reactivation-lockout condition, so a wrongly-"
+            " active FSM had no path back once stuck (confirmed live for 34+ minutes across"
+            " 2 full startup-coalesce cycles). override_grace_fsm.py: added"
+            " UNPROTECTED_GRACE_STARTED — automation.py's _start_grace_period() (the shared"
+            " wrapper for fan-off/window-close/nat-vent-exit/drift-correction grace starts)"
+            " now routes through _resolve_override_grace_fsm_state() instead of calling"
+            " _legacy_set_grace_flags() directly, closing the one gap those 4 triggers all"
+            " shared. All three fixes proven inert on real decisions today: door/window's"
+            " SYNC_RECONCILE and nat-vent's new check can never reach the live authoritative"
+            " path (confirmed structurally); override/grace's fix was proven equivalent"
+            " to the legacy path across the full golden+pending scenario corpus with"
+            " _override_grace_fsm_authoritative=True (same rigor #664's original cutover"
+            " used) before merging, since it does extend what that switch would drive if"
+            " ever flipped."
+        ),
+    },
     670: {
         "version_fixed": "0.6.32",
         "title": (

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -479,6 +479,14 @@ _OVERRIDE_GRACE_FSM_EVENT_TYPE_MAP: dict[str, str] = {
     # still-active state. cancel_override()/clear_manual_override() are called from a
     # handful of real coordinator.py/api.py sites instead; those are fed directly,
     # post-return, via `_feed_override_grace_fsm_cancelled()` below.
+    # Issue #672: _start_grace_period()'s "every other trigger" callers (fan-off,
+    # window-close, nat-vent-exit, drift-correction) emit this DISTINCT event type —
+    # deliberately not the pre-existing generic "grace_started" (which also fires for
+    # the 3 protecting triggers via their own direct dispatcher call sites; reusing it
+    # here would wrongly feed UNPROTECTED_GRACE_STARTED for those too). Confirmed live:
+    # this closes the "production=idle/active_unprotected fsm=idle/none" disagreement
+    # that persisted indefinitely because none of these 4 triggers had ANY feed at all.
+    "unprotected_grace_started": "unprotected_grace_started",
 }
 
 # Issue #647: `check_natural_vent_conditions` was, until now, the ONLY mirrored method

--- a/custom_components/climate_advisor/door_window_fsm.py
+++ b/custom_components/climate_advisor/door_window_fsm.py
@@ -391,6 +391,15 @@ def _sync_reconcile_next_state(
             return DoorWindowLifecycleState.PAUSED_DURING_GRACE
         return current_state
 
+    # Issue #672: a grace period started for a reason unrelated to any door/window pause
+    # (override grace, fan-off grace — cross-lifecycle, same "communicating automata"
+    # convention as natural_vent_active/whf_owns_hvac below) is invisible from a NORMAL
+    # origin — the pause-entry checks below never consult grace_active at all, so a live
+    # production=grace vs fsm=normal disagreement never self-corrects. Mirrors the
+    # PAUSED_ACTIVE/PAUSED_IDLE branch's own "grace_active wins" shape above.
+    if current_state == DoorWindowLifecycleState.NORMAL and inputs.grace_active:
+        return DoorWindowLifecycleState.GRACE
+
     if inputs.natural_vent_active or inputs.whf_owns_hvac:
         return current_state
     if inputs.within_planned_window:

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.32"
+  "version": "0.6.33"
 }

--- a/custom_components/climate_advisor/nat_vent_fsm.py
+++ b/custom_components/climate_advisor/nat_vent_fsm.py
@@ -182,6 +182,31 @@ def _soft_start_inputs(inputs: NatVentFsmInputs, *, full_gate_active: bool) -> N
 
 
 def _transition_from_active(current_state: NatVentLifecycleState, event: NatVentFsmEvent) -> NatVentTransition:
+    # Issue #672: before anything else, recognize a door-pause/reactivation-lockout
+    # condition — the one thing this branch previously had NO way to ever detect once
+    # wrongly active. _transition_from_inactive() already checks this same condition on
+    # every tick from an inactive-like origin, but transition() never routes back there
+    # once current_state is ACTIVE_*, so a stale/incorrect ACTIVE_SOFT_START/ACTIVE_FULL_GATE
+    # state was permanently stuck — decide_nat_vent_exit()'s exit chain below only
+    # recognizes thermal/comfort exit reasons, never a pause/lockout condition. Confirmed
+    # live: 34+ minutes and 2 full startup-coalesce cycles of real ticks landing here with
+    # no way to reach PAUSED_REACTIVATION_LOCKOUT/INACTIVE (2026-08-17). Provably inert on
+    # the live authoritative escalation path (automation.py's soft-start upgrade check) —
+    # production's real flags never present natural_vent_active=True simultaneously with an
+    # active lockout (_exit_nat_vent() always clears the former before/as part of setting
+    # the field that drives the latter) — this only ever fires for the separately-tracked,
+    # staleness-prone coordinator diagnostic state.
+    inputs = event.inputs
+    if inputs.paused_by_door and is_reactivation_locked_out(
+        outdoor_exit_time=inputs.outdoor_exit_time, now=inputs.now, lockout_seconds=inputs.lockout_seconds
+    ):
+        return NatVentTransition(
+            from_state=current_state,
+            to_state=NatVentLifecycleState.PAUSED_REACTIVATION_LOCKOUT,
+            event_kind=event.kind,
+            at=inputs.now,
+        )
+
     # Issue #540 (mirrored, Phase R prep): while soft-started, re-check the full
     # gate each tick — same pure function, same condition production's own
     # upgrade block re-evaluates. Escalating doesn't change the exit-chain

--- a/custom_components/climate_advisor/override_grace_fsm.py
+++ b/custom_components/climate_advisor/override_grace_fsm.py
@@ -113,6 +113,16 @@ class OverrideGraceFsmEventKind(Enum):
     # immediately at the dispatcher level without touching the thermostat path's
     # shared confirm-delay logic at all.
     FAN_OVERRIDE_DETECTED = "fan_override_detected"
+    # Issue #672: _start_grace_period()'s "every other trigger" callers (fan-off,
+    # window-close, nat-vent-exit, drift-correction) were deliberately never modeled at
+    # all — production genuinely starts a real, non-override-protecting grace for these,
+    # but the FSM had no event kind to represent it, so it stayed permanently stuck
+    # wherever it last was (confirmed live: production=idle/active_unprotected vs
+    # fsm=idle/none, indefinitely). Like FAN_OVERRIDE_DETECTED, this is unconditional on
+    # origin state — _legacy_set_grace_flags() never reads prior grace/confirm state,
+    # only the new trigger — so it's handled the same way, before the state-based
+    # dispatch, not inside any of the three _transition_from_* functions.
+    UNPROTECTED_GRACE_STARTED = "unprotected_grace_started"
 
 
 @dataclass(frozen=True)
@@ -397,15 +407,15 @@ def transition(current_state: OverrideGraceLifecycleState, event: OverrideGraceF
     only where it matters, mirroring ``door_window_fsm.py``'s own precedent of
     collapsing sub-states that share almost all their transition logic.
 
-    ``FAN_OVERRIDE_DETECTED`` (Issue #661) is handled here, before the
-    state-based dispatch, rather than inside any of the three
-    ``_transition_from_*`` functions: ``handle_fan_manual_override()`` is fully
-    idempotent and unconditional in production (always lands on
-    ``ACTIVE_PROTECTING_OVERRIDE`` regardless of origin state — see
-    ``_GRACE_TRIGGERS_PROTECTING_OVERRIDE`` in automation.py), so there is no
-    state-dependent branching to do, and short-circuiting here keeps
-    ``_land_after_detection()``'s thermostat-only confirm-delay model completely
-    untouched by the fan path's different contract.
+    ``FAN_OVERRIDE_DETECTED`` (Issue #661) and ``UNPROTECTED_GRACE_STARTED`` (Issue #672)
+    are both handled here, before the state-based dispatch, rather than inside any of the
+    three ``_transition_from_*`` functions: both are fully idempotent and unconditional on
+    origin state in production (``handle_fan_manual_override()`` always lands on
+    ``ACTIVE_PROTECTING_OVERRIDE``; ``_legacy_set_grace_flags()`` — the "every other
+    trigger" flag-write ``_start_grace_period()`` always performs — always lands on
+    ``ACTIVE_UNPROTECTED`` for a non-protecting trigger), so there is no state-dependent
+    branching to do, and short-circuiting here keeps ``_land_after_detection()``'s
+    thermostat-only confirm-delay model completely untouched by either's different contract.
     """
     if event.kind == OverrideGraceFsmEventKind.FAN_OVERRIDE_DETECTED:
         # Issue #664: "unconditional" means unconditional on ORIGIN STATE — it does not
@@ -415,6 +425,28 @@ def transition(current_state: OverrideGraceLifecycleState, event: OverrideGraceF
         next_state = (OverrideConfirmState.IDLE, grace_next)
         return OverrideGraceTransition(
             current_state, next_state, event.kind, "fan_override_immediate", event.inputs.now
+        )
+
+    if event.kind == OverrideGraceFsmEventKind.UNPROTECTED_GRACE_STARTED:
+        # Unlike FAN_OVERRIDE_DETECTED, this does NOT consult inputs.grace_would_start:
+        # that field is computed by _manual_grace_would_start(), which only ever resolves
+        # against the MANUAL grace duration (its own docstring: "every override/grace-
+        # modeled event that starts grace uses source='manual'") — but 3 of this event's
+        # 4 real triggers (window-close, nat-vent-exit x2) use source="automation". Using
+        # it here would silently check the wrong config value. Instead, this event is only
+        # ever dispatched by the caller AFTER _start_grace_period_action() has already
+        # returned True (a real grace, resolved against the correct source, definitely
+        # started) — same established gating convention every other real call site uses
+        # (see resume_from_pause()) — so landing unconditionally on ACTIVE_UNPROTECTED is
+        # correct by construction, not an assumption.
+        #
+        # _legacy_set_grace_flags() never touches _override_confirm_pending — preserve
+        # whatever confirm state carried over, unlike FAN_OVERRIDE_DETECTED above (which
+        # hardcodes IDLE per its own established precedent); only the grace axis changes.
+        confirm, _grace = current_state
+        next_state = (confirm, GraceState.ACTIVE_UNPROTECTED)
+        return OverrideGraceTransition(
+            current_state, next_state, event.kind, "unprotected_grace_started", event.inputs.now
         )
     _confirm, grace = current_state
     if grace == GraceState.NONE:

--- a/tests/test_activity_renderers.py
+++ b/tests/test_activity_renderers.py
@@ -546,10 +546,13 @@ class TestEventRenderersCoverage:
     # dedicated renderer.  Add here only with a comment explaining why.
     _DEFAULT_RENDERER_ALLOWLIST: frozenset[str] = frozenset(
         {
-            # No types currently in the allowlist — all production types have
-            # dedicated renderers.  Add entries here if a new event type is
-            # intentionally left to the default renderer (e.g., rare diagnostic
-            # events where the generic field extraction is sufficient).
+            # Issue #672: purely a technical signal feeding coordinator.py's diagnostic
+            # override/grace FSM tracker (_OVERRIDE_GRACE_FSM_EVENT_TYPE_MAP) — the SAME
+            # real grace-start _start_grace_period_action() already emits as the
+            # user-facing "grace_started" event (which has its own dedicated renderer)
+            # moments earlier. Giving this one its own renderer too would narrate the
+            # identical real-world event twice in the Activity Report.
+            "unprotected_grace_started",
         }
     )
 

--- a/tests/test_door_window_fsm.py
+++ b/tests/test_door_window_fsm.py
@@ -106,6 +106,27 @@ class TestFromNormal:
         )
         assert t.to_state == DoorWindowLifecycleState.NORMAL
 
+    def test_sync_reconcile_grace_active_upgrades_from_normal(self):
+        """Issue #672: a grace period started for a reason unrelated to any door/window
+        pause (override grace, fan-off grace) must not be invisible from NORMAL forever —
+        live incident 2026-08-17 showed production=grace/fsm=normal stuck for 90+ minutes
+        across many SYNC_RECONCILE cycles because this branch never consulted grace_active
+        at all. No sensor open, so the pause-entry checks below would otherwise no-op."""
+        t = transition(
+            DoorWindowLifecycleState.NORMAL,
+            _ev(DoorWindowFsmEventKind.SYNC_RECONCILE, any_sensor_open=False, grace_active=True),
+        )
+        assert t.to_state == DoorWindowLifecycleState.GRACE
+
+    def test_sync_reconcile_no_grace_stays_normal(self):
+        """Negative control: NORMAL with no sensor open and no grace stays NORMAL —
+        confirms the new grace_active check doesn't fire when grace is genuinely inactive."""
+        t = transition(
+            DoorWindowLifecycleState.NORMAL,
+            _ev(DoorWindowFsmEventKind.SYNC_RECONCILE, any_sensor_open=False, grace_active=False),
+        )
+        assert t.to_state == DoorWindowLifecycleState.NORMAL
+
     def test_nat_vent_exited_sensor_still_open_active(self):
         t = transition(
             DoorWindowLifecycleState.NORMAL,

--- a/tests/test_grace_stuck.py
+++ b/tests/test_grace_stuck.py
@@ -519,6 +519,10 @@ class TestGraceProtectsOverrideClassification:
         ae = _make_automation_engine_stub()
         ae._start_grace_period = types.MethodType(AutomationEngine._start_grace_period, ae)
         ae._cancel_grace_timers = types.MethodType(AutomationEngine._cancel_grace_timers, ae)
+        ae._resolve_override_grace_fsm_state = types.MethodType(AutomationEngine._resolve_override_grace_fsm_state, ae)
+        # Issue #672: _start_grace_period() now routes through the dispatcher, which
+        # reads this flag directly (not via a bound-method default) even in legacy mode.
+        ae._override_grace_fsm_authoritative = False
         ae._emit_event_callback = None
         ae.config = {}
         return ae

--- a/tests/test_nat_vent_fsm.py
+++ b/tests/test_nat_vent_fsm.py
@@ -193,6 +193,88 @@ class TestFromActiveExitWiring:
         assert t.exit_reason == NatVentExitReason.COMFORT_FLOOR
 
 
+class TestActiveBranchLockoutRecognition:
+    """Issue #672: _transition_from_active() previously had no way to ever recognize a
+    door-pause/reactivation-lockout condition once wrongly active — only the thermal/
+    comfort exit chain was checked. Live incident 2026-08-17: ticks landed on this branch
+    for 34+ minutes across 2 full startup-coalesce cycles with no path to
+    PAUSED_REACTIVATION_LOCKOUT/INACTIVE while production correctly showed
+    inactive/paused_reactivation_lockout.
+    """
+
+    def test_stuck_active_soft_start_corrects_to_locked_out(self) -> None:
+        """Positive control: a wrongly-active FSM with paused_by_door + an unexpired
+        lockout window must now correct on the very next tick, regardless of what the
+        thermal exit chain would otherwise conclude."""
+        now = datetime(2026, 1, 1, 12, 0, 30, tzinfo=UTC)
+        exit_time = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        t = transition(
+            NatVentLifecycleState.ACTIVE_SOFT_START,
+            _tick(
+                indoor=75.0,
+                outdoor=65.0,
+                comfort_heat_raw=68.0,
+                paused_by_door=True,
+                outdoor_exit_time=exit_time,
+                now=now,
+                lockout_seconds=300.0,
+            ),
+        )
+        assert t.to_state == NatVentLifecycleState.PAUSED_REACTIVATION_LOCKOUT
+
+    def test_stuck_active_full_gate_corrects_to_locked_out(self) -> None:
+        now = datetime(2026, 1, 1, 12, 0, 30, tzinfo=UTC)
+        exit_time = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        t = transition(
+            NatVentLifecycleState.ACTIVE_FULL_GATE,
+            _tick(
+                indoor=75.0,
+                outdoor=65.0,
+                comfort_heat_raw=68.0,
+                paused_by_door=True,
+                outdoor_exit_time=exit_time,
+                now=now,
+                lockout_seconds=300.0,
+            ),
+        )
+        assert t.to_state == NatVentLifecycleState.PAUSED_REACTIVATION_LOCKOUT
+
+    def test_genuinely_active_session_unaffected(self) -> None:
+        """Negative control: no pause, no lockout — the normal exit chain still runs
+        unchanged (this is TestFromActiveExitWiring's own territory; re-asserted here to
+        pin that the new check doesn't fire for the common case)."""
+        t = transition(NatVentLifecycleState.ACTIVE_FULL_GATE, _tick(indoor=72.0, outdoor=65.0))
+        assert not t.changed
+        assert t.exit_reason is None
+
+    def test_live_authoritative_shaped_inputs_never_trigger_new_branch(self) -> None:
+        """Blast-radius pin (Issue #672 investigation): production's real flags never
+        present natural_vent_active=True simultaneously with an active lockout window
+        (_exit_nat_vent() always clears the former before/as part of setting the field
+        that drives the latter) — so the live authoritative escalation check
+        (automation.py:3613-3632), which always feeds a freshly-derived current_state via
+        the nat_vent_lifecycle_state property, can never actually reach this branch with
+        paused_by_door=True + locked-out. This test pins that the new check is additive
+        only for the coordinator's separately-tracked, staleness-prone diagnostic state —
+        confirmed by construction: paused_by_door=False (the only state the live property
+        would ever present alongside a genuinely active session) leaves this branch inert."""
+        now = datetime(2026, 1, 1, 12, 0, 30, tzinfo=UTC)
+        exit_time = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        t = transition(
+            NatVentLifecycleState.ACTIVE_SOFT_START,
+            _tick(
+                indoor=75.0,
+                outdoor=65.0,
+                comfort_heat_raw=68.0,
+                paused_by_door=False,  # the live-property-derived shape while genuinely active
+                outdoor_exit_time=exit_time,
+                now=now,
+                lockout_seconds=300.0,
+            ),
+        )
+        assert t.to_state != NatVentLifecycleState.PAUSED_REACTIVATION_LOCKOUT
+
+
 class TestSoftStartEscalation:
     """Issue #594 Phase R prep: soft-start -> full-gate escalation, mirroring
     automation.py's own mid-session upgrade check (Issue #540)."""

--- a/tests/test_override_grace_fsm.py
+++ b/tests/test_override_grace_fsm.py
@@ -333,3 +333,47 @@ class TestFanOverrideDetected:
         t = transition(_IDLE_NONE, _ev(OverrideGraceFsmEventKind.OVERRIDE_DETECTED, confirm_seconds=600.0))
         assert t.to_state == _PENDING_NONE
         assert t.outcome == "detected"
+
+
+class TestUnprotectedGraceStarted:
+    """Issue #672: _start_grace_period()'s "every other trigger" callers (fan-off,
+    window-close, nat-vent-exit, drift-correction) were deliberately never modeled at
+    all — production genuinely starts a real, non-protecting grace for these, but the
+    FSM had no event kind to represent it, so it stayed permanently stuck (confirmed
+    live: production=idle/active_unprotected vs fsm=idle/none, indefinitely).
+    UNPROTECTED_GRACE_STARTED is short-circuited at the top of transition(), same
+    shape as FAN_OVERRIDE_DETECTED, so this holds from all three origin states."""
+
+    def test_from_no_grace_lands_unprotected_immediately(self):
+        t = transition(_IDLE_NONE, _ev(OverrideGraceFsmEventKind.UNPROTECTED_GRACE_STARTED))
+        assert t.to_state == _IDLE_UNPROTECTED
+        assert t.outcome == "unprotected_grace_started"
+        assert t.changed
+
+    def test_from_grace_protecting_downgrades_to_unprotected(self):
+        """A new unprotected-trigger grace always REPLACES whatever was running before
+        — production's _start_grace_period_action() unconditionally cancels the prior
+        timer first, and _legacy_set_grace_flags() derives fresh from only the new
+        trigger, never the prior state."""
+        t = transition(_IDLE_PROTECTING, _ev(OverrideGraceFsmEventKind.UNPROTECTED_GRACE_STARTED))
+        assert t.to_state == _IDLE_UNPROTECTED
+        assert t.changed
+
+    def test_from_grace_unprotected_stays_unprotected_idempotent(self):
+        t = transition(_IDLE_UNPROTECTED, _ev(OverrideGraceFsmEventKind.UNPROTECTED_GRACE_STARTED))
+        assert t.to_state == _IDLE_UNPROTECTED
+        assert not t.changed
+
+    def test_confirm_state_preserved_not_reset_to_idle(self):
+        """Regression guard distinguishing this from FAN_OVERRIDE_DETECTED: that kind
+        hardcodes IDLE on the confirm axis; this one must not, since
+        _legacy_set_grace_flags() never touches _override_confirm_pending."""
+        t = transition(_PENDING_NONE, _ev(OverrideGraceFsmEventKind.UNPROTECTED_GRACE_STARTED))
+        assert t.to_state == _PENDING_UNPROTECTED
+        assert t.to_state[0] == OverrideConfirmState.PENDING
+
+    def test_fan_override_detected_unaffected_still_hardcodes_idle(self):
+        """Regression guard: the fix must not change FAN_OVERRIDE_DETECTED's own
+        existing confirm-axis behavior."""
+        t = transition(_PENDING_NONE, _ev(OverrideGraceFsmEventKind.FAN_OVERRIDE_DETECTED))
+        assert t.to_state[0] == OverrideConfirmState.IDLE

--- a/tests/test_override_grace_fsm_authoritative_compare.py
+++ b/tests/test_override_grace_fsm_authoritative_compare.py
@@ -145,6 +145,55 @@ class TestDashboardResumePositiveControl:
         assert engine._grace_protects_override is False
 
 
+class TestUnprotectedGraceStartedPositiveControl:
+    """Issue #672: the 4 triggers _start_grace_period() historically never modeled at
+    all (fan-off, window-close, nat-vent-exit, drift-correction) now route through
+    UNPROTECTED_GRACE_STARTED. All 4 share one dispatcher call site
+    (_start_grace_period() itself), so on_fan_turned_off() — the most directly
+    callable — is sufficient to prove the wiring; window-close/nat-vent-exit/drift-
+    correction reuse the exact same code path, not a separate implementation."""
+
+    def test_broken_transition_detected(self) -> None:
+        from unittest.mock import patch
+
+        from custom_components.climate_advisor.override_grace_lifecycle import GraceState, OverrideConfirmState
+
+        engine = _make_engine()
+        with patch(
+            "custom_components.climate_advisor.override_grace_fsm.transition",
+            side_effect=lambda *a, **k: type(
+                "T",
+                (),
+                {"to_state": (OverrideConfirmState.IDLE, GraceState.NONE), "outcome": "broken", "at": None},
+            )(),
+        ):
+            engine.on_fan_turned_off(fan_before="on", fan_after="off")
+
+        assert engine._grace_active is False, (
+            "positive control FAILED: forcing override_grace_fsm.transition() to return grace=NONE "
+            "was not reflected in engine._grace_active — the mock wasn't actually exercised (real "
+            "outcome should be grace=ACTIVE_UNPROTECTED, so an undetected broken swap would "
+            "incorrectly show _grace_active=True instead)"
+        )
+
+    def test_unbroken_transition_starts_unprotected_grace(self) -> None:
+        engine = _make_engine()
+        engine.on_fan_turned_off(fan_before="on", fan_after="off")
+        assert engine._grace_active is True
+        assert engine._grace_protects_override is False, (
+            "fan_off is not in GRACE_TRIGGERS_PROTECTING_OVERRIDE — must land on "
+            "ACTIVE_UNPROTECTED, never ACTIVE_PROTECTING_OVERRIDE"
+        )
+
+    def test_confirm_state_preserved_not_reset(self) -> None:
+        """Unlike FAN_OVERRIDE_DETECTED (which hardcodes IDLE), UNPROTECTED_GRACE_STARTED
+        must preserve whatever _override_confirm_pending was before — production's real
+        _legacy_set_grace_flags() never touches that field."""
+        engine = _make_engine(_override_confirm_pending=True)
+        engine.on_fan_turned_off(fan_before="on", fan_after="off")
+        assert engine._override_confirm_pending is True
+
+
 class TestGraceDisabledPositiveControl:
     """Issue #664's own core finding: manual_grace_seconds=0 must land on
     GraceState.NONE, not be forced to an active state regardless of config. This is
@@ -167,4 +216,12 @@ class TestGraceDisabledPositiveControl:
             _current_classification=None,
         )
         asyncio.run(engine.resume_from_pause())
+        assert engine._grace_active is False
+
+    def test_unprotected_grace_with_grace_disabled_does_not_claim_active(self) -> None:
+        """Issue #672: on_fan_turned_off()'s new UNPROTECTED_GRACE_STARTED path is gated
+        the same way as every other real call site — _start_grace_period_action()
+        returning False (grace disabled) means the dispatcher is never even called."""
+        engine = _make_engine(config={"comfort_heat": 70.0, "comfort_cool": 76.0, "manual_grace_seconds": 0})
+        engine.on_fan_turned_off(fan_before="on", fan_after="off")
         assert engine._grace_active is False

--- a/tests/test_override_grace_fsm_shadow_wiring.py
+++ b/tests/test_override_grace_fsm_shadow_wiring.py
@@ -139,6 +139,68 @@ class TestFsmStateTracking:
         )
 
 
+class TestUnprotectedGraceStartedEventWiring:
+    """Issue #672: closes the exact live disagreement observed 2026-08-17
+    (production=idle/active_unprotected, fsm=idle/none) for fan-off/window-close/
+    nat-vent-exit/drift-correction grace starts — none of these had ANY feed to the
+    coordinator's diagnostic FSM tracker at all before this fix. Runs the real
+    production on_fan_turned_off() call (not direct engine construction) so
+    _emit_event_callback genuinely fires through coordinator._emit_event() ->
+    _feed_lifecycle_fsms_from_event(), the same path the live bug went through.
+    """
+
+    def test_on_fan_turned_off_lands_unprotected_grace_via_event(self) -> None:
+        coordinator, _fake_hass, scheduler, _event_log = build_headless_coordinator()
+        # Pre-fix baseline: a fresh coordinator's tracked state starts (IDLE, NONE) and
+        # nothing would ever move it for this trigger — this assertion is itself the
+        # positive control (the "before" state fails it by construction).
+        assert coordinator._override_grace_fsm_state == (OverrideConfirmState.IDLE, GraceState.NONE)
+
+        _noop_shadow_methods(coordinator, "on_fan_turned_off")
+        with scheduler.installed():
+            coordinator.automation_engine.on_fan_turned_off(fan_before="on", fan_after="off")
+            # Drains the real hass.async_create_task(start_min_fan_runtime_cycles())
+            # fire-and-forget task on_fan_turned_off() schedules — same pattern
+            # build_headless_coordinator()'s own startup sequence uses (Issue #476).
+            scheduler.advance_to(scheduler.now())
+
+        assert coordinator._override_grace_fsm_state == (OverrideConfirmState.IDLE, GraceState.ACTIVE_UNPROTECTED)
+
+    def test_on_fan_turned_off_no_longer_disagrees(self) -> None:
+        coordinator, _fake_hass, scheduler, _event_log = build_headless_coordinator()
+
+        # Matches coordinator.py's real call sites (production call immediately followed
+        # by the mirror) — the diagnostic is only computed inside _mirror_to_shadow()'s
+        # finally block, same pattern test_fan_manual_override_no_longer_disagrees uses.
+        _noop_shadow_methods(coordinator, "on_fan_turned_off")
+        with scheduler.installed():
+            coordinator.automation_engine.on_fan_turned_off(fan_before="on", fan_after="off")
+            _run(coordinator._mirror_to_shadow("on_fan_turned_off", fan_before="on", fan_after="off"))
+            scheduler.advance_to(scheduler.now())
+
+        diag = coordinator.shadow_engine_diagnostic
+        assert diag is not None
+        assert diag["override_grace_production_state"] == "idle/active_unprotected"
+        assert diag["override_grace_fsm_state"] == "idle/active_unprotected"
+        assert diag["override_grace_fsm_agrees"] is True
+
+    def test_shadow_engine_isolated_does_not_leak_into_coordinator_state(self) -> None:
+        """The shadow engine also runs on_fan_turned_off() (it's a mirrored method), but
+        its own emit_event callback (_on_shadow_emit_event) is isolated from
+        coordinator._emit_event() — verify that isolation holds for this new event
+        rather than assuming it, per _build_shadow_automation_callbacks()'s own design."""
+        coordinator, _fake_hass, scheduler, _event_log = build_headless_coordinator()
+
+        with scheduler.installed():
+            coordinator.automation_engine.on_fan_turned_off(fan_before="on", fan_after="off")
+            _run(coordinator._mirror_to_shadow("on_fan_turned_off", fan_before="on", fan_after="off"))
+            scheduler.advance_to(scheduler.now())
+
+        # Exactly one real transition happened (production's own call above) — the
+        # shadow replay must not have fed a second, duplicate event into the tracker.
+        assert coordinator._override_grace_fsm_state == (OverrideConfirmState.IDLE, GraceState.ACTIVE_UNPROTECTED)
+
+
 class TestDiagnosticIntegration:
     def test_diagnostic_includes_override_grace_fsm_state(self) -> None:
         coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()

--- a/tests/test_shadow_engine_coverage.py
+++ b/tests/test_shadow_engine_coverage.py
@@ -321,6 +321,11 @@ _OVERRIDE_GRACE_EVENT_KIND_REGISTRY: dict[str, str] = {
     # transition (_land_after_detection with grace fixed at ACTIVE_PROTECTING_OVERRIDE)
     # correctly matches production's real "confirm re-evaluated, grace untouched" behavior.
     "OVERRIDE_SUPERSEDED": "reachable",
+    # Issue #672: automation.py's _start_grace_period() — the shared wrapper for every
+    # trigger that was never modeled at all (fan-off, window-close, nat-vent-exit,
+    # drift-correction) — now dispatches this kind after _start_grace_period_action()
+    # confirms a real grace actually started.
+    "UNPROTECTED_GRACE_STARTED": "reachable",
 }
 
 

--- a/tools/sim_harness/outcomes.py
+++ b/tools/sim_harness/outcomes.py
@@ -129,6 +129,11 @@ UNMAPPED_PRODUCTION_EVENTS: frozenset[str] = frozenset(
         "nat_vent_floor_imminent_skip",
         "nat_vent_predicted_floor_exit",
         "grace_started",
+        # Issue #672: emitted from the exact same _start_grace_period() call site as
+        # "grace_started" above, moments later — same "always fires last, shadows the
+        # real outcome" reasoning. Feeds coordinator.py's diagnostic override/grace FSM
+        # tracker only; not a decision outcome of its own.
+        "unprotected_grace_started",
         "incident_detected",
         # Issue #523: startup_coalesced is a bookkeeping summary (nat_vent_activated/
         # hvac_commanded/sensors_open_count echoing what the coalesce cycle already


### PR DESCRIPTION
## Summary
- Three separate, previously-unexamined gaps in the shadow-FSM diagnostic architecture (each lifecycle's pure-function state machine, compared against production for observability purposes). Real HVAC/fan behavior was always correct throughout the investigation.
- **door/window**: `SYNC_RECONCILE` never checked `grace_active` from a `NORMAL` origin, so a grace period started for a reason unrelated to any door/window pause (override grace, fan-off grace) was invisible forever — confirmed live: `production=grace fsm=normal`, stuck for 90+ minutes on 2026-08-17.
- **nat-vent**: `_transition_from_active()` only checked the thermal/comfort exit chain, never a door-pause/reactivation-lockout condition, so a wrongly-active FSM had no path back once stuck — confirmed live: 34+ minutes across 2 full startup-coalesce cycles.
- **override/grace**: added `UNPROTECTED_GRACE_STARTED`. `_start_grace_period()` (the shared wrapper for fan-off/window-close/nat-vent-exit/drift-correction grace starts) now routes through the existing authoritative dispatcher instead of writing flags directly, and emits a distinct event so the coordinator's diagnostic tracker — previously fed nothing at all for these 4 triggers — picks it up too.

## Blast radius
- door/window and nat-vent fixes are confirmed diagnostic-only, verified by reading the real authoritative call sites directly: both read a self-consistent, always-fresh-derived property (`nat_vent_lifecycle_state`/`door_window_lifecycle_state`), never the buggy coordinator-tracked value these fixes correct.
- override/grace's fix genuinely extends what the (currently untoggled, but real and working) `_override_grace_fsm_authoritative` switch would drive if ever flipped — backed by the project's existing decision-equivalence-proof test (`test_override_grace_fsm_authoritative_compare.py`) across the full golden+pending scenario corpus, same rigor the original #664 cutover used.
- The new diagnostic-only `unprotected_grace_started` event is registered in `tools/sim_harness/outcomes.py`'s `UNMAPPED_PRODUCTION_EVENTS` (same treatment as its sibling `grace_started`) so it can't shadow real decision outcomes in golden-scenario per-timestamp assertions, and in the Activity Report renderer allowlist (it would otherwise narrate the same real grace-start twice).

## Test plan
- [x] New positive/negative-control unit tests for each of the 3 FSM fixes (door/window, nat-vent, override/grace pure-function level)
- [x] New equivalence-proof-level tests for override/grace (direct-engine positive controls, including a "broken transition" control proving the test would actually catch a regression)
- [x] Full suite: `pytest tests/ -W error::pytest.PytestUnraisableExceptionWarning -W error::RuntimeWarning` — 4885 passed, 6 skipped, zero warnings
- [x] `python tools/simulate.py --check-integrity` — 81 scenarios verified
- [x] `python tools/simulate.py` — 81/81 golden scenarios passed
- [x] `ruff check` / `ruff format` clean

Closes #672