### PR TITLE
Fix #711: re-check active nat-vent session against daytime band at wake_time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.47] — 2026-08-21
+
+- Fix #711: closes a gap where an active whole-house-fan free-cooling session that was already running when you wake up wasn't re-checked against the daytime comfort band until whatever the next unrelated check happened to be — up to 5 minutes later. If indoor drifted below the graceful cycle-off point in that window, the fan could end up cycling off and back on again shortly after, instead of cycling off smoothly right at wake-up.
+
 ## [0.6.46] — 2026-08-20
 
 - Fix #706: closes a gap where, if you opt into the nat-vent state-machine engine, it could lose track of an active manual override in two ways: not recognizing one was already in effect, and — in rare timing cases — briefly overwriting a fan override that started while a decision was in flight. Also teaches it the existing rule that free cooling should keep running during a protected period if the house is genuinely overheating. No change unless you've opted in.

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -6607,8 +6607,24 @@ class AutomationEngine:
         # The low-level _whf_owns_hvac() choke-point guard inside _set_temperature() (used
         # by _apply_comfort_band() below) silently no-ops the actual write for WHF/BOTH;
         # FAN_MODE_HVAC coexists with the compressor so its write goes through normally.
+        #
+        # Issue #711: "leaving fan alone" used to mean literally nothing re-checked the
+        # session until the next periodic/temp-change tick (up to 5 min later, via the
+        # backstop timer) — by which point indoor could already have drifted past the new,
+        # tighter daytime thresholds (this function has just armed a *new* comfort band
+        # above). A session that was healthily cycling under the looser sleep-window band
+        # could coast straight through the graceful daytime cycle-off point and hit the hard
+        # exit floor before daytime rules ever got a look at it (confirmed live, 2026-08-21).
+        # nat_vent_temperature_check() already contains the correct sleep-aware cycling/exit
+        # logic for exactly this situation — call it now, at the moment the new band takes
+        # effect, instead of waiting for an unrelated later tick. Guarded on indoor_temp not
+        # being None: that function's signature requires a real reading, and this same "guard
+        # not available" case already causes the morning pre-cool overshoot check above to
+        # skip entirely.
         if _gate == ScheduledBandGate.DEFER_NAT_VENT:
-            _LOGGER.info("Morning wakeup: nat-vent/WHF session active — leaving fan alone")
+            _LOGGER.info("Morning wakeup: nat-vent/WHF session active — re-checking against daytime band")
+            if indoor_temp is not None:
+                await self.nat_vent_temperature_check(indoor_temp, outdoor=self._last_outdoor_temp)
 
         # Arm the daytime comfort band — waking up exits the sleep window.
         _wakeup_band = select_comfort_band(

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,18 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.46"
+VERSION = "0.6.47"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.47": [
+        "Fix #711: closes a gap where an active whole-house-fan free-cooling"
+        " session that was already running when you wake up wasn't re-checked"
+        " against the daytime comfort band until whatever the next unrelated"
+        " check happened to be — up to 5 minutes later. If indoor drifted"
+        " below the graceful cycle-off point in that window, the fan could"
+        " end up cycling off and back on again shortly after, instead of"
+        " cycling off smoothly right at wake-up.",
+    ],
     "0.6.46": [
         "Fix #707: no user-visible change. After certain restarts with an active"
         " whole-house-fan remote timer, a diagnostic comparison (not any real"
@@ -2160,6 +2169,27 @@ KNOWN_FIXES: dict[int, dict] = {
             " New tests/test_fsm_flag_ownership.py adds a generalized,"
             " AST-based 'exactly one writer' regression guard for all 3 FSMs'"
             " modeled flags."
+        ),
+    },
+    711: {
+        "version_fixed": "0.6.47",
+        "title": (
+            "handle_morning_wakeup()'s DEFER_NAT_VENT branch left an active"
+            " nat-vent/WHF session unchecked against the newly-armed daytime"
+            " comfort band, deferring re-evaluation to whatever the next"
+            " unrelated periodic/temp-change tick happened to be (up to 5 min"
+            " later via the backstop timer) — long enough for indoor to drift"
+            " past the graceful daytime cycle-off point into the hard exit"
+            " floor before daytime rules were ever applied (#705)"
+        ),
+        "scope_covered": (
+            "automation.py: handle_morning_wakeup()'s DEFER_NAT_VENT branch"
+            " now calls nat_vent_temperature_check() immediately with the live"
+            " indoor/outdoor reading, so an already-active session is"
+            " re-evaluated against the new band at the moment it takes"
+            " effect. Already mirrored to the shadow engine via the existing"
+            " _mirror_to_shadow('handle_morning_wakeup', ...) call — no"
+            " separate wiring needed."
         ),
     },
     684: {

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.46"
+  "version": "0.6.47"
 }

--- a/tests/test_fan_control.py
+++ b/tests/test_fan_control.py
@@ -789,6 +789,66 @@ class TestFanTransitions:
 
         assert engine._fan_override_active is False
 
