### PR TITLE
Fix #703: update HACS install docs for default-store availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ An intelligent HVAC management integration that uses weather forecasts, occupanc
 
 [![Latest Release](https://img.shields.io/github/v/release/gunkl/ClimateAdvisor?label=released&style=flat-square)](https://github.com/gunkl/ClimateAdvisor/releases/latest)
 [![Development Version](https://img.shields.io/github/manifest-json/v/gunkl/ClimateAdvisor?filename=custom_components%2Fclimate_advisor%2Fmanifest.json&label=development&style=flat-square)](https://github.com/gunkl/ClimateAdvisor/blob/main/custom_components/climate_advisor/manifest.json)
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=gunkl&repository=ClimateAdvisor&category=integration)
+
+Climate Advisor is available in the [HACS](https://hacs.xyz) default store — search for "Climate Advisor" directly in HACS, no custom repository needed.
 
 ## Dashboard
 
@@ -155,11 +158,9 @@ Parameters are extracted via OLS regression over the full decay or active-phase 
 ### HACS (Recommended)
 
 1. Open HACS in Home Assistant
-2. Click the three dots → Custom repositories
-3. Add `https://github.com/gunkl/ClimateAdvisor` as an Integration
-4. Search for "Climate Advisor" and install
-5. Restart Home Assistant
-6. Go to Settings → Integrations → Add Integration → Climate Advisor
+2. Search for "Climate Advisor" and install
+3. Restart Home Assistant
+4. Go to Settings → Integrations → Add Integration → Climate Advisor
 
 ### Manual
 

--- a/docs/hacs-compliance.md
+++ b/docs/hacs-compliance.md
@@ -1,9 +1,11 @@
 # HACS Compliance Brief
 
-**Anchor:** `hacs-compliance` | **Tier:** 2 | **Status:** Current as of 2026-07-02
+**Anchor:** `hacs-compliance` | **Tier:** 2 | **Status:** Current as of 2026-08-21
 
 This document captures all requirements for ClimateAdvisor to remain compliant with HACS
-(Home Assistant Community Store) and for the default repository PR (#8117) to merge smoothly.
+(Home Assistant Community Store). ClimateAdvisor is in the HACS default store
+(`hacs/default#8117`, merged 2026-08-20) — users can install it by searching HACS directly,
+no custom repository step required.
 
 ## Integration Type
 
@@ -118,8 +120,9 @@ and re-submitted (editing a bot-rejected PR does not work).
 and CI, then merges. Of the last 10+ merged integration PRs, Frenck's comment was always:
 > "Hi @username, thanks for the submission! 👋 Approving and merging now. ../Frenck"
 
-PRs are processed FIFO — the queue has 60+ pending integrations (as of 2026-07-02). Typical
-wait: 6–10 weeks depending on queue depth.
+This is now historical context — CA's own PR merged 2026-08-20. Kept here for reference in case
+CA ever needs to resubmit to `hacs/default` (e.g. after a domain rename): PRs are processed FIFO,
+and the queue ran 60+ pending integrations deep as of 2026-07-02, with a typical 6–10 week wait.
 
 ## Merge Conflict Strategy
 

--- a/docs/promotion/ha-community-post.md
+++ b/docs/promotion/ha-community-post.md
@@ -1,0 +1,45 @@
+# HA Community Forum draft — "Share your Projects" category
+
+**Where to post:** https://community.home-assistant.io/c/projects/9 → New Topic
+
+**Suggested title:**
+Climate Advisor — weather-aware, learning HVAC automation (now in the HACS default store)
+
+**Suggested body:**
+
+---
+
+Hi all — I've been building **Climate Advisor**, a custom integration that manages your HVAC based on weather forecasts, occupancy, and door/window sensors, and learns from how you actually use your home over time. It's now in the **HACS default store**, so you can install it by searching HACS directly — no custom repository needed.
+
+**What it does:**
+
+- Pulls tomorrow's forecast every morning, classifies the day (hot/warm/mild/cool/cold), and picks an HVAC strategy — pre-cooling on hot days, natural ventilation windows on mild days, pre-heating ahead of a cold snap, etc.
+- Tracks occupancy (home/away/vacation/guest) and applies setback temperatures automatically.
+- Supports whole-house fan and HVAC fan-only ventilation, coordinated with an economizer two-phase cooling strategy (cool with AC, maintain with free ventilation).
+- Builds a physics-based thermal model of your house from real HVAC/ventilation/solar behavior — not fixed rate-of-change numbers — so predictions get more accurate the longer it runs.
+- Sends a daily briefing (email/notification) explaining *why* it's doing what it's doing, plus a dashboard with prediction-vs-actual charts.
+- Optional AI Investigator (Claude-powered) cross-references the thermal model, event log, and compliance stats to flag anomalies and suggest fixes.
+
+**Screenshots:**
+
+*(attach docs/screenshots/forecast_3d.png, docs/screenshots/status.png, docs/screenshots/forecast_24h.png, docs/screenshots/ai.png when posting — the forum's image uploader is used at post time, these aren't hosted anywhere yet)*
+
+**Install:**
+
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=gunkl&repository=ClimateAdvisor&category=integration)
+
+Or: HACS → search "Climate Advisor" → install.
+
+**Links:**
+
+- Repo: https://github.com/gunkl/ClimateAdvisor
+- Issues/feature requests: https://github.com/gunkl/ClimateAdvisor/issues
+
+Would love feedback, especially from anyone with a different climate/HVAC setup than mine (I've been developing against my own home, so multi-zone and heat-pump-only setups are areas I'm actively looking to validate).
+
+---
+
+**Notes for posting:**
+- Forum requires a HA Community account (David likely already has one from prior HA use).
+- Attach real screenshots at post time — the placeholders above are file references only.
+- Consider cross-linking this thread from the GitHub README once posted (a "Discuss on the HA Community Forum" link).

--- a/docs/promotion/reddit-post.md
+++ b/docs/promotion/reddit-post.md
@@ -1,0 +1,36 @@
+# r/homeassistant draft — "Show and Tell" flair
+
+**Where to post:** https://reddit.com/r/homeassistant → New Post → flair "Show and Tell"
+
+**Suggested title:**
+Climate Advisor — weather + occupancy aware HVAC automation with a self-learning thermal model (now in HACS default store)
+
+**Suggested body:**
+
+---
+
+Built a custom integration over the past several months that automates HVAC based on weather forecast, occupancy, and door/window state, and learns your house's actual thermal behavior instead of using fixed rate-of-change assumptions.
+
+**Highlights:**
+
+- Classifies each day (hot/warm/mild/cool/cold) from the forecast and picks a strategy — pre-cool before a hot day, natural ventilation on mild days, pre-heat before a cold snap
+- Occupancy-aware setbacks (home/away/vacation/guest)
+- Whole-house fan + HVAC fan-only ventilation support, with an economizer strategy (AC for the initial cool-down, free ventilation to maintain)
+- Physics-based thermal model built from your actual HVAC/ventilation/solar behavior via regression — gets more accurate the longer it runs, works even without HVAC cycles (passive decay observations alone can seed it)
+- Daily briefing explaining *why*, not just what — plus a dashboard with prediction-vs-actual charts
+- Optional Claude-powered "AI Investigator" that cross-references the thermal model, event log, and compliance stats for anomaly detection
+
+Now in the **HACS default store** — no custom repository step, just search "Climate Advisor" in HACS.
+
+[screenshots: forecast_3d.png / status.png attached]
+
+GitHub: https://github.com/gunkl/ClimateAdvisor
+
+Happy to answer questions — especially interested in feedback from multi-zone or heat-pump-only setups since I've mainly been developing/testing against my own single-zone home.
+
+---
+
+**Notes for posting:**
+- Attach 1-2 screenshots directly to the Reddit post (Reddit's own image uploader, not a GitHub link) — Reddit posts with native images get more engagement than link posts.
+- r/homeassistant's rules generally require accounts to have some karma/age before "Show and Tell" posts land well — check current sub rules before posting.
+- Keep it shorter than the forum version; Reddit rewards scannable posts.


### PR DESCRIPTION
## Summary
- ClimateAdvisor merged into the HACS default store (`hacs/default#8117`, 2026-08-20) — README and `docs/hacs-compliance.md` still described the old custom-repository install flow.
- Updated README's `## Installation` section to the direct-search flow, added the "Open in HACS" badge and a one-line callout.
- Updated `docs/hacs-compliance.md` merge status and FIFO-queue section to reflect the merge.
- Added draft promotion posts (`docs/promotion/ha-community-post.md`, `docs/promotion/reddit-post.md`) for the HA Community Forum and r/homeassistant — drafts only, not posted anywhere.

## Test plan
- [x] Docs-only change; no `custom_components/` behavior touched, no version bump needed
- [x] Visual diff confirms only Installation section + badge row changed in README
- [ ] User to manually review and post the two promo drafts when ready

Closes #703 (docs + promotion halves both addressed; brand-icon question is being investigated separately, out of scope for this PR).