### PR TITLE
Fix #676: door/window shadow FSM stuck at paused_idle when grace-expiry re-pause is preempted by nat-vent reactivation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.35] — 2026-08-18
+
+- Fix #676: no user-visible change. Closes a second, separate shadow-diagnostic gap found immediately after #672/#673 shipped: when a grace period expired with a door/window sensor still open and free-cooling conditions happened to be favorable, natural ventilation correctly resumed and the pause was correctly cleared, but the shadow diagnostic engine was never told about it and could show a stuck false "disagreement" for 20+ minutes. Real HVAC/fan behavior was always correct throughout; only the diagnostic mirror could drift.
+
 ## [0.6.34] — 2026-08-17
 
 - Fix #673: no user-visible change. Closes a structural gap in the shadow-diagnostic safety net related to #672 — four nat-vent/door-window fields were never included in the periodic raw-copy step that keeps the shadow diagnostic engine in sync, so a single missed update anywhere in the code could cause a permanent false "disagreement" reading with no way to self-correct. Real HVAC/fan behavior was always correct throughout; only the diagnostic mirror could drift.

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -5192,6 +5192,31 @@ class AutomationEngine:
                 )
                 await self._activate_fan(reason=nat_vent_reason)
                 self._natural_vent_active = True
+
+                from .door_window_fsm import DoorWindowFsmEventKind
+
+                # Issue #676: this branch is structurally identical to
+                # check_natural_vent_conditions()'s own paused-reactivation branch
+                # (automation.py ~3860-3953), which already routes through
+                # _resolve_door_window_pause_flags() and emits
+                # "nat_vent_reactivated_while_paused" — the only event type wired to the
+                # shadow door/window FSM's PAUSED_NAT_VENT_REACTIVATED transition
+                # (coordinator.py's _DOOR_WINDOW_NAT_VENT_REACTIVATED_EVENT_TYPES). This
+                # call site was never updated to match when that mechanism was built
+                # (Issues #647/#660/#668), so the shadow FSM never left paused_idle when
+                # grace expired into this specific reactivation path — production
+                # correctly reactivated nat-vent and cleared its own pause flags below,
+                # but the shadow FSM had no event telling it to do the same, sticking at
+                # paused_idle indefinitely (confirmed live, 2026-08-18: 20+ minutes of
+                # stuck "production=normal fsm=paused_idle" disagreement).
+                def _legacy_clear_pause() -> None:
+                    self._paused_by_door = False
+                    self._paused_with_hvac_already_off = False
+
+                self._resolve_door_window_pause_flags(
+                    kind=DoorWindowFsmEventKind.PAUSED_NAT_VENT_REACTIVATED,
+                    legacy=_legacy_clear_pause,
+                )
                 if not self._doorwindow_fsm_authoritative:
                     # Issue #637 (Phase R Step 1, violation #3): clear the stale pause
                     # flag, matching the structurally identical branch in
@@ -5223,6 +5248,20 @@ class AutomationEngine:
                     nat_vent_threshold,
                 )
                 if self._emit_event_callback:
