### PR TITLE
Fix #706, #707, #708, #709: Phase G cutover-readiness gap closure (v0.6.46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.46] — 2026-08-20
+
+- Fix #706: closes a gap where, if you opt into the nat-vent state-machine engine, it could lose track of an active manual override in two ways: not recognizing one was already in effect, and — in rare timing cases — briefly overwriting a fan override that started while a decision was in flight. Also teaches it the existing rule that free cooling should keep running during a protected period if the house is genuinely overheating. No change unless you've opted in.
+- Fix #707: no user-visible change. After certain restarts with an active whole-house-fan remote timer, a diagnostic comparison (not any real fan/HVAC decision) could report a false disagreement for several minutes. Purely a live-verification signal fix.
+- Fix #708: closes a gap where, if you opt into the nat-vent state-machine engine, one specific moment — deciding whether to resume free cooling right after a grace period ends — was still always decided by the old code regardless of that setting. No change unless you've opted in.
+- Fix #709: closes a gap where, if you opt into the door/window state-machine engine, two of its eight decision points didn't actually change your grace-period status the way the setting implied, and a rare zero-length-grace configuration could leave a phantom grace period reported that never cleared on its own. No change unless you've opted in.
+
 ## [0.6.45] — 2026-08-20
 
 - Fix #684: no user-visible change. A diagnostic-only comparison that checks whether the nat-vent state-machine engine (still not authoritative over any real decision unless you've opted in) agrees with production used a fixed 5-minute reactivation cooldown instead of your actually configured value, when they differ. Only affects installs that changed the reactivation lockout from its default — no change to any real fan/HVAC decision either way.

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -3271,7 +3271,7 @@ class AutomationEngine:
                         f"natural ventilation: outdoor {outdoor:.1f}F < indoor {indoor:.1f}F,"
                         f" outdoor {outdoor:.1f}F <= {nat_vent_threshold:.1f}F"
                     )
-                    await self._activate_fan(reason=nat_vent_reason)
+                    _activation_result = await self._activate_fan(reason=nat_vent_reason)
                     if self._natvent_fsm_authoritative:
                         # Project onto the FSM state that matches legacy's writes at this
                         # site exactly: legacy only ever set _natural_vent_active = True
@@ -3281,10 +3281,16 @@ class AutomationEngine:
                         # ACTIVE_FULL_GATE regardless of _fsm_result.to_state would
                         # silently demote an in-flight soft-start session to full-gate on
                         # a second window opening, which legacy never did.
