### PR TITLE
Fix #714: WHF/nat-vent and an active manual HVAC-mode override can no longer coexist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.48] — 2026-08-21
+
+- Fix #714: the whole-house fan and an active thermostat mode (cool/heat) can no longer run at the same time. If you manually change the thermostat mode while free cooling is running, the fan now stops immediately instead of continuing to cycle in the background, and it won't silently turn your thermostat back off anymore if it happens to reactivate while your manual change is still in effect.
+
 ## [0.6.47] — 2026-08-21
 
 - Fix #711: closes a gap where an active whole-house-fan free-cooling session that was already running when you wake up wasn't re-checked against the daytime comfort band until whatever the next unrelated check happened to be — up to 5 minutes later. If indoor drifted below the graceful cycle-off point in that window, the fan could end up cycling off and back on again shortly after, instead of cycling off smoothly right at wake-up.

--- a/custom_components/climate_advisor/ai_skills_context.py
+++ b/custom_components/climate_advisor/ai_skills_context.py
@@ -1930,6 +1930,18 @@ def _render_nat_vent_comfort_floor_exit(p: dict, unit: str) -> tuple[str, str]:
     return label, ", ".join(parts)
 
 
+def _render_nat_vent_manual_override_exit(p: dict, unit: str) -> tuple[str, str]:
+    indoor = p.get("indoor_temp")
+    mode = p.get("override_mode", "")
+    label = "Nat-vent exit -- manual override conflict"
+    if mode:
+        label = f"Nat-vent exit -- manual override to {mode}"
+        if indoor is not None:
+            with contextlib.suppress(TypeError, ValueError):
+                label += f" (indoor {format_temp(float(indoor), unit)})"
+    return label, "fan: on->auto"
+
+
 def _render_nat_vent_reconcile_exit(p: dict, unit: str) -> tuple[str, str]:
     label = "Nat-vent exit -- fan found running without a CA-owned session"
     reason = p.get("reason", "")
@@ -2389,6 +2401,7 @@ EVENT_RENDERERS: dict[str, Callable[[dict, str], tuple[str, str]]] = {
     "nat_vent_outdoor_rise_exit": _render_nat_vent_outdoor_rise_exit,
     "nat_vent_reconcile_exit": _render_nat_vent_reconcile_exit,
     "nat_vent_comfort_floor_exit": _render_nat_vent_comfort_floor_exit,
+    "nat_vent_manual_override_exit": _render_nat_vent_manual_override_exit,
     "nat_vent_away_ceiling_exit": _render_nat_vent_away_ceiling_exit,
     "nat_vent_soft_start_entered": _render_nat_vent_soft_start_entered,
     "nat_vent_reactivated_while_paused": _render_nat_vent_reactivated_while_paused,

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -1648,6 +1648,46 @@ class AutomationEngine:
         detected_mode = state.state if state else "unknown"
         confirm_seconds = int(self.config.get(CONF_OVERRIDE_CONFIRM_PERIOD, DEFAULT_OVERRIDE_CONFIRM_SECONDS))
 
+        # Issue #714: a manual override to an active HVAC mode structurally conflicts
+        # with WHF/nat-vent (Issue #392's whole premise) — stand the session down the
+        # instant the mode change is observed, independent of whether the confirmation
+        # window below later accepts it as a durable override or it self-resolves as a
+        # transient glitch. The physical fact "the thermostat currently reads an active
+        # mode" is real right now, the same way a sensor-close event is real right now —
+        # mirrors handle_all_doors_windows_closed()'s immediate, event-driven reaction
+        # rather than waiting for nat-vent's own next tick-based re-evaluation to notice.
+        # Deliberately does NOT call _exit_nat_vent(): its sensors-closed branch restores
+        # _pre_fan_hvac_mode (captured before nat-vent started) via _set_hvac_mode(),
+        # which has no override awareness of its own and would silently overwrite the
+        # user's just-set mode right back — the same bug this fix closes elsewhere.
+        if detected_mode not in ("off", "unavailable", "unknown") and self._whf_owns_hvac():
+            _LOGGER.warning(
+                "Manual override to %s detected while WHF owns HVAC — ending free cooling session immediately",
+                detected_mode,
+            )
+            self._natural_vent_active = False
+            self._nat_vent_soft_start = False
+
+            async def _stand_down_nat_vent_for_override(_mode: str = detected_mode) -> None:
+                await self._deactivate_fan(
+                    reason=f"manual override to {_mode} detected — ending free cooling",
+                    restore_hvac=False,
+                    release_suppression=True,
+                    emit_event=False,
+                )
+                if self._emit_event_callback:
+                    self._emit_event_callback(
+                        "nat_vent_manual_override_exit",
+                        {
+                            "indoor_temp": self._indoor_f_for_event(),
+                            "override_mode": _mode,
+                            "fan_device": _fan_device_label(self.config),
+                            "source": "override_detected",
+                        },
+                    )
+
+            self.hass.async_create_task(_stand_down_nat_vent_for_override())
+
         # Architecture-reset Step 2 (session state machine slice): the disabled-vs-pending
         # branch now lives in desired_state.decide_override_confirm() — this method still
         # owns the immediate-accept side effect and the real async_call_later scheduling.
@@ -3808,8 +3848,45 @@ class AutomationEngine:
                         occupancy_mode=self._occupancy_mode,
                         thermal_confidence=thermal.get("confidence", "none"),
                         k_passive=thermal.get("k_passive"),
+                        manual_override_active=self._manual_override_active,
+                        manual_override_mode=self._manual_override_mode,
                     )
                 )
