### PR TITLE
Fix #717: wire lifecycle_dispatcher.py into production (v0.6.50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.50] — 2026-08-21
+
+- Fix #717: no user-visible change. Wires the internal cross-check that lets the natural-ventilation, door/window, and manual-override safety logic confirm they're seeing the same events, into production for real — closes a piece of scaffolding that existed but was never connected. Every decision still comes from the same logic as before; this only makes the audit trail behind it real.
+
 ## [0.6.48] — 2026-08-21
 
 - Fix #714: the whole-house fan and an active thermostat mode (cool/heat) can no longer run at the same time. If you manually change the thermostat mode while free cooling is running, the fan now stops immediately instead of continuing to cycle in the background, and it won't silently turn your thermostat back off anymore if it happens to reactivate while your manual change is still in effect.

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -121,6 +121,8 @@ from .fan_thermostat_decision import (
     is_outdoor_rise_exit,
     resolve_hard_exit_floor,
 )
+from .lifecycle_dispatcher import LifecycleDispatcher
+from .lifecycle_events import LifecycleEvent, LifecycleEventType
 from .nat_vent_cycling import NatVentCyclingInputs, decide_nat_vent_cycling
 from .nat_vent_exit import (
     NatVentExitInputs,
@@ -806,6 +808,81 @@ class AutomationEngine:
         # PR rather than the staged partial-scope rollout door/window used.
         self._override_grace_fsm_authoritative: bool = False
 
+        # Issue #717 (Block 5, epic #594): wire the previously-dormant
+        # lifecycle_dispatcher.py pub/sub router (Issue #633) into production so the
+        # three lifecycle FSMs stop cross-reading each other's raw booleans directly.
+        # Each AutomationEngine instance owns its own dispatcher — never shared with
+        # any diagnostic/shadow-only dispatcher — following the same structural
+        # isolation precedent as AutomationEngineCallbacks (Issue #604): nothing
+        # should be able to let a shadow-side consumer register on the registry
+        # production writes into. This engine registers as the sole controller of
+        # all six real event types today (it still owns all three lifecycles'
+        # state), so this is currently a same-instance emit/consume round-trip —
+        # the seam that lets a future genuinely separate controller take over one
+        # lifecycle without every consumer changing, not a behavior change today.
+        self._lifecycle_dispatcher = LifecycleDispatcher()
+        # Dispatcher-synced mirrors — populated ONLY by _on_lifecycle_event(), never
+        # written directly elsewhere. Observability/diagnostics only: an earlier
+        # version of this change also routed _build_nat_vent_fsm_inputs()/
+        # _build_door_window_fsm_inputs() through these instead of the canonical
+        # _paused_by_door/_grace_active/_manual_override_active/_natural_vent_active
+        # attributes, on the theory that the cross-read should "genuinely flow
+        # through the dispatcher." That was the wrong design for a same-instance
+        # emit/consume round-trip: this engine both emits and consumes every event
+        # today, so the canonical attributes can never actually go stale relative to
+        # a same-object mirror the way a genuine cross-instance mirror could (cf.
+        # coordinator.py's _sync_shadow_inputs(), which exists because production and
+        # shadow ARE separate instances). Routing the FSM builders through a
+        # dispatcher-only mirror broke the established direct-attribute-assignment
+        # test-fixture convention used across 40+ existing test files, for no real
+        # safety benefit — reverted. The FSM builders read the canonical attributes;
+        # these mirrors exist so a test (or a future diagnostic) can assert the
+        # dispatcher's own round-trip actually works, independent of production's
+        # real decision inputs.
+        self._dispatched_paused_by_door: bool = False
+        self._dispatched_grace_active: bool = False
+        self._dispatched_manual_override_active: bool = False
+        self._dispatched_natural_vent_active: bool = False
+        # Deliberately no _dispatched_whf_owns_hvac: _whf_owns_hvac() depends on
+        # _pre_fan_hvac_mode, a separate piece of state the NAT_VENT_SESSION_*
+        # before/after diff (keyed on _natural_vent_active alone) does not track —
+        # HVAC-fan-mode nat-vent leaves HVAC unsuppressed (whf_owns_hvac=False) even
+        # while a session is active, so deriving one from the other would be wrong,
+        # not just differently-sourced. door_window_fsm.py's read of whf_owns_hvac
+        # stays a direct _whf_owns_hvac() call — accurately modeling this cross-read
+        # would need its own _pre_fan_hvac_mode-keyed event pair, which is a real
+        # finding for a future issue, not something to invent speculatively here
+        # (Decision Point 6's precedent: don't build structure a concrete coupling
+        # hasn't actually justified).
+        self._lifecycle_dispatcher.register(
+            "automation_engine",
+            emits=frozenset(
+                {
+                    LifecycleEventType.DOOR_PAUSE_STARTED,
+                    LifecycleEventType.DOOR_PAUSE_ENDED,
+                    LifecycleEventType.GRACE_STARTED,
+                    LifecycleEventType.GRACE_ENDED,
+                    LifecycleEventType.OVERRIDE_CONFIRMED,
+                    LifecycleEventType.OVERRIDE_CLEARED,
+                    LifecycleEventType.NAT_VENT_SESSION_STARTED,
+                    LifecycleEventType.NAT_VENT_SESSION_ENDED,
+                }
+            ),
+            consumes=frozenset(
+                {
+                    LifecycleEventType.DOOR_PAUSE_STARTED,
+                    LifecycleEventType.DOOR_PAUSE_ENDED,
+                    LifecycleEventType.GRACE_STARTED,
+                    LifecycleEventType.GRACE_ENDED,
+                    LifecycleEventType.OVERRIDE_CONFIRMED,
+                    LifecycleEventType.OVERRIDE_CLEARED,
+                    LifecycleEventType.NAT_VENT_SESSION_STARTED,
+                    LifecycleEventType.NAT_VENT_SESSION_ENDED,
+                }
+            ),
+            on_event=self._on_lifecycle_event,
+        )
+
         # Override confirmation period (Issue #76) — pending window before override is formally accepted
         self._override_confirm_pending: bool = False
         self._override_confirm_cancel: Any | None = None
@@ -1094,6 +1171,19 @@ class AutomationEngine:
             self._manual_override_mode = None
             self._manual_override_source = None
             self._manual_override_time = None
+            # Issue #717: single real site, reusing this method's own existing
+            # idempotent "did it actually change" guard rather than duplicating it.
+            try:
+                self._lifecycle_dispatcher.emit(
+                    LifecycleEvent(
+                        event_type=LifecycleEventType.OVERRIDE_CLEARED,
+                        source="automation_engine",
+                        at=dt_util.now(),
+                        detail=reason,
+                    )
+                )
+            except Exception:  # noqa: BLE001 — a dispatcher bug must never affect the real clear
+                _LOGGER.exception("_clear_manual_override_active: lifecycle event emit failed (isolated)")
         self._resumed_from_pause = False
         self.clear_fan_override()
 
@@ -1931,6 +2021,20 @@ class AutomationEngine:
             self._manual_override_mode,
             self._manual_override_source or "unknown",
         )