-                        self._apply_nat_vent_fsm_state(
+                        #
+                        # Issue #706 (Bug F): routed through
+                        # _apply_nat_vent_fsm_state_after_activation() rather than applying
+                        # this pre-await decision directly — a manual override arriving
+                        # during the await above must not be silently overwritten.
+                        self._apply_nat_vent_fsm_state_after_activation(
                             NatVentLifecycleState.ACTIVE_SOFT_START
                             if self._nat_vent_soft_start
-                            else NatVentLifecycleState.ACTIVE_FULL_GATE
+                            else NatVentLifecycleState.ACTIVE_FULL_GATE,
+                            _activation_result,
                         )
                     else:
                         self._natural_vent_active = True
@@ -3552,7 +3558,7 @@ class AutomationEngine:
 
                     if _to_state == NatVentLifecycleState.ACTIVE_FULL_GATE:
                         # Band stays armed — just activate the fan; the compressor self-arbitrates.
-                        await self._activate_fan(
+                        _activation_result = await self._activate_fan(
                             reason=(
                                 f"nat-vent re-engaged: outdoor {outdoor:.1f}°F < indoor {_indoor:.1f}°F"
                                 f" − {_hysteresis:.1f}°F hysteresis, indoor > comfort_heat {_comfort_heat:.1f}°F,"
@@ -3567,8 +3573,12 @@ class AutomationEngine:
                         # here with _paused_by_door=True (e.g. also
                         # _paused_with_hvac_already_off=True) would flip to
                         # _paused_by_door=False, an incoherent pair legacy never produced.
+                        #
+                        # Issue #706 (Bug F): routed through
+                        # _apply_nat_vent_fsm_state_after_activation() — an override
+                        # arriving during the await above must not be silently overwritten.
                         _pre_paused_by_door = self._paused_by_door
-                        self._apply_nat_vent_fsm_state(_to_state)
+                        self._apply_nat_vent_fsm_state_after_activation(_to_state, _activation_result)
                         self._paused_by_door = _pre_paused_by_door
                         await self._apply_nat_vent_hvac_state()
                         # Issue #244: emit so the re-evaluation activation is visible in the
@@ -3592,7 +3602,7 @@ class AutomationEngine:
                             PEAK_DECLINE_MARGIN_F,
                             _comfort_heat,
                         )
-                        await self._activate_fan(
+                        _activation_result = await self._activate_fan(
                             reason=(
                                 f"nat-vent soft-start: outdoor {outdoor:.1f}°F at/below indoor {_indoor:.1f}°F"
                                 " parity, past today's peak and declining — purge/comfort air movement"
@@ -3600,8 +3610,10 @@ class AutomationEngine:
                         )
                         # Preserve _paused_by_door across the apply — see the matching
                         # comment on the ACTIVE_FULL_GATE branch above for the rationale.
+                        # Issue #706 (Bug F): same override-race guard as the
+                        # ACTIVE_FULL_GATE branch above.
                         _pre_paused_by_door = self._paused_by_door
-                        self._apply_nat_vent_fsm_state(_to_state)
+                        self._apply_nat_vent_fsm_state_after_activation(_to_state, _activation_result)
                         self._paused_by_door = _pre_paused_by_door
                         await self._apply_nat_vent_hvac_state()
                         if self._emit_event_callback:
@@ -4026,14 +4038,18 @@ class AutomationEngine:
                         _to_state = NatVentLifecycleState.INACTIVE
 
                     if _to_state == NatVentLifecycleState.ACTIVE_FULL_GATE:
-                        await self._activate_fan(
+                        # Issue #706 (Bug F): route through
+                        # _apply_nat_vent_fsm_state_after_activation() — an override
+                        # arriving during the await below must not be silently
+                        # overwritten by this pre-await _to_state decision.
+                        _activation_result = await self._activate_fan(
                             reason=(
                                 f"natural vent activated: outdoor {outdoor:.1f}°F"
                                 f" < indoor {indoor:.1f}°F − {hysteresis:.1f}°F hysteresis,"
                                 f" outdoor ≤ threshold {threshold:.1f}°F"
                             )
                         )
-                        self._apply_nat_vent_fsm_state(_to_state)
+                        self._apply_nat_vent_fsm_state_after_activation(_to_state, _activation_result)
 
                         from .door_window_fsm import DoorWindowFsmEventKind
 
@@ -4062,13 +4078,15 @@ class AutomationEngine:
                         )
                         await self._apply_nat_vent_hvac_state()
                     elif _to_state == NatVentLifecycleState.ACTIVE_SOFT_START:
-                        await self._activate_fan(
+                        # Issue #706 (Bug F): same override-race guard as the
+                        # ACTIVE_FULL_GATE branch above.
+                        _activation_result = await self._activate_fan(
                             reason=(
                                 f"nat-vent soft-start while paused: outdoor {outdoor:.1f}°F at/below"
                                 f" indoor {indoor:.1f}°F parity, past today's peak and declining"
                             )
                         )
-                        self._apply_nat_vent_fsm_state(_to_state)
+                        self._apply_nat_vent_fsm_state_after_activation(_to_state, _activation_result)
 
                         from .door_window_fsm import DoorWindowFsmEventKind
 
@@ -6788,6 +6806,16 @@ class AutomationEngine:
                 (every other caller) keeps this method's prior behavior
                 (``self._fan_active``) unchanged — harmless either way, since none of
                 those other call sites read ``NatVentTransition.fan_should_be_active``.
+
+        Issue #706 (Bug D): ``override_active``/``grace_active`` are now always read
+        live from engine state — ``bool(self._fan_override_active or
+        self._manual_override_active)`` and ``bool(self._grace_active)`` — the same
+        flags ``coordinator._evaluate_nat_vent_fsm()``'s shadow-diagnostic
+        construction already reads correctly. Before this fix, every real production
+        caller of this method left both fields at their dataclass default (``False``,
+        added for Issue #687/Phase 2a but never wired here), so the FSM was blind to
+        a real override/grace window and could disagree with what
+        ``_activate_fan()``'s own override guard actually did.
         """
         from .nat_vent_fsm import NatVentFsmInputs
 
@@ -6800,6 +6828,8 @@ class AutomationEngine:
         )
         _paused_by_door = paused_by_door if paused_by_door is not None else bool(self._paused_by_door)
         _fan_hardware_active = fan_hardware_active if fan_hardware_active is not None else bool(self._fan_active)
+        _override_active = bool(self._fan_override_active or self._manual_override_active)
+        _grace_active = bool(self._grace_active)
         return NatVentFsmInputs(
             indoor=indoor,
             outdoor=outdoor,
@@ -6824,6 +6854,8 @@ class AutomationEngine:
             ),
             now=now,
             fan_hardware_active=_fan_hardware_active,
+            override_active=_override_active,
+            grace_active=_grace_active,
         )
 
     @property
@@ -6880,6 +6912,38 @@ class AutomationEngine:
         )
         self._nat_vent_soft_start = state == NatVentLifecycleState.ACTIVE_SOFT_START
         self._paused_by_door = state == NatVentLifecycleState.PAUSED_REACTIVATION_LOCKOUT
+
+    def _apply_nat_vent_fsm_state_after_activation(
+        self, to_state: NatVentLifecycleState, activation_result: FanCommandResult
+    ) -> None:
+        """Apply an FSM decision computed BEFORE an ``await self._activate_fan(...)``
+        call, guarding against the Issue #706 Bug F race.
+
+        All 5 production call sites for ``_apply_nat_vent_fsm_state()`` share the
+        same shape: compute a ``to_state`` decision, then ``await
+        self._activate_fan(...)`` — a real event-loop yield point — under
+        ``_decision_lock``/``_decision_pass``, then apply that pre-await decision.
+        ``handle_fan_manual_override()``/``coordinator._async_fan_entity_changed()``
+        are NOT lock-protected and can run to completion during that await window,
+        setting ``_fan_override_active``/starting grace. When that happens,
+        ``_activate_fan()``'s own override guard rejects the real fan command and
+        returns ``FanCommandResult.OVERRIDDEN`` — the definitive, race-free signal
+        that the pre-await ``to_state`` is now stale. In that case, apply
+        ``INACTIVE`` instead of the stale decision so ``_natural_vent_active`` never
+        disagrees with the fact the real command was rejected. Every other
+        ``FanCommandResult`` (``EXECUTED``, ``ALREADY_IN_STATE``,
+        ``RATE_LIMITED_NEW``/``DUP``, ``DISABLED``) means no override intervened
+        mid-await, so the pre-await ``to_state`` is still correct to apply.
+        """
+        if activation_result is FanCommandResult.OVERRIDDEN:
+            _LOGGER.warning(
+                "Nat-vent FSM state application skipped: fan override became active"
+                " during activation — applying INACTIVE instead of stale %s decision",
+                to_state,
+            )
+            self._apply_nat_vent_fsm_state(NatVentLifecycleState.INACTIVE)
+        else:
+            self._apply_nat_vent_fsm_state(to_state)
 
     def _build_door_window_fsm_inputs(self, *, now: datetime):
         """Build the door/window FSM's input snapshot from current engine state

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -5736,13 +5736,56 @@ class AutomationEngine:
             comfort_heat = self._nat_vent_reactivation_floor()
             nat_vent_threshold = comfort_cool + nat_vent_delta
 
-            if self._doorwindow_fsm_authoritative:
+            # Issue #708: this reactivation decision was previously gated ONLY on
+            # _doorwindow_fsm_authoritative (reading a flag already written by the
+            # door/window FSM's own *nested* duplicate nat-vent-reactivation check) —
+            # _natvent_fsm_authoritative was never consulted at all, regardless of its
+            # own state. Checked first and independent of the door/window switch,
+            # matching every other wired nat-vent decision site
+            # (handle_door_window_open's idle-open re-entry, check_natural_vent_
+            # conditions's comfort-ceiling re-entry and paused-by-door reactivation,
+            # reconcile_fan_on_startup's adopt gate) — none of those gate on
+            # _doorwindow_fsm_authoritative either. This keeps the two concerns
+            # independent: door/window's switch only governs how its own pause/grace
+            # flags get derived (via _resolve_door_window_pause_flags() below, which
+            # is correct either way — PAUSED_NAT_VENT_REACTIVATED always transitions
+            # to NORMAL from any origin state, so it doesn't matter whether the flags
+            # it's dispatched against already agree with this decision); nat-vent's
+            # switch governs its own reactivation question.
+            if self._natvent_fsm_authoritative:
+                from .nat_vent_fsm import NatVentFsmEvent, NatVentFsmEventKind
+                from .nat_vent_fsm import transition as _nat_vent_transition
+
+                # The FSM's current_state is forced to INACTIVE, matching the other
+                # two "pure entry-gate question" sites (handle_door_window_open,
+                # reconcile_fan_on_startup) rather than read from
+                # self.nat_vent_lifecycle_state: this legacy call never consulted the
+                # reactivation lockout (unlike the paused-by-door reactivation site in
+                # check_natural_vent_conditions), and never modeled soft-start entry
+                # (no _nat_vent_may_soft_start() call at this site) — an
+                # FSM-produced ACTIVE_SOFT_START result is treated the same as "not
+                # eligible," matching this site's pre-existing scope exactly.
+                # hysteresis=0.0 and paused_by_door=False mirror the legacy call's own
+                # omissions below (see _nat_vent_may_reactivate()'s docstring: this is
+                # one of the 2-of-5 callers that never applied hysteresis, and this
+                # site never consulted _paused_by_door either).
+                _fsm_inputs = self._build_nat_vent_fsm_inputs(
+                    now=dt_util.now(), indoor=indoor, outdoor=outdoor, hysteresis=0.0, paused_by_door=False
+                )
+                _fsm_result = _nat_vent_transition(
+                    NatVentLifecycleState.INACTIVE,
+                    NatVentFsmEvent(kind=NatVentFsmEventKind.TICK, inputs=_fsm_inputs),
+                )
+                _reactivates = _fsm_result.to_state == NatVentLifecycleState.ACTIVE_FULL_GATE
+            elif self._doorwindow_fsm_authoritative:
                 # Issue #660 Step 8: when authoritative, _on_grace_expired() already
                 # applied the FSM's RE_PAUSE outcome (including its own nested
                 # nat-vent reactivation gate check, identical to
                 # _nat_vent_may_reactivate() below) to _paused_by_door BEFORE
                 # scheduling this task — select the matching action by reading that
                 # already-applied flag instead of independently recomputing the gate.
+                # Only reached here when _natvent_fsm_authoritative is False — nat-vent's
+                # own switch takes priority above whenever it is on.
                 _reactivates = not self._paused_by_door
             else:
                 # Issue #411 (Pass 4): shared reactivation gate, previously hand-copied

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -3077,7 +3077,7 @@ class AutomationEngine:
             legacy=_legacy_set_pause,
         )
         # _paused_entity/_paused_since aren't part of _apply_door_window_fsm_state()'s
-        # 3-field derivation (see its own docstring) — direct writes here regardless
+        # 2-field derivation (see its own docstring) — direct writes here regardless
         # of which branch the dispatcher took, matching what
         # _set_door_window_pause_fields() would have written on the legacy path.
         self._paused_entity = entity_label
@@ -5685,10 +5685,16 @@ class AutomationEngine:
         (``_on_grace_expired()``'s 3 branches, ``_check_orphaned_grace()``), and reused
         unchanged by ``_cancel_grace_timers()`` itself for every other caller (``cleanup()``,
         the internal cancel-prior-timer call inside ``_start_grace_period_action()``, and
-        every door/window call site — none of those are override/grace FSM-modeled events;
-        door/window's own dispatcher independently derives and writes ``_grace_active`` from
-        its own FSM/legacy branch regardless of this method, same redundant-but-harmless
-        coexistence already proven safe for door/window's shipped authoritative switch).
+        every door/window call site — none of those are override/grace FSM-modeled events).
+
+        **Issue #709: door/window's dispatcher no longer writes ``_grace_active`` at all.**
+        Prior to #709 this method's docstring claimed the redundant door/window write was
+        "proven safe" as a same-value coexistence — that claim turned out to be false: the
+        two writers could disagree for real, transiently, whenever ``resume_from_pause()``/
+        ``handle_all_doors_windows_closed()`` ran the door/window dispatch before the real
+        grace-start action, with genuine ``await`` points in between. ``_apply_door_window_fsm_state()``
+        was fixed to stop writing this flag; this method (via ``_resolve_override_grace_fsm_state()``
+        and its paired ``legacy()`` closures) is now the flag's sole writer everywhere.
         """
         self._grace_active = False
         self._grace_protects_override = False
@@ -5857,7 +5863,7 @@ class AutomationEngine:
                     notify_type="grace_repause",
                 )
                 # _paused_entity/_paused_since aren't part of
-                # _apply_door_window_fsm_state()'s 3-field derivation — direct writes
+                # _apply_door_window_fsm_state()'s 2-field derivation — direct writes
                 # here, matching what _set_door_window_pause_fields() would have
                 # written on the legacy path below.
                 self._paused_entity = "re-check"
@@ -6673,8 +6679,9 @@ class AutomationEngine:
             # equivalent to "already off" (PAUSED_IDLE), matching
             # decide_door_close_response()'s own truthiness test on pre_pause_mode.
             #
-            # Issue #660 Step 4: routed through the shared dispatcher for the 3 fields
-            # it derives (_paused_by_door/_paused_with_hvac_already_off/_grace_active).
+            # Issue #660 Step 4: routed through the shared dispatcher for the 2 fields
+            # it derives (_paused_by_door/_paused_with_hvac_already_off — Issue #709
+            # removed _grace_active from this derivation, see that method's docstring).
             # _paused_entity/_paused_since aren't part of that derivation (see
             # _apply_door_window_fsm_state()'s own docstring), so they stay direct
             # writes below regardless of which branch the dispatcher took — same
@@ -6915,6 +6922,8 @@ class AutomationEngine:
             whf_owns_hvac=bool(self._whf_owns_hvac()),
             grace_active=bool(self._grace_active),
             pre_pause_mode_active=bool(self._pre_pause_mode),
+            manual_grace_would_start=self._grace_would_start("manual", now),
+            automation_grace_would_start=self._grace_would_start("automation", now),
             now=now,
         )
 
@@ -6945,8 +6954,8 @@ class AutomationEngine:
         )
 
     def _apply_door_window_fsm_state(self, state: DoorWindowLifecycleState) -> None:
-        """Write ``_paused_by_door``/``_paused_with_hvac_already_off``/``_grace_active``
-        from a ``door_window_fsm.transition()`` result (Issue #594 Phase R, Step 2).
+        """Write ``_paused_by_door``/``_paused_with_hvac_already_off`` from a
+        ``door_window_fsm.transition()`` result (Issue #594 Phase R, Step 2).
 
         The inverse of ``door_window_lifecycle_state``'s derivation — see
         ``door_window_lifecycle.py``'s state-to-flags table. Deliberately does NOT
@@ -6956,6 +6965,41 @@ class AutomationEngine:
         (the FSM's ``outcome``/``at`` fields don't carry entity labels or trigger
         names), so every caller keeps writing those itself, same as before this
         method existed.
+
+        **Issue #709: does NOT write ``_grace_active``.** Prior to #709 this method
+        also wrote ``_grace_active`` from the GRACE/PAUSED_DURING_GRACE members of
+        ``state`` — a second, independent writer of a flag ``override_grace_fsm.py``'s
+        own docstring already claims exclusive ownership of (see
+        ``_resolve_override_grace_fsm_state()``'s docstring: "Genuinely mutually
+        exclusive — exactly one of the FSM path or ``legacy()`` ever writes
+        ``_grace_active``"— a claim this method's now-removed write silently
+        falsified). The dual-write was reachable as a real race, not just a
+        theoretical layering violation: ``resume_from_pause()`` and
+        ``handle_all_doors_windows_closed()`` both call
+        ``_resolve_door_window_pause_flags()`` (which used to land here) BEFORE the
+        real grace-start action (``_start_grace_period_action()``), separated by
+        genuine ``await`` points (``_set_hvac_mode()``/``_set_temperature_for_mode()``)
+        that yield control back to the event loop. During that window, a concurrently
+        scheduled task (e.g. ``coordinator._check_orphaned_grace()``) could observe
+        ``_grace_active=True`` with no real timer scheduled and no override
+        protecting it — a phantom grace period this method's write created and only
+        the subsequent real action call (which unconditionally cancels any prior
+        timer via ``_cancel_grace_timers()``) happened to wash out. Now that this
+        method leaves ``_grace_active`` untouched, the ONLY writer is
+        ``_apply_override_grace_fsm_state()`` (FSM path) or the paired ``legacy()``
+        closures passed to ``_resolve_override_grace_fsm_state()`` — both already
+        correctly gated on ``_start_grace_period_action()``'s real return value, so
+        a phantom "grace active, no timer" combination can no longer occur. Door/
+        window's own FSM continues to READ ``_grace_active`` as a cross-lifecycle
+        input (``DoorWindowFsmInputs.grace_active``) — every call site re-derives
+        ``current_state`` from a live read of ``door_window_lifecycle_state`` (which
+        itself reads the live flag) rather than carrying a stale copy, so this
+        state machine self-heals against whatever the real flag is on every
+        subsequent transition; see ``door_window_fsm.py``'s own docstring for the
+        ``manual_grace_would_start``/``automation_grace_would_start`` inputs added in
+        the same fix, which keep the FSM's *own* ``to_state``/``outcome`` audit
+        trail accurate for the 3 transitions that used to unconditionally assume a
+        new grace period would start.
         """
         self._paused_by_door = state in (
             DoorWindowLifecycleState.PAUSED_ACTIVE,
@@ -6963,7 +7007,6 @@ class AutomationEngine:
             DoorWindowLifecycleState.PAUSED_DURING_GRACE,
         )
         self._paused_with_hvac_already_off = state == DoorWindowLifecycleState.PAUSED_IDLE
-        self._grace_active = state in (DoorWindowLifecycleState.GRACE, DoorWindowLifecycleState.PAUSED_DURING_GRACE)
 
     def _resolve_door_window_pause_flags(
         self,
@@ -7056,17 +7099,25 @@ class AutomationEngine:
             grace_would_start=self._manual_grace_would_start(now),
         )
 
-    def _manual_grace_would_start(self, now: datetime) -> bool:
-        """Whether manual grace is currently enabled (``CONF_MANUAL_GRACE_PERIOD`` > 0)
-        (Issue #664). Same ``decide_grace_start()`` call ``_start_grace_period_action()``
-        itself makes — every override/grace-modeled event that starts grace uses
-        ``source="manual"``, so this is always resolved against the manual duration,
-        never the automation one.
+    def _grace_would_start(self, source: str, now: datetime) -> bool:
+        """Whether a grace period for ``source`` ("manual" or "automation") is
+        currently enabled by config — i.e. whether ``_start_grace_period_action()``
+        would actually schedule a real timer for that source right now, without
+        actually starting one (Issue #664, generalized in #709).
+
+        Same ``decide_grace_start()`` call ``_start_grace_period_action()`` itself
+        makes. Both FSMs that model grace (``override_grace_fsm.py``,
+        ``door_window_fsm.py``) consult this — the SOLE computation of "would grace
+        start", never duplicated — since ``decide_grace_start()`` resolves duration/
+        should_notify for BOTH sources from a single call regardless of which one
+        is asked about, this passes the other source's live config values through
+        unconditionally; only the returned duration for ``source`` determines the
+        boolean result.
         """
         manual_duration = self.config.get(CONF_MANUAL_GRACE_PERIOD, DEFAULT_MANUAL_GRACE_SECONDS)
         return (
             decide_grace_start(
-                source="manual",
+                source=source,
                 manual_duration_seconds=manual_duration,
                 manual_should_notify=self.config.get(CONF_MANUAL_GRACE_NOTIFY, True),
                 automation_duration_seconds=self.config.get(
@@ -7077,6 +7128,16 @@ class AutomationEngine:
             )
             is not None
         )
+
+    def _manual_grace_would_start(self, now: datetime) -> bool:
+        """Whether manual grace is currently enabled (``CONF_MANUAL_GRACE_PERIOD`` > 0)
+        (Issue #664). Thin ``source="manual"`` wrapper over ``_grace_would_start()``
+        (Issue #709) — kept as a named method since ``override_grace_fsm.py``'s own
+        docstring documents "every override/grace-modeled event that starts grace
+        uses ``source='manual'``", so every real call site building
+        ``OverrideGraceFsmInputs`` always wants this specific source.
+        """
+        return self._grace_would_start("manual", now)
 
     @property
     def override_grace_lifecycle_state(self) -> OverrideGraceLifecycleState:

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,32 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.45"
+VERSION = "0.6.46"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.46": [
+        "Fix #707: no user-visible change. After certain restarts with an active"
+        " whole-house-fan remote timer, a diagnostic comparison (not any real"
+        " fan/HVAC decision) could report a false disagreement for several"
+        " minutes. Purely a live-verification signal fix.",
+        "Fix #708: closes a gap where, if you opt into the nat-vent state-machine"
+        " engine, one specific moment — deciding whether to resume free cooling"
+        " right after a grace period ends — was still always decided by the old"
+        " code regardless of that setting. No change unless you've opted in.",
+        "Fix #706: closes a gap where, if you opt into the nat-vent state-machine"
+        " engine, it could lose track of an active manual override in two ways:"
+        " not recognizing one was already in effect, and — in rare timing"
+        " cases — briefly overwriting a fan override that started while a"
+        " decision was in flight. Also teaches it the existing rule that free"
+        " cooling should keep running during a protected period if the house is"
+        " genuinely overheating. No change unless you've opted in.",
+        "Fix #709: closes a gap where, if you opt into the door/window"
+        " state-machine engine, two of its eight decision points didn't"
+        " actually change your grace-period status the way the setting implied,"
+        " and a rare zero-length-grace configuration could leave a phantom"
+        " grace period reported that never cleared on its own. No change unless"
+        " you've opted in.",
+    ],
     "0.6.45": [
         "Fix #684: no user-visible change. A diagnostic-only comparison that"
         " checks whether the nat-vent state-machine engine (still not"
@@ -2069,6 +2092,76 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    706: {
+        "version_fixed": "0.6.46",
+        "title": (
+            "Nat-vent FSM's production input builder never populated"
+            " override_active/grace_active (Bug D); a decision computed before"
+            " an await could clobber a real override that started mid-await"
+            " (Bug F); the FSM's grace short-circuit didn't model the Issue"
+            " #134 overheat-during-grace exception (#688)"
+        ),
+        "scope_covered": (
+            "automation.py: _build_nat_vent_fsm_inputs() now reads live"
+            " override/grace state; new _apply_nat_vent_fsm_state_after_"
+            " activation() checks _activate_fan()'s FanCommandResult and"
+            " applies INACTIVE instead of a stale decision when it returns"
+            " OVERRIDDEN, wired into all 5 real call sites. nat_vent_fsm.py:"
+            " new shared _grace_blocks_natvent() models the Issue #134"
+            " exception in both transition functions."
+        ),
+    },
+    707: {
+        "version_fixed": "0.6.46",
+        "title": (
+            "RF-timer restart-resume's inner handle_fan_manual_override() call"
+            " never fed the override/grace shadow FSM tracker, since it's"
+            " invisible to _mirror_to_shadow()'s outer-method-name dispatch"
+        ),
+        "scope_covered": (
+            "coordinator.py: _do_startup_coalesce() now explicitly feeds"
+            " _evaluate_override_grace_fsm(FAN_OVERRIDE_DETECTED) when the"
+            " RF-timer-survives-restart branch actually fires. Diagnostic-only"
+            " — production's real override/grace flags were always correct."
+        ),
+    },
+    708: {
+        "version_fixed": "0.6.46",
+        "title": (
+            "Grace-expiry paused-reactivation (_re_pause_for_open_sensor())"
+            " never consulted the nat-vent FSM at all, gated only by the"
+            " door/window switch"
+        ),
+        "scope_covered": (
+            "automation.py: _re_pause_for_open_sensor() now routes its"
+            " reactivation decision through nat_vent_fsm.transition() when"
+            " natvent_fsm_authoritative is True, independent of the"
+            " door/window switch."
+        ),
+    },
+    709: {
+        "version_fixed": "0.6.46",
+        "title": (
+            "Door/window FSM's _grace_active write conflicted with"
+            " override/grace's sole ownership of that flag; door_window_fsm.py"
+            " had no equivalent of grace_would_start, so 3 grace-landing"
+            " transitions could set a phantom _grace_active with no real timer"
+            " when grace was configured off"
+        ),
+        "scope_covered": (
+            "automation.py: _apply_door_window_fsm_state() no longer writes"
+            " _grace_active/_grace_protects_override — override/grace's"
+            " dispatcher is the sole writer. door_window_fsm.py: new"
+            " manual_grace_would_start/automation_grace_would_start input"
+            " fields gate the 3 real grace-landing transitions"
+            " (_transition_from_paused()'s DASHBOARD_RESUME and"
+            " ALL_SENSORS_CLOSED->RESTORE_AND_GRACE,"
+            " _transition_from_paused_during_grace()'s DASHBOARD_RESUME)."
+            " New tests/test_fsm_flag_ownership.py adds a generalized,"
+            " AST-based 'exactly one writer' regression guard for all 3 FSMs'"
+            " modeled flags."
+        ),
+    },
     684: {
         "version_fixed": "0.6.45",
         "title": (

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -2805,6 +2805,42 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         )
         _LOGGER.debug("[coalesce-diag] after reconcile_fan_on_startup()")
 
+        # Issue #707: reconcile_fan_on_startup()'s RF-timer-survives-restart branch
+        # (_reconcile_fan_on_startup_locked(), automation.py ~5005-5022) calls
+        # handle_fan_manual_override() INTERNALLY when a live remote timer is still
+        # valid — that inner call correctly updates production's real override/grace
+        # flags via _resolve_override_grace_fsm_state(), but is invisible to
+        # _mirror_to_shadow()'s dispatch above, since "reconcile_fan_on_startup" (the
+        # outer mirrored method name) isn't a key in _OVERRIDE_GRACE_FSM_EVENT_KINDS —
+        # only "handle_fan_manual_override" is, and that key is only ever consulted
+        # when _mirror_to_shadow() itself is invoked with that method name, which never
+        # happens here since the inner call is a direct synchronous call inside
+        # automation.py, not a coordinator-level mirrored call. Left the shadow tracker
+        # permanently stuck reporting "none" after every restart with an active RF
+        # timer (confirmed live: production=idle/active_protecting_override vs
+        # fsm=idle/none, sustained 993s+, 2026-08-20 06:54-07:11).
+        #
+        # Fix: feed the FSM tracker directly here, gated on the EXACT same condition
+        # _reconcile_fan_on_startup_locked() uses to decide whether to call
+        # handle_fan_manual_override() (remote_timer_provenance is not None and
+        # thermostat_fan_running) — so this only fires when the inner override call
+        # actually happened, never on the plain "nothing to reconcile" path. By this
+        # point reconcile_fan_on_startup() has already fully returned (including its
+        # synchronous inner handle_fan_manual_override() call), so
+        # self.automation_engine's live flags are already correct — same
+        # read-fresh-from-production pattern _check_orphaned_grace() uses at ~2865-2869.
+        if _remote_timer_provenance is not None and _thermostat_fan_running:
+            from .override_grace_fsm import OverrideGraceFsmEventKind as _OGFEventKind
+
+            try:
+                self._evaluate_override_grace_fsm(_OGFEventKind.FAN_OVERRIDE_DETECTED)
+            except Exception as fsm_exc:  # noqa: BLE001 — FSM errors must never affect production
+                _LOGGER.warning(
+                    "Override/grace FSM evaluation (restart-resume RF-timer-driven) failed"
+                    " (isolated, no production impact): %s",
+                    fsm_exc,
+                )
+
         self._emit_event(
             "startup_coalesced",
             {

--- a/custom_components/climate_advisor/door_window_fsm.py
+++ b/custom_components/climate_advisor/door_window_fsm.py
@@ -242,6 +242,43 @@ class DoorWindowFsmInputs:
                                              grace started running concurrently with an
                                              existing pause (see that function's own
                                              docstring for the fix).
+      manual_grace_would_start             -> self._grace_would_start("manual", now) —
+                                             added under Issue #709 (mirrors
+                                             override_grace_fsm.py's own
+                                             ``grace_would_start`` field, Issue #664):
+                                             whether CONF_MANUAL_GRACE_PERIOD is
+                                             currently > 0. Feeds
+                                             ``_transition_from_paused()``'s
+                                             DASHBOARD_RESUME handler (the real
+                                             ``resume_from_pause()`` call always
+                                             attempts a *manual* grace) and
+                                             ``_transition_from_paused_during_grace()``'s
+                                             DASHBOARD_RESUME handler (same real
+                                             caller, reachable from that origin too
+                                             since ``_paused_by_door`` stays True
+                                             through PAUSED_DURING_GRACE).
+      automation_grace_would_start          -> self._grace_would_start("automation", now)
+                                             — added under Issue #709: whether
+                                             CONF_AUTOMATION_GRACE_PERIOD is currently
+                                             > 0. Feeds ``_transition_from_paused()``'s
+                                             ALL_SENSORS_CLOSED -> RESTORE_AND_GRACE
+                                             handler (the real
+                                             ``handle_all_doors_windows_closed()`` call
+                                             always attempts an *automation* grace via
+                                             ``_start_grace_period("automation", ...)``).
+                                             Deliberately a distinct field from
+                                             ``manual_grace_would_start`` rather than one
+                                             shared boolean — the two real call sites
+                                             this FSM models grace-starting for use
+                                             different sources, and
+                                             ``decide_grace_start()`` resolves duration
+                                             per-source, so collapsing them into one
+                                             field would silently check the wrong config
+                                             value for one of the two (see
+                                             ``override_grace_fsm.py``'s own
+                                             ``UNPROTECTED_GRACE_STARTED`` docstring for
+                                             the same source-mismatch pitfall already
+                                             found there).
       now                                  -> caller-resolved wall-clock time
     """
 
@@ -263,6 +300,8 @@ class DoorWindowFsmInputs:
     grace_active: bool
     pre_pause_mode_active: bool
     now: datetime
+    manual_grace_would_start: bool = True
+    automation_grace_would_start: bool = True
 
 
 @dataclass(frozen=True)
@@ -431,11 +470,20 @@ def _transition_from_paused(current_state: DoorWindowLifecycleState, event: Door
                 pre_pause_mode="restored" if inputs.pre_pause_mode_active else None,
             )
         )
-        next_state = (
-            DoorWindowLifecycleState.GRACE
-            if outcome == DoorCloseResponseOutcome.RESTORE_AND_GRACE
-            else DoorWindowLifecycleState.NORMAL
-        )
+        # Issue #709: RESTORE_AND_GRACE only actually lands on GRACE if the real
+        # automation grace period would start (handle_all_doors_windows_closed()
+        # always attempts source="automation" here) — CONF_AUTOMATION_GRACE_PERIOD=0
+        # is a valid, documented way to disable it (Issue #664's same convention,
+        # extended to door/window), in which case pause still clears but no grace
+        # follows.
+        if outcome == DoorCloseResponseOutcome.RESTORE_AND_GRACE:
+            next_state = (
+                DoorWindowLifecycleState.GRACE
+                if inputs.automation_grace_would_start
+                else DoorWindowLifecycleState.NORMAL
+            )
+        else:
+            next_state = DoorWindowLifecycleState.NORMAL
         return DoorWindowTransition(current_state, next_state, kind, outcome.value, inputs.now)
 
     if kind == DoorWindowFsmEventKind.MANUAL_OVERRIDE_DURING_PAUSE:
@@ -444,7 +492,13 @@ def _transition_from_paused(current_state: DoorWindowLifecycleState, event: Door
         )
 
     if kind == DoorWindowFsmEventKind.DASHBOARD_RESUME:
-        return DoorWindowTransition(current_state, DoorWindowLifecycleState.GRACE, kind, "resumed", inputs.now)
+        # Issue #709: resume_from_pause() always attempts a real source="manual"
+        # grace after clearing the pause, but CONF_MANUAL_GRACE_PERIOD=0 disables it
+        # (Issue #664) — in that case pause clears but the FSM must not claim GRACE.
+        next_state = (
+            DoorWindowLifecycleState.GRACE if inputs.manual_grace_would_start else DoorWindowLifecycleState.NORMAL
+        )
+        return DoorWindowTransition(current_state, next_state, kind, "resumed", inputs.now)
 
     if kind == DoorWindowFsmEventKind.SYNC_RECONCILE:
         # Issue #660: dispatches to the same single reconciliation function every
@@ -583,8 +637,18 @@ def _transition_from_paused_during_grace(
         )
 
     if kind == DoorWindowFsmEventKind.DASHBOARD_RESUME:
-        # Clears pause, unconditionally re-arms grace — lands on GRACE.
-        return DoorWindowTransition(current_state, DoorWindowLifecycleState.GRACE, kind, "resumed", inputs.now)
+        # Issue #709: resume_from_pause() is reachable from PAUSED_DURING_GRACE too
+        # (it guards only on _paused_by_door, which stays True through this
+        # composite state) and always attempts to re-arm a real source="manual"
+        # grace via _start_grace_period_action(), which unconditionally cancels
+        # the existing timer first — so if CONF_MANUAL_GRACE_PERIOD is now 0
+        # (Issue #664), the pre-existing grace does NOT survive; it's cancelled
+        # and nothing replaces it. Clears pause either way; lands on GRACE only
+        # if a real grace would actually (re)start.
+        next_state = (
+            DoorWindowLifecycleState.GRACE if inputs.manual_grace_would_start else DoorWindowLifecycleState.NORMAL
+        )
+        return DoorWindowTransition(current_state, next_state, kind, "resumed", inputs.now)
 
     if kind == DoorWindowFsmEventKind.PAUSED_NAT_VENT_REACTIVATED:
         # Issue #660 Step 3: clears the pause but leaves the already-running grace

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.45"
+  "version": "0.6.46"
 }

--- a/custom_components/climate_advisor/nat_vent_fsm.py
+++ b/custom_components/climate_advisor/nat_vent_fsm.py
@@ -69,14 +69,26 @@ confirmed live as the single largest disagreement bucket in a night of logs
 implement any other new decision authority (see epic #594 Phase R for the
 larger authority question).
 
-**Known remaining edge (diagnostic-only, zero occupant impact — tracked in
-Issue #688):** production's grace guard has an Issue #134 exception that
-*allows* nat-vent to engage during grace when indoor exceeds ``comfort_cool``
-(overheat protection). This short-circuit does not model that exception —
-it always returns ``INACTIVE`` while ``grace_active`` is true. This trades the
-38-line disagreement bucket above for a narrower, rarer one; since this
-tracker is never written back to production, occupant behavior is unaffected
-either way.
+**Issue #134 overheat-during-grace exception (Issue #706, closes #688).**
+Production's grace guard has an exception that *allows* nat-vent to engage
+during grace when indoor genuinely exceeds ``comfort_cool`` (overheat
+protection — ``automation.py``'s real condition:
+``self._grace_active and indoor is not None and indoor > comfort_cool``).
+This module's grace short-circuit now models that same exception via
+``_grace_blocks_natvent()``, shared by both ``_transition_from_active()`` and
+``_transition_from_inactive()``: grace blocks nat-vent UNLESS indoor is known
+and exceeds ``comfort_cool``, in which case the short-circuit does not fire.
+``override_active`` is unaffected — a manual fan override always wins
+regardless of temperature.
+
+This was originally shipped (Issue #687) as a known diagnostic-only gap,
+because at the time this FSM was shadow/diagnostic-only and the field
+defaulted to ``False`` in every real production construction (Issue #706
+Bug D). Once Bug D wires ``grace_active`` to a real live value in
+``automation.py``'s own ``_build_nat_vent_fsm_inputs()``, this exception
+becomes load-bearing — without it, nat-vent would wrongly shut off during a
+genuine overheat-during-grace window once ``_natvent_fsm_authoritative`` is
+enabled.
 """
 
 from __future__ import annotations
@@ -256,15 +268,32 @@ def _soft_start_inputs(inputs: NatVentFsmInputs, *, full_gate_active: bool) -> N
     )
 
 
+def _grace_blocks_natvent(inputs: NatVentFsmInputs) -> bool:
+    """Whether an active grace period should block nat-vent this tick (Issue #706,
+    closes #688).
+
+    Grace blocks nat-vent UNLESS indoor is known and genuinely exceeds
+    ``comfort_cool`` — the Issue #134 overheat-during-grace exception production
+    applies (``automation.py``: ``self._grace_active and indoor is not None and
+    indoor > comfort_cool``). Shared by both ``_transition_from_active()`` and
+    ``_transition_from_inactive()`` so the exception can't drift between the two
+    call paths.
+    """
+    if not inputs.grace_active:
+        return False
+    return not (inputs.indoor is not None and inputs.comfort_cool is not None and inputs.indoor > inputs.comfort_cool)
+
+
 def _transition_from_active(current_state: NatVentLifecycleState, event: NatVentFsmEvent) -> NatVentTransition:
     # Issue #687 (Phase 2a): a manual override or grace period wins over everything
     # else in this function, including the lockout-recognition check right below it.
     # Mirrors production's real guarding, split across two call sites: override
     # is _activate_fan()'s own early return ("Fan override active — skipping fan
     # activation"); grace is enforced separately in check_natural_vent_conditions()
-    # (minus its Issue #134 overheat-during-grace exception — see module docstring,
-    # tracked in Issue #688). Placed first, before any other branch.
-    if event.inputs.override_active or event.inputs.grace_active:
+    # WITH its Issue #134 overheat-during-grace exception, modeled here via
+    # _grace_blocks_natvent() (Issue #706, closes #688). Placed first, before any
+    # other branch.
+    if event.inputs.override_active or _grace_blocks_natvent(event.inputs):
         return NatVentTransition(
             from_state=current_state,
             to_state=NatVentLifecycleState.INACTIVE,
@@ -347,9 +376,11 @@ def _transition_from_inactive(current_state: NatVentLifecycleState, event: NatVe
 
     # Issue #687 (Phase 2a): same override/grace short-circuit as
     # _transition_from_active() — see that function's comment for the production
-    # mirror this reflects. Placed first, before the lockout check, so an
-    # override/grace window can never be masked by (or race with) lockout state.
-    if inputs.override_active or inputs.grace_active:
+    # mirror this reflects, including the Issue #134/#688 overheat-during-grace
+    # exception via _grace_blocks_natvent() (Issue #706). Placed first, before the
+    # lockout check, so an override/grace window can never be masked by (or race
+    # with) lockout state.
+    if inputs.override_active or _grace_blocks_natvent(inputs):
         return NatVentTransition(
             from_state=current_state,
             to_state=NatVentLifecycleState.INACTIVE,

--- a/tests/test_combined_fsm_authoritative_compare.py
+++ b/tests/test_combined_fsm_authoritative_compare.py
@@ -1,0 +1,217 @@
+"""Tests for Phase G's "G-test" deliverable (Epic #594 Phase R): decision
+equivalence and race-safety with ALL THREE FSM-authoritative switches
+(``natvent_fsm_authoritative``, ``doorwindow_fsm_authoritative``,
+``override_grace_fsm_authoritative``) flipped True together.
+
+Occupant-first framing: Phase V flips all three switches in one deploy rather
+than as two sequential live-verification windows. Before this file, nothing in
+the repo — no test, golden scenario, or differential harness — had ever
+exercised that combination; a 2026-08-20 audit confirmed its absence by
+grepping every test file for co-occurring True assignments of all three flags
+and finding none. This file closes that gap: (1) the corpus-wide differential
+comparison proves the combined switch state doesn't change any real commanded
+HVAC/fan action across the golden + pending scenario suite, beyond nat-vent's
+own already-diagnosed divergences; (2) the positive-control class proves
+Blocker F's fix (a manual override arriving mid-activation must not be
+silently clobbered by a stale nat-vent decision) holds under the actual
+combined condition Phase V deploys, not just with natvent_fsm_authoritative
+alone.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.climate_advisor.automation import AutomationEngine, FanCommandResult
+from custom_components.climate_advisor.const import CONF_FAN_MODE, FAN_MODE_WHOLE_HOUSE
+
+# Reuse nat-vent's own diagnosed divergence allowlist rather than duplicating
+# it: door/window's and override/grace's individual comparators are clean
+# across the ENTIRE corpus (no allowlist at all in their own test files), so
+# any divergence the combined run produces beyond nat-vent's already-diagnosed
+# set would be new — either a genuine interaction between the three switches,
+# or a regression. Importing (not copying) means this list can never drift
+# out of sync with the single-switch test's own diagnosis.
+from tests.test_nat_vent_fsm_authoritative_compare import _KNOWN_DIVERGENT_SCENARIOS
+from tools.sim_harness.combined_fsm_authoritative_compare import fsm_authoritative_mutation
+from tools.sim_harness.differential import diff_runs
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_GOLDEN_DIR = _REPO_ROOT / "tools" / "simulations" / "golden"
+_PENDING_DIR = _REPO_ROOT / "tools" / "simulations" / "pending"
+
+
+def _load_scenario(path: Path) -> dict:
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _all_golden_and_pending_scenarios() -> list[Path]:
+    paths = [p for p in _GOLDEN_DIR.glob("*.json") if p.name != "MANIFEST.json"]
+    paths += [p for p in _PENDING_DIR.glob("*.json") if p.name != "MANIFEST.json"]
+    return sorted(paths)
+
+
+class TestCombinedFsmAuthoritativeEquivalence:
+    """All three switches on together must not diverge from production beyond
+    the exact, already-diagnosed nat-vent divergences the single-switch
+    comparator already accepts (Issue #698's deliberate fast-loop widening).
+    A NEW divergence here — one not in nat-vent's own allowlist — means the
+    three switches interact in a way no single-switch comparator could have
+    caught, and must be diagnosed before Phase V's deploy, not silenced."""
+
+    @pytest.mark.parametrize("scenario_path", _all_golden_and_pending_scenarios(), ids=lambda p: p.stem)
+    def test_all_three_switches_produce_identical_or_known_outcome(self, scenario_path: Path) -> None:
+        scenario = _load_scenario(scenario_path)
+        diff = diff_runs(scenario, mutate_b=fsm_authoritative_mutation, scenario_name=scenario_path.stem)
+        assert not diff.a_error and not diff.b_error, (
+            f"{scenario_path.stem}: a_error={diff.a_error!r} b_error={diff.b_error!r}"
+        )
+        if scenario_path.stem in _KNOWN_DIVERGENT_SCENARIOS:
+            known = _KNOWN_DIVERGENT_SCENARIOS[scenario_path.stem]
+            assert not diff.is_clean, (
+                f"{scenario_path.stem}: expected the same known nat-vent-only divergence "
+                f"({known.description}) under the combined switch state but the run came back "
+                "clean — the divergence shape may have changed under the combined condition, "
+                "investigate before trusting this as still nat-vent-only"
+            )
+            assert len(diff.event_divergences) == known.event_count, (
+                f"{scenario_path.stem}: under ALL THREE switches, expected the same "
+                f"{known.event_count} event divergence(s) nat-vent-alone produces "
+                f"({known.description}), got {len(diff.event_divergences)} — door/window or "
+                f"override/grace may be interacting with nat-vent's known divergence; "
+                f"re-diagnose: {[(d.index, d.a, d.b) for d in diff.event_divergences]}"
+            )
+            assert len(diff.action_divergences) == known.action_count, (
+                f"{scenario_path.stem}: under ALL THREE switches, expected the same "
+                f"{known.action_count} action divergence(s) nat-vent-alone produces "
+                f"({known.description}), got {len(diff.action_divergences)} — re-diagnose: "
+                f"{[(d.index, d.a, d.b) for d in diff.action_divergences]}"
+            )
+            return
+        assert diff.is_clean, (
+            f"{scenario_path.stem}: combining all three FSM-authoritative switches diverged from "
+            f"production in a way no single-switch comparator predicted — "
+            f"{len(diff.event_divergences)} event, {len(diff.action_divergences)} action "
+            f"divergences. This is exactly the class of compound-switch interaction Phase G's "
+            f"G-test exists to catch before Phase V's deploy — diagnose the root cause rather "
+            f"than adding this scenario to an allowlist"
+        )
+
+
+class TestCombinedFsmAuthoritativePositiveControl:
+    """Test the test: with a real divergence forced, the combined comparator
+    must actually detect it — otherwise a clean result above would be
+    meaningless."""
+
+    def test_detects_a_forced_divergence(self) -> None:
+        from contextlib import contextmanager
+        from unittest.mock import patch
+
+        from custom_components.climate_advisor import nat_vent_fsm as _nvfsm_mod
+        from custom_components.climate_advisor.nat_vent_fsm import NatVentLifecycleState
+
+        probe = _GOLDEN_DIR / "2026-03-28-overnight.json"
+        scenario = _load_scenario(probe)
+        original = _nvfsm_mod.transition
+
+        def _broken_transition(*args, **kwargs):
+            result = original(*args, **kwargs)
+            # Force the escalation gate permanently shut so a real, detectable
+            # divergence occurs under the combined mutation.
+            if result.to_state == NatVentLifecycleState.ACTIVE_FULL_GATE:
+                object.__setattr__(result, "to_state", NatVentLifecycleState.ACTIVE_SOFT_START)
+            return result
+
+        @contextmanager
+        def _mutate_b_and_break():
+            with fsm_authoritative_mutation(), patch.object(_nvfsm_mod, "transition", side_effect=_broken_transition):
+                yield
+
+        diff = diff_runs(scenario, mutate_b=_mutate_b_and_break, scenario_name=probe.stem)
+        assert not diff.is_clean, (
+            "the combined comparator failed to detect a deliberately forced divergence — "
+            "it cannot be trusted to catch a real one either"
+        )
+
+
+class TestCombinedSwitchBugFRace:
+    """Blocker F's fix (Issue #706) was originally proven with only
+    natvent_fsm_authoritative=True. Phase V deploys with ALL THREE switches
+    on together — this class re-proves the same race-safety property under
+    the actual combined condition, since door/window's and override/grace's
+    own authoritative code paths were never exercised alongside it before."""
+
+    def _make_engine(self, **overrides) -> AutomationEngine:
+        hass = MagicMock()
+        hass.services = MagicMock()
+        hass.services.async_call = AsyncMock()
+
+        def _consume_coroutine(coro):
+            coro.close()
+
+        hass.async_create_task = MagicMock(side_effect=_consume_coroutine)
+
+        climate_state = MagicMock()
+        climate_state.state = "off"
+        climate_state.attributes = {"current_temperature": 72.0}
+        hass.states = MagicMock()
+        hass.states.get = MagicMock(return_value=climate_state)
+
+        config = {
+            "comfort_heat": 68.0,
+            "comfort_cool": 74.0,
+            "setback_heat": 60,
+            "setback_cool": 80,
+            "natural_vent_delta": 3.0,
+            "nat_vent_hysteresis_f": 1.0,
+            "notify_service": "notify.notify",
+            CONF_FAN_MODE: FAN_MODE_WHOLE_HOUSE,
+        }
+        engine = AutomationEngine(
+            hass=hass,
+            climate_entity="climate.thermostat",
+            weather_entity="weather.forecast_home",
+            door_window_sensors=["binary_sensor.front_door"],
+            notify_service="notify.notify",
+            config=config,
+        )
+        engine._natvent_fsm_authoritative = True
+        engine._doorwindow_fsm_authoritative = True
+        engine._override_grace_fsm_authoritative = True
+        for key, value in overrides.items():
+            setattr(engine, key, value)
+        return engine
+
+    def test_idle_open_reentry_does_not_clobber_override_with_all_three_switches_on(self) -> None:
+        engine = self._make_engine(
+            _paused_by_door=False,
+            _natural_vent_active=False,
+            _nat_vent_soft_start=False,
+            _grace_active=False,
+            _fan_override_active=False,
+            _last_outdoor_temp=68.0,
+        )
+        engine._sensor_check_callback = lambda: True
+
+        async def _activate_fan_races_override(*, reason: str, emit_event: bool = True) -> FanCommandResult:
+            # Simulates a real manual override winning the race during this
+            # await window, now with door/window's and override/grace's own
+            # authoritative dispatchers also live (not just nat-vent's).
+            engine._fan_override_active = True
+            engine._grace_active = True
+            return FanCommandResult.OVERRIDDEN
+
+        engine._activate_fan = AsyncMock(side_effect=_activate_fan_races_override)
+        asyncio.run(engine.check_natural_vent_conditions())
+
+        assert engine._natural_vent_active is False, (
+            "with all three FSM switches authoritative together (the real Phase V deploy "
+            "condition), the pre-await ACTIVE_FULL_GATE decision must still not be applied "
+            "once _activate_fan() reports the command was overridden mid-activation"
+        )

--- a/tests/test_door_window.py
+++ b/tests/test_door_window.py
@@ -578,6 +578,76 @@ class TestHandleAllDoorsWindowsClosedFsmAuthoritative:
         engine.hass.services.async_call.assert_not_called()
 
 
+class TestHandleAllDoorsWindowsClosedZeroDurationGrace:
+    """Issue #709 regression: end-to-end proof that handle_all_doors_windows_closed()'s
+    FINAL state, after the full method returns, is never a phantom
+    _grace_active=True with no real timer scheduled.
+
+    Same caveat as TestResumeFromPauseZeroDurationGrace in test_resume_from_pause.py:
+    _start_grace_period_action()'s internal _cancel_grace_timers() call washes out
+    the pre-fix phantom before this method returns, so this class alone does not
+    prove the fix (confirmed while authoring it — reverting the production fix
+    alone leaves this test green). See
+    TestResolveDoorWindowPauseFlagsAllSensorsClosedZeroDurationGraceIsolated below
+    for the real, always-failing-without-the-fix proof, and
+    tests/test_fsm_flag_ownership.py's AST-based ownership check."""
+
+    def test_no_phantom_grace_when_automation_grace_disabled(self):
+        engine = _make_automation_engine({CONF_AUTOMATION_GRACE_PERIOD: 0})
+        engine._doorwindow_fsm_authoritative = True
+        engine._paused_by_door = True
+        engine._paused_with_hvac_already_off = False  # PAUSED_ACTIVE
+        engine._pre_pause_mode = "heat"
+
+        with patch("custom_components.climate_advisor.automation.async_call_later") as mock_call_later:
+            asyncio.run(engine.handle_all_doors_windows_closed())
+
+        assert engine._paused_by_door is False
+        assert engine._grace_active is False
+        assert engine._grace_protects_override is False
+        mock_call_later.assert_not_called()
+        # Mode restore still happens — only grace is affected by the disabled config.
+        engine.hass.services.async_call.assert_any_call(
+            "climate",
+            "set_hvac_mode",
+            {"entity_id": "climate.thermostat", "hvac_mode": "heat"},
+        )
+
+
+class TestResolveDoorWindowPauseFlagsAllSensorsClosedZeroDurationGraceIsolated:
+    """Issue #709: the real proof, mirroring
+    TestResolveDoorWindowPauseFlagsZeroDurationGraceIsolated in
+    test_resume_from_pause.py but for ALL_SENSORS_CLOSED -> RESTORE_AND_GRACE
+    (handle_all_doors_windows_closed()'s real dispatcher call, which also runs
+    before the real _start_grace_period() action). Calling the dispatcher in
+    isolation observes the state immediately after only that one call, before
+    the later real action's wash-out — the only way to see the actual pre-fix
+    bug. Revert-tested: reverting the production fix makes this fail — confirmed
+    while authoring this fix."""
+
+    def test_all_sensors_closed_no_phantom_when_automation_grace_disabled(self):
+        from custom_components.climate_advisor.door_window_fsm import DoorWindowFsmEventKind
+
+        engine = _make_automation_engine({CONF_AUTOMATION_GRACE_PERIOD: 0})
+        engine._doorwindow_fsm_authoritative = True
+        engine._paused_by_door = True
+        engine._paused_with_hvac_already_off = False  # PAUSED_ACTIVE
+        engine._pre_pause_mode = "heat"  # truthy -> decide_door_close_response == RESTORE_AND_GRACE
+        engine._grace_active = False
+
+        engine._resolve_door_window_pause_flags(
+            kind=DoorWindowFsmEventKind.ALL_SENSORS_CLOSED,
+            legacy=MagicMock(),
+        )
+
+        assert engine._grace_active is False, (
+            "_resolve_door_window_pause_flags(ALL_SENSORS_CLOSED) set a phantom "
+            "_grace_active=True with CONF_AUTOMATION_GRACE_PERIOD=0 — no real "
+            "grace timer has been touched at this point in the real call "
+            "sequence yet."
+        )
+
+
 class TestExitNatVentSensorStillOpenFsmAuthoritative:
     """Issue #660 Step 4: _exit_nat_vent()'s sensor-still-open branch, with
     _doorwindow_fsm_authoritative=True, derives its resulting pause flags from
@@ -768,8 +838,17 @@ class TestResolveDoorWindowPauseFlagsDispatcher:
         NORMAL (``_transition_from_normal``'s catch-all). The two origins produce
         different outcomes, so this is a real behavioral distinguisher: if the live
         read (NORMAL) were used instead of the passed-in origin_state (PAUSED_ACTIVE),
-        grace would stay inactive.
+        the pure ``transition()`` call would be invoked with NORMAL instead.
+
+        Issue #709: this used to assert ``_grace_active is True`` as its proxy signal
+        for "the pure transition landed on GRACE" — but ``_apply_door_window_fsm_state()``
+        no longer writes ``_grace_active`` at all (that flag is override/grace's sole
+        write now), so that channel can no longer distinguish the two origins. Asserts
+        directly on the ``current_state`` argument the dispatcher actually passed to
+        ``door_window_fsm.transition()`` instead — a more direct proof of the mechanism
+        under test than a downstream flag that may or may not still be wired to it.
         """
+        from custom_components.climate_advisor import door_window_fsm as dwfsm
         from custom_components.climate_advisor.door_window_fsm import (
             DoorWindowFsmEventKind,
             DoorWindowLifecycleState,
@@ -783,14 +862,19 @@ class TestResolveDoorWindowPauseFlagsDispatcher:
         engine._grace_active = False
 
         # ...but origin_state claims PAUSED_ACTIVE.
-        engine._resolve_door_window_pause_flags(
-            kind=DoorWindowFsmEventKind.DASHBOARD_RESUME,
-            legacy=MagicMock(),
-            origin_state=DoorWindowLifecycleState.PAUSED_ACTIVE,
-        )
+        with patch.object(dwfsm, "transition", wraps=dwfsm.transition) as mock_transition:
+            engine._resolve_door_window_pause_flags(
+                kind=DoorWindowFsmEventKind.DASHBOARD_RESUME,
+                legacy=MagicMock(),
+                origin_state=DoorWindowLifecycleState.PAUSED_ACTIVE,
+            )
 
-        assert engine._grace_active is True
-        assert engine.door_window_lifecycle_state == DoorWindowLifecycleState.GRACE
+        mock_transition.assert_called_once()
+        passed_current_state = mock_transition.call_args[0][0]
+        assert passed_current_state == DoorWindowLifecycleState.PAUSED_ACTIVE
+        # PAUSED_ACTIVE + DASHBOARD_RESUME (manual grace enabled by default config)
+        # clears the pause either way — the 2 fields this method still derives.
+        assert engine._paused_by_door is False
 
 
 class TestApplyNatVentFsmState:
@@ -1019,7 +1103,7 @@ class TestPauseForDoorWindowActionSplit:
 
     def test_wrapper_sets_paused_entity_and_since_when_authoritative(self):
         """Regression guard: _apply_door_window_fsm_state() does NOT write
-        _paused_entity/_paused_since (they aren't part of its 3-field derivation),
+        _paused_entity/_paused_since (they aren't part of its 2-field derivation),
         so the wrapper must still set them directly regardless of which branch the
         dispatcher took -- found during Step 6 verification when the corpus-wide
         FSM-authoritative comparator caught a real divergence (paused_minutes going
@@ -1036,6 +1120,37 @@ class TestPauseForDoorWindowActionSplit:
 
         assert engine._paused_entity == "test-entity"
         assert engine._paused_since is not None
+
+
+class TestApplyDoorWindowFsmStateNeverWritesGraceActive:
+    """Issue #709 regression: _apply_door_window_fsm_state() must never write
+    _grace_active — override_grace_fsm.py's dispatcher (_apply_override_grace_fsm_state()
+    / its paired legacy() closures) is the sole writer. Exercises the method directly
+    across every DoorWindowLifecycleState member, from both a True and False starting
+    value, to prove it is left completely untouched either way (not just "happens to
+    end up correct" for one particular state)."""
+
+    def test_grace_active_untouched_across_all_states_starting_true(self):
+        from custom_components.climate_advisor.door_window_lifecycle import DoorWindowLifecycleState
+
+        engine = _make_automation_engine()
+        for state in DoorWindowLifecycleState:
+            engine._grace_active = True
+            engine._apply_door_window_fsm_state(state)
+            assert engine._grace_active is True, (
+                f"_apply_door_window_fsm_state({state}) modified _grace_active — it must never write this flag"
+            )
+
+    def test_grace_active_untouched_across_all_states_starting_false(self):
+        from custom_components.climate_advisor.door_window_lifecycle import DoorWindowLifecycleState
+
+        engine = _make_automation_engine()
+        for state in DoorWindowLifecycleState:
+            engine._grace_active = False
+            engine._apply_door_window_fsm_state(state)
+            assert engine._grace_active is False, (
+                f"_apply_door_window_fsm_state({state}) modified _grace_active — it must never write this flag"
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_door_window_fsm.py
+++ b/tests/test_door_window_fsm.py
@@ -177,6 +177,24 @@ class TestFromPaused:
         )
         assert t.to_state == DoorWindowLifecycleState.GRACE
 
+    def test_all_sensors_closed_restores_without_grace_when_automation_grace_disabled(self):
+        """Issue #709: handle_all_doors_windows_closed() always attempts a real
+        source="automation" grace after restoring pre_pause_mode, but
+        CONF_AUTOMATION_GRACE_PERIOD=0 disables it (Issue #664's convention,
+        extended to door/window). RESTORE_AND_GRACE must land on NORMAL, not
+        GRACE, when automation_grace_would_start is False — pause still clears
+        (the restore itself is unconditional on config)."""
+        t = transition(
+            DoorWindowLifecycleState.PAUSED_ACTIVE,
+            _ev(
+                DoorWindowFsmEventKind.ALL_SENSORS_CLOSED,
+                pre_pause_mode_active=True,
+                automation_grace_would_start=False,
+            ),
+        )
+        assert t.to_state == DoorWindowLifecycleState.NORMAL
+        assert t.outcome == "restore_and_grace"
+
     def test_manual_override_during_pause_clears_to_normal(self):
         t = transition(DoorWindowLifecycleState.PAUSED_ACTIVE, _ev(DoorWindowFsmEventKind.MANUAL_OVERRIDE_DURING_PAUSE))
         assert t.to_state == DoorWindowLifecycleState.NORMAL
@@ -184,6 +202,17 @@ class TestFromPaused:
     def test_dashboard_resume_starts_grace(self):
         t = transition(DoorWindowLifecycleState.PAUSED_IDLE, _ev(DoorWindowFsmEventKind.DASHBOARD_RESUME))
         assert t.to_state == DoorWindowLifecycleState.GRACE
+
+    def test_dashboard_resume_clears_to_normal_when_manual_grace_disabled(self):
+        """Issue #709: resume_from_pause() always attempts a real source="manual"
+        grace after clearing pause, but CONF_MANUAL_GRACE_PERIOD=0 disables it
+        (Issue #664). DASHBOARD_RESUME must land on NORMAL, not GRACE, when
+        manual_grace_would_start is False."""
+        t = transition(
+            DoorWindowLifecycleState.PAUSED_IDLE,
+            _ev(DoorWindowFsmEventKind.DASHBOARD_RESUME, manual_grace_would_start=False),
+        )
+        assert t.to_state == DoorWindowLifecycleState.NORMAL
 
     def test_sensor_opened_already_paused_noop(self):
         t = transition(DoorWindowLifecycleState.PAUSED_ACTIVE, _ev(DoorWindowFsmEventKind.SENSOR_OPENED))
@@ -365,6 +394,18 @@ class TestFromPausedDuringGrace:
     def test_dashboard_resume_lands_on_grace(self):
         t = transition(DoorWindowLifecycleState.PAUSED_DURING_GRACE, _ev(DoorWindowFsmEventKind.DASHBOARD_RESUME))
         assert t.to_state == DoorWindowLifecycleState.GRACE
+
+    def test_dashboard_resume_clears_to_normal_when_manual_grace_disabled(self):
+        """Issue #709: resume_from_pause() is reachable from PAUSED_DURING_GRACE too
+        (it guards only on _paused_by_door) and always attempts to re-arm a real
+        source="manual" grace, unconditionally cancelling the pre-existing one
+        first. With CONF_MANUAL_GRACE_PERIOD=0, the old grace does not survive —
+        this must land on NORMAL (pause clears, no grace), not GRACE."""
+        t = transition(
+            DoorWindowLifecycleState.PAUSED_DURING_GRACE,
+            _ev(DoorWindowFsmEventKind.DASHBOARD_RESUME, manual_grace_would_start=False),
+        )
+        assert t.to_state == DoorWindowLifecycleState.NORMAL
 
     def test_manual_override_during_pause_lands_on_grace(self):
         t = transition(

--- a/tests/test_fsm_flag_ownership.py
+++ b/tests/test_fsm_flag_ownership.py
@@ -1,0 +1,166 @@
+"""Issue #709: generalized "exactly one writer" regression guard for the flags the
+nat-vent/door-window/override-grace FSMs model.
+
+This is the DRY-methodology deliverable from the #709 plan — a registry-driven,
+AST-based static check in the style of ``tests/test_executor_offload.py``'s
+``_BLOCKING_METHODS`` registry, applied to a different hazard: instead of catching
+a blocking call bypassing an executor, it catches a flag being written by an
+``_apply_*_fsm_state()`` method other than its documented owner(s).
+
+**Root cause this generalizes from.** Prior to #709, ``_apply_door_window_fsm_state()``
+also wrote ``_grace_active`` — a flag ``override_grace_fsm.py``'s own docstring already
+claimed exclusive ownership of via ``_apply_override_grace_fsm_state()``. The two
+writers could disagree for real: ``resume_from_pause()``/
+``handle_all_doors_windows_closed()`` both called the door/window dispatcher (which
+could land unconditionally on a GRACE-ish state) before the real grace-start action,
+with genuine ``await`` points in between where a concurrently scheduled task could
+observe the phantom flag. Nothing caught this by construction — it required reading
+both methods side by side and knowing override/grace's docstring claim was actually
+false. This test makes that comparison automatic and permanent: for every
+``_apply_..._fsm_state()``-shaped method in ``automation.py``, every ``self.<flag> = ...``
+assignment inside it must have that method listed as an allowed owner of ``<flag>`` in
+``_FLAG_OWNERS`` below. Add an entry here whenever a new FSM-modeled flag is introduced.
+
+**Why some flags have more than one allowed owner.** ``_paused_by_door`` is legitimately
+co-owned by ``_apply_door_window_fsm_state()`` (door/window's own pause lifecycle) and
+``_apply_nat_vent_fsm_state()`` (nat-vent reactivating while paused always means "no
+longer paused by door" — a fact nat-vent's own transition genuinely determines, not a
+race-prone speculative write racing against a real side effect the way the fixed
+``_grace_active`` bug was). This is a deliberate cross-FSM composition
+(Issue #631's "communicating automata" convention), not an oversight — unlike the
+``_grace_active`` case, there is no separate real-timer side effect that could
+disagree with this write. If a future flag needs the same multi-owner treatment,
+add every legitimate owner to its ``_FLAG_OWNERS`` entry with a comment explaining why,
+same as this one.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+AUTOMATION_PY = Path(__file__).parent.parent / "custom_components" / "climate_advisor" / "automation.py"
+
+# Pattern identifying the "apply an FSM transition result to real instance flags"
+# method family this test polices — matches _apply_door_window_fsm_state,
+# _apply_override_grace_fsm_state, _apply_nat_vent_fsm_state, and any future
+# sibling automatically, without needing this test file edited when one is added.
+_APPLY_METHOD_PATTERN = re.compile(r"^_apply_.*_fsm_state$")
+
+# Flag -> the method name(s) permitted to write it via `self.<flag> = ...` from
+# inside one of the _apply_*_fsm_state() methods above. Every flag these three FSMs
+# model must appear here, even ones with zero current apply-method writers (e.g.
+# _manual_override_active, _override_confirm_pending's sibling raw flags) — an
+# empty/absent entry means "no apply method may ever write this," so a future
+# violation is still caught the moment it's introduced.
+_FLAG_OWNERS: dict[str, frozenset[str]] = {
+    # Issue #664/#709: override/grace's sole 3-flag derivation.
+    "_grace_active": frozenset({"_apply_override_grace_fsm_state"}),
+    "_grace_protects_override": frozenset({"_apply_override_grace_fsm_state"}),
+    "_override_confirm_pending": frozenset({"_apply_override_grace_fsm_state"}),
+    # Issue #594/#660: door/window's 2-flag derivation (Issue #709 removed
+    # _grace_active from this method's derivation — see its own docstring).
+    # _paused_by_door is legitimately co-owned by nat-vent's apply method too
+    # (see module docstring above).
+    "_paused_by_door": frozenset({"_apply_door_window_fsm_state", "_apply_nat_vent_fsm_state"}),
+    "_paused_with_hvac_already_off": frozenset({"_apply_door_window_fsm_state"}),
+    # Issue #411/#647: nat-vent's own lifecycle flags.
+    "_natural_vent_active": frozenset({"_apply_nat_vent_fsm_state"}),
+    "_nat_vent_soft_start": frozenset({"_apply_nat_vent_fsm_state"}),
+    # Not currently written by any _apply_*_fsm_state() method — real writers are
+    # handle_manual_override()/clear_manual_override()/_confirm_override(), none of
+    # which are apply-method-shaped. Listed with an empty owner set so this test
+    # immediately flags it if a future refactor starts writing it from an apply
+    # method without an explicit decision to allow that.
+    "_manual_override_active": frozenset(),
+}
+
+
+def _extract_apply_fsm_methods(tree: ast.AST) -> list[ast.FunctionDef]:
+    """Every method in automation.py whose name matches the _apply_*_fsm_state
+    naming convention — the method family this test polices."""
+    methods = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and _APPLY_METHOD_PATTERN.match(node.name):
+            methods.append(node)
+    return methods
+
+
+def _self_attr_assignments(fn_node: ast.FunctionDef) -> set[str]:
+    """Every `self.<attr> = ...` (or `self.<attr>: T = ...`) assignment target
+    directly inside fn_node, by attribute name."""
+    attrs: set[str] = set()
+    for node in ast.walk(fn_node):
+        targets: list[ast.expr] = []
+        if isinstance(node, ast.Assign):
+            targets = node.targets
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            targets = [node.target]
+        for t in targets:
+            if isinstance(t, ast.Attribute) and isinstance(t.value, ast.Name) and t.value.id == "self":
+                attrs.add(t.attr)
+    return attrs
+
+
+class TestFsmApplyMethodFlagOwnership:
+    """Every _apply_*_fsm_state() method in automation.py may only write flags it
+    is a documented, registered owner of in _FLAG_OWNERS."""
+
+    def test_no_unauthorized_flag_writes(self):
+        source = AUTOMATION_PY.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+
+        apply_methods = _extract_apply_fsm_methods(tree)
+        assert apply_methods, (
+            "No _apply_*_fsm_state() methods found in automation.py — method(s) renamed? "
+            "This test's whole mechanism depends on the naming convention holding."
+        )
+
+        violations: list[tuple[str, str]] = []
+        for fn in apply_methods:
+            written = _self_attr_assignments(fn)
+            for attr in written:
+                if attr not in _FLAG_OWNERS:
+                    # Not a flag this test is registry-aware of. Fail loudly rather
+                    # than silently ignoring it — every FSM-modeled flag an apply
+                    # method writes must be a deliberate, registered decision, same
+                    # as _BLOCKING_METHODS in test_executor_offload.py.
+                    violations.append((fn.name, attr))
+                    continue
+                if fn.name not in _FLAG_OWNERS[attr]:
+                    violations.append((fn.name, attr))
+
+        assert not violations, (
+            "Unauthorized/unregistered flag write(s) found in _apply_*_fsm_state() "
+            "method(s): "
+            + ", ".join(f"{method}() writes self.{attr}" for method, attr in violations)
+            + ". Either this is a genuine second writer of a flag another FSM's apply "
+            "method already owns (the exact #709 _grace_active bug shape — remove the "
+            "write instead), or it's a legitimate new co-owner that needs an explicit "
+            "entry (with rationale) added to _FLAG_OWNERS in this test file."
+        )
+
+    def test_grace_active_owned_solely_by_override_grace(self):
+        """Direct regression test for the #709 bug shape: _apply_door_window_fsm_state()
+        must not appear anywhere in _grace_active's registered owner set."""
+        assert _FLAG_OWNERS["_grace_active"] == frozenset({"_apply_override_grace_fsm_state"})
+
+    def test_registry_covers_every_flag_actually_written_by_apply_methods(self):
+        """The inverse check: every flag an apply method actually writes today must
+        have a _FLAG_OWNERS entry (not just the well-known 6) — otherwise a newly
+        introduced flag could silently ship with no ownership check at all."""
+        source = AUTOMATION_PY.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+
+        all_written: set[str] = set()
+        for fn in _extract_apply_fsm_methods(tree):
+            all_written |= _self_attr_assignments(fn)
+
+        unregistered = all_written - set(_FLAG_OWNERS)
+        assert not unregistered, (
+            f"Flag(s) written by an _apply_*_fsm_state() method with no _FLAG_OWNERS "
+            f"registry entry at all: {sorted(unregistered)}. Add an entry (even if the "
+            f"owner set is just the one method already writing it) so future dual-writes "
+            f"are caught."
+        )

--- a/tests/test_nat_vent_fsm.py
+++ b/tests/test_nat_vent_fsm.py
@@ -435,6 +435,91 @@ class TestOverrideGraceShortCircuit:
         assert t.changed
 
 
+class TestGraceOverheatException:
+    """Issue #706 (closes #688): the Issue #134 overheat-during-grace exception.
+
+    Production legitimately keeps nat-vent running during grace when indoor
+    genuinely exceeds comfort_cool (automation.py's real condition:
+    ``self._grace_active and indoor is not None and indoor > comfort_cool``).
+    Modeled here via ``_grace_blocks_natvent()``, shared by both
+    ``_transition_from_active()`` and ``_transition_from_inactive()``."""
+
+    def test_grace_active_and_indoor_exceeds_comfort_cool_does_not_block_entry(self) -> None:
+        # indoor (78) > comfort_cool (76) -> overheat exception applies -> grace
+        # must NOT force INACTIVE; ordinary gate math decides instead.
+        t = transition(
+            NatVentLifecycleState.INACTIVE,
+            _tick(indoor=78.0, outdoor=65.0, comfort_heat_raw=68.0, comfort_cool=76.0, grace_active=True),
+        )
+        assert t.to_state == NatVentLifecycleState.ACTIVE_FULL_GATE
+        assert t.changed
+
+    def test_grace_active_and_indoor_at_comfort_cool_still_blocks(self) -> None:
+        # indoor == comfort_cool is NOT "exceeds" (strict >) -> exception does not
+        # apply -> grace still blocks.
+        t = transition(
+            NatVentLifecycleState.INACTIVE,
+            _tick(indoor=76.0, outdoor=65.0, comfort_heat_raw=68.0, comfort_cool=76.0, grace_active=True),
+        )
+        assert t.to_state == NatVentLifecycleState.INACTIVE
+        assert not t.changed
+
+    def test_grace_active_and_indoor_below_comfort_cool_blocks(self) -> None:
+        # indoor (72) < comfort_cool (76) -> no overheat -> grace blocks as before.
+        t = transition(
+            NatVentLifecycleState.INACTIVE,
+            _tick(indoor=72.0, outdoor=65.0, comfort_heat_raw=68.0, comfort_cool=76.0, grace_active=True),
+        )
+        assert t.to_state == NatVentLifecycleState.INACTIVE
+        assert not t.changed
+
+    def test_grace_active_and_indoor_unknown_blocks(self) -> None:
+        # indoor=None -> "exceeds comfort_cool" cannot be evaluated -> conservative
+        # default is grace blocks (matches production's `indoor is not None` guard).
+        t = transition(
+            NatVentLifecycleState.INACTIVE,
+            _tick(indoor=None, outdoor=65.0, comfort_heat_raw=68.0, comfort_cool=76.0, grace_active=True),
+        )
+        assert t.to_state == NatVentLifecycleState.INACTIVE
+
+    def test_active_session_stays_active_during_grace_when_overheating(self) -> None:
+        # Already-active session (e.g. ACTIVE_FULL_GATE) must not be forced to
+        # INACTIVE by grace while indoor is genuinely above comfort_cool -- this
+        # is the actual occupant-facing case: nat-vent already running, grace
+        # starts (e.g. a manual override elsewhere), but the home is overheating
+        # so free cooling should keep running.
+        t = transition(
+            NatVentLifecycleState.ACTIVE_FULL_GATE,
+            _tick(indoor=78.0, outdoor=65.0, comfort_heat_raw=68.0, comfort_cool=76.0, grace_active=True),
+        )
+        assert t.to_state != NatVentLifecycleState.INACTIVE
+
+    def test_active_session_exits_during_grace_when_not_overheating(self) -> None:
+        # Same active session, but indoor has NOT exceeded comfort_cool -> grace
+        # blocks as normal -> forced to INACTIVE.
+        t = transition(
+            NatVentLifecycleState.ACTIVE_FULL_GATE,
+            _tick(indoor=72.0, outdoor=65.0, comfort_heat_raw=68.0, comfort_cool=76.0, grace_active=True),
+        )
+        assert t.to_state == NatVentLifecycleState.INACTIVE
+
+    def test_override_active_still_wins_even_while_overheating(self) -> None:
+        # A manual override always wins regardless of temperature -- only the
+        # grace short-circuit gets the Issue #134 exception, not override.
+        t = transition(
+            NatVentLifecycleState.ACTIVE_FULL_GATE,
+            _tick(
+                indoor=78.0,
+                outdoor=65.0,
+                comfort_heat_raw=68.0,
+                comfort_cool=76.0,
+                override_active=True,
+                grace_active=True,
+            ),
+        )
+        assert t.to_state == NatVentLifecycleState.INACTIVE
+
+
 class TestSoftStartEscalation:
     """Issue #594 Phase R prep: soft-start -> full-gate escalation, mirroring
     automation.py's own mid-session upgrade check (Issue #540)."""

--- a/tests/test_nat_vent_fsm_override_awareness.py
+++ b/tests/test_nat_vent_fsm_override_awareness.py
@@ -1,0 +1,304 @@
+"""Tests for Issue #706 (Bug D, Bug F, closes #688): nat-vent FSM override/grace
+awareness in real production wiring.
+
+Occupant-first framing: without these fixes, a manual fan override (e.g. an
+RF remote or a physical switch) could be silently overridden by Climate
+Advisor's own decision machinery — the dashboard/automation state would claim
+free cooling is running while the actual fan command was rejected, or a
+just-started manual override could be clobbered by a stale decision computed
+a moment earlier. These tests confirm the real ``AutomationEngine`` methods
+(not a re-implementation) now keep decided state and actual hardware/override
+reality in agreement.
+
+- Bug D: ``_build_nat_vent_fsm_inputs()`` (the real production builder used by
+  all 5 real call sites) previously left ``override_active``/``grace_active``
+  at their dataclass default (``False``) always — only
+  ``coordinator._evaluate_nat_vent_fsm()``'s shadow/diagnostic construction
+  passed real values. Fixed by reading ``self._fan_override_active or
+  self._manual_override_active`` and ``self._grace_active`` live.
+- Bug F: 5 production call sites compute an FSM decision, then
+  ``await self._activate_fan(...)`` (a real yield point) under
+  ``_decision_lock``, then apply the pre-await decision. A manual override
+  arriving during that await (via the NOT lock-protected
+  ``handle_fan_manual_override()``/``_async_fan_entity_changed()``) is
+  recorded correctly by override/grace, but the resumed decision then
+  silently overwrote it. Fixed via
+  ``_apply_nat_vent_fsm_state_after_activation()``, which checks
+  ``_activate_fan()``'s return value and applies ``INACTIVE`` instead of the
+  stale decision when it returns ``FanCommandResult.OVERRIDDEN``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.climate_advisor.automation import AutomationEngine, FanCommandResult
+from custom_components.climate_advisor.const import CONF_FAN_MODE, FAN_MODE_WHOLE_HOUSE
+
+_NOW = datetime(2026, 7, 15, 14, 0, 0)
+sys.modules["homeassistant.util.dt"].now = lambda: _NOW
+
+import custom_components.climate_advisor.automation as _automation_mod  # noqa: E402
+
+
+def _real_parse_datetime(dt_str: str):
+    try:
+        return datetime.fromisoformat(dt_str)
+    except Exception:
+        return None
+
+
+_automation_mod.dt_util.parse_datetime = _real_parse_datetime
+
+
+def _make_engine(
+    *,
+    comfort_heat: float = 68.0,
+    comfort_cool: float = 74.0,
+    nat_vent_delta: float = 3.0,
+    hysteresis: float = 1.0,
+    indoor_f: float | None = None,
+    fan_mode: str = FAN_MODE_WHOLE_HOUSE,
+    authoritative: bool = True,
+) -> AutomationEngine:
+    """Create a real AutomationEngine with mocked HA dependencies. Same pattern
+    as tests/test_nat_vent_fsm_phase2b_wiring.py's _make_engine()."""
+    hass = MagicMock()
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+
+    def _consume_coroutine(coro):
+        coro.close()
+
+    hass.async_create_task = MagicMock(side_effect=_consume_coroutine)
+
+    climate_state = MagicMock()
+    climate_state.state = "off"
+    climate_state.attributes = {} if indoor_f is None else {"current_temperature": indoor_f}
+    hass.states = MagicMock()
+    hass.states.get = MagicMock(return_value=climate_state)
+
+    config = {
+        "comfort_heat": comfort_heat,
+        "comfort_cool": comfort_cool,
+        "setback_heat": 60,
+        "setback_cool": 80,
+        "natural_vent_delta": nat_vent_delta,
+        "nat_vent_hysteresis_f": hysteresis,
+        "notify_service": "notify.notify",
+        CONF_FAN_MODE: fan_mode,
+    }
+
+    engine = AutomationEngine(
+        hass=hass,
+        climate_entity="climate.thermostat",
+        weather_entity="weather.forecast_home",
+        door_window_sensors=["binary_sensor.front_door"],
+        notify_service="notify.notify",
+        config=config,
+    )
+    engine._natvent_fsm_authoritative = authoritative
+    return engine
+
+
+# ---------------------------------------------------------------------------
+# (a) Production NatVentFsmInputs build reflects real override/grace state.
+# ---------------------------------------------------------------------------
+
+
+class TestBugDInputsReflectRealState:
+    """_build_nat_vent_fsm_inputs() is the real production builder (used by all
+    5 real call sites, distinct from coordinator.py's shadow-diagnostic
+    construction) -- it must reflect live override/grace flags, not the
+    dataclass default of False."""
+
+    def test_override_active_true_when_fan_override_active(self) -> None:
+        engine = _make_engine()
+        engine._fan_override_active = True
+        engine._manual_override_active = False
+        engine._grace_active = False
+        inputs = engine._build_nat_vent_fsm_inputs(now=_NOW, indoor=72.0, outdoor=65.0)
+        assert inputs.override_active is True
+
+    def test_override_active_true_when_manual_override_active(self) -> None:
+        engine = _make_engine()
+        engine._fan_override_active = False
+        engine._manual_override_active = True
+        engine._grace_active = False
+        inputs = engine._build_nat_vent_fsm_inputs(now=_NOW, indoor=72.0, outdoor=65.0)
+        assert inputs.override_active is True
+
+    def test_override_active_false_when_no_override(self) -> None:
+        engine = _make_engine()
+        engine._fan_override_active = False
+        engine._manual_override_active = False
+        engine._grace_active = False
+        inputs = engine._build_nat_vent_fsm_inputs(now=_NOW, indoor=72.0, outdoor=65.0)
+        assert inputs.override_active is False
+
+    def test_grace_active_reflects_live_flag(self) -> None:
+        engine = _make_engine()
+        engine._fan_override_active = False
+        engine._manual_override_active = False
+        engine._grace_active = True
+        inputs = engine._build_nat_vent_fsm_inputs(now=_NOW, indoor=72.0, outdoor=65.0)
+        assert inputs.grace_active is True
+
+        engine._grace_active = False
+        inputs = engine._build_nat_vent_fsm_inputs(now=_NOW, indoor=72.0, outdoor=65.0)
+        assert inputs.grace_active is False
+
+    def test_all_5_real_call_sites_use_this_shared_builder(self) -> None:
+        """Guards against a future call site bypassing _build_nat_vent_fsm_inputs()
+        and reconstructing NatVentFsmInputs by hand (which would silently
+        reintroduce Bug D at that one site)."""
+        import inspect
+
+        src = inspect.getsource(_automation_mod)
+        assert src.count("self._build_nat_vent_fsm_inputs(") == 5
+
+
+# ---------------------------------------------------------------------------
+# (b) State-desync scenario: override already active before the decision.
+# ---------------------------------------------------------------------------
+
+
+class TestStateDesyncWithPreExistingOverride:
+    """When a manual override is ALREADY active before a nat-vent decision is
+    made, the FSM must never mark _natural_vent_active True -- both because
+    Bug D now feeds override_active=True into the decision itself (so the
+    entry gate is never entered, and _activate_fan() is never even called),
+    and because Bug F's post-activation guard is a backstop if it were."""
+
+    def test_handle_door_window_open_skips_activation_when_override_active(self) -> None:
+        engine = _make_engine(indoor_f=72.0)
+        engine._last_outdoor_temp = 60.0  # would activate easily if override were ignored
+        engine._fan_override_active = True
+        # If Bug D were unfixed, the entry gate would clear (override_active
+        # defaults to False in the FSM inputs) and _activate_fan() WOULD be
+        # called. Track calls to prove it never fires.
+        engine._activate_fan = AsyncMock(return_value=FanCommandResult.EXECUTED)
+        asyncio.run(engine.handle_door_window_open("binary_sensor.front_door"))
+        engine._activate_fan.assert_not_awaited()
+        assert engine._natural_vent_active is False
+
+    def test_handle_door_window_open_skips_activation_when_grace_active(self) -> None:
+        engine = _make_engine(indoor_f=72.0)  # indoor < comfort_cool -> no #134 exception
+        engine._last_outdoor_temp = 60.0
+        engine._grace_active = True
+        engine._activate_fan = AsyncMock(return_value=FanCommandResult.EXECUTED)
+        asyncio.run(engine.handle_door_window_open("binary_sensor.front_door"))
+        engine._activate_fan.assert_not_awaited()
+        assert engine._natural_vent_active is False
+
+
+# ---------------------------------------------------------------------------
+# (c) Bug F race: override arrives DURING the await window.
+# ---------------------------------------------------------------------------
+
+
+class TestBugFRaceDuringActivation:
+    """The FSM decision is computed BEFORE `await self._activate_fan(...)`.
+    _activate_fan() returning FanCommandResult.OVERRIDDEN is the definitive
+    signal a real override intervened during that await -- the pre-await
+    decision must not be applied in that case."""
+
+    def _arm_idle_open(self, engine: AutomationEngine, *, outdoor: float) -> None:
+        engine._paused_by_door = False
+        engine._natural_vent_active = False
+        engine._nat_vent_soft_start = False
+        engine._grace_active = False
+        engine._fan_override_active = False
+        engine._sensor_check_callback = lambda: True
+        engine._last_outdoor_temp = outdoor
+        engine.hass.states.get.return_value.state = "off"
+
+    def test_idle_open_reentry_does_not_clobber_override_that_arrives_mid_activation(self) -> None:
+        engine = _make_engine(comfort_heat=68.0, comfort_cool=74.0, indoor_f=72.0)
+        self._arm_idle_open(engine, outdoor=68.0)  # favorable -> FSM decides ACTIVE_FULL_GATE
+
+        async def _activate_fan_races_override(*, reason: str, emit_event: bool = True) -> FanCommandResult:
+            # Simulates handle_fan_manual_override() winning the race during this
+            # await window: a real override starts and the fan command it
+            # protects is rejected.
+            engine._fan_override_active = True
+            engine._grace_active = True
+            return FanCommandResult.OVERRIDDEN
+
+        engine._activate_fan = AsyncMock(side_effect=_activate_fan_races_override)
+        asyncio.run(engine.check_natural_vent_conditions())
+
+        assert engine._natural_vent_active is False, (
+            "the pre-await ACTIVE_FULL_GATE decision must not be applied once "
+            "_activate_fan() reports the command was overridden mid-activation"
+        )
+
+    def test_paused_reactivation_does_not_clobber_override_that_arrives_mid_activation(self) -> None:
+        engine = _make_engine(comfort_heat=68.0, comfort_cool=74.0, indoor_f=72.0)
+        engine._paused_by_door = True
+        engine._paused_with_hvac_already_off = False
+        engine._natural_vent_active = False
+        engine._nat_vent_soft_start = False
+        engine._last_outdoor_temp = 68.0
+        engine._nat_vent_outdoor_exit_time = None
+        engine._fan_override_active = False
+        engine._grace_active = False
+
+        async def _activate_fan_races_override(*, reason: str, emit_event: bool = True) -> FanCommandResult:
+            engine._fan_override_active = True
+            return FanCommandResult.OVERRIDDEN
+
+        engine._activate_fan = AsyncMock(side_effect=_activate_fan_races_override)
+        asyncio.run(engine.check_natural_vent_conditions())
+
+        assert engine._natural_vent_active is False, (
+            "reactivation-while-paused must not apply its pre-await decision once "
+            "the activation was actually overridden"
+        )
+
+    def test_idle_open_reentry_applies_decision_normally_when_no_race(self) -> None:
+        """Control: without any override intervening, the pre-await decision is
+        still applied exactly as before -- proves the guard doesn't suppress the
+        normal case."""
+        engine = _make_engine(comfort_heat=68.0, comfort_cool=74.0, indoor_f=72.0)
+        self._arm_idle_open(engine, outdoor=68.0)
+        asyncio.run(engine.check_natural_vent_conditions())
+        assert engine._natural_vent_active is True
+
+
+# ---------------------------------------------------------------------------
+# (d) Issue #134 overheat-during-grace exception at the engine level.
+# ---------------------------------------------------------------------------
+
+
+class TestOverheatDuringGraceIntegration:
+    """Complements the pure-function coverage in test_nat_vent_fsm.py's
+    TestGraceOverheatException with an engine-level check: with Bug D now
+    wiring grace_active=True into the real decision, nat-vent must still
+    engage during grace when indoor genuinely exceeds comfort_cool, and must
+    stay inactive during grace otherwise."""
+
+    def test_grace_active_and_overheating_still_engages(self) -> None:
+        engine = _make_engine(comfort_heat=68.0, comfort_cool=74.0, indoor_f=78.0)
+        engine._paused_by_door = False
+        engine._natural_vent_active = False
+        engine._nat_vent_soft_start = False
+        engine._grace_active = True
+        engine._fan_override_active = False
+        engine._last_outdoor_temp = 65.0
+        asyncio.run(engine.check_natural_vent_conditions())
+        assert engine._natural_vent_active is True
+
+    def test_grace_active_and_not_overheating_stays_inactive(self) -> None:
+        engine = _make_engine(comfort_heat=68.0, comfort_cool=74.0, indoor_f=70.0)
+        engine._paused_by_door = False
+        engine._natural_vent_active = False
+        engine._nat_vent_soft_start = False
+        engine._grace_active = True
+        engine._fan_override_active = False
+        engine._last_outdoor_temp = 65.0
+        asyncio.run(engine.check_natural_vent_conditions())
+        assert engine._natural_vent_active is False

--- a/tests/test_nat_vent_fsm_override_awareness.py
+++ b/tests/test_nat_vent_fsm_override_awareness.py
@@ -151,14 +151,19 @@ class TestBugDInputsReflectRealState:
         inputs = engine._build_nat_vent_fsm_inputs(now=_NOW, indoor=72.0, outdoor=65.0)
         assert inputs.grace_active is False
 
-    def test_all_5_real_call_sites_use_this_shared_builder(self) -> None:
+    def test_all_6_real_call_sites_use_this_shared_builder(self) -> None:
         """Guards against a future call site bypassing _build_nat_vent_fsm_inputs()
         and reconstructing NatVentFsmInputs by hand (which would silently
-        reintroduce Bug D at that one site)."""
+        reintroduce Bug D at that one site).
+
+        Count is 6, not 5: Issue #708's fix to _re_pause_for_open_sensor() added a
+        6th real call site, correctly reusing this shared builder rather than
+        hand-rolling inputs — which is exactly why that site automatically picked
+        up Bug D's override/grace wiring fix too."""
         import inspect
 
         src = inspect.getsource(_automation_mod)
-        assert src.count("self._build_nat_vent_fsm_inputs(") == 5
+        assert src.count("self._build_nat_vent_fsm_inputs(") == 6
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_resume_from_pause.py
+++ b/tests/test_resume_from_pause.py
@@ -581,6 +581,97 @@ class TestGraceExpiryRecheck:
 
 
 # ---------------------------------------------------------------------------
+# TestGraceExpiryRecheckFsmAuthoritative (Issue #708)
+# ---------------------------------------------------------------------------
+
+
+class TestGraceExpiryRecheckFsmAuthoritative:
+    """Issue #708: _re_pause_for_open_sensor()'s reactivation decision was
+    previously gated ONLY on _doorwindow_fsm_authoritative (reading a flag
+    already written by the door/window FSM's own *nested* duplicate nat-vent
+    reactivation check) -- _natvent_fsm_authoritative was never consulted at
+    all, regardless of its own state. These tests prove:
+
+    (a) with _natvent_fsm_authoritative=True, the reactivation decision
+        genuinely comes from nat_vent_fsm.transition() -- via a positive-
+        control monkeypatch of decide_nat_vent_gate() (the same technique
+        TestFsmAuthoritativePositiveControl in
+        test_nat_vent_fsm_authoritative_compare.py uses) that forces the
+        gate closed and confirms reactivation is correspondingly
+        suppressed. If the fix merely happened to produce the right answer
+        via legacy code without really calling the FSM, this patch would
+        have no effect and the test would fail.
+    (b) legacy behavior (_natvent_fsm_authoritative=False, the default) is
+        unchanged -- same fixture/assertions as the pre-existing
+        test_repause_clears_paused_by_door_on_nat_vent_reactivation above.
+    """
+
+    def _make_engine_for_reactivation(self) -> AutomationEngine:
+        engine = _make_automation_engine(
+            {
+                CONF_MANUAL_GRACE_PERIOD: 300,
+                CONF_MANUAL_GRACE_NOTIFY: False,
+                CONF_FAN_MODE: FAN_MODE_WHOLE_HOUSE,
+            }
+        )
+        engine._paused_by_door = True
+        engine._paused_with_hvac_already_off = True
+        engine._paused_entity = "binary_sensor.stale_from_prior_pause"
+        engine._paused_since = datetime.now()
+        engine._last_outdoor_temp = 65.0
+        climate_state = MagicMock()
+        climate_state.state = "off"
+        climate_state.attributes.get.return_value = 78.0
+        engine.hass.states.get.return_value = climate_state
+        engine._hourly_forecast_temps = []
+        return engine
+
+    def test_reactivates_via_nat_vent_fsm_when_authoritative(self):
+        """Genuine outdoor/indoor conditions favor reactivation (outdoor 65°F <
+        indoor 78°F, well within the nat-vent delta/comfort-floor gates). With
+        the switch on, this must reactivate via the real FSM path."""
+        engine = self._make_engine_for_reactivation()
+        engine._natvent_fsm_authoritative = True
+
+        asyncio.run(engine._re_pause_for_open_sensor())
+
+        assert engine._natural_vent_active is True
+        assert engine._paused_by_door is False
+
+    def test_positive_control_forcing_fsm_gate_closed_suppresses_reactivation(self):
+        """Monkeypatch nat_vent_fsm.decide_nat_vent_gate() to always return
+        False. If _re_pause_for_open_sensor() genuinely routes its
+        reactivation decision through nat_vent_fsm.transition() when
+        authoritative, this forces the function to re-pause instead of
+        reactivating -- proving the FSM function is actually invoked and its
+        result actually consulted, not just a legacy calculation happening to
+        match (the differential-parity check the plan called for)."""
+        engine = self._make_engine_for_reactivation()
+        engine._natvent_fsm_authoritative = True
+
+        with patch("custom_components.climate_advisor.nat_vent_fsm.decide_nat_vent_gate", lambda inputs: False):
+            asyncio.run(engine._re_pause_for_open_sensor())
+
+        assert engine._natural_vent_active is False
+        assert engine._paused_by_door is True
+
+    def test_legacy_unchanged_when_switch_off(self):
+        """Regression: with _natvent_fsm_authoritative left at its default
+        False, behavior is unchanged from before this fix -- same fixture and
+        outcome as test_repause_clears_paused_by_door_on_nat_vent_reactivation
+        above, restated explicitly alongside the FSM-authoritative tests so
+        the three scenarios (default off / on / on-but-forced-closed) sit
+        together."""
+        engine = self._make_engine_for_reactivation()
+        assert engine._natvent_fsm_authoritative is False
+
+        asyncio.run(engine._re_pause_for_open_sensor())
+
+        assert engine._natural_vent_active is True
+        assert engine._paused_by_door is False
+
+
+# ---------------------------------------------------------------------------
 # TestResumedFromPauseFlag
 # ---------------------------------------------------------------------------
 

--- a/tests/test_resume_from_pause.py
+++ b/tests/test_resume_from_pause.py
@@ -429,6 +429,153 @@ class TestResumeFromPauseFsmAuthoritative:
         engine.hass.services.async_call.assert_not_called()
 
 
+class TestResumeFromPauseZeroDurationGrace:
+    """Issue #709 regression: end-to-end proof that resume_from_pause()'s FINAL
+    state, after the full method returns, is never a phantom _grace_active=True
+    with no real timer scheduled.
+
+    **Revert-tested caveat, documented honestly**: this class alone does NOT
+    prove the fix, because the pre-fix bug was a *transient* phantom, not a
+    permanently-stuck one — _start_grace_period_action()'s own internal
+    _cancel_grace_timers() call unconditionally resets _grace_active=False
+    before it ever checks whether a new grace should start, which happens to
+    wash out door/window's earlier phantom write by the time this async method
+    returns, even on the old buggy code. Reverting only the production fix (git
+    stash push on automation.py/door_window_fsm.py, keeping this test) leaves
+    these particular tests GREEN — confirmed while authoring this fix. The real,
+    always-failing-without-the-fix proof is
+    TestResolveDoorWindowPauseFlagsZeroDurationGraceIsolated below (calls the
+    dispatcher directly, observing the state immediately after just that one
+    call, before the later real action's wash-out) and
+    tests/test_fsm_flag_ownership.py's AST-based ownership check. This class is
+    kept anyway as an end-to-end regression guard against a *different*
+    potential future break (e.g. someone removing the wash-out itself)."""
+
+    def test_no_phantom_grace_from_paused_active_when_manual_grace_disabled(self):
+        engine = _make_automation_engine(
+            {
+                CONF_MANUAL_GRACE_PERIOD: 0,
+                CONF_MANUAL_GRACE_NOTIFY: False,
+            }
+        )
+        engine._doorwindow_fsm_authoritative = True
+        engine._paused_by_door = True
+        engine._pre_pause_mode = "cool"
+        engine._current_classification = _make_classification(hvac_mode="cool")
+
+        with patch(_PATCH_CALL_LATER), patch(_PATCH_CALLBACK, side_effect=lambda f: f):
+            result = asyncio.run(engine.resume_from_pause())
+
+        assert engine._paused_by_door is False
+        assert engine._grace_active is False
+        assert engine._grace_protects_override is False
+        assert engine._manual_grace_cancel is None
+        assert result == "cool"
+
+    def test_no_phantom_grace_from_paused_during_grace_when_manual_grace_disabled(self):
+        """Same zero-duration edge case, but starting from PAUSED_DURING_GRACE — a
+        pre-existing real grace was running; resume_from_pause() unconditionally
+        cancels it and (with duration now 0) does not replace it. The FSM's own
+        DASHBOARD_RESUME transition from this origin must also land on NORMAL, not
+        GRACE, for the same reason."""
+        engine = _make_automation_engine(
+            {
+                CONF_MANUAL_GRACE_PERIOD: 0,
+                CONF_MANUAL_GRACE_NOTIFY: False,
+            }
+        )
+        engine._doorwindow_fsm_authoritative = True
+        engine._paused_by_door = True
+        engine._grace_active = True
+        engine._current_classification = _make_classification(hvac_mode="cool")
+
+        with patch(_PATCH_CALL_LATER), patch(_PATCH_CALLBACK, side_effect=lambda f: f):
+            asyncio.run(engine.resume_from_pause())
+
+        assert engine._paused_by_door is False
+        assert engine._grace_active is False
+        assert engine._manual_grace_cancel is None
+
+
+class TestResolveDoorWindowPauseFlagsZeroDurationGraceIsolated:
+    """Issue #709: the real proof. Calls _resolve_door_window_pause_flags()
+    directly with kind=DASHBOARD_RESUME — the exact call resume_from_pause()
+    makes BEFORE it ever reaches the real _start_grace_period_action() (which is
+    what washes out the pre-fix phantom by the time the full async method
+    returns, per TestResumeFromPauseZeroDurationGrace's docstring). Observing
+    _grace_active immediately after only this one call is the only way to see
+    the actual pre-fix bug: with CONF_MANUAL_GRACE_PERIOD=0,
+    _apply_door_window_fsm_state() used to write _grace_active=True right here,
+    with no real timer anywhere in existence yet — visible to any concurrently
+    scheduled task for as long as the caller's subsequent awaits take.
+
+    Revert-tested: reverting the production fix (door_window_fsm.py's
+    manual_grace_would_start gating, or restoring _apply_door_window_fsm_state()'s
+    _grace_active write) makes both tests below fail — confirmed while authoring
+    this fix, see the PR/commit description for the exact revert-and-rerun log.
+    """
+
+    def test_dashboard_resume_from_paused_active_no_phantom_when_manual_grace_disabled(self):
+        from custom_components.climate_advisor.door_window_fsm import DoorWindowFsmEventKind
+
+        engine = _make_automation_engine({CONF_MANUAL_GRACE_PERIOD: 0})
+        engine._doorwindow_fsm_authoritative = True
+        engine._paused_by_door = True
+        engine._paused_with_hvac_already_off = False  # PAUSED_ACTIVE origin
+        engine._grace_active = False
+
+        engine._resolve_door_window_pause_flags(
+            kind=DoorWindowFsmEventKind.DASHBOARD_RESUME,
+            legacy=MagicMock(),
+        )
+
+        assert engine._grace_active is False, (
+            "_resolve_door_window_pause_flags(DASHBOARD_RESUME) set a phantom "
+            "_grace_active=True with CONF_MANUAL_GRACE_PERIOD=0 — no real grace "
+            "timer has been touched at this point in the real call sequence yet."
+        )
+
+    def test_dashboard_resume_from_paused_during_grace_lands_on_normal_when_manual_grace_disabled(self):
+        """Same origin family, but starting from PAUSED_DURING_GRACE — a
+        pre-existing real grace was already running, so _grace_active is
+        already True going in and (correctly, post-fix) the dispatcher never
+        writes it either way, meaning this specific origin can't demonstrate a
+        False -> True phantom the way the PAUSED_ACTIVE case above can (a
+        version of this test asserting engine._grace_active is False here would
+        pass identically whether the fix is applied or not, since the flag was
+        never False to begin with — caught while authoring this fix). What CAN
+        regress for this origin is the FSM's own transition decision: it must
+        resolve to NORMAL (matching what resume_from_pause()'s real, unconditional
+        cancel-then-maybe-restart action is about to enforce), not GRACE — proven
+        directly against the real transition() call, mirroring
+        TestFromPausedDuringGrace's pure-function-level coverage in
+        test_door_window_fsm.py but confirming the real dispatcher actually
+        threads manual_grace_would_start=False through to it end to end."""
+        from custom_components.climate_advisor import door_window_fsm as dwfsm
+        from custom_components.climate_advisor.door_window_fsm import (
+            DoorWindowFsmEventKind,
+            DoorWindowLifecycleState,
+        )
+
+        engine = _make_automation_engine({CONF_MANUAL_GRACE_PERIOD: 0})
+        engine._doorwindow_fsm_authoritative = True
+        engine._paused_by_door = True
+        engine._grace_active = True  # PAUSED_DURING_GRACE origin
+
+        real_transition = dwfsm.transition
+        with patch.object(dwfsm, "transition", wraps=real_transition) as mock_transition:
+            engine._resolve_door_window_pause_flags(
+                kind=DoorWindowFsmEventKind.DASHBOARD_RESUME,
+                legacy=MagicMock(),
+            )
+
+        mock_transition.assert_called_once()
+        called_state, called_event = mock_transition.call_args[0]
+        assert called_state == DoorWindowLifecycleState.PAUSED_DURING_GRACE
+        result = real_transition(called_state, called_event)
+        assert result.to_state == DoorWindowLifecycleState.NORMAL
+
+
 # ---------------------------------------------------------------------------
 # TestGraceExpiryRecheck
 # ---------------------------------------------------------------------------

--- a/tests/test_startup_coalesce_shadow_fsm.py
+++ b/tests/test_startup_coalesce_shadow_fsm.py
@@ -1,0 +1,199 @@
+"""Tests for Issue #707: restart-resume with a surviving RF fan timer never fed
+the override/grace shadow FSM tracker.
+
+Background: ``coordinator._do_startup_coalesce()`` calls
+``reconcile_fan_on_startup()`` wrapped in ``_mirror_to_shadow("reconcile_fan_on_startup",
+...)``. ``"reconcile_fan_on_startup"`` is not a key in
+``_OVERRIDE_GRACE_FSM_EVENT_KINDS``, so the mirror dispatch never feeds the
+override/grace shadow tracker for that outer call. When a live RF remote fan
+timer survives an HA restart, ``AutomationEngine._reconcile_fan_on_startup_locked()``
+calls ``handle_fan_manual_override()`` INTERNALLY (automation.py ~5005-5022) —
+this correctly updates production's real override/grace flags, but that inner
+call is invisible to the mirror dispatch (which only inspects the outer method
+name), so the shadow tracker was left permanently stuck reporting
+``(idle, none)`` after every such restart. Confirmed live 2026-08-20 06:54-07:11:
+production=idle/active_protecting_override, fsm=idle/none, sustained 993s+.
+
+Occupant impact: none — production's real override/grace flags are correct
+either way, since ``_resolve_override_grace_fsm_state()`` runs correctly inside
+``handle_fan_manual_override()`` regardless of this bug. This is purely a
+diagnostic-signal gap (the live-verification comparison signal an upcoming
+combined observation window depends on being trustworthy), not a
+production-behavior bug.
+
+Fix: ``_do_startup_coalesce()`` now feeds
+``self._evaluate_override_grace_fsm(OverrideGraceFsmEventKind.FAN_OVERRIDE_DETECTED)``
+directly, gated on the exact same condition
+(``remote_timer_provenance is not None and thermostat_fan_running``)
+``_reconcile_fan_on_startup_locked()`` uses to decide whether to call
+``handle_fan_manual_override()`` — so it only fires when the inner override
+call actually happened.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+from tools.sim_harness._loop import run_coro
+from tools.sim_harness.build_coordinator import build_headless_coordinator
+from tools.sim_harness.fake_hass import FakeState
+from tools.sim_harness.ha_stubs import install_ha_stubs
+
+install_ha_stubs()
+
+from custom_components.climate_advisor.override_grace_fsm import OverrideGraceFsmEventKind  # noqa: E402
+from custom_components.climate_advisor.override_grace_lifecycle import GraceState, OverrideConfirmState  # noqa: E402
+
+# Issue #685: build_headless_coordinator's stub environment leaves
+# homeassistant.util.dt.now() returning a MagicMock — _update_shadow_engine_
+# diagnostic()'s wall-clock debounce arithmetic needs a real, fixed datetime
+# when called directly outside a _mirror_to_shadow()-driven cycle.
+_FIXED_NOW = datetime(2026, 8, 20, 7, 0, 0, tzinfo=UTC)
+
+
+def _run(coro):
+    return run_coro(coro)
+
+
+def _build_coord_with_fan_running(remote_timer_provenance):
+    """Build a headless coordinator whose thermostat reports a running fan and
+    whose live remote-timer-provenance read is stubbed to the given value."""
+    coordinator, fake_hass, scheduler, event_log = build_headless_coordinator(
+        skip_startup_coalesce=True,
+    )
+    climate_entity = coordinator.config["climate_entity"]
+    fake_hass.states.set(
+        climate_entity,
+        FakeState(
+            state="off",
+            attributes={"fan_mode": "on", "hvac_action": "fan", "hvac_modes": ["off", "heat", "cool"]},
+        ),
+    )
+    coordinator._resolved_sensors = []  # no windows open — isolate the fan-reconcile path
+    coordinator._read_live_remote_timer_provenance = lambda: remote_timer_provenance
+    return coordinator, fake_hass, scheduler, event_log
+
+
+class TestRestartResumeRfTimerFeedsShadowFsm:
+    def test_rf_timer_survives_restart_feeds_fan_override_detected(self) -> None:
+        """The exact live bug scenario: a valid live RF timer survives restart, the
+        fan is still physically running — reconcile_fan_on_startup() internally
+        re-arms the manual override via handle_fan_manual_override(). Without the
+        fix, coordinator._override_grace_fsm_state stays stuck at (idle, none)."""
+        coordinator, _fake_hass, scheduler, _event_log = _build_coord_with_fan_running(
+            remote_timer_provenance=(25200.0, 8.0)
+        )
+        assert coordinator._override_grace_fsm_state == (OverrideConfirmState.IDLE, GraceState.NONE)
+
+        with scheduler.installed():
+            _run(coordinator._do_startup_coalesce())
+            scheduler.advance_to(scheduler.now())
+
+        # Production's real flags were correctly set by the inner
+        # handle_fan_manual_override() call regardless of this bug.
+        ae = coordinator.automation_engine
+        assert ae._fan_override_active is True
+        assert ae._grace_active is True
+        assert ae._grace_protects_override is True
+
+        # The fix under test: the shadow tracker now reflects that real state
+        # instead of staying stuck at (idle, none).
+        assert coordinator._override_grace_fsm_state == (
+            OverrideConfirmState.IDLE,
+            GraceState.ACTIVE_PROTECTING_OVERRIDE,
+        )
+
+    def test_diagnostic_agrees_after_rf_timer_restart(self) -> None:
+        """The live-verification diagnostic (what the upcoming combined observation
+        window depends on) must report agreement, not a stuck disagreement.
+
+        The diagnostic snapshot itself is only recomputed inside
+        ``_mirror_to_shadow()``'s finally block (i.e. on the next coordinator
+        update cycle's mirrored call) — the fix's direct FSM feed in
+        ``_do_startup_coalesce()`` updates ``_override_grace_fsm_state`` immediately
+        (asserted above) but the diagnostic snapshot itself lags to that next
+        cycle by design, same as every other coordinator-originated FSM feed
+        (``_check_orphaned_grace()``). Calling ``_update_shadow_engine_diagnostic()``
+        directly here simulates that next cycle's snapshot."""
+        coordinator, _fake_hass, scheduler, _event_log = _build_coord_with_fan_running(
+            remote_timer_provenance=(25200.0, 8.0)
+        )
+
+        with scheduler.installed():
+            _run(coordinator._do_startup_coalesce())
+            scheduler.advance_to(scheduler.now())
+
+        with patch("custom_components.climate_advisor.coordinator.dt_util.now", return_value=_FIXED_NOW):
+            coordinator._update_shadow_engine_diagnostic()
+        diag = coordinator.shadow_engine_diagnostic
+        assert diag is not None
+        assert diag["override_grace_production_state"] == "idle/active_protecting_override"
+        assert diag["override_grace_fsm_state"] == "idle/active_protecting_override"
+        assert diag["override_grace_fsm_agrees"] is True
+
+    def test_normal_coalesce_no_timer_no_spurious_fsm_feed(self) -> None:
+        """Control case: no live remote timer provenance and no fan running — the
+        plain 'nothing to reconcile' path. The FSM tracker must stay at its
+        initial (idle, none) state — no spurious event feed for the ordinary,
+        no-active-fan-timer restart path."""
+        coordinator, fake_hass, scheduler, _event_log = build_headless_coordinator(
+            skip_startup_coalesce=True,
+        )
+        climate_entity = coordinator.config["climate_entity"]
+        fake_hass.states.set(
+            climate_entity,
+            FakeState(state="off", attributes={"fan_mode": "off", "hvac_modes": ["off", "heat", "cool"]}),
+        )
+        coordinator._resolved_sensors = []
+        coordinator._read_live_remote_timer_provenance = lambda: None
+        assert coordinator._override_grace_fsm_state == (OverrideConfirmState.IDLE, GraceState.NONE)
+
+        with scheduler.installed():
+            _run(coordinator._do_startup_coalesce())
+            scheduler.advance_to(scheduler.now())
+
+        assert coordinator._override_grace_fsm_state == (OverrideConfirmState.IDLE, GraceState.NONE)
+
+    def test_provenance_present_but_fan_not_running_no_spurious_feed(self) -> None:
+        """Provenance is live and valid, but the fan already reads off — the inner
+        RF-timer branch is deliberately skipped (thermostat_fan_running gate), so
+        this must not feed FAN_OVERRIDE_DETECTED either."""
+        coordinator, fake_hass, scheduler, _event_log = build_headless_coordinator(
+            skip_startup_coalesce=True,
+        )
+        climate_entity = coordinator.config["climate_entity"]
+        fake_hass.states.set(
+            climate_entity,
+            FakeState(state="off", attributes={"fan_mode": "off", "hvac_modes": ["off", "heat", "cool"]}),
+        )
+        coordinator._resolved_sensors = []
+        coordinator._read_live_remote_timer_provenance = lambda: (25200.0, 8.0)
+
+        with scheduler.installed():
+            _run(coordinator._do_startup_coalesce())
+            scheduler.advance_to(scheduler.now())
+
+        assert coordinator._override_grace_fsm_state == (OverrideConfirmState.IDLE, GraceState.NONE)
+
+    def test_called_with_explicit_event_kind_only_when_gate_passes(self) -> None:
+        """Intercept _evaluate_override_grace_fsm directly (same technique as
+        tests/test_override_grace_fsm_shadow_wiring.py) to pin the exact event kind
+        fired, independent of the FSM's own transition table."""
+        coordinator, _fake_hass, scheduler, _event_log = _build_coord_with_fan_running(
+            remote_timer_provenance=(25200.0, 8.0)
+        )
+        called: list[OverrideGraceFsmEventKind] = []
+        original = coordinator._evaluate_override_grace_fsm
+
+        def _capture(event_kind):
+            called.append(event_kind)
+            return original(event_kind)
+
+        coordinator._evaluate_override_grace_fsm = _capture
+
+        with scheduler.installed():
+            _run(coordinator._do_startup_coalesce())
+            scheduler.advance_to(scheduler.now())
+
+        assert OverrideGraceFsmEventKind.FAN_OVERRIDE_DETECTED in called

--- a/tools/sim_harness/combined_fsm_authoritative_compare.py
+++ b/tools/sim_harness/combined_fsm_authoritative_compare.py
@@ -1,0 +1,52 @@
+"""combined_fsm_authoritative_compare — all-three-switches-together equivalence
+proof (Epic #594 Phase R, Phase G's G-test deliverable).
+
+The three individual comparators (``nat_vent_fsm_authoritative_compare.py``,
+``doorwindow_fsm_authoritative_compare.py``, ``override_grace_fsm_authoritative_
+compare.py``) each flip exactly one switch in isolation. Nothing in the repo,
+before this module, ever flipped all three together — confirmed absent by a
+2026-08-20 audit that specifically searched for this and found none.
+
+This matters because the combined rollout (Phase V) flips
+``natvent_fsm_authoritative``, ``doorwindow_fsm_authoritative``, and
+``override_grace_fsm_authoritative`` all at once, in a single deploy, rather
+than as two sequential live-verification windows. Blocker F (a real race
+between nat-vent's ``await self._activate_fan(...)`` yield point and an
+unlocked, synchronously-invoked ``handle_fan_manual_override()``) only exists
+once *both* ``natvent_fsm_authoritative`` and ``override_grace_fsm_
+authoritative`` are on together — no single-switch comparator could ever have
+found it, and none did; it was found by manual trace.
+
+Use exactly like the single-switch comparators: ``tools.sim_harness.
+differential.diff_runs(scenario, mutate_b=fsm_authoritative_mutation)``. Run A
+is untouched production (all three flags default False), run B forces all
+three True on every engine constructed during that run.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+
+@contextmanager
+def fsm_authoritative_mutation() -> Iterator[None]:
+    """Force all three ``*_fsm_authoritative`` flags True together on every
+    engine constructed while this context is active — the "run B" side of a
+    combined diff_runs comparison.
+    """
+    from unittest.mock import patch
+
+    from custom_components.climate_advisor.automation import AutomationEngine
+
+    original_init = AutomationEngine.__init__
+
+    def _wrapped_init(self: Any, *args: Any, **kwargs: Any) -> None:
+        original_init(self, *args, **kwargs)
+        self._natvent_fsm_authoritative = True
+        self._doorwindow_fsm_authoritative = True
+        self._override_grace_fsm_authoritative = True
+
+    with patch.object(AutomationEngine, "__init__", _wrapped_init):
+        yield


### PR DESCRIPTION
## Summary

Closes the last code gaps found by a 2026-08-20 readiness audit before Epic #594 Phase R's three FSM-authoritative switches (nat-vent, door/window, override/grace) can be safely flipped together in a single combined deploy-and-observe window (Phase V), rather than as separate sequential rollouts.

- Fixes #706 — nat-vent FSM's production input builder never populated `override_active`/`grace_active` (Bug D); a decision computed before an `await` could clobber a real override that started mid-await (Bug F); the FSM's grace short-circuit didn't model the Issue #134 overheat-during-grace exception (closes #688).
- Fixes #707 — RF-timer restart-resume's inner `handle_fan_manual_override()` call never fed the override/grace shadow FSM tracker (diagnostic-signal-only, no production impact).
- Fixes #708 — grace-expiry paused-reactivation never consulted the nat-vent FSM at all, gated only by the door/window switch.
- Fixes #709 — door/window FSM's `_grace_active` write conflicted with override/grace's sole ownership of that flag; a config-dependent phantom-grace edge case; adds a generalized "exactly one writer" regression guard for all three FSMs' modeled flags.
- Adds `tools/sim_harness/combined_fsm_authoritative_compare.py` + `tests/test_combined_fsm_authoritative_compare.py` — the first-ever test coverage with all three switches on together, closing a confirmed gap (no test in the repo had ever exercised this combination). Corpus-wide differential comparison clean (beyond nat-vent's own already-diagnosed divergences), plus a re-proof of the Bug F race-safety fix under the real combined switch state.
- Version bump to 0.6.46 with RELEASE_NOTES/KNOWN_FIXES/CHANGELOG entries for all four issues.

All four fixes were independently implemented, tested, and revert-tested (each confirmed to fail with the predicted symptom when temporarily undone) before merging into this branch.

## Test plan

- [x] `ruff check` / `ruff format` clean
- [x] Full suite: `pytest tests/ -W error::pytest.PytestUnraisableExceptionWarning -W error::RuntimeWarning` — 5130 passed, 6 skipped
- [x] `python tools/simulate.py` — 81/81 golden scenarios
- [x] New combined-switch differential comparator — 91/91 passed
- [x] Each of the 4 fixes individually revert-tested; the combined Bug F race fix additionally revert-tested under the true 3-switch condition