### PR TITLE
Fix #694: wire nat-vent's 4 bypassed decision points through transition() (Epic #594 Phase R, Phase 2b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.43] — 2026-08-19
+
+- Fix #694: fixed 3 defects introduced by the previous nat-vent state-machine wiring pass (still not authoritative over any real decision by default). With the state-machine switch enabled, an in-flight natural-ventilation session (free cooling already running) could be killed outright or silently downgraded from a stronger cooling mode to a weaker one whenever a second door or window was opened during that session — even though nothing about outdoor/indoor conditions had changed. Also fixed a case where reopening a window during an existing door/window pause could leave the automation's internal pause bookkeeping in an inconsistent state. No change for installs that haven't opted into the state-machine switch.
+
 ## [0.6.42] — 2026-08-19
 
 - Fix #690: two separate places that decide when to end a natural-ventilation session (a fast check and a slower 30-minute check) used to disagree by one degree of temperature precision at the exact moment outdoor and indoor temperatures matched — the fast check would end the session, the slow one wouldn't, for up to 30 minutes. Both now agree and end the session at the same instant once free cooling is genuinely gone. Rare edge case; no change for the common case where temperatures aren't at exact equality.

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -3152,13 +3152,49 @@ class AutomationEngine:
             # Issue #411 (Pass 4): shared reactivation gate, previously hand-copied here as
             # "Issue #392 Fix 1: mirror the ODE ceiling guard's dormancy condition on
             # reactivation." No hysteresis applied at this call site (default 0.0).
-            _nat_vent_gate_entered = self._nat_vent_may_reactivate(
-                outdoor=outdoor,
-                indoor=indoor,
-                comfort_heat=comfort_heat,
-                comfort_cool=comfort_cool,
-                nat_vent_delta=nat_vent_delta,
-            )
+            #
+            # Issue #694 (epic #594 Phase R, Phase 2b): while FSM-authoritative, this
+            # boolean is decided by nat_vent_fsm.transition() instead of the direct legacy
+            # call, restricted to its ACTIVE_FULL_GATE outcome only. This call site has
+            # never modeled soft-start entry (no _nat_vent_may_soft_start() call here) —
+            # Phase 2b is wiring-only, not new decision authority — so an FSM-produced
+            # ACTIVE_SOFT_START result is treated the same as "not entered" here, matching
+            # this site's pre-existing scope. The non-authoritative branch is unchanged.
+            if self._natvent_fsm_authoritative:
+                from .nat_vent_fsm import NatVentFsmEvent, NatVentFsmEventKind
+                from .nat_vent_fsm import transition as _nat_vent_transition
+
+                # The FSM's current_state is deliberately forced to INACTIVE rather than
+                # read from self.nat_vent_lifecycle_state: this call site fires on ANY
+                # window opening, including a second opening during an already-active
+                # nat-vent session, but the question asked here is a pure entry-gate
+                # question ("should nat-vent start now"), not an exit question. Reading
+                # the live lifecycle state would route an in-flight active session
+                # through the FSM's exit chain (decide_nat_vent_exit()) instead of the
+                # entry gate, killing sessions that should have kept running. Same
+                # always-fresh-compute semantics as _nat_vent_may_reactivate() and the
+                # same INACTIVE-forcing already used in reconcile_fan_on_startup (see
+                # that method's rationale comment above its transition() call).
+                _fsm_current_state = NatVentLifecycleState.INACTIVE
+                # hysteresis=0.0: this call site is one of the 2 (of 5)
+                # _nat_vent_may_reactivate() callers that deliberately omits hysteresis
+                # (see that method's docstring) — _build_nat_vent_fsm_inputs()'s default
+                # would otherwise read the configured value, diverging from legacy here.
+                _fsm_inputs = self._build_nat_vent_fsm_inputs(
+                    now=dt_util.now(), indoor=indoor, outdoor=outdoor, hysteresis=0.0
+                )
+                _fsm_result = _nat_vent_transition(
+                    _fsm_current_state, NatVentFsmEvent(kind=NatVentFsmEventKind.TICK, inputs=_fsm_inputs)
+                )
+                _nat_vent_gate_entered = _fsm_result.to_state == NatVentLifecycleState.ACTIVE_FULL_GATE
+            else:
+                _nat_vent_gate_entered = self._nat_vent_may_reactivate(
+                    outdoor=outdoor,
+                    indoor=indoor,
+                    comfort_heat=comfort_heat,
+                    comfort_cool=comfort_cool,
+                    nat_vent_delta=nat_vent_delta,
+                )
             if _nat_vent_gate_entered:
                 _skip_nat_vent = False
 
@@ -3234,7 +3270,22 @@ class AutomationEngine:
                         f" outdoor {outdoor:.1f}F <= {nat_vent_threshold:.1f}F"
                     )
                     await self._activate_fan(reason=nat_vent_reason)
