### PR TITLE
Feat #738: strangler-fig completion Phase 2 — shadow-disagreement to golden-scenario capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.59] — 2026-08-22
+
+- Feat #738: no user-visible change. Strangler-fig completion program Phase 2 — a sustained live disagreement between the production automation engine and its shadow-engine comparison now automatically becomes a candidate regression-test scenario via the existing pending/golden review pipeline, instead of only a WARNING log line a human has to notice.
+
 ## [0.6.58] — 2026-08-22
 
 - Feat #737: no user-visible change. Strangler-fig completion program Phase 1 — adds an automated static check catching two or more functions that independently reimplement the same decision gate before they drift apart. Validated against Issue #608: found the duplication claim was 2/3 already fixed and corrected the stale doc; found 2 additional real duplicate-gate instances and tracked all of them in the checker's enforced registry.

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,16 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.58"
+VERSION = "0.6.59"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.59": [
+        "Feat #738: no user-visible change. Strangler-fig completion program Phase 2"
+        " — a sustained live disagreement between the production automation engine and"
+        " its shadow-engine comparison now automatically becomes a candidate regression"
+        " test scenario (via the existing pending/golden review pipeline) instead of"
+        " only a WARNING log line a human has to notice and hand-convert.",
+    ],
     "0.6.58": [
         "Feat #737: no user-visible change. Strangler-fig completion program Phase 1"
         " — adds an automated static check that catches two or more functions"
@@ -2192,6 +2199,31 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    738: {
+        "version_fixed": "0.6.59",
+        "title": (
+            "Phase 2 of the strangler-fig completion program: a new shadow_disagreement"
+            " incident class fires (event-driven, per mirrored production call, guarded"
+            " by a level-trigger so one sustained streak emits exactly one incident) when"
+            " the live shadow-engine diagnostic sustains a real per-axis disagreement"
+            " between production and its comparison engine/FSM. A new"
+            " find_shadow_disagreement_windows() function in build_historical_scenario.py"
+            " feeds it into the existing incident-to-pending-scenario pipeline. The"
+            " scenario's assertion checks production's own real recorded decision at the"
+            " incident timestamp (reusing outcomes.py's existing event-to-outcome mapping)"
+            " rather than the disagreement itself, since the offline single-engine"
+            " harness has no second shadow engine to mechanically compare against — the"
+            " disagreement is documented in the scenario's notes field for human review."
+            " Scoped to the lifetime of the shadow-engine mechanism; a later graduation"
+            " phase will remove it along with the mechanism itself."
+        ),
+        "scope_covered": (
+            "custom_components/climate_advisor/coordinator.py"
+            " (_emit_shadow_disagreement_incident, _shadow_diag_incident_emitted);"
+            " tools/build_historical_scenario.py"
+            " (find_shadow_disagreement_windows, _preceding_production_outcome)"
+        ),
+    },
     737: {
         "version_fixed": "0.6.58",
         "title": (

--- a/custom_components/climate_advisor/coordinator.py
+++ b/custom_components/climate_advisor/coordinator.py
@@ -682,6 +682,13 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         self._shadow_diag_disagreement_since: dict[str, datetime | None] = dict.fromkeys(_SHADOW_DIAG_AXES)
         self._shadow_diag_cumulative_seconds: dict[str, float] = dict.fromkeys(_SHADOW_DIAG_AXES, 0.0)
         self._shadow_diag_cumulative_date: date = dt_util.now().date()
+        # Issue #738: level-triggered guard so a sustained per-axis disagreement emits
+        # exactly one `shadow_disagreement` incident for its streak, not one per mirrored
+        # production call (this diagnostic recomputes on every mirrored decision method,
+        # far more often than the 30-min reactive incident cycle) — reset to False by
+        # _shadow_diag_update_axis() the moment that axis resolves back to agreement, so
+        # a later, distinct disagreement streak on the same axis emits its own incident.
+        self._shadow_diag_incident_emitted: dict[str, bool] = dict.fromkeys(_SHADOW_DIAG_AXES, False)
         # Issue #633: the unified nat-vent FSM's own independently-tracked state —
         # never written onto either engine, purely a third comparison point. Starts
         # INACTIVE unconditionally (same clean-slate convention as restore_state()'s
@@ -1569,7 +1576,51 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
         if since is not None:
             self._shadow_diag_cumulative_seconds[axis] += (now - since).total_seconds()
             self._shadow_diag_disagreement_since[axis] = None
+            # Issue #738: axis resolved back to agreement — clear the incident-emitted
+            # guard so a future, distinct disagreement streak on this axis can emit its
+            # own shadow_disagreement incident again.
+            self._shadow_diag_incident_emitted[axis] = False
         return 0.0, False
+
+    def _emit_shadow_disagreement_incident(
+        self,
+        axis: str,
+        now: datetime,
+        production_state: str,
+        comparison_state: str,
+        comparison_kind: str,
+        duration_seconds: float,
+    ) -> None:
+        """Emit a ``shadow_disagreement`` incident for one sustained comparison-axis
+        disagreement (Issue #738).
+
+        Feeds the same simulation-feedback-loop pipeline the other 8 incident classes
+        already use (``docs/simulation-feedback-loop.md``) — a live shadow-engine A/B
+        catch becomes a permanent regression test candidate instead of a one-off WARNING
+        a human has to notice in the logs. Called once per sustained disagreement streak
+        (the `_shadow_diag_incident_emitted` level-trigger guard in
+        ``_update_shadow_engine_diagnostic()`` prevents re-emitting on every mirrored
+        production call while the streak continues).
+        """
+        current_data = self.data or {}
+        self._emit_incident(
+            "shadow_disagreement",
+            now.isoformat(),
+            extra={
+                "axis": axis,
+                "production_state": production_state,
+                "comparison_state": comparison_state,
+                "comparison_kind": comparison_kind,
+                "disagreement_seconds": round(duration_seconds),
+                "indoor_f": current_data.get("indoor_temp"),
+                "outdoor_f": current_data.get("outdoor_temp"),
+                "hvac_mode": current_data.get("hvac_mode"),
+                "nat_vent_active": (self.automation_engine._natural_vent_active if self.automation_engine else None),
+                "manual_override_active": (
+                    self.automation_engine._manual_override_active if self.automation_engine else None
+                ),
+            },
+        )
 
     def _update_shadow_engine_diagnostic(self) -> None:
         """Recompute production/shadow nat-vent lifecycle state agreement (Issue #613),
@@ -1761,6 +1812,11 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 shadow_state,
                 mirror_duration,
             )
+            if not self._shadow_diag_incident_emitted["mirror"]:
+                self._emit_shadow_disagreement_incident(
+                    "mirror", now, production_state, shadow_state, "shadow", mirror_duration
+                )
+                self._shadow_diag_incident_emitted["mirror"] = True
         if fsm_sustained:
             _LOGGER.warning(
                 "Nat-vent FSM disagreement (Issue #633): production=%s fsm=%s (sustained %.0fs)",
@@ -1768,6 +1824,9 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 fsm_state,
                 fsm_duration,
             )
+            if not self._shadow_diag_incident_emitted["fsm"]:
+                self._emit_shadow_disagreement_incident("fsm", now, production_state, fsm_state, "fsm", fsm_duration)
+                self._shadow_diag_incident_emitted["fsm"] = True
         if door_window_mirror_sustained:
             _LOGGER.warning(
                 "Door/window shadow engine disagreement (Issue #637): production=%s shadow=%s (sustained %.0fs)",
@@ -1775,6 +1834,16 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 door_window_shadow_state,
                 door_window_mirror_duration,
             )
+            if not self._shadow_diag_incident_emitted["door_window_mirror"]:
+                self._emit_shadow_disagreement_incident(
+                    "door_window_mirror",
+                    now,
+                    door_window_production_state,
+                    door_window_shadow_state,
+                    "shadow",
+                    door_window_mirror_duration,
+                )
+                self._shadow_diag_incident_emitted["door_window_mirror"] = True
         if door_window_fsm_sustained:
             _LOGGER.warning(
                 "Door/window FSM disagreement (Issue #637): production=%s fsm=%s (sustained %.0fs)",
@@ -1782,6 +1851,16 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 door_window_fsm_state,
                 door_window_fsm_duration,
             )
+            if not self._shadow_diag_incident_emitted["door_window_fsm"]:
+                self._emit_shadow_disagreement_incident(
+                    "door_window_fsm",
+                    now,
+                    door_window_production_state,
+                    door_window_fsm_state,
+                    "fsm",
+                    door_window_fsm_duration,
+                )
+                self._shadow_diag_incident_emitted["door_window_fsm"] = True
         if override_grace_mirror_sustained:
             _LOGGER.warning(
                 "Override/grace shadow engine disagreement (Issue #639): production=%s shadow=%s (sustained %.0fs)",
@@ -1789,6 +1868,16 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 override_grace_shadow_state,
                 override_grace_mirror_duration,
             )
+            if not self._shadow_diag_incident_emitted["override_grace_mirror"]:
+                self._emit_shadow_disagreement_incident(
+                    "override_grace_mirror",
+                    now,
+                    override_grace_production_state,
+                    override_grace_shadow_state,
+                    "shadow",
+                    override_grace_mirror_duration,
+                )
+                self._shadow_diag_incident_emitted["override_grace_mirror"] = True
         if override_grace_fsm_sustained:
             _LOGGER.warning(
                 "Override/grace FSM disagreement (Issue #639): production=%s fsm=%s (sustained %.0fs)",
@@ -1796,6 +1885,16 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 override_grace_fsm_state,
                 override_grace_fsm_duration,
             )
+            if not self._shadow_diag_incident_emitted["override_grace_fsm"]:
+                self._emit_shadow_disagreement_incident(
+                    "override_grace_fsm",
+                    now,
+                    override_grace_production_state,
+                    override_grace_fsm_state,
+                    "fsm",
+                    override_grace_fsm_duration,
+                )
+                self._shadow_diag_incident_emitted["override_grace_fsm"] = True
         if fan_mirror_sustained:
             _LOGGER.warning(
                 "Fan/WHF shadow engine disagreement (Issue #731): production=%s shadow=%s (sustained %.0fs)",
@@ -1803,6 +1902,11 @@ class ClimateAdvisorCoordinator(DataUpdateCoordinator):
                 fan_shadow_state,
                 fan_mirror_duration,
             )
+            if not self._shadow_diag_incident_emitted["fan_mirror"]:
+                self._emit_shadow_disagreement_incident(
+                    "fan_mirror", now, fan_production_state, fan_shadow_state, "shadow", fan_mirror_duration
+                )
+                self._shadow_diag_incident_emitted["fan_mirror"] = True
 
     @property
     def shadow_engine_diagnostic(self) -> dict[str, Any] | None:

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.58"
+  "version": "0.6.59"
 }

--- a/docs/incident-classes.md
+++ b/docs/incident-classes.md
@@ -6,7 +6,7 @@
 
 | Question | Short answer (<= 2 sentences) | -> Full answer |
 |---|---|---|
-| Which incident classes are proactive (fire at command time)? | One: `setpoint_mode_inconsistency` -- fires inside automation.py _set_temperature() before the HA service call. All other classes are reactive and fire post-cycle in coordinator._detect_and_emit_incidents. (Issue #641 briefly added a proactive `fan_rapid_cycling` class when the rate-limit backstop suppressed a command; removed in #649 -- a suppressed-and-deferred toggle is the backstop working correctly, not an anomaly, and is now surfaced as a `fan_toggle_deferred`-flavored event payload plus a WHF status-card suffix instead of an incident.) | [Proactive vs. Reactive column below](#incident-class-reference) |
+| Which incident classes are proactive (fire at command time)? | One: `setpoint_mode_inconsistency` -- fires inside automation.py _set_temperature() before the HA service call. Most other classes are reactive and fire post-cycle in coordinator._detect_and_emit_incidents. (Issue #641 briefly added a proactive `fan_rapid_cycling` class when the rate-limit backstop suppressed a command; removed in #649 -- a suppressed-and-deferred toggle is the backstop working correctly, not an anomaly, and is now surfaced as a `fan_toggle_deferred`-flavored event payload plus a WHF status-card suffix instead of an incident.) `shadow_disagreement` (Issue #738) is a third timing category: event-driven, firing per mirrored production call rather than at command time or on the 30-min cycle -- see below. | [Proactive vs. Reactive column below](#incident-class-reference) |
 | What is the `incident_detected` event payload schema? | `type`, `time`, `incident_class`, `incident_id`, `indoor_f`, `outdoor_f`, `hvac_mode`, `comfort_cool`, `comfort_heat`, plus class-specific fields (`nat_vent_active`, `manual_override_active`, `occupancy_mode`, `setpoint_f`). | [Event Payload](#event-payload) |
 | Does `comfort_violation`/`comfort_undertemp` require a sustained 15-min deviation? | No -- both are a **point-in-time** check (>0.5 F past the comfort band edge) with a 30-min incident-dedup window, not a duration tracker; as of Issue #411 they also skip emission when the deviation is within nat-vent-cycling tolerance (`coordinator._is_nat_vent_tolerated_deviation()`). | [Incident Class Reference below](#incident-class-reference) |
 | Which classes were added for bugs #220-222? | Four new classes: `setpoint_mode_inconsistency` (#222 -- silent wrong setpoint), `rapid_override_after_automation` (#221 -- false override detection), `occupancy_transition` (#220 -- coverage gap), `override_active_on_occupancy` (compound condition at occupancy change). | [Bug Motivation column below](#incident-class-reference) |
@@ -28,6 +28,7 @@
 | `rapid_override_after_automation` | `override_detected` event within 60s of any automation decision event in event_log | Reactive | Integration | **HIGH** | #221 -- automation-driven setpoint change falsely flagged as manual override |
 | `occupancy_transition` | Any `occupancy_change` event in event_log during the last cycle | Reactive | Both | Medium | #220 -- near-zero occupancy transition coverage in golden suite |
 | `override_active_on_occupancy` | `manual_override_active=True` at the time of an `occupancy_change` event | Reactive | Integration | Medium | Compound condition exposed by #220 investigation |
+| `shadow_disagreement` | Sustained per-axis disagreement (past `SHADOW_ENGINE_DIAGNOSTIC_DEBOUNCE_S`) between production and the shadow engine/FSM on one of 7 comparison axes | **Event-driven** (per mirrored production call, not the 30-min cycle) | Integration | Medium (visible only as a WARNING log line until #738) | Live shadow-engine A/B catch (Issues #613-#731); converts a real production divergence into a regression-test candidate instead of a one-off log line a human must notice |
 
 ---
 
@@ -55,6 +56,8 @@ All `incident_detected` events share a common payload schema:
 
 All numeric fields are in Fahrenheit regardless of the user's display unit setting. `setpoint_f` is the applied setpoint (relevant for `setpoint_mode_inconsistency`; null for other classes where no setpoint was issued). `nat_vent_active`, `manual_override_active`, `occupancy_mode` provide context for all classes -- they reflect coordinator state at the time of detection. As of Issue #411, `comfort_undertemp` also carries `nat_vent_active` (matching `comfort_violation`, which already had it), so a genuine sustained violation that fires *during* an active nat-vent session is still visible with full context, even though in-tolerance deviations during nat-vent cycling no longer emit an incident at all.
 
+`shadow_disagreement` (Issue #738) additionally carries: `axis` (one of `mirror`, `fsm`, `door_window_mirror`, `door_window_fsm`, `override_grace_mirror`, `override_grace_fsm`, `fan_mirror`), `production_state` and `comparison_state` (the two disagreeing lifecycle-state strings), `comparison_kind` (`"shadow"` or `"fsm"` -- which side of the axis `comparison_state` came from), and `disagreement_seconds` (how long the streak had been sustained at emission time, always >= `SHADOW_ENGINE_DIAGNOSTIC_DEBOUNCE_S`).
+
 ---
 
 ## Deduplication
@@ -74,6 +77,7 @@ All numeric fields are in Fahrenheit regardless of the user's display unit setti
 | Class | Where it fires | Code location |
 |---|---|---|
 | `setpoint_mode_inconsistency` | Before HA service call | `automation.py _set_temperature()` |
+| `shadow_disagreement` | Per mirrored production decision call (sustained-streak edge) | `coordinator.py _update_shadow_engine_diagnostic()` / `_emit_shadow_disagreement_incident()` |
 | All others | Post-cycle | `coordinator.py _detect_and_emit_incidents()` |
 
 The `incident_detected` event is appended to `coordinator._event_log` in both cases. It is visible in the event log API at `GET /api/climate_advisor/event_log`.

--- a/docs/simulation-feedback-loop.md
+++ b/docs/simulation-feedback-loop.md
@@ -9,7 +9,7 @@
 | What is the closed loop and what problem does it solve? | Production incidents are automatically converted to pending BSpec scenarios, validated against simulate.py (logic) and production event logs (integration), and surfaced to a human for approval into the golden suite. It was built because bugs #220-222 all involved occupancy-mode transitions with near-zero simulation coverage. | [What the loop is](#what-the-loop-is) |
 | What is the difference between a Logic Trace and an Integration Trace? | A Logic Trace is what simulate.py produces by running the real production `AutomationEngine` headless (Tier A harness). An Integration Trace is what the coordinator + HA together actually did in production, observed from the event log. | [Two Validation Tracks](#two-validation-tracks) |
 | What is a BSpec and how does it differ from a golden scenario? | A BSpec is a scenario JSON expressing what the system SHOULD do (assertions). It lives in pending/ until a human approves it. A golden scenario is a BSpec that has been reviewed, signed, and promoted to golden/. | [Key Concepts](#key-concepts) |
-| What are the 8 incident classes and which are proactive vs reactive? | comfort_violation, nat_vent_escalation, override_detected, system_restart are reactive. setpoint_mode_inconsistency, rapid_override_after_automation, occupancy_transition, override_active_on_occupancy are new classes added for bugs #220-222. setpoint_mode_inconsistency is the only proactive class (fires at command time). | [Incident Classes](#incident-classes) |
+| What are the 9 incident classes and which are proactive vs reactive? | comfort_violation, nat_vent_escalation, override_detected, system_restart are reactive. setpoint_mode_inconsistency, rapid_override_after_automation, occupancy_transition, override_active_on_occupancy are classes added for bugs #220-222. setpoint_mode_inconsistency is the only cycle-proactive class (fires at command time). shadow_disagreement (Issue #738) fires on a third timing: per mirrored production decision call, event-driven — see Detection Timing. | [Incident Classes](#incident-classes) |
 | What is the full lifecycle from production event to golden test? | production event -> incident_detected emitted -> build_historical_scenario.py -> pending/ BSpec -> simulation_loop.py validates -> Validation Record written -> Dashboard Tests tab -> human approves -> golden/ | [Lifecycle](#lifecycle) |
 | When does incident detection run -- proactive or reactive? | Proactive: setpoint_mode_inconsistency fires at command time inside automation.py _set_temperature, before the HA service call. All other classes are reactive: they fire post-cycle in coordinator._detect_and_emit_incidents after each 30-min update. | [Detection Timing](#detection-timing) |
 | What is the Promotion Gate? | A human reviews per-BSpec pass/fail statistics in the Dashboard Tests tab, then clicks Approve. The approve endpoint runs --sign, moves the file from pending/ to golden/, and updates MANIFEST.json. | [Promotion Gate](#promotion-gate) |
@@ -61,7 +61,7 @@ A BSpec can contain both track types. The Dashboard shows logic pass rate and in
 
 ## Incident Classes
 
-Eight classes are defined. See [incident-classes.md](incident-classes.md) for the full reference table including production signals, detection timing, and bug motivations.
+Nine classes are defined. See [incident-classes.md](incident-classes.md) for the full reference table including production signals, detection timing, and bug motivations.
 
 Brief summary:
 
@@ -76,8 +76,9 @@ Brief summary:
 | rapid_override_after_automation | Integration | Reactive |
 | occupancy_transition | Both | Reactive |
 | override_active_on_occupancy | Integration | Reactive |
+| shadow_disagreement | Integration | Event-driven (per mirrored call, not the 30-min cycle) |
 
-Bold classes (setpoint_mode_inconsistency, rapid_override_after_automation, occupancy_transition, override_active_on_occupancy) are new, motivated by bugs #220-222.
+Bold classes (setpoint_mode_inconsistency, rapid_override_after_automation, occupancy_transition, override_active_on_occupancy) are new, motivated by bugs #220-222. `shadow_disagreement` (Issue #738) is a separate later addition, motivated by the shadow-engine A/B comparison mechanism (Issues #613-#731) rather than #220-222 — it converts a sustained live shadow/production disagreement into a pending regression scenario via `tools/build_historical_scenario.py`'s `find_shadow_disagreement_windows()`. Scoped to the lifetime of the shadow engine mechanism itself, which a later graduation phase will remove.
 
 ---
 
@@ -88,6 +89,12 @@ Bold classes (setpoint_mode_inconsistency, rapid_override_after_automation, occu
 `setpoint_mode_inconsistency` fires inside `automation.py _set_temperature()`, BEFORE the HA service call. If the applied setpoint is below `comfort_heat` while the HVAC mode is `cool`, or above `comfort_cool` while in `heat` mode, the incident is emitted immediately. This is the only class that fires at command time.
 
 Rationale: Bug #222 produced a 61 F setpoint in cool mode. This failure is silent -- no comfort violation fires for hours because the room must first cool down to 61 F. Proactive detection catches it at the moment the bad command is issued.
+
+**Event-driven (per mirrored call, Issue #738):**
+
+`shadow_disagreement` fires from `coordinator._update_shadow_engine_diagnostic()`, which itself is called from `_dispatch_shadow_mirror_call()`'s `finally` block on every mirrored production decision method -- not from `_detect_and_emit_incidents()`'s 30-min reactive cycle, and not at HA-service-call time like the proactive class above. Each of the 7 comparison axes (mirror, fsm, door_window_mirror, door_window_fsm, override_grace_mirror, override_grace_fsm, fan_mirror) already tracks its own wall-clock disagreement streak via `_shadow_diag_update_axis()` (Issue #685's cascade-noise debounce). The incident fires once per sustained streak -- on the edge where that axis's `sustained` flag first goes True -- guarded by a level-trigger dict (`_shadow_diag_incident_emitted`) so a streak that stays disagreeing across many mirrored calls emits exactly one incident, and a fresh streak after the axis resolves back to agreement can emit its own.
+
+Rationale: the shadow engine is a live production A/B comparison (Issues #613-#731); a sustained disagreement is the same kind of real signal a human currently only sees as a WARNING log line. This closes that gap the same way the other 8 classes closed #220-222's gap -- convert the live catch into a permanent regression-test candidate via the existing pending/golden pipeline, rather than requiring a human to notice the log and hand-build a scenario.
 
 **Reactive (post-cycle):**
 

--- a/tests/test_build_historical_scenario_shadow_disagreement.py
+++ b/tests/test_build_historical_scenario_shadow_disagreement.py
@@ -1,0 +1,354 @@
+"""Tests for tools/build_historical_scenario.py's shadow_disagreement support (Issue #738).
+
+Covers the pure/near-pure pieces of the incident->BSpec pipeline for the
+`shadow_disagreement` incident class:
+- _preceding_production_outcome(): finds production's real, mapped decision
+  outcome at/before the incident timestamp, reusing
+  tools/sim_harness/outcomes.py's _map_event_to_outcome() (the same mapping
+  simulate.py applies at validation time) rather than re-deriving it.
+- find_shadow_disagreement_windows(): extracts chart-log context windows around
+  shadow_disagreement incident_detected events, mirroring the existing
+  find_setpoint_mode_inconsistency_windows()/find_rapid_override_windows() shape.
+- build_scenario_json(): produces a BSpec asserting on production's own real
+  recorded decision (genuinely evaluable by the offline single-engine harness),
+  with the shadow/FSM disagreement itself recorded in `notes` for human review
+  rather than as a mechanically-checked assertion — the offline harness never
+  constructs a second "shadow" engine to compare against.
+
+Does not exercise the SSH/HA-API fetch path (fetch_chart_log_ssh, _fetch_event_log)
+or main() end-to-end — those are inherently live/manual per the existing pipeline's
+own design (docs/simulation-feedback-loop.md), same as the other find_*_windows
+functions have never had that layer unit-tested either.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+_TOOLS_DIR = Path(__file__).parent.parent / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+from build_historical_scenario import (  # noqa: E402
+    _preceding_production_outcome,
+    build_scenario_json,
+    find_shadow_disagreement_windows,
+)
+
+
+def _chart_entry(ts: datetime, indoor: float, outdoor: float, hvac: str = "off", fan: bool = False) -> dict:
+    return {
+        "ts": ts.isoformat(),
+        "indoor": indoor,
+        "outdoor": outdoor,
+        "hvac": hvac,
+        "fan": fan,
+        "windows_open": False,
+    }
+
+
+def _incident_event(
+    ts: datetime,
+    axis: str = "mirror",
+    production_state: str = "active",
+    comparison_state: str = "inactive",
+    comparison_kind: str = "shadow",
+    disagreement_seconds: float = 950.0,
+) -> dict:
+    return {
+        "time": ts.isoformat(),
+        "type": "incident_detected",
+        "incident_class": "shadow_disagreement",
+        "incident_id": ts.isoformat(),
+        "axis": axis,
+        "production_state": production_state,
+        "comparison_state": comparison_state,
+        "comparison_kind": comparison_kind,
+        "disagreement_seconds": disagreement_seconds,
+        "indoor_f": 72.0,
+        "outdoor_f": 68.0,
+        "hvac_mode": "off",
+        "comfort_heat": 70.0,
+        "comfort_cool": 75.0,
+        "occupancy_mode": "home",
+    }
+
+
+def _classification_applied_event(ts: datetime) -> dict:
+    """A real, mappable production decision event (see outcomes.py's
+    _map_event_to_outcome — classification_applied -> 'classification_applied')."""
+    return {"time": ts.isoformat(), "type": "classification_applied"}
+
+
+def _warm_day_setback_event(ts: datetime, new_setpoint_f: float = 68.0) -> dict:
+    """Maps to outcome 'setback_applied' with a target_temp — used to prove
+    _preceding_production_outcome() genuinely reuses _map_event_to_outcome()
+    rather than just echoing the raw event type string."""
+    return {"time": ts.isoformat(), "type": "warm_day_setback_applied", "new_setpoint_f": new_setpoint_f}
+
+
+class TestPrecedingProductionOutcome:
+    """Direct unit tests of the pure helper introduced by the Issue #738 fix."""
+
+    def test_finds_mapped_outcome_at_or_before_incident_ts(self) -> None:
+        now = datetime.now(UTC)
+        incident_ts = now
+        preceding_ts = now - timedelta(minutes=5)
+        event_entries = [_classification_applied_event(preceding_ts)]
+
+        outcome = _preceding_production_outcome(event_entries, incident_ts)
+
+        assert outcome == "classification_applied"
+
+    def test_reuses_real_outcome_mapping_not_raw_event_type(self) -> None:
+        """warm_day_setback_applied maps to 'setback_applied', not its own event
+        type string — proves this helper calls the real _map_event_to_outcome()
+        rather than a shortcut like `return ev["type"]`."""
+        now = datetime.now(UTC)
+        incident_ts = now
+        preceding_ts = now - timedelta(minutes=5)
+        event_entries = [_warm_day_setback_event(preceding_ts)]
+
+        outcome = _preceding_production_outcome(event_entries, incident_ts)
+
+        assert outcome == "setback_applied"
+
+    def test_ignores_events_after_incident_ts(self) -> None:
+        now = datetime.now(UTC)
+        incident_ts = now - timedelta(minutes=10)
+        after_ts = now  # after the incident
+        event_entries = [_classification_applied_event(after_ts)]
+
+        assert _preceding_production_outcome(event_entries, incident_ts) is None
+
+    def test_ignores_incident_detected_events(self) -> None:
+        now = datetime.now(UTC)
+        incident_ts = now
+        preceding_ts = now - timedelta(minutes=5)
+        event_entries = [_incident_event(preceding_ts)]
+
+        assert _preceding_production_outcome(event_entries, incident_ts) is None
+
+    def test_returns_none_when_no_events(self) -> None:
+        assert _preceding_production_outcome([], datetime.now(UTC)) is None
+
+    def test_picks_most_recent_of_multiple_preceding_events(self) -> None:
+        now = datetime.now(UTC)
+        incident_ts = now
+        earlier_ts = now - timedelta(minutes=20)
+        later_ts = now - timedelta(minutes=5)
+        event_entries = [
+            _warm_day_setback_event(earlier_ts),
+            _classification_applied_event(later_ts),
+        ]
+
+        outcome = _preceding_production_outcome(event_entries, incident_ts)
+
+        assert outcome == "classification_applied"
+
+
+class TestFindShadowDisagreementWindows:
+    def test_finds_window_around_incident(self) -> None:
+        now = datetime.now(UTC)
+        incident_ts = now - timedelta(hours=1)
+        chart_entries = [
+            _chart_entry(incident_ts - timedelta(minutes=10), 71.0, 65.0),
+            _chart_entry(incident_ts, 72.0, 68.0),
+            _chart_entry(incident_ts + timedelta(minutes=10), 72.5, 69.0),
+        ]
+        event_entries = [_incident_event(incident_ts, axis="mirror")]
+
+        windows = find_shadow_disagreement_windows(chart_entries, event_entries, hours=72)
+
+        assert len(windows) == 1
+        window = windows[0]
+        assert window["axis"] == "mirror"
+        assert window["comparison_kind"] == "shadow"
+        assert window["production_state"] == "active"
+        assert window["comparison_state"] == "inactive"
+        assert len(window["entries"]) == 3
+        assert "shadow_disagreement_mirror" in window["description"]
+
+    def test_no_event_entries_returns_empty(self) -> None:
+        chart_entries = [_chart_entry(datetime.now(UTC), 72.0, 68.0)]
+        assert find_shadow_disagreement_windows(chart_entries, [], hours=72) == []
+
+    def test_ignores_other_incident_classes(self) -> None:
+        now = datetime.now(UTC)
+        incident_ts = now - timedelta(hours=1)
+        chart_entries = [_chart_entry(incident_ts, 72.0, 68.0)]
+        event_entries = [
+            {
+                "time": incident_ts.isoformat(),
+                "type": "incident_detected",
+                "incident_class": "comfort_violation",
+            }
+        ]
+        assert find_shadow_disagreement_windows(chart_entries, event_entries, hours=72) == []
+
+    def test_ignores_events_outside_hours_cutoff(self) -> None:
+        now = datetime.now(UTC)
+        old_ts = now - timedelta(hours=200)
+        chart_entries = [_chart_entry(old_ts, 72.0, 68.0)]
+        event_entries = [_incident_event(old_ts)]
+        assert find_shadow_disagreement_windows(chart_entries, event_entries, hours=72) == []
+
+    def test_skips_window_with_no_matching_chart_entries(self) -> None:
+        now = datetime.now(UTC)
+        incident_ts = now - timedelta(hours=1)
+        # Chart entries far outside the +/-30/15 min window around the incident.
+        chart_entries = [_chart_entry(incident_ts - timedelta(hours=5), 72.0, 68.0)]
+        event_entries = [_incident_event(incident_ts)]
+        assert find_shadow_disagreement_windows(chart_entries, event_entries, hours=72) == []
+
+    def test_axis_filter_selects_only_matching_axis(self) -> None:
+        now = datetime.now(UTC)
+        ts1 = now - timedelta(hours=1)
+        ts2 = now - timedelta(hours=2)
+        chart_entries = [
+            _chart_entry(ts1, 72.0, 68.0),
+            _chart_entry(ts2, 73.0, 70.0),
+        ]
+        event_entries = [
+            _incident_event(ts1, axis="mirror"),
+            _incident_event(ts2, axis="fan_mirror"),
+        ]
+
+        windows = find_shadow_disagreement_windows(chart_entries, event_entries, hours=72, axis="fan_mirror")
+
+        assert len(windows) == 1
+        assert windows[0]["axis"] == "fan_mirror"
+
+    def test_axis_none_includes_all_axes(self) -> None:
+        now = datetime.now(UTC)
+        ts1 = now - timedelta(hours=1)
+        ts2 = now - timedelta(hours=2)
+        chart_entries = [
+            _chart_entry(ts1, 72.0, 68.0),
+            _chart_entry(ts2, 73.0, 70.0),
+        ]
+        event_entries = [
+            _incident_event(ts1, axis="mirror"),
+            _incident_event(ts2, axis="fan_mirror"),
+        ]
+
+        windows = find_shadow_disagreement_windows(chart_entries, event_entries, hours=72, axis=None)
+
+        assert {w["axis"] for w in windows} == {"mirror", "fan_mirror"}
+
+    def test_carries_disagreement_seconds_from_incident(self) -> None:
+        now = datetime.now(UTC)
+        incident_ts = now - timedelta(hours=1)
+        chart_entries = [_chart_entry(incident_ts, 72.0, 68.0)]
+        event_entries = [_incident_event(incident_ts, disagreement_seconds=1234.0)]
+
+        windows = find_shadow_disagreement_windows(chart_entries, event_entries, hours=72)
+
+        assert windows[0]["disagreement_seconds"] == 1234.0
+
+    def test_carries_preceding_production_outcome_when_derivable(self) -> None:
+        now = datetime.now(UTC)
+        incident_ts = now - timedelta(hours=1)
+        preceding_ts = incident_ts - timedelta(minutes=5)
+        chart_entries = [_chart_entry(incident_ts, 72.0, 68.0)]
+        event_entries = [
+            _classification_applied_event(preceding_ts),
+            _incident_event(incident_ts),
+        ]
+
+        windows = find_shadow_disagreement_windows(chart_entries, event_entries, hours=72)
+
+        assert windows[0]["preceding_production_outcome"] == "classification_applied"
+
+    def test_preceding_production_outcome_none_when_not_derivable(self) -> None:
+        now = datetime.now(UTC)
+        incident_ts = now - timedelta(hours=1)
+        chart_entries = [_chart_entry(incident_ts, 72.0, 68.0)]
+        event_entries = [_incident_event(incident_ts)]  # no preceding decision event
+
+        windows = find_shadow_disagreement_windows(chart_entries, event_entries, hours=72)
+
+        assert windows[0]["preceding_production_outcome"] is None
+
+
+class TestBuildScenarioJsonShadowDisagreement:
+    def test_asserts_on_production_real_outcome_not_shadow_agreement(self) -> None:
+        """Issue #738 fix: the assertion must be genuinely evaluable by the
+        offline single-engine harness — it asserts production's own recorded
+        decision (checked via simulate.py's default production_outcome_at()
+        fallback path), NOT a fake 'shadow_engine_agrees' expect string with no
+        check_assertion() branch and no second engine to compare against."""
+        now = datetime.now(UTC)
+        incident_ts = now - timedelta(hours=1)
+        preceding_ts = incident_ts - timedelta(minutes=5)
+        chart_entries = [_chart_entry(incident_ts, 72.0, 68.0)]
+        event_entries = [
+            _classification_applied_event(preceding_ts),
+            _incident_event(
+                incident_ts,
+                axis="override_grace_fsm",
+                production_state="confirmed/active",
+                comparison_state="pending/active",
+                comparison_kind="fsm",
+            ),
+        ]
+        windows = find_shadow_disagreement_windows(chart_entries, event_entries, hours=72)
+        assert len(windows) == 1
+
+        scenario = build_scenario_json(windows[0], "shadow_disagreement", comfort_cool_f=75.0, comfort_heat_f=70.0)
+
+        assert scenario["verdict"]["type"] == "pending"
+        assert scenario["issue"] == "#738"
+
+        incident_events = [e for e in scenario["events"] if e.get("type") == "incident_detected"]
+        assert len(incident_events) == 1
+        incident_event = incident_events[0]
+        assert incident_event["incident_class"] == "shadow_disagreement"
+        assert incident_event["axis"] == "override_grace_fsm"
+
+        assert len(scenario["assertions"]) == 1
+        assertion = scenario["assertions"][0]
+        # The real, checkable production outcome — not the unevaluable
+        # "shadow_engine_agrees" string.
+        assert assertion["expect"] == "classification_applied"
+        assert assertion["track"] == "logic"
+        assert "shadow_engine_agrees" not in str(scenario["assertions"])
+
+        # The disagreement itself (production vs. shadow/FSM state) is documented
+        # in notes for human review, not asserted on.
+        notes_blob = " ".join(scenario["notes"])
+        assert "override_grace_fsm" in notes_blob
+        assert "confirmed/active" in notes_blob
+        assert "pending/active" in notes_blob
+
+    def test_no_assertion_when_no_preceding_production_decision(self) -> None:
+        """When nothing evaluable is derivable from the window (no preceding
+        mappable production decision), ship with an empty assertions list —
+        same precedent find_comfort_violations()/find_nat_vent_windows() set for
+        incident types where 'what should have happened' isn't known offline.
+        The disagreement must still be recorded in notes."""
+        now = datetime.now(UTC)
+        incident_ts = now - timedelta(hours=1)
+        chart_entries = [_chart_entry(incident_ts, 72.0, 68.0)]
+        event_entries = [_incident_event(incident_ts, axis="fan_mirror")]
+        windows = find_shadow_disagreement_windows(chart_entries, event_entries, hours=72)
+
+        scenario = build_scenario_json(windows[0], "shadow_disagreement", comfort_cool_f=75.0, comfort_heat_f=70.0)
+
+        assert scenario["assertions"] == []
+        notes_blob = " ".join(scenario["notes"])
+        assert "fan_mirror" in notes_blob
+
+    def test_scenario_name_is_deterministic_from_window(self) -> None:
+        now = datetime.now(UTC)
+        incident_ts = now - timedelta(hours=1)
+        chart_entries = [_chart_entry(incident_ts, 72.0, 68.0)]
+        event_entries = [_incident_event(incident_ts, axis="mirror")]
+        windows = find_shadow_disagreement_windows(chart_entries, event_entries, hours=72)
+
+        scenario = build_scenario_json(windows[0], "shadow_disagreement", comfort_cool_f=75.0, comfort_heat_f=70.0)
+
+        assert "shadow_disagreement" in scenario["name"]
+        assert scenario["config"] == {"comfort_heat": 70.0, "comfort_cool": 75.0}

--- a/tests/test_shadow_engine_live.py
+++ b/tests/test_shadow_engine_live.py
@@ -699,5 +699,128 @@ class TestNewlyMirroredDecisionMethods:
         assert called == [True]
 
 
+class TestShadowDisagreementIncident:
+    """Issue #738: a sustained per-axis shadow/production disagreement must emit a
+    ``shadow_disagreement`` incident_detected event, feeding the same simulation
+    feedback loop the other 8 incident classes already use
+    (docs/simulation-feedback-loop.md). Trigger is event-driven — wired directly
+    into ``_update_shadow_engine_diagnostic()`` (called from
+    ``_dispatch_shadow_mirror_call()``'s finally block on every mirrored production
+    call), NOT the 30-min ``_detect_and_emit_incidents()`` reactive cycle, since the
+    diagnostic itself never runs from that cycle.
+    """
+
+    def _shadow_disagreement_events(self, coordinator) -> list[dict]:
+        return [
+            e
+            for e in coordinator._event_log
+            if e.get("type") == "incident_detected" and e.get("incident_class") == "shadow_disagreement"
+        ]
+
+    def test_sustained_disagreement_emits_incident(self) -> None:
+        """A disagreement streak already past SHADOW_ENGINE_DIAGNOSTIC_DEBOUNCE_S
+        (same seeding pattern as test_disagreement_logs_warning) must emit exactly
+        one shadow_disagreement incident with axis='mirror' and the two disagreeing
+        state strings."""
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        coordinator.data = {"indoor_temp": 72.0, "outdoor_temp": 68.0, "hvac_mode": "off"}
+        coordinator.shadow_automation_engine._natural_vent_active = True
+        coordinator.automation_engine._natural_vent_active = False
+        coordinator._shadow_diag_disagreement_since["mirror"] = _FIXED_NOW - timedelta(
+            seconds=SHADOW_ENGINE_DIAGNOSTIC_DEBOUNCE_S + 1
+        )
+        with patch("custom_components.climate_advisor.coordinator.dt_util.now", return_value=_FIXED_NOW):
+            coordinator._update_shadow_engine_diagnostic()
+
+        incidents = self._shadow_disagreement_events(coordinator)
+        assert len(incidents) == 1
+        incident = incidents[0]
+        assert incident["axis"] == "mirror"
+        assert incident["comparison_kind"] == "shadow"
+        assert incident["production_state"] != incident["comparison_state"]
+        assert incident["indoor_f"] == 72.0
+        assert incident["outdoor_f"] == 68.0
+        assert incident["hvac_mode"] == "off"
+        assert incident["disagreement_seconds"] >= SHADOW_ENGINE_DIAGNOSTIC_DEBOUNCE_S
+
+    def test_fresh_disagreement_does_not_emit_incident(self) -> None:
+        """A single-tick, not-yet-sustained disagreement (the debounce window itself
+        exists to suppress cascade noise, Issue #685) must NOT emit an incident."""
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        coordinator.shadow_automation_engine._natural_vent_active = True
+        coordinator.automation_engine._natural_vent_active = False
+        with patch("custom_components.climate_advisor.coordinator.dt_util.now", return_value=_FIXED_NOW):
+            coordinator._update_shadow_engine_diagnostic()
+
+        assert self._shadow_disagreement_events(coordinator) == []
+
+    def test_incident_emitted_once_per_streak_not_per_mirrored_call(self) -> None:
+        """The diagnostic recomputes on every mirrored production call — far more
+        often than a 30-min cycle. A streak that stays sustained across multiple
+        recomputes must emit exactly one incident, not one per call."""
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        coordinator.shadow_automation_engine._natural_vent_active = True
+        coordinator.automation_engine._natural_vent_active = False
+        coordinator._shadow_diag_disagreement_since["mirror"] = _FIXED_NOW - timedelta(
+            seconds=SHADOW_ENGINE_DIAGNOSTIC_DEBOUNCE_S + 1
+        )
+        with patch("custom_components.climate_advisor.coordinator.dt_util.now", return_value=_FIXED_NOW):
+            coordinator._update_shadow_engine_diagnostic()
+            coordinator._update_shadow_engine_diagnostic()
+            coordinator._update_shadow_engine_diagnostic()
+
+        assert len(self._shadow_disagreement_events(coordinator)) == 1
+
+    def test_incident_emits_again_after_streak_resolves_and_recurs(self) -> None:
+        """Once the axis resolves back to agreement, the emitted-guard clears —
+        a later, distinct disagreement streak on the same axis emits its own
+        incident."""
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        coordinator.shadow_automation_engine._natural_vent_active = True
+        coordinator.automation_engine._natural_vent_active = False
+        coordinator._shadow_diag_disagreement_since["mirror"] = _FIXED_NOW - timedelta(
+            seconds=SHADOW_ENGINE_DIAGNOSTIC_DEBOUNCE_S + 1
+        )
+        with patch("custom_components.climate_advisor.coordinator.dt_util.now", return_value=_FIXED_NOW):
+            coordinator._update_shadow_engine_diagnostic()
+        assert len(self._shadow_disagreement_events(coordinator)) == 1
+
+        # Resolve: engines agree again.
+        coordinator.shadow_automation_engine._natural_vent_active = False
+        with patch("custom_components.climate_advisor.coordinator.dt_util.now", return_value=_FIXED_NOW):
+            coordinator._update_shadow_engine_diagnostic()
+        assert coordinator._shadow_diag_incident_emitted["mirror"] is False
+
+        # New sustained streak on the same axis.
+        coordinator.shadow_automation_engine._natural_vent_active = True
+        later = _FIXED_NOW + timedelta(seconds=SHADOW_ENGINE_DIAGNOSTIC_DEBOUNCE_S + 1)
+        coordinator._shadow_diag_disagreement_since["mirror"] = later - timedelta(
+            seconds=SHADOW_ENGINE_DIAGNOSTIC_DEBOUNCE_S + 1
+        )
+        with patch("custom_components.climate_advisor.coordinator.dt_util.now", return_value=later):
+            coordinator._update_shadow_engine_diagnostic()
+
+        assert len(self._shadow_disagreement_events(coordinator)) == 2
+
+    def test_other_axes_stay_independent(self) -> None:
+        """A sustained disagreement on the door/window mirror axis must not emit
+        (or be blocked by) an incident on the unrelated nat-vent mirror axis."""
+        coordinator, _fake_hass, _scheduler, _event_log = build_headless_coordinator()
+        for ae in (coordinator.automation_engine, coordinator.shadow_automation_engine):
+            ae._natural_vent_active = False
+        coordinator.automation_engine._paused_by_door = False
+        coordinator.shadow_automation_engine._paused_by_door = True
+        coordinator._shadow_diag_disagreement_since["door_window_mirror"] = _FIXED_NOW - timedelta(
+            seconds=SHADOW_ENGINE_DIAGNOSTIC_DEBOUNCE_S + 1
+        )
+        with patch("custom_components.climate_advisor.coordinator.dt_util.now", return_value=_FIXED_NOW):
+            coordinator._update_shadow_engine_diagnostic()
+
+        incidents = self._shadow_disagreement_events(coordinator)
+        assert len(incidents) == 1
+        assert incidents[0]["axis"] == "door_window_mirror"
+        assert incidents[0]["comparison_kind"] == "shadow"
+
+
 def _run(coro):
     return run_coro(coro)

--- a/tools/build_historical_scenario.py
+++ b/tools/build_historical_scenario.py
@@ -7,12 +7,14 @@ scenario JSON files for pending simulation.
 
 Usage:
     python tools/build_historical_scenario.py [--hours 72] [--type comfort_violation|nat_vent|
-        occupancy_transition|setpoint_mode_inconsistency|rapid_override_after_automation]
+        occupancy_transition|setpoint_mode_inconsistency|rapid_override_after_automation|
+        shadow_disagreement]
     python tools/build_historical_scenario.py --hours 48 --type comfort_violation
     python tools/build_historical_scenario.py --hours 168 --type nat_vent --comfort-cool 76
     python tools/build_historical_scenario.py --hours 24 --type occupancy_transition
     python tools/build_historical_scenario.py --hours 72 --type setpoint_mode_inconsistency
     python tools/build_historical_scenario.py --hours 48 --type rapid_override_after_automation
+    python tools/build_historical_scenario.py --hours 72 --type shadow_disagreement --axis mirror
 
 Chart_log entries have fields: ts, hvac, fan, indoor, outdoor, windows_open
 """
@@ -550,6 +552,151 @@ def find_rapid_override_windows(
     return windows
 
 
+def _preceding_production_outcome(event_entries: list[dict], incident_ts: datetime) -> str | None:
+    """Return production's real, mapped decision outcome at/just before ``incident_ts``.
+
+    Issue #738 fix: the offline single-engine sim harness has no second "shadow"
+    engine to compare against (``coordinator.py``'s ``_engine_a``/``_engine_b`` A/B
+    pairing is a live-only construct — ``run_production_scenario()`` never builds
+    one), so a ``shadow_disagreement`` scenario cannot mechanically check "did
+    production and shadow agree" the way the live diagnostic does. What the
+    offline harness CAN evaluate is production's own real recorded decision —
+    same pattern as ``find_occupancy_transition_windows()``'s ``setback_applied``
+    assertion (checked via the exact same fallback path in
+    ``simulate.py``'s runner: ``_out.production_outcome_at(decisions, at)``).
+
+    Reuses ``tools/sim_harness/outcomes.py``'s ``_map_event_to_outcome()`` — the
+    SAME mapping ``simulate.py`` applies to the replayed run's own event_log at
+    validation time — against the raw event_log fetched at build time, rather
+    than inventing a second, parallel mapping here (CLAUDE.md doctrine: never
+    re-derive logic that already exists as a single source of truth).
+
+    Returns None if no mappable preceding event exists, in which case the
+    caller ships the scenario with no assertion — the same precedent
+    ``find_comfort_violations()``/``find_nat_vent_windows()`` already set for
+    incident types where "what should have happened" isn't derivable from the
+    window alone.
+    """
+    # Local import: keeps this module importable standalone (e.g. by tests that
+    # only need the SSH-independent pure functions) without requiring
+    # tools/sim_harness's own import chain unless this specific window type is
+    # actually built — same lazy-import convention build_historical_scenario.py
+    # has no precedent against (its own SSH/urllib imports are similarly scoped
+    # to the functions that need them).
+    from sim_harness.outcomes import _map_event_to_outcome
+
+    best_ts: datetime | None = None
+    best_outcome: str | None = None
+    for ev in event_entries:
+        ev_type = ev.get("type")
+        if not ev_type or ev_type == "incident_detected":
+            continue
+        ts_str = ev.get("time", "")
+        if not ts_str:
+            continue
+        try:
+            ev_ts = _parse_ts(ts_str)
+        except Exception:
+            continue
+        if ev_ts.tzinfo is None:
+            ev_ts = ev_ts.replace(tzinfo=UTC)
+        if ev_ts > incident_ts:
+            continue
+        mapped = _map_event_to_outcome(ev_type, ev, ts_str)
+        if mapped is None:
+            continue
+        if best_ts is None or ev_ts > best_ts:
+            best_ts = ev_ts
+            best_outcome = mapped.outcome
+
+    return best_outcome
+
+
+def find_shadow_disagreement_windows(
+    chart_entries: list[dict],
+    event_entries: list[dict],
+    hours: int,
+    axis: str | None = None,
+) -> list[dict]:
+    """Find windows around shadow_disagreement incidents from event_log (Issue #738).
+
+    Looks for incident_detected events with incident_class=shadow_disagreement —
+    emitted by coordinator._update_shadow_engine_diagnostic() once per sustained
+    per-axis disagreement streak between production and the shadow engine/FSM.
+    Extracts 30-min before, 15-min after for chart context, same convention as
+    find_setpoint_mode_inconsistency_windows()/find_rapid_override_windows().
+
+    Pass ``axis`` to filter to one of the 7 comparison axes (mirror, fsm,
+    door_window_mirror, door_window_fsm, override_grace_mirror,
+    override_grace_fsm, fan_mirror); omit to include all axes.
+    """
+    if not event_entries:
+        return []
+
+    cutoff = datetime.now(UTC) - timedelta(hours=hours)
+    windows = []
+
+    incident_events = [
+        e
+        for e in event_entries
+        if e.get("type") == "incident_detected"
+        and e.get("incident_class") == "shadow_disagreement"
+        and (axis is None or e.get("axis") == axis)
+    ]
+
+    for event in incident_events:
+        try:
+            event_ts = _parse_ts(event.get("time", ""))
+        except Exception:
+            continue
+
+        if event_ts.tzinfo is None:
+            event_ts = event_ts.replace(tzinfo=UTC)
+        if event_ts < cutoff:
+            continue
+
+        before_ts = event_ts - timedelta(minutes=30)
+        after_ts = event_ts + timedelta(minutes=15)
+
+        window_entries = [
+            e
+            for e in chart_entries
+            if (
+                e.get("ts")
+                and (lambda ts: before_ts <= ts <= after_ts)(
+                    _parse_ts(e["ts"]).replace(tzinfo=UTC) if _parse_ts(e["ts"]).tzinfo is None else _parse_ts(e["ts"])
+                )
+            )
+        ]
+
+        if not window_entries:
+            continue
+
+        evt_axis = event.get("axis", "unknown")
+        production_state = event.get("production_state", "unknown")
+        comparison_state = event.get("comparison_state", "unknown")
+        description = f"shadow_disagreement_{evt_axis}_{production_state}_vs_{comparison_state}"
+
+        windows.append(
+            {
+                "start_ts": before_ts.isoformat(),
+                "end_ts": after_ts.isoformat(),
+                "incident_ts": event_ts.isoformat(),
+                "axis": evt_axis,
+                "production_state": production_state,
+                "comparison_state": comparison_state,
+                "comparison_kind": event.get("comparison_kind", "unknown"),
+                "disagreement_seconds": event.get("disagreement_seconds"),
+                "preceding_production_outcome": _preceding_production_outcome(event_entries, event_ts),
+                "description": description,
+                "entries": window_entries,
+                "incident_source": event,
+            }
+        )
+
+    return windows
+
+
 def build_scenario_json(
     window: dict,
     window_type: str,
@@ -581,6 +728,20 @@ def build_scenario_json(
             events.append(event)
 
     # Add incident-specific event for new handlers
+    if window_type == "shadow_disagreement":
+        incident_source = window.get("incident_source", {})
+        events.append(
+            {
+                "time": window.get("incident_ts", ""),
+                "type": "incident_detected",
+                "incident_class": "shadow_disagreement",
+                "axis": window.get("axis", "unknown"),
+                "production_state": window.get("production_state", "unknown"),
+                "comparison_state": window.get("comparison_state", "unknown"),
+                "comparison_kind": window.get("comparison_kind", "unknown"),
+                "disagreement_seconds": incident_source.get("disagreement_seconds"),
+            }
+        )
     if window_type == "occupancy_transition":
         event_source = window.get("event_source", {})
         occ_event_type = event_source.get("type", "occupancy_change")
@@ -594,15 +755,31 @@ def build_scenario_json(
             }
         )
 
+    notes = [
+        "Generated from real climate_advisor_chart_log entries and event_log.",
+        "Manual review recommended before simulation.",
+    ]
+    if window_type == "shadow_disagreement":
+        # Issue #738 fix: the production-vs-shadow/FSM disagreement itself has no
+        # offline equivalent to mechanically check (the sim harness never builds a
+        # second "shadow" engine — see _preceding_production_outcome()'s docstring),
+        # so it is documented here for human review instead of asserted on.
+        notes.append(
+            f"Live shadow-engine disagreement: axis='{window.get('axis', 'unknown')}', "
+            f"production_state='{window.get('production_state', 'unknown')}', "
+            f"comparison_state='{window.get('comparison_state', 'unknown')}' "
+            f"({window.get('comparison_kind', 'unknown')}), "
+            f"sustained {window.get('incident_source', {}).get('disagreement_seconds', '?')}s "
+            "before the live diagnostic fired. Only production's own recorded outcome "
+            "is asserted below (the offline harness cannot re-check the disagreement)."
+        )
+
     scenario = {
         "name": f"{start_ts_str[:10]}-{window_type}-{window.get('description', 'scenario')}",
         "description": f"{window_type} window: {window.get('description', '')}",
         "source": "build_historical_scenario",
-        "issue": "#223",
-        "notes": [
-            "Generated from real climate_advisor_chart_log entries and event_log.",
-            "Manual review recommended before simulation.",
-        ],
+        "issue": "#738" if window_type == "shadow_disagreement" else "#223",
+        "notes": notes,
         "config": {
             "comfort_heat": comfort_heat_f,
             "comfort_cool": comfort_cool_f,
@@ -646,6 +823,40 @@ def build_scenario_json(
                 "reason": "Override detected after automation action within 60s gap",
             }
         ]
+    elif window_type == "shadow_disagreement":
+        # Issue #738 fix: "shadow_engine_agrees" was mechanically unevaluable —
+        # tools/simulate.py's runner has no check_assertion() branch for it, and
+        # more fundamentally the offline sim harness never constructs a second
+        # "shadow" AutomationEngine to compare against (that A/B pairing is a live
+        # coordinator.py-only construct). Every track:"integration" assertion with
+        # no matching branch either silently skips forever (use_coordinator=False,
+        # the default) or always fails (use_coordinator=True) — neither is a real
+        # check. Assert instead on production's own real recorded decision at the
+        # incident timestamp (see _preceding_production_outcome()) — genuinely
+        # evaluable via the existing production_outcome_at() fallback path, same
+        # mechanism occupancy_transition's "setback_applied" assertion already
+        # relies on. The disagreement itself (production_state vs comparison_state)
+        # is documented in `notes` above for human review, not checked here.
+        preceding_outcome = window.get("preceding_production_outcome")
+        if preceding_outcome:
+            scenario["assertions"] = [
+                {
+                    "at": window.get("incident_ts", ""),
+                    "expect": preceding_outcome,
+                    "track": "logic",
+                    "reason": (
+                        f"Production's own real recorded decision at the time of the "
+                        f"'{window.get('axis', 'unknown')}' shadow-disagreement incident "
+                        f"was '{preceding_outcome}' — pinned as a regression anchor for "
+                        "production's own behavior at this timestamp. This does NOT "
+                        "check the shadow/FSM disagreement (see notes)."
+                    ),
+                }
+            ]
+        # else: no mappable preceding production decision — ship with no
+        # assertion, same precedent find_comfort_violations()/find_nat_vent_windows()
+        # already set for incident types where nothing evaluable is derivable from
+        # the window alone. The notes field still documents the disagreement.
 
     return scenario
 
@@ -764,6 +975,7 @@ def main() -> None:
             "occupancy_transition",
             "setpoint_mode_inconsistency",
             "rapid_override_after_automation",
+            "shadow_disagreement",
         ],
         default="comfort_violation",
         help="Type of window to extract (default: comfort_violation)",
@@ -773,6 +985,16 @@ def main() -> None:
     )
     parser.add_argument(
         "--comfort-heat", type=float, default=70.0, help="Comfort heat threshold in degrees F (default: 70.0)"
+    )
+    parser.add_argument(
+        "--axis",
+        type=str,
+        default=None,
+        help=(
+            "Filter --type shadow_disagreement to one comparison axis (mirror, fsm, "
+            "door_window_mirror, door_window_fsm, override_grace_mirror, override_grace_fsm, "
+            "fan_mirror). Omit to include all axes."
+        ),
     )
     parser.add_argument(
         "--output-dir",
@@ -810,7 +1032,12 @@ def main() -> None:
 
     # Fetch event_log for incident handlers
     event_entries = []
-    if args.type in ("occupancy_transition", "setpoint_mode_inconsistency", "rapid_override_after_automation"):
+    if args.type in (
+        "occupancy_transition",
+        "setpoint_mode_inconsistency",
+        "rapid_override_after_automation",
+        "shadow_disagreement",
+    ):
         try:
             config = load_config()
             event_entries = _fetch_event_log(config, args.hours)
@@ -846,6 +1073,9 @@ def main() -> None:
     elif args.type == "rapid_override_after_automation":
         windows = find_rapid_override_windows(entries, event_entries, args.hours)
         print(f"\nFound {len(windows)} rapid_override_after_automation window(s):\n")
+    elif args.type == "shadow_disagreement":
+        windows = find_shadow_disagreement_windows(entries, event_entries, args.hours, axis=args.axis)
+        print(f"\nFound {len(windows)} shadow_disagreement window(s):\n")
 
     if not windows:
         print(f"No {args.type} windows found in the last {args.hours} hours.")
@@ -869,7 +1099,7 @@ def main() -> None:
                 print("  Override active: True")
             if window.get("setpoint_at_transition") is not None:
                 print(f"  Setpoint: {window.get('setpoint_at_transition', '?'):.1f}F")
-        elif args.type in ("setpoint_mode_inconsistency", "rapid_override_after_automation"):
+        elif args.type in ("setpoint_mode_inconsistency", "rapid_override_after_automation", "shadow_disagreement"):
             print(f"  Description: {window.get('description', 'N/A')}")
         else:
             print(f"  HVAC during: {window.get('hvac_mode_during', '?')} (fan={window.get('fan_during', '?')})")


### PR DESCRIPTION
## Summary
Phase 2 of the strangler-fig completion program (see #594, #735-737). Atlas priority #1, standing since Revision 5.

- New `shadow_disagreement` incident class, event-driven per mirrored production call, level-triggered (one incident per sustained streak).
- New `find_shadow_disagreement_windows()` in `tools/build_historical_scenario.py` feeding the existing incident→pending→golden pipeline.
- Assertion checks production's own real recorded decision at the incident timestamp (via the existing `_map_event_to_outcome()`, reused not re-derived) — the offline single-engine harness has no shadow engine to compare against, so the disagreement itself is documented in `notes` for human review instead of mechanically asserted.

**Caught and fixed during verification**: the first version's assertion (`"expect": "shadow_engine_agrees"`) had no `check_assertion()` handler anywhere and could never actually evaluate — sent back to the executor, root-caused via five-whys, and redesigned around what the offline harness can genuinely check.

Scoped to the shadow-engine mechanism's lifetime — removed by the later graduation phase along with the mechanism itself. No behavior change to production HVAC/fan decisions.

## Test plan
- [x] `ruff check`/`format` clean
- [x] Full suite: 5,405 passed, 6 skipped, warnings-as-errors — independently re-run and confirmed
- [x] `test_build_historical_scenario_shadow_disagreement.py` (16 tests) + `TestShadowDisagreementIncident` (5 tests in `test_shadow_engine_live.py`)
- [x] `test_version_sync.py` passes
- [x] Verified `_map_event_to_outcome` import target actually exists (not hallucinated) before accepting the fix