+    def test_morning_wakeup_rechecks_active_nat_vent_session_against_new_band(self):
+        """Issue #711: an active nat-vent/WHF session must be re-checked against the
+        just-armed daytime band immediately at wake_time, not left running until
+        whatever the next unrelated tick happens to be (previously up to 5 minutes,
+        via the periodic backstop — long enough for indoor to drift straight through
+        the graceful daytime cycle-off point into the hard exit floor before daytime
+        rules ever got a look at the session; confirmed live, 2026-08-21).
+        """
+        engine = _make_automation_engine({CONF_FAN_MODE: FAN_MODE_WHOLE_HOUSE, CONF_FAN_ENTITY: "fan.attic"})
+        engine._current_classification = _make_hot_classification()
+        engine._natural_vent_active = True
+        engine._fan_active = True
+        engine._last_outdoor_temp = 60.0
+        engine.nat_vent_temperature_check = AsyncMock()
+
+        asyncio.run(engine.handle_morning_wakeup(indoor_temp=69.0))
+
+        engine.nat_vent_temperature_check.assert_awaited_once_with(69.0, outdoor=60.0)
+
+    def test_morning_wakeup_skips_nat_vent_recheck_when_indoor_unavailable(self):
+        """indoor_temp=None (sensor unavailable) must not be passed through to
+        nat_vent_temperature_check(), which requires a real reading — mirrors the
+        existing None-guard already used by the morning pre-cool overshoot check."""
+        engine = _make_automation_engine({CONF_FAN_MODE: FAN_MODE_WHOLE_HOUSE, CONF_FAN_ENTITY: "fan.attic"})
+        engine._current_classification = _make_hot_classification()
+        engine._natural_vent_active = True
+        engine._fan_active = True
+        engine.nat_vent_temperature_check = AsyncMock()
+
+        asyncio.run(engine.handle_morning_wakeup(indoor_temp=None))
+
+        engine.nat_vent_temperature_check.assert_not_awaited()
+
+    def test_morning_wakeup_cycles_fan_off_gracefully_instead_of_stale_hard_exit(self):
+        """End-to-end reproduction of the 2026-08-21 live incident, using the real
+        (unmocked) nat_vent_temperature_check(): comfort_heat=68/comfort_cool=74 ->
+        daytime cycling target=71, off_threshold=70, on_threshold=72. Indoor=69 sits
+        below the graceful cycle-off point but above the hard exit floor (68) — the
+        session must cycle the fan off and stay active, not wait for a later tick and
+        risk hard-exiting once indoor drifts further down.
+        """
+        engine = _make_automation_engine(
+            {
+                CONF_FAN_MODE: FAN_MODE_WHOLE_HOUSE,
+                CONF_FAN_ENTITY: "fan.attic",
+                "comfort_heat": 68,
+                "comfort_cool": 74,
+            }
+        )
+        engine._current_classification = _make_hot_classification()
+        engine._natural_vent_active = True
+        engine._fan_active = True
+        engine._last_outdoor_temp = 56.0
+        engine._sensor_check_callback = lambda: True  # windows still open, matches live incident
+
+        asyncio.run(engine.handle_morning_wakeup(indoor_temp=69.0))
+
+        assert engine._fan_active is False, "Fan should cycle off at the graceful 70F threshold"
+        assert engine._natural_vent_active is True, "Session must stay active — this is a cycle, not an exit"
+
     def test_bedtime_preserves_fan_active_at_override_but_clears_override_bookkeeping(self):
         """Issue #498: a fan the user was actively overriding at bedtime must be left
         running — clear_manual_override()'s unconditional clear_fan_override() call


### PR DESCRIPTION
## Summary
- Closes #711 (and addresses the same class of symptom reported in #705)
- `handle_morning_wakeup()`'s `DEFER_NAT_VENT` branch previously left an already-active nat-vent/WHF session unchecked against the newly-armed daytime comfort band, deferring re-evaluation to whatever the next unrelated tick happened to be — up to 5 minutes later via the periodic backstop timer
- Confirmed live on 2026-08-21: indoor drifted from a healthy sleep-window reading straight through the daytime graceful cycle-off point (70°F) into the hard exit floor (68°F) before daytime rules were ever applied, producing a felt WHF off→on→off flap
- Fix: `handle_morning_wakeup()` now calls the existing `nat_vent_temperature_check()` immediately in the `DEFER_NAT_VENT` branch — pure reuse of existing logic, no new decision function or config, already mirrored to the shadow engine

## Test plan
- [x] `pytest tests/test_fan_control.py -k morning_wakeup -v` — 5/5 passed (3 new tests added)
- [x] Full suite: `pytest tests/` — 5133 passed, 6 skipped, no regressions
- [x] `python tools/simulate.py` — 81/81 golden scenarios passed
- [x] Version bump (0.6.46 → 0.6.47), RELEASE_NOTES, KNOWN_FIXES, CHANGELOG.md updated