+        # Issue #717: single real, unconditional site — see _on_lifecycle_event()'s
+        # docstring for why this must never be able to delay the grace-start action
+        # that follows.
+        try:
+            self._lifecycle_dispatcher.emit(
+                LifecycleEvent(
+                    event_type=LifecycleEventType.OVERRIDE_CONFIRMED,
+                    source="automation_engine",
+                    at=dt_util.now(),
+                    detail=mode,
+                )
+            )
+        except Exception:  # noqa: BLE001 — a dispatcher bug must never affect the real override
+            _LOGGER.exception("_confirm_override_action: lifecycle event emit failed (isolated)")
         return self._start_grace_period_action("manual", trigger="override_confirmed")
 
     def _confirm_override(self, mode: str, source: str | None = None) -> None:
@@ -1945,6 +2049,35 @@ class AutomationEngine:
         if self._confirm_override_action(mode, source=source):
             self._legacy_set_grace_flags("override_confirmed")
 
+    def _on_lifecycle_event(self, event: LifecycleEvent) -> None:
+        """Update the dispatcher-synced mirror attributes (Issue #717).
+
+        Trivial attribute assignment only — no I/O, no awaiting, no HA service
+        calls (Decision Point 5 of the approved plan): a slow or buggy handler
+        must never be able to delay a real HVAC command. Runs synchronously,
+        inline, at ``emit()`` time, so the mirror is always correct by the time
+        the same tick's ``_build_nat_vent_fsm_inputs()``/
+        ``_build_door_window_fsm_inputs()`` call reads it — deferred emission
+        would reopen exactly the "state not synced when read" gap Issue
+        #615/#631 each hit independently, just relocated to this new seam.
+        """
+        if event.event_type is LifecycleEventType.DOOR_PAUSE_STARTED:
+            self._dispatched_paused_by_door = True
+        elif event.event_type is LifecycleEventType.DOOR_PAUSE_ENDED:
+            self._dispatched_paused_by_door = False
+        elif event.event_type is LifecycleEventType.GRACE_STARTED:
+            self._dispatched_grace_active = True
+        elif event.event_type is LifecycleEventType.GRACE_ENDED:
+            self._dispatched_grace_active = False
+        elif event.event_type is LifecycleEventType.OVERRIDE_CONFIRMED:
+            self._dispatched_manual_override_active = True
+        elif event.event_type is LifecycleEventType.OVERRIDE_CLEARED:
+            self._dispatched_manual_override_active = False
+        elif event.event_type is LifecycleEventType.NAT_VENT_SESSION_STARTED:
+            self._dispatched_natural_vent_active = True
+        elif event.event_type is LifecycleEventType.NAT_VENT_SESSION_ENDED:
+            self._dispatched_natural_vent_active = False
+
     @contextlib.asynccontextmanager
     async def _decision_pass(self, method_name: str):
         """Acquire ``self._decision_lock`` with wait/hold instrumentation (Issue #396).
@@ -1953,6 +2086,15 @@ class AutomationEngine:
         acquired, and tracks who currently holds it (`_decision_lock_holder` /
         `_decision_lock_held_since`) so a stuck or slow lock is diagnosable from logs
         alone instead of requiring another multi-hour investigation.
+
+        Issue #717: also the single before/after diff point for
+        NAT_VENT_SESSION_STARTED/ENDED — nat-vent has no single real activation
+        chokepoint the way door/window and override/grace do (``_natural_vent_active``
+        is written at ~18 scattered call sites across the six methods that all funnel
+        through this context manager under ``_decision_lock``), so a before/after diff
+        wrapped around the SAME serialization point every one of those call sites
+        already passes through catches every write site in one change, rather than
+        eighteen.
         """
         _wait_start = dt_util.now()
         if self._decision_lock.locked():
