### PR TITLE
Fix #684: shadow diagnostic hardcoded lockout_seconds=300 instead of reading config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.45] — 2026-08-20
+
+- Fix #684: no user-visible change. A diagnostic-only comparison that checks whether the nat-vent state-machine engine (still not authoritative over any real decision unless you've opted in) agrees with production used a fixed 5-minute reactivation cooldown instead of your actually configured value, when they differ. Only affects installs that changed the reactivation lockout from its default — no change to any real fan/HVAC decision either way.
+
 ## [0.6.44] — 2026-08-20
 
 - Feat #698: the whole-house fan can now briefly pause itself mid-session once the room hits your comfort target, then resume automatically if it drifts back — instead of running the whole time regardless. With the state-machine switch enabled, a running free-cooling session also now reacts immediately (instead of waiting up to 30 minutes) if conditions change enough to end it for any reason, not just if the house gets too cold. Also fixed a small pre-existing mismatch where the fan could stay on slightly too long after outdoor air warmed past indoor, by reusing the same shared check used elsewhere. No change for installs that haven't opted into the state-machine switch, aside from the outdoor-air mismatch fix, which applies to everyone.

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,18 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.44"
+VERSION = "0.6.45"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.45": [
+        "Fix #684: no user-visible change. A diagnostic-only comparison that"
+        " checks whether the nat-vent state-machine engine (still not"
+        " authoritative over any real decision unless you've opted in) agrees"
+        " with production used a fixed 5-minute reactivation cooldown instead"
+        " of your actually configured value, when they differ. Only affects"
+        " installs that changed the reactivation lockout from its default —"
+        " no change to any real fan/HVAC decision either way.",
+    ],
     "0.6.44": [
         "Feat #698: the whole-house fan can now briefly pause itself mid-session"
         " once the room hits your comfort target, then resume automatically if"
@@ -2060,6 +2069,29 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    684: {
+        "version_fixed": "0.6.45",
+        "title": (
+            "Shadow diagnostic's nat-vent lifecycle re-derivation hardcoded"
+            " lockout_seconds=300 instead of reading the configured"
+            " CONF_NAT_VENT_REACTIVATION_LOCKOUT_S value"
+        ),
+        "scope_covered": (
+            "coordinator.py: _update_shadow_engine_diagnostic()'s nested"
+            " _state_for() helper now reads"
+            " self.config.get(CONF_NAT_VENT_REACTIVATION_LOCKOUT_S,"
+            " NAT_VENT_REACTIVATION_LOCKOUT_S), matching the pattern"
+            " _evaluate_nat_vent_fsm() has always used correctly. Since the"
+            " default lockout is also 300s, the bug was invisible on any"
+            " install using the default value — only installs with a"
+            " configured lockout different from 300s could see this"
+            " diagnostic-only comparison's production_state/shadow_state re-"
+            " derivation systematically disagree with the FSM's own"
+            " (correctly config-driven) state for the full duration of any"
+            " lockout window. No real fan/HVAC decision was ever affected —"
+            " this function's output is never written back to either engine."
+        ),
+    },
     698: {
         "version_fixed": "0.6.44",
         "title": (

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -1400,7 +1400,9 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 paused_by_door=bool(ae._paused_by_door),
                 outdoor_exit_time=ae._nat_vent_outdoor_exit_time,
                 now=now,
-                lockout_seconds=300,
+                lockout_seconds=float(
+                    self.config.get(CONF_NAT_VENT_REACTIVATION_LOCKOUT_S, NAT_VENT_REACTIVATION_LOCKOUT_S)
+                ),
             )
             return derive_nat_vent_lifecycle_state(inputs).value
 

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.44"
+  "version": "0.6.45"
 }

--- a/tests/test_shadow_engine_live.py
+++ b/tests/test_shadow_engine_live.py
@@ -272,6 +272,35 @@ class TestShadowEngineDiagnostic:
         assert diag["debounce"]["mirror"]["sustained"] is False
         assert 0.0 <= diag["debounce"]["mirror"]["disagreement_seconds"] < 1.0
 
+    def test_production_state_honors_configured_lockout_seconds(self) -> None:
+        """Issue #684: ``_state_for()`` used to hardcode ``lockout_seconds=300``
+        instead of reading the configured ``CONF_NAT_VENT_REACTIVATION_LOCKOUT_S``
+        value (which ``_evaluate_nat_vent_fsm()`` has always read correctly).
+        Default lockout is also 300s, so the bug was invisible on any install
+        using the default — this test configures a shorter lockout (60s) and
+        an outdoor-exit timestamp 120s in the past: with the fix, the
+        (already-elapsed) lockout means the derived state is INACTIVE; with the
+        old hardcoded 300s, 120s is still inside the window and the state would
+        incorrectly read PAUSED_REACTIVATION_LOCKOUT.
+        """
+        from custom_components.climate_advisor.const import CONF_NAT_VENT_REACTIVATION_LOCKOUT_S
+
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        coordinator.config[CONF_NAT_VENT_REACTIVATION_LOCKOUT_S] = 60
+        for ae in (coordinator.automation_engine, coordinator.shadow_automation_engine):
+            ae._natural_vent_active = False
+            ae._paused_by_door = True
+            ae._nat_vent_outdoor_exit_time = _FIXED_NOW - timedelta(seconds=120)
+        with patch("custom_components.climate_advisor.coordinator.dt_util.now", return_value=_FIXED_NOW):
+            coordinator._update_shadow_engine_diagnostic()
+        diag = coordinator.shadow_engine_diagnostic
+        # Nat-vent-specific fields only — setting _paused_by_door also feeds the
+        # unrelated door/window FSM comparison, which is out of scope here and
+        # not staged for this test.
+        assert diag["production_state"] == "inactive"
+        assert diag["shadow_state"] == "inactive"
+        assert diag["nat_vent_fsm_state"] == "inactive"
+
 
 class TestShadowEngineShutdown:
     def test_async_shutdown_cleans_up_shadow_timers(self) -> None:


### PR DESCRIPTION
## Summary
`coordinator._update_shadow_engine_diagnostic()`'s nested `_state_for()` helper hardcoded `lockout_seconds=300` when re-deriving the nat-vent lifecycle state for the production/shadow comparison, instead of reading `CONF_NAT_VENT_REACTIVATION_LOCKOUT_S` — which `_evaluate_nat_vent_fsm()` has always read correctly via `config.get(CONF_NAT_VENT_REACTIVATION_LOCKOUT_S, NAT_VENT_REACTIVATION_LOCKOUT_S)`.

Discovered during Epic #594 Phase R, Phase 0d investigation while root-causing a live 522-second FSM disagreement episode.

## Fix
`coordinator.py`'s `_state_for()` now reads the configured value the same way, matching the established pattern.

## Why this was invisible until now
The default lockout is also 300s, so this bug produced no observable effect on any install using the default value. It could only manifest — and would then systematically disagree with the FSM's own correctly-config-driven state for the full duration of any lockout window — on an install with a configured lockout different from 300s.

## Test
New test `test_production_state_honors_configured_lockout_seconds` in `tests/test_shadow_engine_live.py`: configures a 60s lockout with an outdoor-exit timestamp 120s in the past (past the configured 60s window, still inside the old hardcoded 300s window), asserting the derived state is `inactive` rather than the bug's `paused_reactivation_lockout`. Revert-tested: confirmed the test fails against the pre-fix code and passes against the fix.

## Occupant impact
None — this is a diagnostic-only comparison function whose output is never written back to either the production or shadow engine. No real fan/HVAC decision was ever affected by this bug.

Full suite: 4998 passed / 6 skipped (warnings-as-errors). `tools/simulate.py`: 81/81 golden scenarios (unaffected — this function isn't in any golden scenario's decision path).

Version bumped 0.6.44 → 0.6.45.

Closes #684.