+
+                if exit_decision.reason == NatVentExitReason.MANUAL_OVERRIDE_CONFLICT:
+                    # Issue #714: a manual override to an active HVAC mode structurally
+                    # conflicts with WHF/nat-vent — end the session immediately. Deliberately
+                    # does NOT call _exit_nat_vent() here: that function's sensors-closed
+                    # branch restores _pre_fan_hvac_mode (the mode captured BEFORE nat-vent
+                    # started) via _set_hvac_mode(), which has no override awareness of its
+                    # own and would silently overwrite the user's just-set mode right back —
+                    # the exact bug this fix closes. Release suppression without writing any
+                    # mode; the thermostat already reads the user's chosen mode and that's
+                    # exactly where it should stay.
+                    _LOGGER.warning(
+                        "Nat-vent exit: manual override to %s conflicts with WHF — ending free"
+                        " cooling session (indoor %.1f°F)",
+                        self._manual_override_mode,
+                        indoor if indoor is not None else 0.0,
+                    )
+                    self._natural_vent_active = False
+                    self._nat_vent_soft_start = False
+                    await self._deactivate_fan(
+                        reason=f"manual override to {self._manual_override_mode} — ending free cooling",
+                        restore_hvac=False,
+                        release_suppression=True,
+                        emit_event=False,
+                    )
+                    if self._emit_event_callback:
+                        self._emit_event_callback(
+                            "nat_vent_manual_override_exit",
+                            {
+                                "indoor_temp": indoor,
+                                "override_mode": self._manual_override_mode,
+                                "fan_device": _fan_device_label(self.config),
+                            },
+                        )
+                    return
 
                 if exit_decision.reason == NatVentExitReason.COMFORT_FLOOR:
                     # Note (Issue #620 investigation): like fan_thermostat_check()'s
@@ -4386,14 +4463,22 @@ class AutomationEngine:
                         occupancy_mode=self._occupancy_mode,
                         thermal_confidence=thermal_nvtc.get("confidence", "none"),
                         k_passive=thermal_nvtc.get("k_passive"),
+                        manual_override_active=self._manual_override_active,
+                        manual_override_mode=self._manual_override_mode,
                     )
                 )
                 _exit_reason = exit_decision.reason
             else:
                 exit_decision = None
-                _exit_reason = (
-                    NatVentExitReason.COMFORT_FLOOR if current_temp <= _hard_floor else NatVentExitReason.NONE
-                )
+                # Issue #714: manual-override conflict takes priority over the hard floor,
+                # matching decide_nat_vent_exit()'s own priority order — a manual override to
+                # an active mode structurally conflicts with WHF regardless of indoor temp.
+                if self._manual_override_active and self._manual_override_mode not in (None, "off"):
+                    _exit_reason = NatVentExitReason.MANUAL_OVERRIDE_CONFLICT
+                elif current_temp <= _hard_floor:
+                    _exit_reason = NatVentExitReason.COMFORT_FLOOR
+                else:
+                    _exit_reason = NatVentExitReason.NONE
 
             # Hard floor (or, while FSM-authoritative, any of the 5 exit reasons) takes
             # priority over cycling. Sleep window: _hard_floor = sleep_heat - hysteresis (one
@@ -4422,6 +4507,37 @@ class AutomationEngine:
                             {
                                 "indoor": current_temp,
                                 "comfort_cool": comfort_cool,
+                                "fan_device": _fan_device_label(self.config),
+                                "source": "temp_check",
+                            },
+                        )
+                    return
+
+                if _exit_reason == NatVentExitReason.MANUAL_OVERRIDE_CONFLICT:
+                    # Issue #714: same bypass as check_natural_vent_conditions()'s own branch —
+                    # deliberately not routed through _exit_nat_vent(), whose sensors-closed
+                    # path would restore _pre_fan_hvac_mode (captured before nat-vent started)
+                    # via _set_hvac_mode(), overwriting the user's just-set mode right back.
+                    _LOGGER.warning(
+                        "Nat-vent exit: manual override to %s conflicts with WHF via temp-check —"
+                        " ending free cooling session (indoor %.1f°F)",
+                        self._manual_override_mode,
+                        current_temp,
+                    )
+                    self._natural_vent_active = False
+                    self._nat_vent_soft_start = False
+                    await self._deactivate_fan(
+                        reason=f"manual override to {self._manual_override_mode} — ending free cooling",
+                        restore_hvac=False,
+                        release_suppression=True,
+                        emit_event=False,
+                    )
+                    if self._emit_event_callback:
+                        self._emit_event_callback(
+                            "nat_vent_manual_override_exit",
+                            {
+                                "indoor_temp": current_temp,
+                                "override_mode": self._manual_override_mode,
                                 "fan_device": _fan_device_label(self.config),
                                 "source": "temp_check",
                             },
@@ -4749,6 +4865,8 @@ class AutomationEngine:
             in_sleep_window=in_sleep_window,
             hysteresis=hysteresis_ftc,
             natural_vent_active=self._natural_vent_active,
+            manual_override_active=self._manual_override_active,
+            manual_override_mode=self._manual_override_mode,
         )
         outcome = decide_fan_thermostat_check(inputs)
 