+                    # Issue #676: emitted BEFORE "sensor_opened" below, deliberately —
+                    # feeds the shadow door/window FSM's PAUSED_NAT_VENT_REACTIVATED
+                    # transition; unrelated to and consumed independently of
+                    # "sensor_opened" (Activity Report rendering, etc.). Ordered first
+                    # so "sensor_opened" — the event the golden-scenario harness's
+                    # production_outcome_at() already maps to this branch's
+                    # "natural_ventilation" outcome — remains the last-emitted event at
+                    # this instant, unchanged from pre-fix behavior; this new event type
+                    # has no outcome mapping of its own (diagnostic-only) and would
+                    # otherwise shadow it.
+                    self._emit_event_callback(
+                        "nat_vent_reactivated_while_paused",
+                        {"outdoor": outdoor, "indoor": indoor, "threshold": nat_vent_threshold},
+                    )
                     self._emit_event_callback(
                         "sensor_opened",
                         {

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,19 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.34"
+VERSION = "0.6.35"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.35": [
+        "Fix #676: no user-visible change. Closes a second, separate shadow-diagnostic"
+        " gap found immediately after #672/#673 shipped: when a grace period expired"
+        " with a door/window sensor still open and free-cooling conditions happened to"
+        " be favorable, natural ventilation correctly resumed and the pause was"
+        " correctly cleared, but the shadow diagnostic engine was never told about it"
+        " and could show a stuck false 'disagreement' for 20+ minutes. Real HVAC/fan"
+        " behavior was always correct throughout; only the diagnostic mirror could"
+        " drift.",
+    ],
     "0.6.34": [
         "Fix #673: no user-visible change. Closes a structural gap in the shadow-"
         " diagnostic safety net related to #672 — four nat-vent/door-window fields"
@@ -1963,6 +1973,28 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    676: {
+        "version_fixed": "0.6.35",
+        "title": (
+            "Door/window shadow FSM stuck at paused_idle when a grace-expiry re-pause"
+            " check was preempted by nat-vent reactivation — production correctly"
+            " resumed but the shadow FSM never received the transition"
+        ),
+        "scope_covered": (
+            "automation.py: AutomationEngine._re_pause_for_open_sensor()'s nat-vent"
+            " reactivation branch (_reactivates=True) now calls"
+            " _resolve_door_window_pause_flags(kind=PAUSED_NAT_VENT_REACTIVATED, ...)"
+            " and emits the dedicated 'nat_vent_reactivated_while_paused' event type,"
+            " matching the structurally identical sibling branch already fixed in"
+            " check_natural_vent_conditions() by Issues #647/#660/#668. This call site"
+            " was the one remaining place emitting only the unrelated 'sensor_opened'"
+            " event (kept unchanged for its own consumers), which is not wired to any"
+            " door/window-FSM-clearing transition. Confirmed unrelated to the"
+            " natvent_fsm_authoritative switch (Issue #594 Phase R) and to #672/#673's"
+            " raw-flag-sync fix — this is a distinct event-wiring gap in a third call"
+            " site, found via live overnight logs the night #672/#673 shipped."
+        ),
+    },
     673: {
         "version_fixed": "0.6.34",
         "title": (

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.34"
+  "version": "0.6.35"
 }

--- a/tests/test_shadow_fsm_harness_event_coverage.py
+++ b/tests/test_shadow_fsm_harness_event_coverage.py
@@ -302,3 +302,91 @@ class TestPausedNatVentReactivatedPositiveControl:
             "reproduce the live bug (shadow FSM wrongly reset to NORMAL) — if this assertion "
             "fails, the tests above are not actually exercising the dispatch table they claim to"
         )
+
+
+class TestRePauseForOpenSensorReactivationEventCoverage:
+    """Issue #676: ``_re_pause_for_open_sensor()`` (the async task ``_on_grace_expired()``
+    schedules when grace expires with a sensor still open) has a reactivation branch
+    structurally identical to ``check_natural_vent_conditions()``'s own paused-by-door
+    reactivation block (covered above by ``TestPausedNatVentReactivatedEventCoverage``) —
+    but it was never updated when Issues #647/#660/#668 wired
+    ``PAUSED_NAT_VENT_REACTIVATED``/``"nat_vent_reactivated_while_paused"`` into that
+    sibling branch. Confirmed live, 2026-08-18: after grace expired with a sensor still
+    open, production correctly reactivated nat-vent and cleared its own pause flags, but
+    the shadow door/window FSM stuck at ``PAUSED_IDLE`` for 20+ minutes
+    (``production=normal fsm=paused_idle``).
+    """
+
+    def test_real_reactivation_clears_shadow_fsm(self) -> None:
+        """Outdoor genuinely cool enough to reactivate nat-vent while paused — reaches
+        the ``_reactivates`` branch's ``_resolve_door_window_pause_flags(kind=
+        PAUSED_NAT_VENT_REACTIVATED, ...)`` call this fix added. Calls production's real
+        ``ae._re_pause_for_open_sensor()`` directly (not ``_mirror_to_shadow``, which
+        replays on the shadow engine and never reaches the event-driven feed — that's
+        fed only from production's own ``_emit_event_callback``, wired to
+        ``coordinator._emit_event``, same reasoning as the sibling tests above)."""
+        coordinator, _fake_hass, scheduler, _event_log, ae = _build_paused_by_door_coordinator(
+            outdoor=58.5, indoor=73.0, hvac_already_off=False
+        )
+
+        with scheduler.installed():
+            run_coro(ae._re_pause_for_open_sensor())
+            scheduler.advance_to(scheduler.now())
+
+        assert ae._paused_by_door is False, "production must have actually reactivated — sanity check"
+        assert ae._natural_vent_active is True, "production must have actually reactivated — sanity check"
+        assert coordinator._door_window_fsm_state == DoorWindowLifecycleState.NORMAL, (
+            f"shadow door/window FSM ({coordinator._door_window_fsm_state}) disagreed with "
+            "production's real reactivation via _re_pause_for_open_sensor() — the fix's new "
+            "event emit must reach the shadow FSM feed (Issue #676)"
+        )
+
+    def test_no_reactivation_leaves_shadow_fsm_paused(self) -> None:
+        """Outdoor too warm to reactivate — the `_reactivates` branch is never taken, so
+        the shadow FSM must stay PAUSED_IDLE, not get reset (mirrors the sibling
+        no-reactivation test's correctness-preserving direction)."""
+        coordinator, _fake_hass, scheduler, _event_log, ae = _build_paused_by_door_coordinator(
+            outdoor=85.0, indoor=73.0, hvac_already_off=False
+        )
+
+        with scheduler.installed():
+            run_coro(ae._re_pause_for_open_sensor())
+            scheduler.advance_to(scheduler.now())
+
+        assert ae._paused_by_door is True, "production must not have reactivated — sanity check"
+        assert coordinator._door_window_fsm_state == DoorWindowLifecycleState.PAUSED_IDLE, (
+            f"shadow door/window FSM ({coordinator._door_window_fsm_state}) was wrongly reset — "
+            "_re_pause_for_open_sensor() ran but did not actually reactivate nat-vent"
+        )
+
+
+class TestRePauseForOpenSensorReactivationPositiveControl:
+    """Proves the test above is load-bearing: filtering out just the new
+    "nat_vent_reactivated_while_paused" emit (simulating the pre-#676 code, which never
+    emitted it from this call site) must make the shadow FSM stick at PAUSED_IDLE even
+    though production correctly reactivated."""
+
+    def test_filtering_the_new_event_reproduces_the_bug(self) -> None:
+        coordinator, _fake_hass, scheduler, _event_log, ae = _build_paused_by_door_coordinator(
+            outdoor=58.5, indoor=73.0, hvac_already_off=False
+        )
+
+        real_emit = coordinator._emit_event
+
+        def _filtered_emit(event_type: str, data: dict | None = None) -> None:
+            if event_type == "nat_vent_reactivated_while_paused":
+                return
+            real_emit(event_type, data)
+
+        ae._emit_event_callback = _filtered_emit
+
+        with scheduler.installed():
+            run_coro(ae._re_pause_for_open_sensor())
+            scheduler.advance_to(scheduler.now())
+
+        assert ae._paused_by_door is False, "production's own reactivation is unaffected by the filter"
+        assert coordinator._door_window_fsm_state == DoorWindowLifecycleState.PAUSED_IDLE, (
+            "positive control FAILED: filtering out the new event should reproduce the live bug "
+            "(shadow FSM stuck at PAUSED_IDLE) — if this assertion fails, the test above is not "
+            "actually exercising the new event this fix added"
+        )


### PR DESCRIPTION
## Summary

- Closes a second, separate shadow-diagnostic gap found immediately after #672/#673 shipped (2026-08-18 overnight live logs, confirmed unrelated to the `natvent_fsm_authoritative` switch).
- `AutomationEngine._re_pause_for_open_sensor()`'s nat-vent reactivation branch correctly reactivates nat-vent and clears production's own pause flags, but only emitted `"sensor_opened"` — never `_resolve_door_window_pause_flags(kind=PAUSED_NAT_VENT_REACTIVATED, ...)` nor the dedicated `"nat_vent_reactivated_while_paused"` event its structurally-identical sibling branch in `check_natural_vent_conditions()` already emits (built by #647/#660/#668). Shadow door/window FSM stuck at `paused_idle` for 20+ minutes live.
- Fix is additive only: emits the missing event (ordered before the existing `"sensor_opened"` emit so the golden-scenario harness's outcome mapping — which keys off `"sensor_opened"` — is unaffected) and calls the existing flag-resolution helper. Zero change to production's real HVAC/fan decisions.
- See #676 for full root-cause writeup.

## Test plan
- [x] New tests in `tests/test_shadow_fsm_harness_event_coverage.py`: reactivation clears the shadow FSM, no-reactivation leaves it untouched, and a positive control proving the fix is load-bearing (filtering the new event reproduces the stuck-`paused_idle` bug).
- [x] Full suite: `pytest tests/ -W error::pytest.PytestUnraisableExceptionWarning -W error::RuntimeWarning` — 4896 passed, 6 skipped.
- [x] `ruff check` / `ruff format` clean.
- [x] `tools/simulate.py --check-integrity` — 81 scenarios verified; `tools/simulate.py` — 81/81 golden scenarios pass (including the one this fix's initial version transiently broke via event-ordering, now fixed).