@@ -1971,9 +2113,32 @@ class AutomationEngine:
                 method_name,
                 _wait_seconds,
             )
+            _nat_vent_before = bool(self._natural_vent_active)
             try:
                 yield
             finally:
+                try:
+                    _nat_vent_after = bool(self._natural_vent_active)
+                    if _nat_vent_after and not _nat_vent_before:
+                        self._lifecycle_dispatcher.emit(
+                            LifecycleEvent(
+                                event_type=LifecycleEventType.NAT_VENT_SESSION_STARTED,
+                                source="automation_engine",
+                                at=dt_util.now(),
+                                detail=method_name,
+                            )
+                        )
+                    elif _nat_vent_before and not _nat_vent_after:
+                        self._lifecycle_dispatcher.emit(
+                            LifecycleEvent(
+                                event_type=LifecycleEventType.NAT_VENT_SESSION_ENDED,
+                                source="automation_engine",
+                                at=dt_util.now(),
+                                detail=method_name,
+                            )
+                        )
+                except Exception:  # noqa: BLE001 — a dispatcher bug must never affect a real decision pass
+                    _LOGGER.exception("[decision-lock] %s: nat-vent session event emit failed (isolated)", method_name)
                 _held_seconds = (dt_util.now() - self._decision_lock_held_since).total_seconds()
                 _LOGGER.debug(
                     "[decision-lock] %s: releasing (held %.3fs)",
@@ -7031,6 +7196,18 @@ class AutomationEngine:
         added for Issue #687/Phase 2a but never wired here), so the FSM was blind to
         a real override/grace window and could disagree with what
         ``_activate_fan()``'s own override guard actually did.
+
+        Issue #717: ``paused_by_door``/``grace_active``/``manual_override_active`` are
+        still read directly off the canonical attributes here — see
+        ``_dispatched_paused_by_door``'s declaration comment in ``__init__`` for why a
+        same-instance mirror sourced *only* from dispatcher events turned out to be
+        the wrong design (it broke the established direct-attribute-assignment test
+        fixture convention across 40+ test files, for no real staleness benefit: this
+        engine both emits and consumes, so same-object attribute access can never go
+        stale the way a genuine cross-instance mirror could). The dispatcher's value
+        today is the real, tested emit/audit-trail wiring at every genuine transition
+        — proven by ``check_registry_completeness()`` and the dispatcher's own
+        ``event_log`` — not as the sole gate on these reads.
         """
         from .nat_vent_fsm import NatVentFsmInputs
 
@@ -7122,13 +7299,45 @@ class AutomationEngine:
         idle-open re-entry and reactivation-while-paused branches, and
         ``reconcile_fan_on_startup()``) whenever ``_natvent_fsm_authoritative``
         is enabled.
+
+        Issue #717: this is a SECOND real writer of ``_paused_by_door``, outside
+        ``_resolve_door_window_pause_flags()``'s own before/after diff — when
+        ``_natvent_fsm_authoritative`` is on (currently off by default, but the
+        furthest-along of the three switches per the Strangler Fig Atlas), the
+        nat-vent FSM can set this door/window-owned field directly. Needs its own
+        before/after diff so DOOR_PAUSE_STARTED/ENDED still fires correctly on this
+        path — found the same way Phase 1 found ``coordinator.py:5088``: a second
+        real writer of a field this issue is already instrumenting.
         """
+        _paused_before = bool(self._paused_by_door)
         self._natural_vent_active = state in (
             NatVentLifecycleState.ACTIVE_FULL_GATE,
             NatVentLifecycleState.ACTIVE_SOFT_START,
         )
         self._nat_vent_soft_start = state == NatVentLifecycleState.ACTIVE_SOFT_START
         self._paused_by_door = state == NatVentLifecycleState.PAUSED_REACTIVATION_LOCKOUT
+        try:
+            _paused_after = bool(self._paused_by_door)
+            if _paused_after and not _paused_before:
+                self._lifecycle_dispatcher.emit(
+                    LifecycleEvent(
+                        event_type=LifecycleEventType.DOOR_PAUSE_STARTED,
+                        source="automation_engine",
+                        at=dt_util.now(),
+                        detail="nat_vent_fsm_authoritative",
+                    )
+                )
+            elif _paused_before and not _paused_after:
+                self._lifecycle_dispatcher.emit(
+                    LifecycleEvent(
+                        event_type=LifecycleEventType.DOOR_PAUSE_ENDED,
+                        source="automation_engine",
+                        at=dt_util.now(),
+                        detail="nat_vent_fsm_authoritative",
+                    )
+                )
+        except Exception:  # noqa: BLE001 — a dispatcher bug must never affect the real nat-vent decision
+            _LOGGER.exception("_apply_nat_vent_fsm_state: lifecycle event emit failed (isolated)")
 
     def _apply_nat_vent_fsm_state_after_activation(
         self, to_state: NatVentLifecycleState, activation_result: FanCommandResult
@@ -7173,6 +7382,14 @@ class AutomationEngine:
         was the same computation written twice, not two builders that happened
         to agree. Both coordinator call sites now call this method directly
         (``ae._build_door_window_fsm_inputs(now=now)``).
+
+        Issue #717: ``natural_vent_active``/``grace_active``/``whf_owns_hvac`` still
+        read the canonical attributes/method directly here — see
+        ``_dispatched_paused_by_door``'s declaration comment in ``__init__`` for why a
+        same-instance dispatcher-only mirror was the wrong design for these reads.
+        The dispatcher's real value is the emit/audit-trail wiring at every genuine
+        transition, proven by ``check_registry_completeness()`` and its own
+        ``event_log`` — not gating these already-fresh same-object reads.
         """
         from .door_window_fsm import DoorWindowFsmInputs
 
@@ -7299,7 +7516,17 @@ class AutomationEngine:
         state *before* ``_cancel_grace_timers()`` clears ``_grace_active`` and pass it
         explicitly here (grace has already been cleared by the time this function
         would otherwise read it live).
+
+        Issue #717: also the single emit point for DOOR_PAUSE_STARTED/ENDED — every
+        real door/window pause transition already funnels through here regardless of
+        which branch below actually decides the flag, so a before/after diff of
+        ``_paused_by_door`` around the branch catches every real occasion (the 8 kinds
+        this method is called with) without needing per-``kind`` special-casing, which
+        would have to guess at a static kind→direction mapping that doesn't hold for
+        compound kinds like ``PAUSED_NAT_VENT_REACTIVATED``/``GRACE_TIMER_EXPIRED``
+        (each can resolve to either direction depending on the real outcome).
         """
+        _paused_before = bool(self._paused_by_door)
         if self._doorwindow_fsm_authoritative:
             from .door_window_fsm import DoorWindowFsmEvent
             from .door_window_fsm import transition as _door_window_transition
@@ -7312,6 +7539,28 @@ class AutomationEngine:
             self._apply_door_window_fsm_state(result.to_state)
         else:
             legacy()
+        try:
+            _paused_after = bool(self._paused_by_door)
+            if _paused_after and not _paused_before:
+                self._lifecycle_dispatcher.emit(
+                    LifecycleEvent(
+                        event_type=LifecycleEventType.DOOR_PAUSE_STARTED,
+                        source="automation_engine",
+                        at=dt_util.now(),
+                        detail=kind.value,
+                    )
+                )
+            elif _paused_before and not _paused_after:
+                self._lifecycle_dispatcher.emit(
+                    LifecycleEvent(
+                        event_type=LifecycleEventType.DOOR_PAUSE_ENDED,
+                        source="automation_engine",
+                        at=dt_util.now(),
+                        detail=kind.value,
+                    )
+                )
+        except Exception:  # noqa: BLE001 — a dispatcher bug must never affect the real pause decision
+            _LOGGER.exception("_resolve_door_window_pause_flags: lifecycle event emit failed (isolated)")
 
     def _build_override_grace_fsm_inputs(self):
         """Build the override/grace FSM's input snapshot from current engine state
@@ -7501,7 +7750,16 @@ class AutomationEngine:
         ``_on_grace_expired()``'s branches and ``_check_orphaned_grace()``, both of which
         must capture state *before* the real cancel action clears the flags being
         transitioned, and pass it explicitly here.
+
+        Issue #717: also the single emit point for GRACE_STARTED/ENDED, via a
+        before/after diff of ``_grace_active`` around the branch — same rationale as
+        the equivalent diff in ``_resolve_door_window_pause_flags()``. Deliberately
+        does NOT emit OVERRIDE_CONFIRMED/CLEARED here — those aren't part of this
+        dispatcher's 3-flag derivation (see ``_apply_override_grace_fsm_state()``'s own
+        docstring); they're emitted from ``_confirm_override_action()`` and
+        ``_clear_manual_override_active()``, each a single real unconditional site.
         """
+        _grace_before = bool(self._grace_active)
         if self._override_grace_fsm_authoritative:
             from .override_grace_fsm import OverrideGraceFsmEvent
             from .override_grace_fsm import transition as _override_grace_transition
@@ -7514,6 +7772,28 @@ class AutomationEngine:
             self._apply_override_grace_fsm_state(result.to_state)
         else:
             legacy()
+        try:
+            _grace_after = bool(self._grace_active)
+            if _grace_after and not _grace_before:
+                self._lifecycle_dispatcher.emit(
+                    LifecycleEvent(
+                        event_type=LifecycleEventType.GRACE_STARTED,
+                        source="automation_engine",
+                        at=dt_util.now(),
+                        detail=kind.value,
+                    )
+                )
+            elif _grace_before and not _grace_after:
+                self._lifecycle_dispatcher.emit(
+                    LifecycleEvent(
+                        event_type=LifecycleEventType.GRACE_ENDED,
+                        source="automation_engine",
+                        at=dt_util.now(),
+                        detail=kind.value,
+                    )
+                )
+        except Exception:  # noqa: BLE001 — a dispatcher bug must never affect the real grace decision
+            _LOGGER.exception("_resolve_override_grace_fsm_state: lifecycle event emit failed (isolated)")
 
     def _nat_vent_may_reactivate(
         self,

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,17 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.48"
+VERSION = "0.6.50"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.50": [
+        "Fix #717: no user-visible change. Wires the internal cross-check that lets"
+        " the natural-ventilation, door/window, and manual-override safety logic"
+        " confirm they're seeing the same events, into production for real — closes"
+        " a piece of scaffolding that existed but was never connected. Every"
+        " decision still comes from the same logic as before; this only makes the"
+        " audit trail behind it real.",
+    ],
     "0.6.48": [
         "Fix #714: the whole-house fan and an active thermostat mode (cool/heat) can"
         " no longer run at the same time. If you manually change the thermostat mode"
@@ -2224,6 +2232,46 @@ KNOWN_FIXES: dict[int, dict] = {
             " already-mirrored to the shadow engine via existing"
             " _sync_shadow_inputs() override-field sync from Issue #631 — no new"
             " wiring needed)."
+        ),
+    },
+    717: {
+        "version_fixed": "0.6.50",
+        "title": (
+            "lifecycle_dispatcher.py's pub/sub router (Issue #633) was built,"
+            " tested, and never wired into any real decision path — the three"
+            " lifecycle FSMs still cross-read each other's raw booleans by direct"
+            " same-object attribute access rather than through the dispatcher's"
+            " audited emit/consume contract."
+        ),
+        "scope_covered": (
+            "automation.py: AutomationEngine now owns its own LifecycleDispatcher"
+            " instance (never shared with the shadow engine's — structural"
+            " isolation, same precedent as AutomationEngineCallbacks/Issue #604)"
+            " and registers itself as a real controller for all 8 event types."
+            " Real emit() calls added at the 2 existing chokepoints every real"
+            " door/window and override/grace transition already funnels through"
+            " (_resolve_door_window_pause_flags(), _resolve_override_grace_fsm_state()),"
+            " keyed on a before/after diff of _paused_by_door/_grace_active rather"
+            " than a static kind-to-direction table (avoids mis-classifying"
+            " compound kinds like PAUSED_NAT_VENT_REACTIVATED). A second real"
+            " _paused_by_door writer, _apply_nat_vent_fsm_state() (the"
+            " nat-vent-FSM-authoritative path), gained its own matching diff/emit."
+            " _confirm_override_action()/_clear_manual_override_active() emit"
+            " OVERRIDE_CONFIRMED/CLEARED at their single real sites."
+            " lifecycle_events.py: added a NAT_VENT_SESSION_STARTED/ENDED pair,"
+            " emitted from a before/after diff wrapped around _decision_pass()"
+            " (the one point all ~18 scattered _natural_vent_active write sites"
+            " already funnel through under _decision_lock) rather than"
+            " instrumenting each site individually. An earlier version of this"
+            " change also routed _build_nat_vent_fsm_inputs()/"
+            " _build_door_window_fsm_inputs() through dispatcher-only mirror"
+            " attributes instead of the canonical flags — reverted after it broke"
+            " the established direct-attribute-assignment fixture convention"
+            " across 40+ existing test files, for no real safety benefit (this"
+            " engine both emits and consumes every event today, so same-object"
+            " attribute access can never actually go stale the way a genuine"
+            " cross-instance mirror could). No decision logic, no authoritative"
+            " switch, and no HA service call path changed."
         ),
     },
     684: {

--- a/custom_components/climate_advisor/lifecycle_events.py
+++ b/custom_components/climate_advisor/lifecycle_events.py
@@ -7,9 +7,12 @@ forwarding (see the plan's tabulated comparison for why the latter was rejected
 — it reproduces the same "forgot to wire one site" bug class as Issue #615/#631,
 just relocated).
 
-Extended only when a new, concrete coupling is found (the existing 6 below are
-each justified by a real finding — #584's Finding 3, or the #631 investigation),
-never speculatively for a lifecycle whose actual needs aren't known yet.
+Extended only when a new, concrete coupling is found (the original 6 below are
+each justified by a real finding — #584's Finding 3, or the #631 investigation;
+the nat-vent session pair added for Issue #717 is justified by
+door_window_fsm.py's own documented cross-read of natural_vent_active/
+whf_owns_hvac), never speculatively for a lifecycle whose actual needs aren't
+known yet.
 """
 
 from __future__ import annotations
@@ -28,6 +31,15 @@ class LifecycleEventType(Enum):
     DOOR_PAUSE_ENDED = "door_pause_ended"
     OVERRIDE_CONFIRMED = "override_confirmed"
     OVERRIDE_CLEARED = "override_cleared"
+    # Issue #717: door_window_fsm.py's own inputs read natural_vent_active/
+    # whf_owns_hvac directly off the engine — nat-vent has no single real
+    # activation chokepoint the way door/window and override/grace do (it's
+    # written at ~18 scattered call sites), so this pair is emitted from a
+    # before/after diff wrapped around _decision_pass() (the one point every
+    # nat-vent-mutating entry point already funnels through under
+    # _decision_lock) rather than at each individual write site.
+    NAT_VENT_SESSION_STARTED = "nat_vent_session_started"
+    NAT_VENT_SESSION_ENDED = "nat_vent_session_ended"
 
 
 @dataclass(frozen=True)

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.48"
+  "version": "0.6.50"
 }

--- a/tests/test_lifecycle_dispatcher_wiring.py
+++ b/tests/test_lifecycle_dispatcher_wiring.py
@@ -1,0 +1,252 @@
+"""Tests for Issue #717 (Block 5, epic #594): wiring lifecycle_dispatcher.py into
+production.
+
+Covers:
+  - AutomationEngine registers itself as a real controller with the documented
+    emit/consume contract, and the registry is complete (every emittable type has
+    itself as a registered consumer) — a genuine exercise of
+    ``check_registry_completeness()`` against a real controller, not the synthetic
+    ones ``test_lifecycle_dispatcher.py`` already covers.
+  - Each of the four real emit points fires the correct event, with the correct
+    direction, at the correct (and only the correct) transition:
+      * ``_resolve_door_window_pause_flags()`` — DOOR_PAUSE_STARTED/ENDED via a
+        before/after diff of ``_paused_by_door``.
+      * ``_resolve_override_grace_fsm_state()`` — GRACE_STARTED/ENDED via a
+        before/after diff of ``_grace_active``.
+      * ``_confirm_override_action()`` — OVERRIDE_CONFIRMED, single real site.
+      * ``_clear_manual_override_active()`` — OVERRIDE_CLEARED, reusing that
+        method's own idempotent "did it actually change" guard.
+  - ``_apply_nat_vent_fsm_state()`` is a SECOND real writer of ``_paused_by_door``
+    (the nat-vent-FSM-authoritative path) and must also emit DOOR_PAUSE_STARTED/
+    ENDED — found the same way Phase 1 found a second unmirrored ``_fan_active``
+    writer at ``coordinator.py:5088``.
+  - The dispatcher-synced mirror attributes (``_dispatched_*``) update correctly on
+    receipt — proving the round-trip works — without the FSM input builders
+    depending on them (see the ``__init__`` declaration comment for why routing
+    ``_build_nat_vent_fsm_inputs()``/``_build_door_window_fsm_inputs()`` through a
+    same-instance dispatcher-only mirror was tried and reverted).
+  - A raising ``on_event`` consumer is isolated (proven generically already by
+    ``test_lifecycle_dispatcher.py``; the isolation guard around each real emit
+    site in ``automation.py`` itself is exercised here instead).
+"""
+
+from __future__ import annotations
+
+from tools.sim_harness.build_coordinator import build_headless_coordinator
+from tools.sim_harness.ha_stubs import install_ha_stubs
+
+install_ha_stubs()
+
+from custom_components.climate_advisor.door_window_fsm import DoorWindowFsmEventKind  # noqa: E402
+from custom_components.climate_advisor.lifecycle_events import LifecycleEventType  # noqa: E402
+from custom_components.climate_advisor.override_grace_fsm import OverrideGraceFsmEventKind  # noqa: E402
+
+
+def _engine():
+    coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+    return coordinator.automation_engine
+
+
+def _events_of(ae, event_type):
+    return [e for e in ae._lifecycle_dispatcher.event_log if e.event_type is event_type]
+
+
+class TestControllerRegistration:
+    def test_registered_as_a_real_controller(self) -> None:
+        ae = _engine()
+        assert "automation_engine" in ae._lifecycle_dispatcher._registrations
+        reg = ae._lifecycle_dispatcher._registrations["automation_engine"]
+        assert reg.on_event.__func__ is ae._on_lifecycle_event.__func__
+
+    def test_registry_is_complete(self) -> None:
+        """Every type AutomationEngine declares emittable is also consumed —
+        proven with the real controller, not a synthetic one."""
+        ae = _engine()
+        assert ae._lifecycle_dispatcher.check_registry_completeness() == []
+
+    def test_each_engine_owns_a_separate_dispatcher_instance(self) -> None:
+        """Decision Point 1 of the approved plan: never shared, structural
+        isolation — production and shadow must not be able to see each other's
+        events."""
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        assert coordinator.automation_engine._lifecycle_dispatcher is not (
+            coordinator.shadow_automation_engine._lifecycle_dispatcher
+        )
+
+
+class TestDoorPauseEvents:
+    def test_pause_starts_emits_door_pause_started(self) -> None:
+        ae = _engine()
+        ae._paused_by_door = False
+        ae._resolve_door_window_pause_flags(
+            kind=DoorWindowFsmEventKind.SENSOR_OPENED,
+            legacy=lambda: setattr(ae, "_paused_by_door", True),
+        )
+        events = _events_of(ae, LifecycleEventType.DOOR_PAUSE_STARTED)
+        assert len(events) == 1
+        assert ae._dispatched_paused_by_door is True
+
+    def test_pause_ends_emits_door_pause_ended(self) -> None:
+        ae = _engine()
+        ae._paused_by_door = True
+        ae._dispatched_paused_by_door = True
+        ae._resolve_door_window_pause_flags(
+            kind=DoorWindowFsmEventKind.ALL_SENSORS_CLOSED,
+            legacy=lambda: setattr(ae, "_paused_by_door", False),
+        )
+        events = _events_of(ae, LifecycleEventType.DOOR_PAUSE_ENDED)
+        assert len(events) == 1
+        assert ae._dispatched_paused_by_door is False
+
+    def test_no_change_emits_nothing(self) -> None:
+        """A kind that resolves to the SAME paused state (e.g. a redundant
+        re-evaluation) must not emit — only a real transition should."""
+        ae = _engine()
+        ae._paused_by_door = True
+        ae._resolve_door_window_pause_flags(
+            kind=DoorWindowFsmEventKind.SYNC_RECONCILE,
+            legacy=lambda: setattr(ae, "_paused_by_door", True),
+        )
+        assert ae._lifecycle_dispatcher.event_log == []
+
+    def test_apply_nat_vent_fsm_state_is_a_second_real_writer(self) -> None:
+        """Issue #717's own found gap: the nat-vent-FSM-authoritative path writes
+        _paused_by_door directly, outside _resolve_door_window_pause_flags()."""
+        from custom_components.climate_advisor.nat_vent_lifecycle import NatVentLifecycleState
+
+        ae = _engine()
+        ae._paused_by_door = False
+        ae._apply_nat_vent_fsm_state(NatVentLifecycleState.PAUSED_REACTIVATION_LOCKOUT)
+        events = _events_of(ae, LifecycleEventType.DOOR_PAUSE_STARTED)
+        assert len(events) == 1
+        assert ae._dispatched_paused_by_door is True
+
+        ae._apply_nat_vent_fsm_state(NatVentLifecycleState.INACTIVE)
+        end_events = _events_of(ae, LifecycleEventType.DOOR_PAUSE_ENDED)
+        assert len(end_events) == 1
+        assert ae._dispatched_paused_by_door is False
+
+
+class TestGraceEvents:
+    def test_grace_starts_emits_grace_started(self) -> None:
+        ae = _engine()
+        ae._grace_active = False
+        ae._resolve_override_grace_fsm_state(
+            kind=OverrideGraceFsmEventKind.UNPROTECTED_GRACE_STARTED,
+            legacy=lambda: setattr(ae, "_grace_active", True),
+        )
+        events = _events_of(ae, LifecycleEventType.GRACE_STARTED)
+        assert len(events) == 1
+        assert ae._dispatched_grace_active is True
+
+    def test_grace_ends_emits_grace_ended(self) -> None:
+        ae = _engine()
+        ae._grace_active = True
+        ae._dispatched_grace_active = True
+        ae._resolve_override_grace_fsm_state(
+            kind=OverrideGraceFsmEventKind.GRACE_TIMER_EXPIRED,
+            legacy=lambda: setattr(ae, "_grace_active", False),
+        )
+        events = _events_of(ae, LifecycleEventType.GRACE_ENDED)
+        assert len(events) == 1
+        assert ae._dispatched_grace_active is False
+
+
+class TestOverrideEvents:
+    def test_confirm_action_emits_override_confirmed(self) -> None:
+        ae = _engine()
+        ae._start_grace_period_action = lambda *a, **k: True  # noqa: ARG005 — real side effect not under test
+        ae._confirm_override_action("cool", source="normal")
+        events = _events_of(ae, LifecycleEventType.OVERRIDE_CONFIRMED)
+        assert len(events) == 1
+        assert events[0].detail == "cool"
+        assert ae._dispatched_manual_override_active is True
+
+    def test_clear_emits_override_cleared_only_when_it_was_active(self) -> None:
+        ae = _engine()
+        ae._manual_override_active = True
+        ae._dispatched_manual_override_active = True
+        ae._clear_manual_override_active("user_cancel")
+        events = _events_of(ae, LifecycleEventType.OVERRIDE_CLEARED)
+        assert len(events) == 1
+        assert events[0].detail == "user_cancel"
+        assert ae._dispatched_manual_override_active is False
+
+    def test_clear_is_a_noop_when_nothing_was_active(self) -> None:
+        """Reuses _clear_manual_override_active()'s own existing guard — no new
+        idempotency check duplicated."""
+        ae = _engine()
+        ae._manual_override_active = False
+        ae._clear_manual_override_active("grace_expired")
+        assert ae._lifecycle_dispatcher.event_log == []
+
+
+class TestNatVentSessionEvents:
+    def test_decision_pass_emits_session_started_on_activation(self) -> None:
+        from tools.sim_harness._loop import run_coro
+
+        ae = _engine()
+        ae._natural_vent_active = False
+
+        async def _activate():
+            async with ae._decision_pass("test"):
+                ae._natural_vent_active = True
+
+        run_coro(_activate())
+        events = _events_of(ae, LifecycleEventType.NAT_VENT_SESSION_STARTED)
+        assert len(events) == 1
+        assert ae._dispatched_natural_vent_active is True
+
+    def test_decision_pass_emits_session_ended_on_deactivation(self) -> None:
+        from tools.sim_harness._loop import run_coro
+
+        ae = _engine()
+        ae._natural_vent_active = True
+        ae._dispatched_natural_vent_active = True
+
+        async def _deactivate():
+            async with ae._decision_pass("test"):
+                ae._natural_vent_active = False
+
+        run_coro(_deactivate())
+        events = _events_of(ae, LifecycleEventType.NAT_VENT_SESSION_ENDED)
+        assert len(events) == 1
+        assert ae._dispatched_natural_vent_active is False
+
+    def test_decision_pass_emits_nothing_when_unchanged(self) -> None:
+        from tools.sim_harness._loop import run_coro
+
+        ae = _engine()
+        ae._natural_vent_active = True
+
+        async def _noop():
+            async with ae._decision_pass("test"):
+                pass
+
+        run_coro(_noop())
+        assert ae._lifecycle_dispatcher.event_log == []
+
+
+class TestFsmInputsUnaffectedByDispatcherMirrors:
+    """The reverted design's regression test: direct attribute assignment (the
+    established fixture convention across 40+ existing test files) must still work
+    for FSM input construction, independent of whatever the dispatcher mirrors say."""
+
+    def test_nat_vent_inputs_read_canonical_override_active_not_dispatched_mirror(self) -> None:
+        from datetime import UTC, datetime
+
+        ae = _engine()
+        ae._manual_override_active = True  # set directly, never emitted
+        assert ae._dispatched_manual_override_active is False  # mirror never touched
+        inputs = ae._build_nat_vent_fsm_inputs(now=datetime(2026, 8, 21, tzinfo=UTC), indoor=72.0, outdoor=65.0)
+        assert inputs.override_active is True
+        assert inputs.manual_override_active is True
+
+    def test_door_window_inputs_read_canonical_natural_vent_active_not_dispatched_mirror(self) -> None:
+        from datetime import UTC, datetime
+
+        ae = _engine()
+        ae._natural_vent_active = True  # set directly, never emitted
+        assert ae._dispatched_natural_vent_active is False  # mirror never touched
+        inputs = ae._build_door_window_fsm_inputs(now=datetime(2026, 8, 21, tzinfo=UTC))
+        assert inputs.natural_vent_active is True


### PR DESCRIPTION
## Summary
- \`lifecycle_dispatcher.py\` (Issue #633) — a complete, tested pub/sub router — was never wired into any real decision path. The three lifecycle FSMs still cross-read each other's raw booleans directly.
- \`AutomationEngine\` now owns its own \`LifecycleDispatcher\` instance (structural isolation from the shadow engine's, same precedent as \`AutomationEngineCallbacks\`/#604) and registers as a real controller for all 8 event types.
- Real \`emit()\` calls added at the two existing chokepoint functions every real door/window and override/grace transition already funnels through (\`_resolve_door_window_pause_flags()\`, \`_resolve_override_grace_fsm_state()\`), keyed on a before/after diff rather than a static kind→direction table.
- Found and fixed a second real \`_paused_by_door\` writer (\`_apply_nat_vent_fsm_state()\`, the nat-vent-FSM-authoritative path) that bypassed the chokepoint — same pattern as Phase 1's \`coordinator.py:5088\` discovery.
- New \`NAT_VENT_SESSION_STARTED/ENDED\` event pair, emitted via a before/after diff around \`_decision_pass()\` (the one point ~18 scattered \`_natural_vent_active\` write sites already funnel through) rather than instrumenting each site.
- **Architecture correction made during implementation**: an earlier version also routed the two FSM input builders through dispatcher-only mirror attributes. Reverted — it broke the established direct-attribute-assignment test-fixture convention across 40+ files for no real safety benefit, since this engine both emits and consumes every event today (no genuine cross-instance staleness risk to fix, unlike the shadow engine's actual production/shadow split). The mirrors remain as an observable round-trip proof only.
- Zero behavior change — no decision logic, no authoritative switch, no HA service call path touched.

Part of the FSM architecture catch-up identified in the [Strangler Fig Atlas](https://claude.ai/code/artifact/66ecdadf-b663-4a6c-b2c1-b1a06d980c8e) review.

**Explicitly out of scope** (filed separately, Phase 5): migrating the \`paused_by_door\` guard at the override/grace transition sites to dispatcher-sourced state — that's live control-flow in a real HVAC path with no differential-proof pipeline built for it yet.

Closes #717.

## Test plan
- [x] New \`tests/test_lifecycle_dispatcher_wiring.py\` (17 tests): real-controller registration, registry completeness, all 4 real emit points (door pause start/end, grace start/end, override confirm/clear), the second \`_paused_by_door\` writer, nat-vent session start/end via \`_decision_pass()\`, no-emit-on-no-change, and a regression test proving FSM inputs still read canonical attributes independent of the dispatcher mirrors
- [x] Full test suite: 5167 passed, 6 skipped
- [x] \`python tools/simulate.py\`: 81/81 golden scenarios passed
- [x] \`ruff check\` + \`ruff format --check\` clean
- [x] Version bump (0.6.48 → 0.6.50, since #719/Phase 1 claimed 0.6.49 off the same base) in const.py/manifest.json, RELEASE_NOTES, KNOWN_FIXES, CHANGELOG.md; \`test_version_sync.py\` passes