@@ -4760,6 +4878,37 @@ class AutomationEngine:
                 f"{outdoor:.1f}" if outdoor is not None else "unavailable",
                 True,
             )
+            return
+
+        if outcome is FanThermostatOutcome.STOP_MANUAL_OVERRIDE_CONFLICT:
+            # Issue #714: deliberately not routed through _exit_nat_vent() — its
+            # sensors-closed branch restores _pre_fan_hvac_mode (captured before nat-vent
+            # started) via _set_hvac_mode(), which has no override awareness of its own
+            # and would silently overwrite the user's just-set mode right back.
+            _LOGGER.warning(
+                "Fan thermostat check: manual override to %s conflicts with WHF —"
+                " ending free cooling session (indoor %.1f°F)",
+                self._manual_override_mode,
+                indoor if indoor is not None else 0.0,
+            )
+            self._natural_vent_active = False
+            self._nat_vent_soft_start = False
+            await self._deactivate_fan(
+                reason=f"manual override to {self._manual_override_mode} — ending free cooling",
+                restore_hvac=False,
+                release_suppression=True,
+                emit_event=False,
+            )
+            if self._emit_event_callback:
+                self._emit_event_callback(
+                    "nat_vent_manual_override_exit",
+                    {
+                        "indoor_temp": indoor,
+                        "override_mode": self._manual_override_mode,
+                        "fan_device": _fan_device_label(self.config),
+                        "source": "fan_thermostat_check",
+                    },
+                )
             return
 
         if outcome is FanThermostatOutcome.STOP_VIA_NAT_VENT_EXIT:
@@ -6922,6 +7071,8 @@ class AutomationEngine:
             fan_hardware_active=_fan_hardware_active,
             override_active=_override_active,
             grace_active=_grace_active,
+            manual_override_active=bool(self._manual_override_active),
+            manual_override_mode=self._manual_override_mode,
         )
 
     @property
@@ -7875,6 +8026,21 @@ class AutomationEngine:
 
         if self._fan_override_active:
             _LOGGER.info("Fan override active — skipping fan activation")
+            return FanCommandResult.OVERRIDDEN
+
+        # Issue #714: a manual override to an active HVAC mode (heat/cool/heat_cool)
+        # structurally conflicts with WHF — starting the fan would call
+        # _suppress_hvac_for_whf() below and force the thermostat straight back to "off",
+        # silently reverting the user's manual choice with no override check at all (the
+        # entry-side half of the #705 bug; the exit-side half is handled by the new
+        # MANUAL_OVERRIDE_CONFLICT checks in nat_vent_exit.py/fan_thermostat_decision.py).
+        # Mirrors the _fan_override_active guard immediately above.
+        if self._manual_override_active and self._manual_override_mode not in (None, "off"):
+            _LOGGER.info(
+                "Manual override active (mode=%s) — skipping fan activation (%s)",
+                self._manual_override_mode,
+                reason,
+            )
             return FanCommandResult.OVERRIDDEN
 
         # Issue #392 Fix 1c: idempotency guard — collapse redundant re-decisions from

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,17 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.47"
+VERSION = "0.6.48"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.48": [
+        "Fix #714: the whole-house fan and an active thermostat mode (cool/heat) can"
+        " no longer run at the same time. If you manually change the thermostat mode"
+        " while free cooling is running, the fan now stops immediately instead of"
+        " continuing to cycle in the background, and it won't silently turn your"
+        " thermostat back off anymore if it happens to reactivate while your manual"
+        " change is still in effect.",
+    ],
     "0.6.47": [
         "Fix #711: closes a gap where an active whole-house-fan free-cooling"
         " session that was already running when you wake up wasn't re-checked"
@@ -2190,6 +2198,32 @@ KNOWN_FIXES: dict[int, dict] = {
             " effect. Already mirrored to the shadow engine via the existing"
             " _mirror_to_shadow('handle_morning_wakeup', ...) call — no"
             " separate wiring needed."
+        ),
+    },
+    714: {
+        "version_fixed": "0.6.48",
+        "title": (
+            "The _whf_owns_hvac() mutex (Issue #392) only choked CA's own"
+            " automation-initiated HVAC writes; a manual override the user makes"
+            " directly at the thermostat never called _set_hvac_mode(), so nothing"
+            " ended an active nat-vent/WHF session — and worse, _activate_fan() would"
+            " silently force the thermostat back to 'off' on WHF reactivation even"
+            " over a live manual 'cool' override, with no override check at all (#705)"
+        ),
+        "scope_covered": (
+            "automation.py: start_override_confirmation() now ends an active"
+            " nat-vent/WHF session immediately the instant a mode change to an"
+            " active mode is detected (event-driven, same as"
+            " handle_all_doors_windows_closed()), not routed through"
+            " _exit_nat_vent() to avoid restoring a stale pre-fan HVAC mode over the"
+            " user's live override. _activate_fan() gained the same"
+            " override-respecting guard _fan_override_active already has."
+            " nat_vent_exit.py/fan_thermostat_decision.py: decide_nat_vent_exit()/"
+            " decide_fan_thermostat_check() gained a new highest-priority"
+            " manual-override-conflict check (defense-in-depth, tick-based,"
+            " already-mirrored to the shadow engine via existing"
+            " _sync_shadow_inputs() override-field sync from Issue #631 — no new"
+            " wiring needed)."
         ),
     },
     684: {

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -1151,6 +1151,8 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 now=now,
                 override_active=bool(ae._fan_override_active or ae._manual_override_active),
                 grace_active=bool(ae._grace_active),
+                manual_override_active=bool(ae._manual_override_active),
+                manual_override_mode=ae._manual_override_mode,
             ),
         )
         result = transition(self._nat_vent_fsm_state, event)