-                    self._natural_vent_active = True
+                    if self._natvent_fsm_authoritative:
+                        # Project onto the FSM state that matches legacy's writes at this
+                        # site exactly: legacy only ever set _natural_vent_active = True
+                        # here, leaving _nat_vent_soft_start unchanged and _paused_by_door
+                        # untouched (guaranteed False already — this method returns early
+                        # at the top if _paused_by_door is True). Hardcoding
+                        # ACTIVE_FULL_GATE regardless of _fsm_result.to_state would
+                        # silently demote an in-flight soft-start session to full-gate on
+                        # a second window opening, which legacy never did.
+                        self._apply_nat_vent_fsm_state(
+                            NatVentLifecycleState.ACTIVE_SOFT_START
+                            if self._nat_vent_soft_start
+                            else NatVentLifecycleState.ACTIVE_FULL_GATE
+                        )
+                    else:
+                        self._natural_vent_active = True
                     _LOGGER.info(
                         "Natural ventilation mode: outdoor %.1f°F < indoor %.1f°F,"
                         " outdoor ≤ target %.1f°F — fan on, applying nat-vent HVAC state",
@@ -3463,7 +3514,106 @@ class AutomationEngine:
                 # Issue #411 Pass 4: this was a 4th hand-copied instance of the shared
                 # reactivation gate (found after the initial 3-site extraction) — folded
                 # into _nat_vent_may_reactivate() for consistency, not left as a copy.
-                if self._nat_vent_may_reactivate(
+                #
+                # Issue #694 (epic #594 Phase R, Phase 2b): while FSM-authoritative, both
+                # the full-gate reactivation and the soft-start sub-gate below are decided
+                # by a single nat_vent_fsm.transition() call instead of the two
+                # hand-sequenced legacy calls — same priority order
+                # (decide_nat_vent_gate() first, decide_nat_vent_soft_start_gate() only if
+                # that fails), same pure functions underneath. The non-authoritative branch
+                # is untouched.
+                if self._natvent_fsm_authoritative:
+                    from .nat_vent_fsm import NatVentFsmEvent, NatVentFsmEventKind
+                    from .nat_vent_fsm import transition as _nat_vent_transition
+
+                    _fsm_current_state = self.nat_vent_lifecycle_state
+                    # paused_by_door=False: this idle-open re-entry site only ever runs
+                    # when _actively_paused is False (see the outer guard above) — legacy
+                    # never consults the reactivation lockout here (only the separate
+                    # paused-reactivation call site below does). See
+                    # _build_nat_vent_fsm_inputs()'s docstring for the full rationale.
+                    _fsm_inputs = self._build_nat_vent_fsm_inputs(
+                        now=dt_util.now(), indoor=_indoor, outdoor=outdoor, paused_by_door=False
+                    )
+                    _fsm_result = _nat_vent_transition(
+                        _fsm_current_state, NatVentFsmEvent(kind=NatVentFsmEventKind.TICK, inputs=_fsm_inputs)
+                    )
+                    _to_state = _fsm_result.to_state
+                    if _to_state == NatVentLifecycleState.ACTIVE_SOFT_START and not self.config.get(
+                        CONF_NAT_VENT_SOFT_START_ENABLED, DEFAULT_NAT_VENT_SOFT_START_ENABLED
+                    ):
+                        # CONF_NAT_VENT_SOFT_START_ENABLED has no FSM-side field —
+                        # decide_nat_vent_soft_start_gate() always evaluates the condition;
+                        # same caller-side-guard treatment as the Phase 2c forecast/thermal
+                        # guards (nat_vent_fsm.py does not gain a new field for this).
+                        _to_state = NatVentLifecycleState.INACTIVE
+
+                    if _to_state == NatVentLifecycleState.ACTIVE_FULL_GATE:
+                        # Band stays armed — just activate the fan; the compressor self-arbitrates.
+                        await self._activate_fan(
+                            reason=(
+                                f"nat-vent re-engaged: outdoor {outdoor:.1f}°F < indoor {_indoor:.1f}°F"
+                                f" − {_hysteresis:.1f}°F hysteresis, indoor > comfort_heat {_comfort_heat:.1f}°F,"
+                                f" outdoor ≤ threshold {threshold:.1f}°F — free cooling still favorable"
+                            )
+                        )
+                        # Preserve _paused_by_door across the apply: legacy's
+                        # `self._natural_vent_active = True` write at this site never
+                        # touched _paused_by_door, but _apply_nat_vent_fsm_state()'s
+                        # projection unconditionally clears it (it only reads True from
+                        # PAUSED_REACTIVATION_LOCKOUT). Without this, a caller that enters
+                        # here with _paused_by_door=True (e.g. also
+                        # _paused_with_hvac_already_off=True) would flip to
+                        # _paused_by_door=False, an incoherent pair legacy never produced.
+                        _pre_paused_by_door = self._paused_by_door
+                        self._apply_nat_vent_fsm_state(_to_state)
+                        self._paused_by_door = _pre_paused_by_door
+                        await self._apply_nat_vent_hvac_state()
+                        # Issue #244: emit so the re-evaluation activation is visible in the
+                        # event log / timeline / AI report (previously this path was silent).
+                        if self._emit_event_callback:
+                            self._emit_event_callback(
+                                "sensor_opened",
+                                {
+                                    "entity": "natural_vent_reeval",
+                                    "result": "natural_ventilation",
+                                    "trigger": "open_door_reeval",
+                                },
+                            )
+                    elif _to_state == NatVentLifecycleState.ACTIVE_SOFT_START:
+                        _LOGGER.info(
+                            "Nat-vent soft-start entered: outdoor %.1f°F <= indoor %.1f°F,"
+                            " past today's peak %.1f°F by >= %.1f°F, indoor > comfort_heat %.1f°F",
+                            outdoor,
+                            _indoor,
+                            self._outdoor_temp_today_peak or 0.0,
+                            PEAK_DECLINE_MARGIN_F,
+                            _comfort_heat,
+                        )
+                        await self._activate_fan(
+                            reason=(
+                                f"nat-vent soft-start: outdoor {outdoor:.1f}°F at/below indoor {_indoor:.1f}°F"
+                                " parity, past today's peak and declining — purge/comfort air movement"
+                            )
+                        )
+                        # Preserve _paused_by_door across the apply — see the matching
+                        # comment on the ACTIVE_FULL_GATE branch above for the rationale.
+                        _pre_paused_by_door = self._paused_by_door
+                        self._apply_nat_vent_fsm_state(_to_state)
+                        self._paused_by_door = _pre_paused_by_door
+                        await self._apply_nat_vent_hvac_state()
+                        if self._emit_event_callback:
+                            self._emit_event_callback(
+                                "nat_vent_soft_start_entered",
+                                {
+                                    "outdoor": outdoor,
+                                    "indoor": _indoor,
+                                    "outdoor_today_peak": self._outdoor_temp_today_peak,
+                                    "comfort_heat": _comfort_heat,
+                                    "decline_margin_f": PEAK_DECLINE_MARGIN_F,
+                                },
+                            )
+                elif self._nat_vent_may_reactivate(
                     outdoor=outdoor,
                     indoor=_indoor,
                     comfort_heat=_comfort_heat,
@@ -3835,6 +3985,141 @@ class AutomationEngine:
                     self.config.get(CONF_NAT_VENT_REACTIVATION_LOCKOUT_S, NAT_VENT_REACTIVATION_LOCKOUT_S)
                 )
                 comfort_heat = self._nat_vent_reactivation_floor()
+
+                # Issue #694 (epic #594 Phase R, Phase 2b): while FSM-authoritative, the
+                # lockout check, full-gate reactivation, and soft-start sub-gate below are
+                # all decided by a single nat_vent_fsm.transition() call — the FSM's
+                # PAUSED_REACTIVATION_LOCKOUT branch re-implements the same
+                # is_reactivation_locked_out() check this block used to call directly. The
+                # non-authoritative branch (else, below) is untouched.
+                if self._natvent_fsm_authoritative:
+                    from .nat_vent_fsm import NatVentFsmEvent, NatVentFsmEventKind
+                    from .nat_vent_fsm import transition as _nat_vent_transition
+
+                    _fsm_current_state = self.nat_vent_lifecycle_state
+                    _fsm_inputs = self._build_nat_vent_fsm_inputs(now=dt_util.now(), indoor=indoor, outdoor=outdoor)
+                    _fsm_result = _nat_vent_transition(
+                        _fsm_current_state, NatVentFsmEvent(kind=NatVentFsmEventKind.TICK, inputs=_fsm_inputs)
+                    )
+                    _to_state = _fsm_result.to_state
+
+                    if _to_state == NatVentLifecycleState.PAUSED_REACTIVATION_LOCKOUT:
+                        _lockout_check_now = dt_util.now()
+                        if self._nat_vent_outdoor_exit_time is not None:
+                            elapsed = (_lockout_check_now - self._nat_vent_outdoor_exit_time).total_seconds()
+                            _LOGGER.debug(
+                                "Nat vent paused-by-door: lockout active — %.0fs elapsed of %.0fs (%.0fs remaining)",
+                                elapsed,
+                                lockout_s,
+                                lockout_s - elapsed,
+                            )
+                        return
+
+                    if _to_state == NatVentLifecycleState.ACTIVE_SOFT_START and not self.config.get(
+                        CONF_NAT_VENT_SOFT_START_ENABLED, DEFAULT_NAT_VENT_SOFT_START_ENABLED
+                    ):
+                        # CONF_NAT_VENT_SOFT_START_ENABLED has no FSM-side field — see the
+                        # identical caller-side-guard treatment at the idle-open re-entry
+                        # site above.
+                        _to_state = NatVentLifecycleState.INACTIVE
+
+                    if _to_state == NatVentLifecycleState.ACTIVE_FULL_GATE:
+                        await self._activate_fan(
+                            reason=(
+                                f"natural vent activated: outdoor {outdoor:.1f}°F"
+                                f" < indoor {indoor:.1f}°F − {hysteresis:.1f}°F hysteresis,"
+                                f" outdoor ≤ threshold {threshold:.1f}°F"
+                            )
+                        )
+                        self._apply_nat_vent_fsm_state(_to_state)
+
+                        from .door_window_fsm import DoorWindowFsmEventKind
+
+                        def _legacy_clear_pause() -> None:
+                            self._paused_by_door = False
+                            self._paused_with_hvac_already_off = False
+
+                        self._resolve_door_window_pause_flags(
+                            kind=DoorWindowFsmEventKind.PAUSED_NAT_VENT_REACTIVATED,
+                            legacy=_legacy_clear_pause,
+                        )
+                        if self._emit_event_callback:
+                            self._emit_event_callback(
+                                "nat_vent_reactivated_while_paused",
+                                {"outdoor": outdoor, "indoor": indoor, "threshold": threshold},
+                            )
+                        self._paused_entity = None
+                        self._paused_since = None
+                        _LOGGER.info(
+                            "Natural vent activated: outdoor %.1f°F < indoor %.1f°F − %.1f°F hysteresis,"
+                            " outdoor ≤ threshold %.1f°F while paused",
+                            outdoor,
+                            indoor,
+                            hysteresis,
+                            threshold,
+                        )
+                        await self._apply_nat_vent_hvac_state()
+                    elif _to_state == NatVentLifecycleState.ACTIVE_SOFT_START:
+                        await self._activate_fan(
+                            reason=(
+                                f"nat-vent soft-start while paused: outdoor {outdoor:.1f}°F at/below"
+                                f" indoor {indoor:.1f}°F parity, past today's peak and declining"
+                            )
+                        )
+                        self._apply_nat_vent_fsm_state(_to_state)
+
+                        from .door_window_fsm import DoorWindowFsmEventKind
+
+                        def _legacy_clear_pause() -> None:
+                            self._paused_by_door = False
+                            self._paused_with_hvac_already_off = False
+
+                        self._resolve_door_window_pause_flags(
+                            kind=DoorWindowFsmEventKind.PAUSED_NAT_VENT_REACTIVATED,
+                            legacy=_legacy_clear_pause,
+                        )
+                        if self._emit_event_callback:
+                            self._emit_event_callback(
+                                "nat_vent_reactivated_while_paused",
+                                {"outdoor": outdoor, "indoor": indoor, "threshold": threshold},
+                            )
+                        self._paused_entity = None
+                        self._paused_since = None
+                        _LOGGER.info(
+                            "Nat-vent soft-start activated while paused: outdoor %.1f°F <= indoor %.1f°F,"
+                            " past today's peak %.1f°F by >= %.1f°F",
+                            outdoor,
+                            indoor,
+                            self._outdoor_temp_today_peak or 0.0,
+                            PEAK_DECLINE_MARGIN_F,
+                        )
+                        if self._emit_event_callback:
+                            self._emit_event_callback(
+                                "nat_vent_soft_start_entered",
+                                {
+                                    "outdoor": outdoor,
+                                    "indoor": indoor,
+                                    "outdoor_today_peak": self._outdoor_temp_today_peak,
+                                    "comfort_heat": comfort_heat,
+                                    "decline_margin_f": PEAK_DECLINE_MARGIN_F,
+                                },
+                            )
+                        await self._apply_nat_vent_hvac_state()
+                    else:
+                        _floor_ok = indoor > comfort_heat
+                        _ceiling_ok = outdoor < threshold
+                        _LOGGER.debug(
+                            "Nat vent paused-by-door: conditions not met — "
+                            "outdoor=%.1f°F indoor=%.1f°F delta=%.1f°F (need>%.1f°F) "
+                            "floor_ok=%s ceiling_ok=%s",
+                            outdoor,
+                            indoor,
+                            indoor - outdoor,
+                            hysteresis,
+                            _floor_ok,
+                            _ceiling_ok,
+                        )
+                    return
 
                 # Enforce lockout after outdoor-warm exit. Architecture-reset Step 2: the
                 # decision itself now lives in
@@ -4587,18 +4872,54 @@ class AutomationEngine:
         # Issue #417: folded into the shared _nat_vent_may_reactivate() gate instead of a
         # 5th hand-rolled copy — this hand-rolled version was also missing the sleep-aware
         # floor and the ceiling dormancy check the shared gate already accounts for.
-        nat_vent_eligible = (
-            fan_mode != FAN_MODE_DISABLED
-            and any_sensor_open
-            and self._nat_vent_may_reactivate(
-                outdoor=outdoor,
-                indoor=indoor,
-                comfort_heat=comfort_heat,
-                comfort_cool=comfort_cool,
-                nat_vent_delta=nat_vent_delta,
-                hysteresis=hysteresis,
+        #
+        # Issue #694 (epic #594 Phase R, Phase 2b): while FSM-authoritative, this eligibility
+        # question is decided by nat_vent_fsm.transition() instead of the direct legacy call,
+        # restricted to its ACTIVE_FULL_GATE outcome only — this call site (like
+        # handle_door_window_open()) has never modeled soft-start adoption, so an
+        # FSM-produced ACTIVE_SOFT_START result is treated the same as "not eligible" here.
+        # The FSM's current_state is deliberately forced to INACTIVE rather than read from
+        # self.nat_vent_lifecycle_state: this call site is a pure entry-gate question
+        # ("should today's already-physically-running fan be trusted as CA-owned nat-vent"),
+        # independent of whatever _natural_vent_active/_paused_by_door happen to read at
+        # reconcile time (e.g. restored-but-stale post-restart state) — exactly the same
+        # always-fresh-compute semantics _nat_vent_may_reactivate() has. Forcing INACTIVE
+        # routes transition() through _transition_from_inactive(), the FSM branch that calls
+        # the same two pure functions (decide_nat_vent_gate(), decide_nat_vent_soft_start_gate())
+        # in the same priority order the legacy call here always has. The non-authoritative
+        # branch is unchanged.
+        if self._natvent_fsm_authoritative:
+            from .nat_vent_fsm import NatVentFsmEvent, NatVentFsmEventKind
+            from .nat_vent_fsm import transition as _nat_vent_transition
+
+            # paused_by_door=False: legacy _nat_vent_may_reactivate() here never
+            # consulted _paused_by_door/the reactivation lockout — see
+            # _build_nat_vent_fsm_inputs()'s docstring for the shared rationale (also
+            # applied at the idle-open re-entry site).
+            _fsm_inputs = self._build_nat_vent_fsm_inputs(
+                now=dt_util.now(), indoor=indoor, outdoor=outdoor, paused_by_door=False
             )
-        )
+            _fsm_result = _nat_vent_transition(
+                NatVentLifecycleState.INACTIVE, NatVentFsmEvent(kind=NatVentFsmEventKind.TICK, inputs=_fsm_inputs)
+            )
+            nat_vent_eligible = (
+                fan_mode != FAN_MODE_DISABLED
+                and any_sensor_open
+                and _fsm_result.to_state == NatVentLifecycleState.ACTIVE_FULL_GATE
+            )
+        else:
+            nat_vent_eligible = (
+                fan_mode != FAN_MODE_DISABLED
+                and any_sensor_open
+                and self._nat_vent_may_reactivate(
+                    outdoor=outdoor,
+                    indoor=indoor,
+                    comfort_heat=comfort_heat,
+                    comfort_cool=comfort_cool,
+                    nat_vent_delta=nat_vent_delta,
+                    hysteresis=hysteresis,
+                )
+            )
 
         if nat_vent_eligible:
             # Adopt the running fan as CA-owned nat-vent
@@ -6214,17 +6535,55 @@ class AutomationEngine:
             return float(self.config.get(CONF_SLEEP_HEAT, comfort_heat))
         return comfort_heat
 
-    def _build_nat_vent_fsm_inputs(self, *, now: datetime, indoor: float | None, outdoor: float | None):
+    def _build_nat_vent_fsm_inputs(
+        self,
+        *,
+        now: datetime,
+        indoor: float | None,
+        outdoor: float | None,
+        hysteresis: float | None = None,
+        paused_by_door: bool | None = None,
+    ):
         """Build the FSM's input snapshot from current engine state (Issue #594
         Phase R, Step 2). Same field set ``coordinator._evaluate_nat_vent_fsm()``
         already builds for the shadow-diagnostic comparison — kept as a single
         definition callers on both sides can share rather than two independently
         maintained copies of the same construction.
+
+        Args:
+            hysteresis: Overrides the configured ``CONF_NAT_VENT_HYSTERESIS_F`` value
+                when provided. Issue #694 (Phase 2b): ``_nat_vent_may_reactivate()``'s
+                own docstring documents that 2 of its 5 call sites
+                (``handle_door_window_open``, ``_re_pause_for_open_sensor``) pass
+                ``hysteresis=0.0`` explicitly rather than the configured value — this
+                parameter lets a caller preserve that same per-site distinction when
+                building FSM inputs instead of always reading the configured value.
+                ``None`` (every pre-#694 call site) keeps this method's prior
+                behavior unchanged.
+            paused_by_door: Overrides ``self._paused_by_door`` when provided. Issue #694
+                (Phase 2b): ``check_natural_vent_conditions()``'s idle-open re-entry site
+                only ever runs when ``_actively_paused`` is False (see that method's own
+                guard) — a real ``_paused_by_door=True and _paused_with_hvac_already_off=
+                True`` combination is possible there (the window was never actively
+                interrupting HVAC), and the legacy call at that site has never consulted
+                the reactivation lockout (only the separate paused-reactivation call site
+                does). Feeding the FSM ``self._paused_by_door``'s real value at the
+                idle-open site would apply the lockout somewhere legacy never has —
+                new decision authority, out of this wiring-only issue's scope. ``False``
+                is passed explicitly at that one call site to preserve the exact legacy
+                gap; ``None`` (every other caller) keeps this method's prior behavior
+                (``self._paused_by_door``) unchanged.
         """
         from .nat_vent_fsm import NatVentFsmInputs
 
         comfort_heat_raw = float(self.config.get("comfort_heat", DEFAULT_COMFORT_HEAT))
         thermal_model = self._thermal_model or {}
+        _hysteresis = (
+            hysteresis
+            if hysteresis is not None
+            else float(self.config.get(CONF_NAT_VENT_HYSTERESIS_F, NAT_VENT_HYSTERESIS_F))
+        )
+        _paused_by_door = paused_by_door if paused_by_door is not None else bool(self._paused_by_door)
         return NatVentFsmInputs(
             indoor=indoor,
             outdoor=outdoor,
@@ -6233,7 +6592,7 @@ class AutomationEngine:
             in_sleep_window=_in_sleep_window(now, self.config),
             comfort_cool=float(self.config.get("comfort_cool", DEFAULT_COMFORT_COOL)),
             nat_vent_delta=float(self.config.get(CONF_NATURAL_VENT_DELTA, DEFAULT_NATURAL_VENT_DELTA)),
-            hysteresis=float(self.config.get(CONF_NAT_VENT_HYSTERESIS_F, NAT_VENT_HYSTERESIS_F)),
+            hysteresis=_hysteresis,
             fan_mode=str(self.config.get(CONF_FAN_MODE, "whole_house_fan")),
             aggressive_savings=bool(self.config.get("aggressive_savings", False)),
             occupancy_mode=self._occupancy_mode,
@@ -6242,7 +6601,7 @@ class AutomationEngine:
             outdoor_today_peak=self._outdoor_temp_today_peak,
             outdoor_sample_count=self._outdoor_temp_today_sample_count,
             peak_decline_margin=PEAK_DECLINE_MARGIN_F,
-            paused_by_door=bool(self._paused_by_door),
+            paused_by_door=_paused_by_door,
             outdoor_exit_time=self._nat_vent_outdoor_exit_time,
             lockout_seconds=float(
                 self.config.get(CONF_NAT_VENT_REACTIVATION_LOCKOUT_S, NAT_VENT_REACTIVATION_LOCKOUT_S)
@@ -6254,10 +6613,18 @@ class AutomationEngine:
     def nat_vent_lifecycle_state(self) -> NatVentLifecycleState:
         """Current nat-vent session state, derived from existing flags (Issue #606).
 
-        Read-only observability — not called from any production decision path.
         Purely a computed view of ``_natural_vent_active``/``_nat_vent_soft_start``/
         ``_paused_by_door``/``_nat_vent_outdoor_exit_time``, so it cannot desync from
         the flags it reads. See ``nat_vent_lifecycle.py`` for the pure derivation.
+
+        As of Issue #694 (epic #594 Phase R, Phase 2b), this is a production decision
+        input, not read-only observability: when ``_natvent_fsm_authoritative`` is set,
+        it supplies the FSM's starting state at 3 of the 4 wired call sites (the
+        idle-open re-entry site and both paused-reactivation branches) —
+        ``handle_door_window_open()``'s entry-gate site and
+        ``reconcile_fan_on_startup()`` deliberately force ``INACTIVE`` instead, since
+        those are pure entry-gate questions independent of live session state (see
+        their own rationale comments).
         """
         lockout_s = float(self.config.get(CONF_NAT_VENT_REACTIVATION_LOCKOUT_S, NAT_VENT_REACTIVATION_LOCKOUT_S))
         return derive_nat_vent_lifecycle_state(
@@ -6284,9 +6651,11 @@ class AutomationEngine:
         needed to arm it, same exclusion-list treatment as door/window's
         ``_grace_end_time``.
 
-        Not yet called from any production code path — added ahead of the
-        wiring work that will invoke it, matching the same additive-first
-        pattern already used for Issue #687's override/grace awareness.
+        Called from production at 5 sites (Issue #594 Phase R, Phase 2b —
+        ``handle_door_window_open()``, ``check_natural_vent_conditions()``'s
+        idle-open re-entry and reactivation-while-paused branches, and
+        ``reconcile_fan_on_startup()``) whenever ``_natvent_fsm_authoritative``
+        is enabled.
         """
         self._natural_vent_active = state in (
             NatVentLifecycleState.ACTIVE_FULL_GATE,

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,23 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.42"
+VERSION = "0.6.43"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.43": [
+        "Fix #694: fixed 3 defects introduced by the previous nat-vent"
+        " state-machine wiring pass (still not authoritative over any real"
+        " decision by default). With the state-machine switch enabled, an"
+        " in-flight natural-ventilation session (free cooling already"
+        " running) could be killed outright or silently downgraded from a"
+        " stronger cooling mode to a weaker one whenever a second door or"
+        " window was opened during that session — even though nothing about"
+        " outdoor/indoor conditions had changed. Also fixed a case where"
+        " reopening a window during an existing door/window pause could"
+        " leave the automation's internal pause bookkeeping in an"
+        " inconsistent state. No change for installs that haven't opted"
+        " into the state-machine switch.",
+    ],
     "0.6.42": [
         "Fix #690: two separate places that decide when to end a natural-"
         "ventilation session (a fast check and a slower 30-minute check) used"
@@ -2035,6 +2049,44 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    694: {
+        "version_fixed": "0.6.43",
+        "title": (
+            "Phase 2b FSM wiring (nat-vent decision points behind"
+            " _natvent_fsm_authoritative) killed or silently downgraded an"
+            " in-flight nat-vent session on a second door/window opening"
+        ),
+        "scope_covered": (
+            "automation.py: 3 defects in the Phase 2b wiring, all gated"
+            " behind _natvent_fsm_authoritative (off by default). (1)"
+            " handle_door_window_open()'s nat-vent gate check (~line 3163)"
+            " read self.nat_vent_lifecycle_state as the FSM's starting"
+            " state for what is a pure entry-gate question, routing an"
+            " already-active session through the FSM's exit chain instead"
+            " of the entry gate on a second window opening; now forces"
+            " NatVentLifecycleState.INACTIVE, matching"
+            " reconcile_fan_on_startup()'s existing rationale for the same"
+            " pattern. (2) The same call site's activation branch"
+            " hardcoded NatVentLifecycleState.ACTIVE_FULL_GATE regardless"
+            " of the FSM result, silently demoting an in-flight soft-start"
+            " session to full-gate via _apply_nat_vent_fsm_state()'s"
+            " unconditional projection; now projects ACTIVE_SOFT_START when"
+            " _nat_vent_soft_start is already set, matching legacy's"
+            " narrower write at this site. (3) The idle-open re-entry site"
+            " (both ACTIVE_FULL_GATE and ACTIVE_SOFT_START branches, ~lines"
+            " 3560/3589) called _apply_nat_vent_fsm_state(), whose"
+            " projection unconditionally clears _paused_by_door, whereas"
+            " legacy's write here never touched that flag — now the"
+            " pre-call value of _paused_by_door is captured and restored"
+            " after the apply. The paused-reactivation site (~line 4006)"
+            " was confirmed unaffected — it deliberately clears pause flags"
+            " via _resolve_door_window_pause_flags(), matching legacy"
+            " already. Also corrected nat_vent_lifecycle_state's stale"
+            " 'read-only observability' docstring, which no longer reflects"
+            " its Phase 2b role as a production decision input at 3 of the"
+            " 4 wired call sites."
+        ),
+    },
     690: {
         "version_fixed": "0.6.42",
         "title": (

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.42"
+  "version": "0.6.43"
 }

--- a/tests/test_nat_vent_fsm_phase2b_wiring.py
+++ b/tests/test_nat_vent_fsm_phase2b_wiring.py
@@ -1,0 +1,417 @@
+"""Tests for Issue #694 (epic #594 Phase R, Phase 2b): wiring the 4 remaining
+real nat-vent decision points through ``nat_vent_fsm.transition()`` when
+``AutomationEngine._natvent_fsm_authoritative`` is True:
+
+  1. ``handle_door_window_open()``'s entry gate
+  2. ``check_natural_vent_conditions()``'s idle-open re-entry (full-gate + soft-start)
+  3. ``check_natural_vent_conditions()``'s reactivation-while-paused (lockout +
+     full-gate + soft-start)
+  4. ``reconcile_fan_on_startup()``'s adopt-on eligibility gate
+
+Each site is exercised both with the flag True (routes through the FSM) and
+False (legacy gate functions) to prove the two paths still agree — a
+revert-test in spirit: flipping the flag must not change what the real engine
+does for these scenarios. Real ``AutomationEngine`` methods are invoked
+directly (no re-implementation of the decision logic under test), per this
+project's doctrine against mirror tests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from custom_components.climate_advisor.automation import AutomationEngine
+from custom_components.climate_advisor.const import (
+    CONF_FAN_MODE,
+    CONF_NAT_VENT_SOFT_START_ENABLED,
+    FAN_MODE_WHOLE_HOUSE,
+)
+
+_NOW = datetime(2026, 7, 15, 14, 0, 0)
+sys.modules["homeassistant.util.dt"].now = lambda: _NOW
+
+import custom_components.climate_advisor.automation as _automation_mod  # noqa: E402
+
+# automation.py's own `dt_util` reference is a child mock of homeassistant.util,
+# distinct from sys.modules["homeassistant.util.dt"] — tests that exercise the
+# reactivation-lockout datetime math (elapsed = now - outdoor_exit_time) must
+# patch this exact path, mirroring test_nat_vent_activation.py's _DT_NOW_PATH.
+_DT_NOW_PATH = "custom_components.climate_advisor.automation.dt_util.now"
+
+
+def _real_parse_datetime(dt_str: str):
+    try:
+        return datetime.fromisoformat(dt_str)
+    except Exception:
+        return None
+
+
+_automation_mod.dt_util.parse_datetime = _real_parse_datetime
+
+
+def _make_engine(
+    *,
+    comfort_heat: float = 68.0,
+    comfort_cool: float = 74.0,
+    nat_vent_delta: float = 3.0,
+    hysteresis: float = 1.0,
+    indoor_f: float | None = None,
+    fan_mode: str = FAN_MODE_WHOLE_HOUSE,
+    soft_start_enabled: bool = True,
+    authoritative: bool = False,
+) -> AutomationEngine:
+    """Create a real AutomationEngine with mocked HA dependencies."""
+    hass = MagicMock()
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+
+    def _consume_coroutine(coro):
+        coro.close()
+
+    hass.async_create_task = MagicMock(side_effect=_consume_coroutine)
+
+    climate_state = MagicMock()
+    climate_state.state = "cool"
+    climate_state.attributes = {} if indoor_f is None else {"current_temperature": indoor_f}
+    hass.states = MagicMock()
+    hass.states.get = MagicMock(return_value=climate_state)
+
+    config = {
+        "comfort_heat": comfort_heat,
+        "comfort_cool": comfort_cool,
+        "setback_heat": 60,
+        "setback_cool": 80,
+        "natural_vent_delta": nat_vent_delta,
+        "nat_vent_hysteresis_f": hysteresis,
+        "notify_service": "notify.notify",
+        CONF_FAN_MODE: fan_mode,
+        CONF_NAT_VENT_SOFT_START_ENABLED: soft_start_enabled,
+    }
+
+    engine = AutomationEngine(
+        hass=hass,
+        climate_entity="climate.thermostat",
+        weather_entity="weather.forecast_home",
+        door_window_sensors=["binary_sensor.front_door"],
+        notify_service="notify.notify",
+        config=config,
+    )
+    engine._natvent_fsm_authoritative = authoritative
+    return engine
+
+
+# ---------------------------------------------------------------------------
+# Site 1: handle_door_window_open()
+# ---------------------------------------------------------------------------
+
+
+class TestSite1DoorWindowOpenEntry:
+    """Full-gate entry via handle_door_window_open() — FSM-authoritative vs legacy."""
+
+    def _run(self, *, authoritative: bool, outdoor: float, indoor: float) -> AutomationEngine:
+        engine = _make_engine(indoor_f=indoor, authoritative=authoritative)
+        engine._last_outdoor_temp = outdoor
+        asyncio.run(engine.handle_door_window_open("binary_sensor.front_door"))
+        return engine
+
+    def test_authoritative_activates_when_gate_clears(self):
+        # outdoor 60 well below indoor 72 -> decide_nat_vent_gate() clears easily.
+        engine = self._run(authoritative=True, outdoor=60.0, indoor=72.0)
+        assert engine._natural_vent_active is True
+        assert engine._paused_by_door is False
+
+    def test_legacy_activates_when_gate_clears(self):
+        engine = self._run(authoritative=False, outdoor=60.0, indoor=72.0)
+        assert engine._natural_vent_active is True
+        assert engine._paused_by_door is False
+
+    def test_authoritative_and_legacy_agree_when_gate_fails(self):
+        # outdoor(75) > indoor(72) -> directional guard fails both ways -> pause.
+        for authoritative in (True, False):
+            engine = self._run(authoritative=authoritative, outdoor=75.0, indoor=72.0)
+            assert engine._natural_vent_active is False, f"authoritative={authoritative}"
+            assert engine._paused_by_door is True, f"authoritative={authoritative}"
+
+    def test_authoritative_uses_zero_hysteresis_matching_legacy(self):
+        """This call site is one of only 2 (of 5) _nat_vent_may_reactivate() callers
+        that always uses hysteresis=0.0, not the configured value (here 1.0F).
+        outdoor=69.5, indoor=70.0: with hysteresis=0 the gate clears (69.5 < 70);
+        with the configured 1.0F hysteresis it would NOT (69.5 is not < 69.0). Both
+        paths must activate — proving the FSM branch was fed hysteresis=0.0, not
+        the configured value _build_nat_vent_fsm_inputs() would otherwise supply."""
+        for authoritative in (True, False):
+            engine = self._run(authoritative=authoritative, outdoor=69.5, indoor=70.0)
+            assert engine._natural_vent_active is True, (
+                f"authoritative={authoritative}: hysteresis must be 0.0 at this call site"
+            )
+
+    def test_authoritative_never_enters_soft_start_at_this_site(self):
+        """This call site has never modeled soft-start entry (no
+        _nat_vent_may_soft_start() call here) -- Phase 2b is wiring-only, so an
+        FSM-produced ACTIVE_SOFT_START result must be treated as "not entered"
+        here, same as legacy. outdoor==indoor (parity) satisfies the soft-start
+        sub-gate but not the full bulk-cooling gate."""
+        engine = _make_engine(
+            comfort_heat=68.0,
+            comfort_cool=74.0,
+            indoor_f=76.0,
+            authoritative=True,
+        )
+        engine._last_outdoor_temp = 76.0  # parity, not below indoor
+        engine._outdoor_temp_today_peak = 90.0
+        engine._outdoor_temp_today_sample_count = 5
+        asyncio.run(engine.handle_door_window_open("binary_sensor.front_door"))
+        assert engine._natural_vent_active is False
+        assert engine._nat_vent_soft_start is False
+        assert engine._paused_by_door is True
+
+    def test_authoritative_keeps_in_flight_soft_start_session_running(self):
+        """Defect 1/2 regression (Issue #694 Verification): a second door/window
+        opening during an already-active soft-start nat-vent session must not
+        kill the session (routing an entry-gate question through the FSM's exit
+        chain via a live nat_vent_lifecycle_state) nor silently promote it to
+        full-gate (hardcoding ACTIVE_FULL_GATE regardless of the FSM result).
+        Legacy at this call site only ever writes `_natural_vent_active = True`,
+        leaving `_nat_vent_soft_start` alone -- the fix must reproduce exactly
+        that flag-for-flag outcome."""
+        engine = _make_engine(
+            comfort_heat=68.0,
+            comfort_cool=74.0,
+            indoor_f=75.0,  # at/above comfort_cool
+            authoritative=True,
+        )
+        engine._occupancy_mode = "away"
+        engine._natural_vent_active = True
+        engine._nat_vent_soft_start = True
+        engine._paused_by_door = False
+        engine._last_outdoor_temp = 60.0  # favorable for free cooling
+        asyncio.run(engine.handle_door_window_open("binary_sensor.front_door"))
+        assert engine._natural_vent_active is True
+        assert engine._nat_vent_soft_start is True, (
+            "in-flight soft-start session must not be silently promoted to full-gate"
+        )
+        assert engine._paused_by_door is False
+
+
+# ---------------------------------------------------------------------------
+# Site 2: check_natural_vent_conditions() idle-open re-entry
+# ---------------------------------------------------------------------------
+
+
+class TestSite2IdleOpenReentry:
+    def _arm_idle_open(self, engine: AutomationEngine, *, outdoor: float) -> None:
+        engine._paused_by_door = False
+        engine._natural_vent_active = False
+        engine._nat_vent_soft_start = False
+        engine._grace_active = False
+        engine._sensor_check_callback = lambda: True
+        engine._last_outdoor_temp = outdoor
+        engine.hass.states.get.return_value.state = "off"
+
+    def test_authoritative_full_gate_reactivates(self):
+        for authoritative in (True, False):
+            engine = _make_engine(comfort_heat=68.0, comfort_cool=74.0, indoor_f=72.0, authoritative=authoritative)
+            self._arm_idle_open(engine, outdoor=68.0)
+            asyncio.run(engine.check_natural_vent_conditions())
+            assert engine._natural_vent_active is True, f"authoritative={authoritative}"
+            assert engine._nat_vent_soft_start is False, f"authoritative={authoritative}"
+
+    def test_authoritative_soft_start_reactivates_when_full_gate_not_cleared(self):
+        for authoritative in (True, False):
+            engine = _make_engine(comfort_heat=68.0, comfort_cool=74.0, indoor_f=76.0, authoritative=authoritative)
+            self._arm_idle_open(engine, outdoor=76.0)  # parity, past peak below
+            engine._outdoor_temp_today_peak = 90.0
+            engine._outdoor_temp_today_sample_count = 5
+            asyncio.run(engine.check_natural_vent_conditions())
+            assert engine._natural_vent_active is True, f"authoritative={authoritative}"
+            assert engine._nat_vent_soft_start is True, f"authoritative={authoritative}"
+
+    def test_authoritative_respects_soft_start_disabled_config(self):
+        """CONF_NAT_VENT_SOFT_START_ENABLED has no FSM-side field -- the FSM's pure
+        decide_nat_vent_soft_start_gate() always evaluates the condition. Phase 2b's
+        caller-side post-filter must suppress the ACTIVE_SOFT_START result when the
+        user has this feature disabled, matching legacy's own opt-out check inside
+        _nat_vent_may_soft_start()."""
+        engine = _make_engine(
+            comfort_heat=68.0,
+            comfort_cool=74.0,
+            indoor_f=76.0,
+            soft_start_enabled=False,
+            authoritative=True,
+        )
+        self._arm_idle_open(engine, outdoor=76.0)
+        engine._outdoor_temp_today_peak = 90.0
+        engine._outdoor_temp_today_sample_count = 5
+        asyncio.run(engine.check_natural_vent_conditions())
+        assert engine._natural_vent_active is False
+        assert engine._nat_vent_soft_start is False
+
+    def test_authoritative_and_legacy_agree_when_neither_gate_clears(self):
+        for authoritative in (True, False):
+            engine = _make_engine(comfort_heat=68.0, comfort_cool=74.0, indoor_f=72.0, authoritative=authoritative)
+            self._arm_idle_open(engine, outdoor=80.0)  # outdoor far above indoor
+            asyncio.run(engine.check_natural_vent_conditions())
+            assert engine._natural_vent_active is False, f"authoritative={authoritative}"
+
+    def test_authoritative_ignores_stale_paused_by_door_lockout(self):
+        """Real production incident (see issue-641-whf-proactive-exit-reactivation-
+        flip-flop.json): this site only ever runs when _actively_paused is False,
+        which can coincide with _paused_by_door=True (HVAC was already off, nothing
+        to interrupt). Legacy never consults the reactivation lockout at this call
+        site (only the paused-reactivation site, tested below, does) -- the FSM
+        path must reproduce that exact scope, not apply a lockout legacy never has
+        here."""
+        for authoritative in (True, False):
+            engine = _make_engine(comfort_heat=68.0, comfort_cool=74.0, indoor_f=69.0, authoritative=authoritative)
+            self._arm_idle_open(engine, outdoor=58.6)
+            engine._paused_by_door = True
+            engine._paused_with_hvac_already_off = True
+            engine._nat_vent_outdoor_exit_time = _NOW - timedelta(seconds=5)  # well within the 300s lockout
+            with patch(_DT_NOW_PATH, return_value=_NOW):
+                asyncio.run(engine.check_natural_vent_conditions())
+            assert engine._natural_vent_active is True, (
+                f"authoritative={authoritative}: idle-open re-entry must not be blocked by a "
+                "lockout this call site has never enforced"
+            )
+
+    def test_authoritative_preserves_paused_by_door_flag(self):
+        """Defect 3 regression (Issue #694 Verification): _apply_nat_vent_fsm_state()'s
+        projection unconditionally clears _paused_by_door, but legacy's write at this
+        site (`self._natural_vent_active = True`) never touched it. Entering with
+        _paused_by_door=True + _paused_with_hvac_already_off=True must leave
+        _paused_by_door=True afterward -- otherwise the pair becomes incoherent
+        (_paused_by_door=False while _paused_with_hvac_already_off=True)."""
+        for authoritative in (True, False):
+            engine = _make_engine(comfort_heat=68.0, comfort_cool=74.0, indoor_f=69.0, authoritative=authoritative)
+            self._arm_idle_open(engine, outdoor=58.6)
+            engine._paused_by_door = True
+            engine._paused_with_hvac_already_off = True
+            engine._nat_vent_outdoor_exit_time = _NOW - timedelta(seconds=5)  # well within the 300s lockout
+            with patch(_DT_NOW_PATH, return_value=_NOW):
+                asyncio.run(engine.check_natural_vent_conditions())
+            assert engine._natural_vent_active is True, f"authoritative={authoritative}"
+            assert engine._paused_by_door is True, (
+                f"authoritative={authoritative}: _paused_by_door must survive the FSM apply"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Site 3: check_natural_vent_conditions() reactivation-while-paused
+# ---------------------------------------------------------------------------
+
+
+class TestSite3PausedReactivation:
+    def _arm_paused(self, engine: AutomationEngine, *, outdoor: float, exit_time: datetime | None = None) -> None:
+        engine._paused_by_door = True
+        engine._paused_with_hvac_already_off = False  # -> _actively_paused True, reaches site 3
+        engine._natural_vent_active = False
+        engine._nat_vent_soft_start = False
+        engine._last_outdoor_temp = outdoor
+        engine._nat_vent_outdoor_exit_time = exit_time
+
+    def test_authoritative_full_gate_reactivates_while_paused(self):
+        for authoritative in (True, False):
+            engine = _make_engine(comfort_heat=68.0, comfort_cool=74.0, indoor_f=72.0, authoritative=authoritative)
+            self._arm_paused(engine, outdoor=68.0)
+            asyncio.run(engine.check_natural_vent_conditions())
+            assert engine._natural_vent_active is True, f"authoritative={authoritative}"
+            assert engine._paused_by_door is False, f"authoritative={authoritative}"
+
+    def test_authoritative_soft_start_reactivates_while_paused(self):
+        for authoritative in (True, False):
+            engine = _make_engine(comfort_heat=68.0, comfort_cool=74.0, indoor_f=76.0, authoritative=authoritative)
+            self._arm_paused(engine, outdoor=76.0)
+            engine._outdoor_temp_today_peak = 90.0
+            engine._outdoor_temp_today_sample_count = 5
+            asyncio.run(engine.check_natural_vent_conditions())
+            assert engine._natural_vent_active is True, f"authoritative={authoritative}"
+            assert engine._nat_vent_soft_start is True, f"authoritative={authoritative}"
+            assert engine._paused_by_door is False, f"authoritative={authoritative}"
+
+    def test_authoritative_lockout_blocks_reactivation(self):
+        """Issue #641: a proactive-floor exit arms a 300s reactivation lockout via
+        _nat_vent_outdoor_exit_time. Both paths must stay paused through the very
+        next tick even though the instantaneous gate would otherwise clear."""
+        for authoritative in (True, False):
+            engine = _make_engine(comfort_heat=68.0, comfort_cool=74.0, indoor_f=69.0, authoritative=authoritative)
+            self._arm_paused(engine, outdoor=58.6, exit_time=_NOW - timedelta(seconds=5))
+            with patch(_DT_NOW_PATH, return_value=_NOW):
+                asyncio.run(engine.check_natural_vent_conditions())
+            assert engine._natural_vent_active is False, f"authoritative={authoritative}"
+            assert engine._paused_by_door is True, f"authoritative={authoritative}"
+
+    def test_authoritative_lockout_expires_and_reactivates(self):
+        for authoritative in (True, False):
+            engine = _make_engine(comfort_heat=68.0, comfort_cool=74.0, indoor_f=69.0, authoritative=authoritative)
+            self._arm_paused(engine, outdoor=58.6, exit_time=_NOW - timedelta(seconds=301))
+            with patch(_DT_NOW_PATH, return_value=_NOW):
+                asyncio.run(engine.check_natural_vent_conditions())
+            assert engine._natural_vent_active is True, f"authoritative={authoritative}"
+            assert engine._paused_by_door is False, f"authoritative={authoritative}"
+
+    def test_authoritative_and_legacy_agree_when_gate_fails(self):
+        for authoritative in (True, False):
+            engine = _make_engine(comfort_heat=68.0, comfort_cool=74.0, indoor_f=72.0, authoritative=authoritative)
+            self._arm_paused(engine, outdoor=80.0)
+            asyncio.run(engine.check_natural_vent_conditions())
+            assert engine._natural_vent_active is False, f"authoritative={authoritative}"
+            assert engine._paused_by_door is True, f"authoritative={authoritative}"
+
+
+# ---------------------------------------------------------------------------
+# Site 4: reconcile_fan_on_startup()
+# ---------------------------------------------------------------------------
+
+
+class TestSite4ReconcileFanOnStartup:
+    def _run_reconcile(
+        self, engine: AutomationEngine, *, indoor: float, outdoor: float, any_sensor_open: bool = True
+    ) -> None:
+        asyncio.run(
+            engine.reconcile_fan_on_startup(
+                indoor=indoor,
+                outdoor=outdoor,
+                thermostat_fan_running=True,
+                any_sensor_open=any_sensor_open,
+                trigger="ha_restart",
+            )
+        )
+
+    def test_authoritative_adopts_when_gate_clears(self):
+        for authoritative in (True, False):
+            engine = _make_engine(comfort_heat=68.0, comfort_cool=74.0, authoritative=authoritative)
+            self._run_reconcile(engine, indoor=72.0, outdoor=68.0)
+            assert engine._natural_vent_active is True, f"authoritative={authoritative}"
+
+    def test_authoritative_turns_off_when_gate_fails(self):
+        for authoritative in (True, False):
+            engine = _make_engine(comfort_heat=68.0, comfort_cool=74.0, authoritative=authoritative)
+            engine._exit_nat_vent = AsyncMock()
+            self._run_reconcile(engine, indoor=72.0, outdoor=80.0)
+            engine._exit_nat_vent.assert_awaited()
+
+    def test_authoritative_never_adopts_via_soft_start_at_this_site(self):
+        """Like handle_door_window_open(), this call site has never modeled
+        soft-start adoption -- an FSM-produced ACTIVE_SOFT_START must be treated
+        as "not eligible", not silently adopted as a full session."""
+        engine = _make_engine(comfort_heat=68.0, comfort_cool=74.0, authoritative=True)
+        engine._outdoor_temp_today_peak = 90.0
+        engine._outdoor_temp_today_sample_count = 5
+        engine._exit_nat_vent = AsyncMock()
+        self._run_reconcile(engine, indoor=76.0, outdoor=76.0)  # parity only -> soft-start territory
+        assert engine._natural_vent_active is False
+        engine._exit_nat_vent.assert_awaited()
+
+    def test_authoritative_ignores_stale_paused_by_door_state(self):
+        """This is a pure entry-gate question independent of restored/stale
+        _paused_by_door state at reconcile time -- legacy never consults it here,
+        and the FSM path must not either."""
+        for authoritative in (True, False):
+            engine = _make_engine(comfort_heat=68.0, comfort_cool=74.0, authoritative=authoritative)
+            engine._paused_by_door = True
+            engine._nat_vent_outdoor_exit_time = _NOW - timedelta(seconds=5)
+            self._run_reconcile(engine, indoor=72.0, outdoor=68.0)
+            assert engine._natural_vent_active is True, f"authoritative={authoritative}"

--- a/tests/test_window_hvac_interaction.py
+++ b/tests/test_window_hvac_interaction.py
@@ -95,6 +95,7 @@ def _make_ae_stub(**overrides) -> AutomationEngine:
     ae._paused_with_hvac_already_off = False
     ae._pre_pause_mode = None
     ae._doorwindow_fsm_authoritative = False
+    ae._natvent_fsm_authoritative = False
     ae._override_grace_fsm_authoritative = False
     ae._grace_active = False
     ae._grace_protects_override = False


### PR DESCRIPTION
## Summary
Part of Epic #594 Phase R (nat-vent FSM build-out). Wires the four real nat-vent decision points that previously called legacy gate/exit functions directly through `nat_vent_fsm.transition()`, gated by `_natvent_fsm_authoritative`:

- `handle_door_window_open()`'s entry logic
- `check_natural_vent_conditions()`'s idle-open re-entry
- `check_natural_vent_conditions()`'s reactivation-while-paused
- `reconcile_fan_on_startup()`

Applies results via Phase 2f's `_apply_nat_vent_fsm_state()` projection layer (#691). Legacy `else:` branches are untouched — no behavior change for the default-off switch position.

## Two-pass verification caught real bugs before merge
An independent Verification pass swept input combinations through both branches and found 3 real divergences in the first wiring attempt, all fixed and independently re-verified:
1. Site 1 used the live lifecycle state as the FSM's starting point, wrongly routing an *already-active* session through the FSM's exit chain when a second window opened — could kill a running free-cooling session. Fixed: forced `INACTIVE` starting state (pure entry-gate question), matching the precedent already set at the `reconcile_fan_on_startup()` site.
2. Site 1 hardcoded `ACTIVE_FULL_GATE`, silently demoting an in-flight soft-start session to full-gate. Fixed: derives the correct state from `_nat_vent_soft_start`.
3. Site 2's projection unconditionally cleared `_paused_by_door`, which legacy left alone at that call site. Fixed: preserve/restore across the apply.

Final independent verification: ruff clean, full suite 4961 passed / 6 skipped (warnings-as-errors), `tools/simulate.py` 81/81 golden scenarios, zero divergence from legacy on the reproduction inputs that originally caught the 3 defects.

## Occupant impact
None when the switch is off (default). When on (currently enabled on the reporter's live install), decisions at these 4 points are now computed identically to legacy but via the FSM instead of duplicated inline logic — verified equivalent, not intentionally different.

Version bumped 0.6.42 → 0.6.43.

Closes #694.