### PR TITLE
Fix #673: shadow-engine mirror raw-copy safety net missing 4 nat-vent/door-window fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.34] — 2026-08-17
+
+- Fix #673: no user-visible change. Closes a structural gap in the shadow-diagnostic safety net related to #672 — four nat-vent/door-window fields were never included in the periodic raw-copy step that keeps the shadow diagnostic engine in sync, so a single missed update anywhere in the code could cause a permanent false "disagreement" reading with no way to self-correct. Real HVAC/fan behavior was always correct throughout; only the diagnostic mirror could drift.
+
 ## [0.6.33] — 2026-08-17
 
 - Fix #672: no user-visible change. Three shadow-diagnostic state machines (door/window, nat-vent, override/grace) each had their own reason for getting permanently stuck out of sync with real production state after a restart or a specific state transition — real HVAC/fan behavior was always correct throughout. Fixed all three.

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,20 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.33"
+VERSION = "0.6.34"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.34": [
+        "Fix #673: no user-visible change. Closes a structural gap in the shadow-"
+        " diagnostic safety net related to #672 — four nat-vent/door-window fields"
+        " (whether natural ventilation is active, soft-start state, door-pause"
+        " state, and the outdoor-rise exit timer) were never included in the"
+        " periodic raw-copy step that keeps the shadow diagnostic engine in sync,"
+        " so a single missed update anywhere in the code could cause a permanent"
+        " false 'disagreement' reading with no way to self-correct. Real HVAC/fan"
+        " behavior was always correct throughout; only the diagnostic mirror could"
+        " drift.",
+    ],
     "0.6.33": [
         "Fix #672: no user-visible change. Three shadow-diagnostic state machines"
         " (door/window, nat-vent, override/grace) each had their own reason for"
@@ -1952,6 +1963,32 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    673: {
+        "version_fixed": "0.6.34",
+        "title": (
+            "Shadow-engine mirror comparison's periodic raw-copy safety net was missing 4"
+            " nat-vent/door-window fields, so any missed or exception-interrupted"
+            " _mirror_to_shadow() call site touching them caused a permanent,"
+            " non-self-healing divergence"
+        ),
+        "scope_covered": (
+            "coordinator.py: _sync_shadow_inputs() now raw-copies _natural_vent_active,"
+            " _nat_vent_soft_start, _paused_by_door, and _nat_vent_outdoor_exit_time from"
+            " the production engine to the shadow engine every cycle, extending the same"
+            " precedent #613/#631 already established for outdoor temp/forecast/thermal"
+            " model and grace/override state. _paused_by_door is read by both the"
+            " nat-vent and door/window mirror derivations, so this closes both classes of"
+            " shadow-engine disagreement in one change. Phase 3 audit (same issue): the"
+            " test_shadow_engine_coverage.py registry already tracked all 4 fields and"
+            " classified every mutating method mirrored/internal — confirmed still"
+            " accurate, no gap found. nat_vent_fsm.py's 6 unused NatVentFsmEventKind"
+            " members (DOOR_PAUSE_STARTED, DOOR_PAUSE_ENDED, GRACE_STARTED, GRACE_ENDED,"
+            " OVERRIDE_CONFIRMED, OVERRIDE_CLEARED) confirmed safe as documented: only"
+            " TICK is ever fed from a real call site, and transition() never branches on"
+            " event.kind (grepped — it's only ever recorded into the result), so feeding"
+            " TICK for any of those triggers produces an identical transition."
+        ),
+    },
     672: {
         "version_fixed": "0.6.33",
         "title": (

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -970,6 +970,16 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         se._override_confirm_source = ae._override_confirm_source
         se._paused_with_hvac_already_off = ae._paused_with_hvac_already_off
 
+        # Issue #673: nat-vent/door-window state — same gap class as #613/#631 above.
+        # These 4 fields were never added to this raw-copy block when it was created,
+        # so any missed or exception-interrupted _mirror_to_shadow() call site touching
+        # them causes a permanent, non-self-healing divergence. _paused_by_door is read
+        # by both the nat-vent and door/window mirror derivations.
+        se._natural_vent_active = ae._natural_vent_active
+        se._nat_vent_soft_start = ae._nat_vent_soft_start
+        se._paused_by_door = ae._paused_by_door
+        se._nat_vent_outdoor_exit_time = ae._nat_vent_outdoor_exit_time
+
     def _dispatch_fsm_evaluators(
         self,
         key: str,

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.33"
+  "version": "0.6.34"
 }

--- a/custom_components/climate_advisor/nat_vent_fsm.py
+++ b/custom_components/climate_advisor/nat_vent_fsm.py
@@ -82,6 +82,13 @@ class NatVentFsmEventKind(Enum):
     GRACE_ENDED = "grace_ended"
     OVERRIDE_CONFIRMED = "override_confirmed"
     OVERRIDE_CLEARED = "override_cleared"
+    # Issue #673 Phase 3 audit: confirmed only TICK is fed from any real call site
+    # (automation.py, coordinator.py) — the other 6 members are unused-in-v1, exactly
+    # as this class's own docstring above says. Confirmed safe by grep: transition()
+    # only ever assigns `event_kind=event.kind` into the result record, never branches
+    # on it (`if`/`==` against .kind does not appear anywhere in this module), so
+    # feeding TICK for a door-pause/grace/override-triggered re-evaluation produces the
+    # identical transition a "correctly" kinded event would. No gap; not wired further.
 
 
 @dataclass(frozen=True)

--- a/tests/test_shadow_engine_live.py
+++ b/tests/test_shadow_engine_live.py
@@ -28,6 +28,13 @@ Issue #631 (second coverage-gap follow-up) adds:
     their companion mode/source/time/duration fields — with a positive control
     reproducing the confirmed live incident (shadow disagreed for 2h38m because its
     ``_grace_active`` never reflected production's active manual-override grace period).
+
+Issue #673 (third coverage-gap follow-up, Phase 2) adds:
+  - ``_sync_shadow_inputs()`` nat-vent/door-window parity: ``_natural_vent_active``,
+    ``_nat_vent_soft_start``, ``_paused_by_door``, ``_nat_vent_outdoor_exit_time`` —
+    the 4 fields confirmed absent from the raw-copy block despite the #613/#631
+    precedent already covering everything else. Same shape as #615/#631: a positive
+    control proves the fields stay stale on the shadow without the raw copy.
 """
 
 from __future__ import annotations
@@ -341,6 +348,51 @@ class TestSyncShadowInputsGraceOverride:
         coordinator._sync_shadow_inputs = lambda: None  # type: ignore[method-assign]
         _run(coordinator._mirror_to_shadow("apply_classification", None))
         assert coordinator.shadow_automation_engine._grace_active is False
+
+
+class TestSyncShadowInputsNatVentDoorWindow:
+    """Issue #673: same gap class as #615/#631, different field set — nat-vent/
+    door-window state confirmed absent from _sync_shadow_inputs()'s raw-copy block.
+    Any missed or exception-interrupted _mirror_to_shadow() call site touching these
+    fields caused a permanent, non-self-healing divergence with no way to recover
+    short of a coordinator restart."""
+
+    def test_natural_vent_active_parity_after_mirror_call(self) -> None:
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        coordinator.automation_engine._natural_vent_active = True
+        _run(coordinator._mirror_to_shadow("apply_classification", None))
+        assert coordinator.shadow_automation_engine._natural_vent_active is True
+
+    def test_nat_vent_soft_start_parity(self) -> None:
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        coordinator.automation_engine._nat_vent_soft_start = True
+        _run(coordinator._mirror_to_shadow("apply_classification", None))
+        assert coordinator.shadow_automation_engine._nat_vent_soft_start is True
+
+    def test_paused_by_door_parity(self) -> None:
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        coordinator.automation_engine._paused_by_door = True
+        _run(coordinator._mirror_to_shadow("apply_classification", None))
+        assert coordinator.shadow_automation_engine._paused_by_door is True
+
+    def test_nat_vent_outdoor_exit_time_parity(self) -> None:
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        coordinator.automation_engine._nat_vent_outdoor_exit_time = "2026-08-17T21:02:02-07:00"
+        _run(coordinator._mirror_to_shadow("apply_classification", None))
+        assert coordinator.shadow_automation_engine._nat_vent_outdoor_exit_time == "2026-08-17T21:02:02-07:00"
+
+    def test_positive_control_missing_sync_reproduces_the_stuck_disagreement(self) -> None:
+        """Without these 4 fields in _sync_shadow_inputs(), _natural_vent_active stays
+        False on the shadow even after production activates nat-vent for real — proves
+        this test would have caught the confirmed live "production=active fsm/shadow=
+        inactive, stuck for hours" class of incident before it shipped."""
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        coordinator.automation_engine._natural_vent_active = True
+        coordinator.automation_engine._paused_by_door = True
+        coordinator._sync_shadow_inputs = lambda: None  # type: ignore[method-assign]
+        _run(coordinator._mirror_to_shadow("apply_classification", None))
+        assert coordinator.shadow_automation_engine._natural_vent_active is False
+        assert coordinator.shadow_automation_engine._paused_by_door is False
 
 
 class TestNewlyMirroredDecisionMethods:


### PR DESCRIPTION
## Summary
- Phase 2 of the shadow-diagnostic gap class (sibling of #672): `_sync_shadow_inputs()`'s raw-copy safety net (established by #615/#631 for outdoor temp/forecast/thermal model and grace/override state) never covered `_natural_vent_active`, `_nat_vent_soft_start`, `_paused_by_door`, or `_nat_vent_outdoor_exit_time` — any missed or exception-interrupted `_mirror_to_shadow()` call site touching these caused a permanent, non-self-healing shadow-engine disagreement. `_paused_by_door` is read by both the nat-vent and door/window mirror derivations, so this closes both disagreement classes in one change.
- Phase 3 audit (not blind rewiring): confirmed `test_shadow_engine_coverage.py`'s registry already tracked these 4 fields with accurate mirrored/internal classifications (no gap), and confirmed `nat_vent_fsm.py`'s 6 unused `NatVentFsmEventKind` members are safe as documented — only `TICK` is ever fed, and `transition()` never branches on `event.kind`.
- No user-visible change: real HVAC/fan behavior was always correct; only the diagnostic shadow mirror could drift.

## Test plan
- [x] New `TestSyncShadowInputsNatVentDoorWindow` class (5 tests) in `test_shadow_engine_live.py` — parity for all 4 fields plus a positive control reproducing the confirmed live "production=active shadow=inactive, stuck for hours" incident class without the fix
- [x] Full suite: 4893 passed, 6 skipped, warnings-as-errors clean
- [x] `tools/simulate.py --check-integrity` + full run: 81/81 golden scenarios passed
- [x] ruff check/format clean on all modified files