--- a/custom_components/climate_advisor/fan_thermostat_decision.py
+++ b/custom_components/climate_advisor/fan_thermostat_decision.py
@@ -33,9 +33,10 @@ from enum import Enum
 
 
 class FanThermostatOutcome(Enum):
-    """The four real outcomes fan_thermostat_check() can produce."""
+    """The real outcomes fan_thermostat_check() can produce."""
 
     KEEP = "keep"
+    STOP_MANUAL_OVERRIDE_CONFLICT = "stop_manual_override_conflict"
     STOP_VIA_NAT_VENT_EXIT = "stop_via_nat_vent_exit"
     STOP_DEACTIVATE = "stop_deactivate"
     STOP_COOLED_TO_FLOOR = "stop_cooled_to_floor"
@@ -58,6 +59,8 @@ class FanThermostatInputs:
       natural_vent_active  -> self._natural_vent_active — determines whether Check 1's
                                stop routes through the nat-vent exit path or a plain
                                deactivate
+      manual_override_active -> self._manual_override_active (Issue #714)
+      manual_override_mode   -> self._manual_override_mode (Issue #714)
     """
 
     indoor: float | None
@@ -67,6 +70,8 @@ class FanThermostatInputs:
     in_sleep_window: bool
     hysteresis: float
     natural_vent_active: bool
+    manual_override_active: bool
+    manual_override_mode: str | None
 
 
 def resolve_hard_exit_floor(
@@ -131,6 +136,13 @@ def decide_fan_thermostat_check(inputs: FanThermostatInputs) -> FanThermostatOut
     Preconditions (fan active, not overridden) are the shell's responsibility,
     not this function's — mirrors decide_nat_vent_gate()'s scoping.
     """
+    # --- Check 0: manual override conflict (Issue #714) ---
+    # A manual override to an active HVAC mode structurally conflicts with WHF/nat-vent —
+    # checked before every other condition, mirroring nat_vent_exit.decide_nat_vent_exit()'s
+    # own priority order for the same reason.
+    if inputs.manual_override_active and inputs.manual_override_mode not in (None, "off"):
+        return FanThermostatOutcome.STOP_MANUAL_OVERRIDE_CONFLICT
+
     # --- Check 1: free-cooling direction guard (Issue #327) ---
     # Non-strict >=, NO hysteresis — this boundary is deliberately different
     # from the reactivation gate's strict < with configurable hysteresis.

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.47"
+  "version": "0.6.48"
 }

--- a/custom_components/climate_advisor/nat_vent_exit.py
+++ b/custom_components/climate_advisor/nat_vent_exit.py
@@ -46,10 +46,11 @@ OCCUPANCY_AWAY = "away"
 
 
 class NatVentExitReason(Enum):
-    """The 5 exit reasons check_natural_vent_conditions() checks, in priority
+    """The exit reasons check_natural_vent_conditions() checks, in priority
     order — first match wins. NONE means the session should continue."""
 
     NONE = "none"
+    MANUAL_OVERRIDE_CONFLICT = "manual_override_conflict"
     COMFORT_FLOOR = "comfort_floor"
     AWAY_CEILING = "away_ceiling"
     PROACTIVE_FLOOR = "proactive_floor"
@@ -87,6 +88,8 @@ class NatVentExitInputs:
       occupancy_mode         -> self._occupancy_mode
       thermal_confidence     -> (self._thermal_model or {}).get("confidence", "none")
       k_passive              -> (self._thermal_model or {}).get("k_passive")
+      manual_override_active -> self._manual_override_active (Issue #714)
+      manual_override_mode   -> self._manual_override_mode (Issue #714)
     """
 
     indoor: float | None
@@ -100,6 +103,8 @@ class NatVentExitInputs:
     occupancy_mode: str
     thermal_confidence: str
     k_passive: float | None
+    manual_override_active: bool
+    manual_override_mode: str | None
 
 
 def _resolve_reactivation_floor(inputs: NatVentExitInputs) -> float:
@@ -120,7 +125,16 @@ def decide_nat_vent_exit(inputs: NatVentExitInputs) -> NatVentExitDecision:
     real call site's own ``if self._natural_vent_active:`` guard, which this
     function does not re-check (the flag itself isn't one of its inputs).
     """
-    # 1. Comfort-floor exit (Issue #99/#456) — checked first.
+    # 0. Manual override conflict (Issue #714) — checked before every other
+    # reason. A manual override to an active HVAC mode (heat/cool/heat_cool)
+    # structurally conflicts with WHF/nat-vent (Issue #392's whole premise) —
+    # this must win over every other condition, including comfort-floor,
+    # since the user's own thermostat choice is not something the automation
+    # should keep silently working around.
+    if inputs.manual_override_active and inputs.manual_override_mode not in (None, "off"):
+        return NatVentExitDecision(reason=NatVentExitReason.MANUAL_OVERRIDE_CONFLICT)
+
+    # 1. Comfort-floor exit (Issue #99/#456).
     vent_floor = resolve_hard_exit_floor(
         comfort_heat_raw=inputs.comfort_heat_raw,
         sleep_heat=inputs.sleep_heat,

--- a/custom_components/climate_advisor/nat_vent_fsm.py
+++ b/custom_components/climate_advisor/nat_vent_fsm.py
@@ -181,6 +181,15 @@ class NatVentFsmInputs:
     # ``_transition_from_active()`` below) -- those other call sites don't read
     # ``NatVentTransition.fan_should_be_active`` at all.
     fan_hardware_active: bool = False
+    # Issue #714: distinct from override_active above (which OR's in
+    # _fan_override_active and carries no mode information) -- this pair is
+    # specifically the HVAC-mode override the manual-override-vs-nat-vent mutex
+    # needs (NatVentExitInputs.manual_override_active/manual_override_mode). A
+    # bare fan-on override doesn't set an HVAC mode and must not trip this check.
+    # Default False/None mirrors this dataclass's own established non-breaking-
+    # default precedent for every field added after the original construction.
+    manual_override_active: bool = False
+    manual_override_mode: str | None = None
 
 
 @dataclass(frozen=True)
@@ -223,6 +232,8 @@ def _exit_inputs(inputs: NatVentFsmInputs) -> NatVentExitInputs:
         occupancy_mode=inputs.occupancy_mode,
         thermal_confidence=inputs.thermal_confidence,
         k_passive=inputs.k_passive,
+        manual_override_active=inputs.manual_override_active,
+        manual_override_mode=inputs.manual_override_mode,
     )
 
 

--- a/tests/test_fan_control.py
+++ b/tests/test_fan_control.py
@@ -28,7 +28,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 # Patch dt_util.now to return a real datetime (needed for isoformat() calls)
 sys.modules["homeassistant.util.dt"].now = lambda: datetime(2026, 3, 19, 14, 30, 0)
 
-from custom_components.climate_advisor.automation import AutomationEngine  # noqa: E402
+from custom_components.climate_advisor.automation import AutomationEngine, FanCommandResult  # noqa: E402
 from custom_components.climate_advisor.classifier import DayClassification  # noqa: E402
 from custom_components.climate_advisor.const import (  # noqa: E402
     ATTR_FAN_OVERRIDE_SINCE,
@@ -684,6 +684,43 @@ class TestFanOverride:
         engine.hass.services.async_call.assert_not_called()
         assert engine._fan_active is False
 
+    def test_activate_fan_skips_when_manual_hvac_override_active(self):
+        """Issue #714/#705: _activate_fan must not start WHF while a manual override
+        to an active HVAC mode is in effect — starting it would call
+        _suppress_hvac_for_whf() -> _set_hvac_mode('off', ...) and silently force the
+        thermostat back to 'off', overriding the user's manual choice with no
+        override check at all (the entry-side half of the #705 bug)."""
+        engine = _make_automation_engine(
+            {
+                CONF_FAN_MODE: FAN_MODE_WHOLE_HOUSE,
+                CONF_FAN_ENTITY: "fan.attic",
+            }
+        )
+        engine._manual_override_active = True
+        engine._manual_override_mode = "cool"
+
+        result = asyncio.run(engine._activate_fan(reason="test"))
+
+        engine.hass.services.async_call.assert_not_called()
+        assert engine._fan_active is False
+        assert result is FanCommandResult.OVERRIDDEN
+
+    def test_activate_fan_proceeds_when_manual_override_mode_is_off(self):
+        """A manual override that resolved to 'off' (or was cleared) must not block
+        activation — only an active mode (heat/cool/heat_cool) conflicts with WHF."""
+        engine = _make_automation_engine(
+            {
+                CONF_FAN_MODE: FAN_MODE_WHOLE_HOUSE,
+                CONF_FAN_ENTITY: "fan.attic",
+            }
+        )
+        engine._manual_override_active = True
+        engine._manual_override_mode = "off"
+
+        asyncio.run(engine._activate_fan(reason="test"))
+
+        assert engine._fan_active is True
+
     def test_deactivate_fan_skips_when_override_active(self):
         """_deactivate_fan does nothing when _fan_override_active is True."""
         engine = _make_automation_engine(
@@ -714,6 +751,103 @@ class TestFanOverride:
         assert engine._manual_override_active is False
         assert engine._fan_override_active is False
         assert engine._fan_override_time is None
+
+
+class TestManualOverrideEndsNatVentImmediately:
+    """Issue #714/#705: reproduction of the live incident — WHF cycling, nat-vent
+    flagged active, HVAC shown "cool" and enabled, windows open, all at once.
+
+    A manual override to an active HVAC mode must end an already-running nat-vent/
+    WHF session the instant the mode change is detected (event-driven, same as
+    handle_all_doors_windows_closed() reacting to a sensor closing) — not on some
+    later tick.
+    """
+
+    def _engine_with_active_nat_vent(self) -> AutomationEngine:
+        engine = _make_automation_engine(
+            {
+                CONF_FAN_MODE: FAN_MODE_WHOLE_HOUSE,
+                CONF_FAN_ENTITY: "fan.attic",
+            }
+        )
+        engine._natural_vent_active = True
+        engine._fan_active = True
+        engine._pre_fan_hvac_mode = "off"  # captured before nat-vent started (stale by design)
+        state_mock = MagicMock()
+        state_mock.state = "cool"  # the user's just-set thermostat mode
+        engine.hass.states.get = MagicMock(return_value=state_mock)
+        return engine
+
+    def test_override_detection_clears_nat_vent_flag_synchronously(self):
+        """_natural_vent_active must flip False the instant the override is detected
+        — before the scheduled fan-off task has even run — mirroring how
+        _exit_nat_vent() itself clears the flag synchronously ahead of its own await."""
+        engine = self._engine_with_active_nat_vent()
+        engine.hass.async_create_task = MagicMock(side_effect=_consume_coroutine)
+
+        engine.handle_manual_override(source="normal", old_mode="off", new_mode="cool")
+
+        assert engine._natural_vent_active is False
+        engine.hass.async_create_task.assert_called_once()
+
+    def test_override_detection_turns_off_the_fan_without_restoring_stale_mode(self):
+        """The scheduled stand-down must turn off the fan but must NOT write any HVAC
+        mode — _pre_fan_hvac_mode ("off", captured before nat-vent started) must never
+        be written back over the user's just-set "cool", which is exactly the bug this
+        fix closes (_exit_nat_vent()'s default restore would do exactly that)."""
+        engine = self._engine_with_active_nat_vent()
+        scheduled: list = []
+        engine.hass.async_create_task = MagicMock(side_effect=lambda coro: scheduled.append(coro))
+
+        engine.handle_manual_override(source="normal", old_mode="off", new_mode="cool")
+
+        assert scheduled, "Expected the stand-down coroutine to be scheduled"
+        for coro in scheduled:
+            asyncio.run(coro)
+
+        fan_calls = [c for c in engine.hass.services.async_call.call_args_list if c.args[0] == "fan"]
+        assert fan_calls, "Expected the fan to be turned off"
+        hvac_mode_calls = [
+            c for c in engine.hass.services.async_call.call_args_list if c.args[:2] == ("climate", "set_hvac_mode")
+        ]
+        assert not hvac_mode_calls, (
+            f"Must not write any HVAC mode — the thermostat already reads the user's chosen"
+            f" mode. Got: {hvac_mode_calls}"
+        )
+        assert engine._pre_fan_hvac_mode is None, "Suppression snapshot must be released, not left stranded"
+
+    def test_no_action_when_whf_not_currently_owning_hvac(self):
+        """A mode change with no active WHF suppression session must not touch
+        nat-vent bookkeeping — this is a targeted mutex fix, not a blanket override
+        reaction."""
+        engine = _make_automation_engine(
+            {
+                CONF_FAN_MODE: FAN_MODE_WHOLE_HOUSE,
+                CONF_FAN_ENTITY: "fan.attic",
+            }
+        )
+        state_mock = MagicMock()
+        state_mock.state = "cool"
+        engine.hass.states.get = MagicMock(return_value=state_mock)
+        scheduled: list = []
+        engine.hass.async_create_task = MagicMock(side_effect=lambda coro: scheduled.append(coro))
+
+        engine.handle_manual_override(source="normal", old_mode="off", new_mode="cool")
+
+        assert not scheduled, "No WHF suppression session active — nothing to stand down"
+
+    def test_override_to_off_does_not_trigger_standdown(self):
+        """Reverting to 'off' is never a conflict — the guard only fires for an
+        active mode, matching _whf_owns_hvac()'s own scope."""
+        engine = self._engine_with_active_nat_vent()
+        engine.hass.states.get.return_value.state = "off"
+        scheduled: list = []
+        engine.hass.async_create_task = MagicMock(side_effect=lambda coro: scheduled.append(coro))
+
+        engine.handle_manual_override(source="normal", old_mode="cool", new_mode="off")
+
+        assert not scheduled
+        assert engine._natural_vent_active is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_fan_thermostat_decision.py
+++ b/tests/test_fan_thermostat_decision.py
@@ -24,11 +24,48 @@ _BASE = {
     "in_sleep_window": False,
     "hysteresis": 1.0,
     "natural_vent_active": False,
+    "manual_override_active": False,
+    "manual_override_mode": None,
 }
 
 
 def _inputs(**overrides) -> FanThermostatInputs:
     return FanThermostatInputs(**{**_BASE, **overrides})
+
+
+class TestCheck0ManualOverrideConflict:
+    """Issue #714/#705: a manual override to an active HVAC mode structurally
+    conflicts with WHF and must win over every other check, including a
+    favorable outdoor/indoor direction that would otherwise KEEP the fan on."""
+
+    def test_fires_even_with_favorable_direction(self):
+        result = decide_fan_thermostat_check(
+            _inputs(outdoor=65.0, indoor=74.0, manual_override_active=True, manual_override_mode="cool")
+        )
+        assert result == FanThermostatOutcome.STOP_MANUAL_OVERRIDE_CONFLICT
+
+    def test_fires_ahead_of_comfort_floor(self):
+        result = decide_fan_thermostat_check(
+            _inputs(
+                indoor=70.0,
+                comfort_heat_raw=70.0,
+                manual_override_active=True,
+                manual_override_mode="heat",
+            )
+        )
+        assert result == FanThermostatOutcome.STOP_MANUAL_OVERRIDE_CONFLICT
+
+    def test_no_fire_when_mode_is_off(self):
+        result = decide_fan_thermostat_check(
+            _inputs(outdoor=65.0, indoor=74.0, manual_override_active=True, manual_override_mode="off")
+        )
+        assert result == FanThermostatOutcome.KEEP
+
+    def test_no_fire_when_override_not_active(self):
+        result = decide_fan_thermostat_check(
+            _inputs(outdoor=65.0, indoor=74.0, manual_override_active=False, manual_override_mode="cool")
+        )
+        assert result == FanThermostatOutcome.KEEP
 
 
 class TestCheck1DirectionReversal:

--- a/tests/test_nat_vent_exit.py
+++ b/tests/test_nat_vent_exit.py
@@ -33,6 +33,8 @@ def _inputs(
     occupancy_mode: str = "home",
     thermal_confidence: str = "none",
     k_passive: float | None = None,
+    manual_override_active: bool = False,
+    manual_override_mode: str | None = None,
 ) -> NatVentExitInputs:
     return NatVentExitInputs(
         indoor=indoor,
@@ -46,6 +48,8 @@ def _inputs(
         occupancy_mode=occupancy_mode,
         thermal_confidence=thermal_confidence,
         k_passive=k_passive,
+        manual_override_active=manual_override_active,
+        manual_override_mode=manual_override_mode,
     )
 
 
@@ -55,6 +59,67 @@ class TestNoExit:
         # below indoor and below threshold.
         decision = decide_nat_vent_exit(_inputs(indoor=72.0, outdoor=65.0, comfort_cool=76.0, nat_vent_delta=3.0))
         assert decision.reason == NatVentExitReason.NONE
+
+
+class TestManualOverrideConflictExit:
+    """Issue #714/#705: a manual override to an active HVAC mode structurally
+    conflicts with WHF/nat-vent and must win over every other exit reason."""
+
+    def test_fires_when_override_active_and_mode_is_active(self) -> None:
+        decision = decide_nat_vent_exit(
+            _inputs(indoor=72.0, outdoor=65.0, manual_override_active=True, manual_override_mode="cool")
+        )
+        assert decision.reason == NatVentExitReason.MANUAL_OVERRIDE_CONFLICT
+
+    def test_fires_for_heat_mode_too_not_just_cool(self) -> None:
+        decision = decide_nat_vent_exit(
+            _inputs(indoor=72.0, outdoor=65.0, manual_override_active=True, manual_override_mode="heat")
+        )
+        assert decision.reason == NatVentExitReason.MANUAL_OVERRIDE_CONFLICT
+
+    def test_no_fire_when_override_mode_is_off(self) -> None:
+        decision = decide_nat_vent_exit(
+            _inputs(indoor=72.0, outdoor=65.0, manual_override_active=True, manual_override_mode="off")
+        )
+        assert decision.reason == NatVentExitReason.NONE
+
+    def test_no_fire_when_override_mode_is_none(self) -> None:
+        decision = decide_nat_vent_exit(
+            _inputs(indoor=72.0, outdoor=65.0, manual_override_active=True, manual_override_mode=None)
+        )
+        assert decision.reason == NatVentExitReason.NONE
+
+    def test_no_fire_when_override_not_active_even_with_a_mode_set(self) -> None:
+        # Stale/cleared override: mode string lingers but active=False must not fire.
+        decision = decide_nat_vent_exit(
+            _inputs(indoor=72.0, outdoor=65.0, manual_override_active=False, manual_override_mode="cool")
+        )
+        assert decision.reason == NatVentExitReason.NONE
+
+    def test_takes_priority_over_comfort_floor(self) -> None:
+        # Both conditions technically satisfiable — override conflict must win (checked first).
+        decision = decide_nat_vent_exit(
+            _inputs(
+                indoor=70.0,
+                comfort_heat_raw=70.0,
+                manual_override_active=True,
+                manual_override_mode="cool",
+            )
+        )
+        assert decision.reason == NatVentExitReason.MANUAL_OVERRIDE_CONFLICT
+
+    def test_takes_priority_over_away_ceiling(self) -> None:
+        decision = decide_nat_vent_exit(
+            _inputs(
+                indoor=76.0,
+                comfort_cool=76.0,
+                occupancy_mode="away",
+                comfort_heat_raw=60.0,
+                manual_override_active=True,
+                manual_override_mode="cool",
+            )
+        )
+        assert decision.reason == NatVentExitReason.MANUAL_OVERRIDE_CONFLICT
 
 
 class TestComfortFloorExit:

--- a/tools/sim_harness/fan_thermostat_decision_compare.py
+++ b/tools/sim_harness/fan_thermostat_decision_compare.py
@@ -57,6 +57,8 @@ def _reconstruct_inputs(self: Any, indoor: float | None, outdoor: float | None) 
         in_sleep_window=in_sleep_window,
         hysteresis=hysteresis,
         natural_vent_active=self._natural_vent_active,
+        manual_override_active=self._manual_override_active,
+        manual_override_mode=self._manual_override_mode,
     )
 
 
@@ -67,6 +69,8 @@ def _classify_observation(exit_called: bool, deactivate_reason: str | None) -> t
     if exit_called:
         return FanThermostatOutcome.STOP_VIA_NAT_VENT_EXIT, None
     if deactivate_reason is not None:
+        if "manual override to" in deactivate_reason:
+            return FanThermostatOutcome.STOP_MANUAL_OVERRIDE_CONFLICT, None
         if "free cooling gone" in deactivate_reason:
             return FanThermostatOutcome.STOP_DEACTIVATE, None
         if "cooled to floor" in deactivate_reason:


### PR DESCRIPTION
## Summary
- Closes #714 (addresses Issue #705's core complaint: WHF cycling, nat-vent flagged active, HVAC mode showing "cool" and enabled, and windows open -- all at once)
- The existing `_whf_owns_hvac()` mutex (Issue #392 Fix 1b) only chokes CA's own automation-initiated HVAC writes; it was never extended to cover a manual override the user makes directly at the thermostat
- Two confirmed gaps, both closed: (1) detecting a manual override to an active mode did nothing to an already-running nat-vent/WHF session, and (2) `_activate_fan()` would silently force HVAC back to "off" on WHF reactivation even over a live manual "cool" override, with no override check at all -- more severe than passive coexistence, an active unacknowledged fight against the user's own thermostat choice
- Fix is event-driven (matches how `handle_all_doors_windows_closed()` reacts to a sensor closing immediately), plus a tick-based defense-in-depth check in the shared, already-mirrored `decide_nat_vent_exit()`/`decide_fan_thermostat_check()` pure functions -- no new shadow-engine wiring needed since the override fields were already synced there since Issue #631

## Test plan
- [x] New unit tests: `test_nat_vent_exit.py::TestManualOverrideConflictExit`, `test_fan_thermostat_decision.py::TestCheck0ManualOverrideConflict`, `test_fan_control.py::TestManualOverrideEndsNatVentImmediately` (full reproduction of #705's exact scenario) + `_activate_fan()` guard tests
- [x] Full suite: `pytest tests/` -- 5150 passed, 6 skipped, no regressions
- [x] `python tools/simulate.py` -- 81/81 golden scenarios passed
- [x] `python tools/fan_thermostat_decision_diff.py` -- 464/464 agree, 0 errors
- [x] Shadow-agreement suites (`test_shadow_engine_pair.py`, `test_shadow_engine_coverage.py`, `test_nat_vent_fsm_authoritative_compare.py`) -- all green, no legacy/state-machine disagreement introduced
- [x] Version bump (0.6.47 -> 0.6.48), RELEASE_NOTES, KNOWN_FIXES, CHANGELOG.md updated