### PR TITLE
Fix #696: nat-vent idle-open reactivation bypasses the anti-flap lockout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Climate Advisor are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [0.6.65] — 2026-08-23
+
+- Fix #696: closes a gap where the whole-house fan could briefly turn back on below your daytime comfort band shortly after shutting off at the comfort floor. The re-check that runs after a pause now properly waits out the same 5-minute cooldown other exit types already respect, instead of restarting the fan the moment indoor ticks up by even 1°F.
+
 ## [0.6.64] — 2026-08-22
 
 - Feat #749: adds a hard-invariant watchdog that checks, every update cycle, whether the AC and the whole-house fan are ever physically running at the same time — a condition that should never happen. If it ever does, you'll see an immediate notification and a warning on the Status tab, even if the automation's own internal bookkeeping looks fine. Detects and alerts only — it never takes any action on its own.

--- a/custom_components/climate_advisor/automation.py
+++ b/custom_components/climate_advisor/automation.py
@@ -4139,14 +4139,21 @@ class AutomationEngine:
                     from .nat_vent_fsm import transition as _nat_vent_transition
 
                     _fsm_current_state = self.nat_vent_lifecycle_state
-                    # paused_by_door=False: this idle-open re-entry site only ever runs
-                    # when _actively_paused is False (see the outer guard above) — legacy
-                    # never consults the reactivation lockout here (only the separate
-                    # paused-reactivation call site below does). See
-                    # _build_nat_vent_fsm_inputs()'s docstring for the full rationale.
-                    _fsm_inputs = self._build_nat_vent_fsm_inputs(
-                        now=dt_util.now(), indoor=_indoor, outdoor=outdoor, paused_by_door=False
-                    )
+                    # Issue #696: previously hardcoded paused_by_door=False here, on the
+                    # premise that this idle-open re-entry site only ever runs when
+                    # _actively_paused is False and so could never legitimately have
+                    # _paused_by_door=True. That premise missed the
+                    # _paused_with_hvac_already_off=True case Issue #523 deliberately made
+                    # reachable here: _actively_paused (= paused_by_door AND NOT
+                    # hvac_already_off) is False even while the real _paused_by_door flag
+                    # is True (sensor still open, HVAC was already idle at exit) — exactly
+                    # what a COMFORT_FLOOR exit with an open sensor produces. Passing the
+                    # real flag lets the FSM's existing PAUSED_REACTIVATION_LOCKOUT branch
+                    # (_transition_from_inactive(), nat_vent_fsm.py) apply here the same way
+                    # it already does at the paused-by-door reactivation call site below —
+                    # outdoor_exit_time/lockout_seconds are unaffected by this parameter and
+                    # were already correctly populated either way.
+                    _fsm_inputs = self._build_nat_vent_fsm_inputs(now=dt_util.now(), indoor=_indoor, outdoor=outdoor)
                     _fsm_result = _nat_vent_transition(
                         _fsm_current_state, NatVentFsmEvent(kind=NatVentFsmEventKind.TICK, inputs=_fsm_inputs)
                     )
@@ -4231,6 +4238,28 @@ class AutomationEngine:
                                     "decline_margin_f": PEAK_DECLINE_MARGIN_F,
                                 },
                             )
+                elif self._paused_by_door and is_reactivation_locked_out(
+                    outdoor_exit_time=self._nat_vent_outdoor_exit_time,
+                    now=dt_util.now(),
+                    lockout_seconds=float(
+                        self.config.get(CONF_NAT_VENT_REACTIVATION_LOCKOUT_S, NAT_VENT_REACTIVATION_LOCKOUT_S)
+                    ),
+                ):
+                    # Issue #696: legacy (non-FSM) twin of the FSM branch's fix above —
+                    # this idle-open re-entry site never consulted the reactivation lockout
+                    # even when _paused_by_door=True (the _paused_with_hvac_already_off=True
+                    # case Issue #523 made reachable here). Mirrors the paused-by-door
+                    # reactivation call site's own lockout check further below.
+                    _lockout_elapsed = (
+                        (dt_util.now() - self._nat_vent_outdoor_exit_time).total_seconds()
+                        if self._nat_vent_outdoor_exit_time is not None
+                        else 0.0
+                    )
+                    _LOGGER.debug(
+                        "Nat vent idle-open re-entry: lockout active — %.0fs elapsed of %.0fs",
+                        _lockout_elapsed,
+                        float(self.config.get(CONF_NAT_VENT_REACTIVATION_LOCKOUT_S, NAT_VENT_REACTIVATION_LOCKOUT_S)),
+                    )
                 elif self._nat_vent_may_reactivate(
                     outdoor=outdoor,
                     indoor=_indoor,
@@ -5106,7 +5135,15 @@ class AutomationEngine:
                             self._current_classification.hvac_mode if self._current_classification else "unknown"
                         ),
                     }
-                    _set_outdoor_exit_time = False
+                    # Issue #696: previously False on the (now-disproven) assumption that
+                    # exit and re-entry always check the identical comfort_heat quantity at
+                    # a fixed reading, so they could never both be satisfied by the same
+                    # indoor temperature. That holds only within a single tick — indoor
+                    # legitimately drifts across the floor between ticks in production (a
+                    # real 68->69F rise over 5 real minutes triggered this exact gap on
+                    # 2026-08-23), so this exit needs the same anti-flap protection as the
+                    # other three exit reasons below.
+                    _set_outdoor_exit_time = True
                 elif _exit_reason == NatVentExitReason.PROACTIVE_FLOOR:
                     _ttf = (exit_decision.time_to_floor_hr if exit_decision is not None else None) or 0.0
                     _cf_now = (exit_decision.comfort_heat_now if exit_decision is not None else None) or _hard_floor

--- a/custom_components/climate_advisor/const.py
+++ b/custom_components/climate_advisor/const.py
@@ -4,9 +4,16 @@ DOMAIN = "climate_advisor"
 
 # Integration version — MUST match manifest.json "version" field.
 # A test in tests/test_version_sync.py enforces this.
-VERSION = "0.6.64"
+VERSION = "0.6.65"
 
 RELEASE_NOTES: dict[str, list[str]] = {
+    "0.6.65": [
+        "Fix #696: closes a gap where the whole-house fan could briefly turn back on"
+        " below your daytime comfort band shortly after shutting off at the comfort"
+        " floor. The re-check that runs after a pause now properly waits out the"
+        " same 5-minute cooldown other exit types already respect, instead of"
+        " restarting the fan the moment indoor ticks up by even 1°F.",
+    ],
     "0.6.64": [
         "Feat #749: adds a hard-invariant watchdog that checks, every update cycle,"
         " whether the AC and the whole-house fan are ever physically running at the"
@@ -2239,6 +2246,44 @@ RELEASE_NOTES: dict[str, list[str]] = {
 # GitHub issue instead — the Investigator already reads live open issues.
 # Add an entry here as part of the definition of done when closing any issue.
 KNOWN_FIXES: dict[int, dict] = {
+    696: {
+        "version_fixed": "0.6.65",
+        "title": (
+            "Fixed a nat-vent reactivation gap traced from a live 2026-08-23 incident:"
+            " the whole-house fan re-engaged ~5 minutes after a comfort-floor exit,"
+            " below the daytime cycling band's off-threshold, because the idle-open"
+            " re-entry path inside check_natural_vent_conditions() (reached whenever a"
+            " pause leaves _paused_with_hvac_already_off=True, per Issue #523) never"
+            " consulted the reactivation lockout at all, regardless of whether any exit"
+            " had armed it. Root cause was a documented but disproven scope decision in"
+            " nat_vent_reactivation_lockout.py, contradicted by Issue #523's own"
+            " widening. Fix arms set_outdoor_exit_time=True on the COMFORT_FLOOR exit"
+            " (nat_vent_temperature_check()) and wires is_reactivation_locked_out() into"
+            " both the FSM branch (stop overriding paused_by_door=False when building"
+            " FSM inputs) and the legacy branch (explicit guard mirroring the existing"
+            " paused-by-door reactivation site) of the idle-open block. As a side"
+            " effect, also collapsed a previously-tracked same-tick reactivation race"
+            " (Issue #699) for the PROACTIVE_FLOOR/OUTDOOR_RISE exit reasons — the"
+            " AWAY_CEILING variant of #699 remains open, untouched by this fix. A"
+            " related but distinct gap (fan_thermostat_check()'s STOP_COOLED_TO_FLOOR"
+            " exit, same disproven self-complementary-floor reasoning) was found during"
+            " this fix's blast-radius check and filed separately as #755, not fixed"
+            " here."
+        ),
+        "scope_covered": (
+            "custom_components/climate_advisor/automation.py"
+            " nat_vent_temperature_check() COMFORT_FLOOR branch,"
+            " check_natural_vent_conditions() idle-open re-entry block (FSM + legacy);"
+            " nat_vent_reactivation_lockout.py docstring correction;"
+            " tests/test_nat_vent_exit_lockout_coverage.py registry entry;"
+            " tests/test_nat_vent_fsm_phase2b_wiring.py,"
+            " tests/test_nat_vent_lifecycle_state.py,"
+            " tests/test_shadow_fsm_harness_event_coverage.py,"
+            " tests/test_nat_vent_fsm_authoritative_compare.py — updated to assert the"
+            " corrected behavior in place of the previously-encoded bug;"
+            " docs/nat-vent-lifecycle-spec.md"
+        ),
+    },
     749: {
         "version_fixed": "0.6.64",
         "title": (

--- a/custom_components/climate_advisor/manifest.json
+++ b/custom_components/climate_advisor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/gunkl/ClimateAdvisor/issues",
   "requirements": ["anthropic>=0.49.0"],
-  "version": "0.6.64"
+  "version": "0.6.65"
 }

--- a/custom_components/climate_advisor/nat_vent_reactivation_lockout.py
+++ b/custom_components/climate_advisor/nat_vent_reactivation_lockout.py
@@ -1,22 +1,38 @@
 """Pure decision core for the nat-vent reactivation lockout (architecture-reset Step 2).
 
-Guards against rapid re-activation flapping right after an outdoor-warm exit:
-once nat-vent exits because outdoor rose above indoor (the ONLY exit reason
-that records `_nat_vent_outdoor_exit_time`, per `_exit_nat_vent()`'s
-docstring), the paused-by-door reactivation check inside
-`check_natural_vent_conditions()` must wait out a configured lockout window
-before considering reactivation again.
+Guards against rapid re-activation flapping right after an exit that arms
+`_nat_vent_outdoor_exit_time` (originally only the outdoor-warm-rise exit; as
+of Issue #641/#696 also the proactive-floor, ceiling-threshold, and
+comfort-floor exits — see `_exit_nat_vent()` call sites in `automation.py` for
+the current, authoritative list, since it has grown more than once and this
+docstring should not be trusted as the enumeration).
 
-Verified narrowly and deliberately scoped to this ONE call site, not a gap to
-spread to the other 4 reactivation-gate call sites (`handle_door_window_open`,
-the Priority-0 grace+ceiling re-entry check, `reconcile_fan_on_startup`,
-`_re_pause_for_open_sensor`): each of those is structurally unreachable in the
-immediate aftermath of an outdoor-warm exit-with-pause, because they're each
-guarded by a `not self._paused_by_door` (or equivalent) condition that is
-already False at that moment — `_paused_by_door` and `_natural_vent_active`
-being True is exactly what a pause/reactivation cycle means, and none of the
-other 4 sites can even be entered while paused. Applying the lockout there
-too would be dead code, not a fix.
+As of Issue #696, this is consulted at TWO call sites in
+`check_natural_vent_conditions()`: the paused-by-door reactivation block, and
+the idle-open/"Priority-0 grace+ceiling re-entry" block (both its FSM and
+legacy branches). It was previously scoped to the paused-by-door block ONLY,
+on the claim that the idle-open block is "structurally unreachable... guarded
+by `not self._paused_by_door`, already False at that moment." That claim was
+wrong: the idle-open block's actual guard is `_actively_paused = paused_by_door
+and not paused_with_hvac_already_off` (Issue #523), which is deliberately
+False — making the block reachable — whenever `_paused_by_door=True` AND
+`_paused_with_hvac_already_off=True`. A `COMFORT_FLOOR` exit with the
+monitored sensor still open produces exactly that combination, and did so in
+production on 2026-08-23 (WHF reactivated ~5 minutes after a comfort-floor
+exit, unblocked, because the idle-open path never checked this lockout). See
+Issue #696 for the full incident.
+
+The other 3 reactivation-gate call sites (`handle_door_window_open`,
+`reconcile_fan_on_startup`, `_re_pause_for_open_sensor`) were individually
+re-read (not assumed) during the #696 fix and their exemptions do hold, each
+for its own distinct reason — `handle_door_window_open` genuinely guards on
+plain `not self._paused_by_door`; `reconcile_fan_on_startup` is exempted by
+call cadence (runs at most once per restart/30-min backstop, structurally
+incapable of sub-minute repeats) rather than by reachability;
+`_re_pause_for_open_sensor` only fires after a grace-period expiry, a
+different branch of the exit lifecycle than the pause branch this lockout
+protects. Re-verify each individually before trusting this summary if any of
+their guards change.
 """
 
 from __future__ import annotations

--- a/docs/nat-vent-lifecycle-spec.md
+++ b/docs/nat-vent-lifecycle-spec.md
@@ -9,7 +9,7 @@
 | What are the 4 nat-vent session states and how do they map to flags? | `INACTIVE`, `ACTIVE_FULL_GATE`, `ACTIVE_SOFT_START`, `PAUSED_REACTIVATION_LOCKOUT` — derived purely from `_natural_vent_active`/`_nat_vent_soft_start`/`_paused_by_door`/`_nat_vent_outdoor_exit_time`. | [State Transitions](#state-transitions) |
 | Where is the derivation computed, and is it load-bearing? | `nat_vent_lifecycle.py::derive_nat_vent_lifecycle_state()`, exposed read-only via `AutomationEngine.nat_vent_lifecycle_state`. Purely observational — not called from any production decision path. | [Scope](#scope) |
 | Does every nat-vent exit hand off through the same choke point? | No — `_exit_nat_vent()` is the choke point for most exits (10 call sites, per `tests/test_nat_vent_exit_lockout_coverage.py`'s AST scan), but the comfort-floor exit inside `check_natural_vent_conditions()`, the away-mode ceiling exit, the ODE ceiling-escalation exit, and two reconcile/bedtime paths mutate the flags directly instead. | [Exit Paths](#exit-paths-not-unified-through-a-single-function) |
-| What is the reactivation lockout and how long is it? | 300s default (`NAT_VENT_REACTIVATION_LOCKOUT_S`). Originally armed only by the outdoor-warm-rise exit; Issue #641 extended arming to the proactive-floor, ceiling-threshold, and fan_thermostat_check's tick-level direction-reversal exits, once all three were found to hand off into the same paused-reactivation race the lockout exists to prevent. | [State Transitions](#state-transitions) |
+| What is the reactivation lockout and how long is it? | 300s default (`NAT_VENT_REACTIVATION_LOCKOUT_S`). Originally armed only by the outdoor-warm-rise exit; Issue #641 extended arming to the proactive-floor, ceiling-threshold, and fan_thermostat_check's tick-level direction-reversal exits; Issue #696 extended it to the comfort-floor exit and — separately — wired the idle-open re-entry call site (previously unchecked entirely, see next row) to actually consult it. | [State Transitions](#state-transitions) |
 | What happens when nat-vent exits and the sensor is still open — pause or grace? | `_exit_nat_vent()` forks: sensor still open → hands off into the pause lifecycle; sensors closed → hands off into the grace lifecycle. See `grace-periods-spec.md` for what happens next in either lifecycle. | [Handoff to Pause/Grace](#handoff-to-pausegrace) |
 | How was this spec's accuracy verified? | Differential replay: `derive_nat_vent_lifecycle_state()` run against the real final engine flags from all 74 golden + 4 pending scenarios (Issue #606), plus 3 hand-reasoned ground-truth scenarios. | [Verification](#verification) |
 | Is every `_exit_nat_vent()` call site's lockout-arming decision enforced, not just documented? | Yes — `tests/test_nat_vent_exit_lockout_coverage.py` AST-scans every call site and requires each to be explicitly classified `"arms lockout"` / `"exempted: <reason>"`, with a positive control that checks the claim against the actual `set_outdoor_exit_time=True` argument (Issue #641). | [Incident: WHF fast-cycling](#incident-whf-fast-cycling-proactive-floor-exit-vs-instant-reactivation-issue-641) |
@@ -48,8 +48,8 @@
 |---|---|---|---|---|
 | `INACTIVE` | Door/window opens, full gate passes | `ACTIVE_FULL_GATE` | `decide_nat_vent_gate()` | `~L2841` (`handle_door_window_open`) |
 | `INACTIVE` | Door/window opens, only soft-start gate passes | `ACTIVE_SOFT_START` | `decide_nat_vent_soft_start_gate()` | `~L3093-3094` |
-| `INACTIVE` / `PAUSED_REACTIVATION_LOCKOUT` | Idle-open re-eval, full gate passes | `ACTIVE_FULL_GATE` | `_nat_vent_may_reactivate()` (includes lockout check) | `~L3053`, `~L3381` |
-| `INACTIVE` / `PAUSED_REACTIVATION_LOCKOUT` | Idle-open re-eval, soft-start only | `ACTIVE_SOFT_START` | same, soft-start variant | `~L3412-3413` |
+| `INACTIVE` / `PAUSED_REACTIVATION_LOCKOUT` | Idle-open re-eval, full gate passes | `ACTIVE_FULL_GATE` | `_nat_vent_may_reactivate()`, now preceded by an explicit lockout check (Issue #696 — this call site never consulted the lockout before, despite this row's prior claim) | `~L4147` (FSM), `~L4241` (legacy) |
+| `INACTIVE` / `PAUSED_REACTIVATION_LOCKOUT` | Idle-open re-eval, soft-start only | `ACTIVE_SOFT_START` | same, soft-start variant — also now gated by the same lockout check (Issue #696) | `~L4147` (FSM), `~L4273` (legacy) |
 | `ACTIVE_SOFT_START` | Full gate independently clears | `ACTIVE_FULL_GATE` | `_nat_vent_may_reactivate()` | `~L3125` — label-only, fan/HVAC untouched |
 | `INACTIVE` | Fan already physically running at startup/reconcile, eligible | `ACTIVE_FULL_GATE` | `reconcile_fan_on_startup()` eligibility check | `~L3955` |
 
@@ -243,6 +243,48 @@ exit reason added later without a classification fails immediately. Separately,
 durations at the same 300s minimum — a configured value outside roughly [5, 55]
 minutes would otherwise schedule its own off/on command inside the rate-limit window,
 stranding the fan far longer than the configured cycle intended.
+
+### Incident: idle-open re-entry never consulted the lockout at all (Issue #696)
+
+Reported/confirmed 2026-08-23: after the wake-up routine's 06:30 comfort-floor exit
+(indoor at exactly the 68°F floor), the WHF reactivated ~5 minutes later at indoor
+69°F — still below the 70–72°F daytime cycling band — ran for ~5 minutes pulling in
+59°F outside air, then was corrected by the next periodic cycling check. Filed as
+Issue #696 on 2026-08-20 (three days before this specific occurrence) from a code
+audit during the #694 FSM-wiring verification; this incident is the live confirmation.
+
+Root cause, distinct from #641's: not a missing `set_outdoor_exit_time=True` on one
+more exit reason (though `COMFORT_FLOOR` also had that gap and was fixed alongside
+this), but that the **idle-open re-entry block** inside
+`check_natural_vent_conditions()` (both its FSM and legacy branches) never called
+`is_reactivation_locked_out()` at all, regardless of whether any exit had armed the
+timer. `nat_vent_reactivation_lockout.py`'s own docstring had scoped this
+deliberately, reasoning the block was "structurally unreachable... guarded by `not
+self._paused_by_door`, already False at that moment." That reasoning predates (or
+overlooked) **Issue #523**, which deliberately widened the block's real guard to
+`_actively_paused = paused_by_door and not paused_with_hvac_already_off` specifically
+so a pause where HVAC was already off would *not* block it — exactly the flag
+combination a `COMFORT_FLOOR` exit with the sensor still open produces. The two
+decisions contradicted each other; this incident is where that surfaced.
+
+Fix: armed `set_outdoor_exit_time=True` on the `COMFORT_FLOOR` exit
+(`nat_vent_temperature_check()`), and wired both idle-open branches to actually
+consult the lockout — the FSM branch by no longer overriding `paused_by_door=False`
+when building FSM inputs (letting the FSM's existing `PAUSED_REACTIVATION_LOCKOUT`
+handling apply, the same as the sibling paused-by-door call site already does), the
+legacy branch with an explicit `is_reactivation_locked_out()` guard mirroring that
+same sibling site. The other 3 reactivation-gate call sites named in the lockout
+module's docstring were individually re-verified (not assumed) and their exemptions
+do hold, each for a different, still-valid reason — see the corrected module
+docstring in `nat_vent_reactivation_lockout.py`.
+
+**Known residual limitation, out of scope for #696**: the periodic evaluation that
+re-triggers `check_natural_vent_conditions()` appears to land on a ~5-minute
+clock-aligned cadence — the same order of magnitude as the 300s default lockout. In
+the reported incident, elapsed time between exit and reactivation was ≈300.02s,
+right at the lockout's edge; the fix closes the "never checked at all" gap
+unconditionally, but does not guarantee every occurrence lands outside the lockout
+window by a comfortable margin. Tracked as separate follow-up work, not fixed here.
 
 ### Follow-up: rate-limit reporting was misleading and mis-framed as an incident (Issue #649)
 

--- a/tests/test_nat_vent_exit_lockout_coverage.py
+++ b/tests/test_nat_vent_exit_lockout_coverage.py
@@ -66,10 +66,20 @@ _COVERAGE_REGISTRY: dict[tuple[str, int], str] = {
         "takes the sensors-closed grace-period branch, lockout never consulted"
     ),
     ("nat_vent_temperature_check", 2): (
-        "exempted: hard-floor exit (indoor <= comfort floor) shares the same comparison "
-        "quantity as the reactivation gate's own comfort_heat floor check — self-complementary "
-        "at a fixed reading, cannot both be satisfied by the same indoor temperature the way "
-        "PROACTIVE_FLOOR's independent predictive math could"
+        "exempted: this ordinal is ONE shared _exit_nat_vent() call site serving all 4 of "
+        "this function's exit reasons (COMFORT_FLOOR/PROACTIVE_FLOOR/OUTDOOR_RISE/"
+        "CEILING_THRESHOLD) via a per-branch local (`_set_outdoor_exit_time`), not a literal "
+        "at the call site — so `_find_calls_with_lockout_flag()`'s literal-True check "
+        "structurally cannot confirm arming here for ANY of the 4 reasons, not just this one "
+        "(verified by direct reading, not by this positive control). 3 of the 4 branches "
+        "(PROACTIVE_FLOOR/OUTDOOR_RISE/CEILING_THRESHOLD) already set that local True. Issue "
+        "#696: COMFORT_FLOOR (previously the one holdout, on the now-disproven claim that "
+        "exit and re-entry check the same quantity at a fixed reading and so can't both be "
+        "satisfied by the same indoor temperature — false once indoor drifts across the floor "
+        "between ticks, as it did in production on 2026-08-23) now sets it True too — see the "
+        "COMFORT_FLOOR branch in `nat_vent_temperature_check()` directly, and "
+        "`tools/simulations/pending/issue_696_idle_open_reactivation_bypasses_lockout.json` "
+        "for the regression scenario."
     ),
     ("fan_thermostat_check", 1): (
         "arms lockout — STOP_VIA_NAT_VENT_EXIT, the tick-level twin of "

--- a/tests/test_nat_vent_fsm_authoritative_compare.py
+++ b/tests/test_nat_vent_fsm_authoritative_compare.py
@@ -122,66 +122,47 @@ _KNOWN_DIVERGENT_SCENARIOS: dict[str, _KnownDivergence] = {
         event_count=1,
         action_count=0,
     ),
-    # Timing-only + one same-tick reactivation race (same root cause as
-    # issue-411-natvent-floor-exit-consistency below, now also reachable here).
+    # Cosmetic-only as of Issue #696: the same-tick reactivation race this entry used to
+    # document is gone. #696 wired the idle-open re-entry path (both its FSM and legacy
+    # branches) to actually consult is_reactivation_locked_out() — PROACTIVE_FLOOR already
+    # armed _nat_vent_outdoor_exit_time (Issue #641), so with the lockout now enforced at
+    # this call site, the baseline (legacy) run no longer reactivates within the same tick
+    # either, matching the authoritative run. This also resolves #699's manifestation for
+    # this scenario (see GitHub issue #699 for the still-open AWAY_CEILING variant, which
+    # #696 did not touch — that exit reason still never arms the lockout).
     "issue-641-whf-proactive-exit-reactivation-flip-flop": _KnownDivergence(
         description=(
-            "5 event divergences, 2 action divergences. (1) payload gains source=temp_check "
-            "(cosmetic) on the PROACTIVE_FLOOR exit event; k_passive is present and identical "
-            "in both runs (Issue #698 Verification Defect 1 fix — the fast loop previously "
-            "dropped this key, which had made this entry's prior 'same actions' description "
-            "harder to trust than it should have been). (2)-(4) the 3 events immediately "
-            "following (whf_hvac_suppressed, fan_activated, sensor_opened) all fire ~5s "
-            "earlier via the fast loop than the slow loop — same event type and payload, "
-            "retimed only. The 2 action divergences (set_hvac_mode off, fan turn_on) are the "
-            "same retiming, ~5s earlier. (5) index 10: an EXTRA nat_vent_predicted_floor_exit "
-            "event (the deferred second exit, 'fan_mode_change: deferred (5-min floor...)') "
-            "appears ONLY in the authoritative run, not in both runs as an earlier version of "
-            "this comment incorrectly claimed — the baseline run's slow-loop cadence never "
-            "revisits the same tick, so it has no equivalent entry. This is the same same-tick "
-            "reactivation race as issue-411-natvent-floor-exit-consistency below (also now "
-            "tracked as GitHub issue #699); the 5-min fan rate limiter defers the reactivation's "
-            "own second exit rather than producing unbounded thrash, but does not prevent the "
-            "extra event/action pair from occurring in the authoritative run."
+            "1 event divergence, 0 action divergences: payload gains source=temp_check "
+            "(cosmetic) on the PROACTIVE_FLOOR exit event — k_passive is present and "
+            "identical in both runs (Issue #698 Verification Defect 1 fix). No retiming, no "
+            "extra reactivation event/action pair — Issue #696 closed the same-tick "
+            "reactivation race this entry previously documented."
         ),
-        event_count=5,
-        action_count=2,
+        event_count=1,
+        action_count=0,
     ),
-    # Genuine (bounded) behavior difference — diagnosed root cause, not just observed:
-    # check_natural_vent_conditions()'s PROACTIVE_FLOOR branch calls _exit_nat_vent()
-    # and returns immediately, so its own idle-open reactivation check (earlier in the
-    # same function) never re-runs within that same invocation — reactivation can only
-    # be attempted on a LATER, separate call. The fast loop's exit lives in a different
-    # function (nat_vent_temperature_check()); when check_natural_vent_conditions() is
-    # also invoked later in the same tick, it starts fresh and its idle-open check (see
-    # automation.py's "_idle_open" gate) DOES see the just-exited state within the same
-    # tick. Since the exit paused with _paused_with_hvac_already_off=True (nat-vent had
-    # already suppressed HVAC to off), _actively_paused is False (see automation.py's
-    # "_actively_paused = self._paused_by_door and not self._paused_with_hvac_already_off"),
-    # so the idle-open gate isn't blocked, and — because indoor hasn't moved between the
-    # exit and this same-tick re-check — the instantaneous reactivation gate re-arms,
-    # producing one extra activate/deactivate cycle at the exit's own timestamp. This is
-    # the SAME "residual, still-present one-cycle reactivation race" this scenario's own
-    # notes already document as a known gap explicitly out of Issue #411's fix scope
-    # ("Recommend filing this as an explicit follow-up issue...") — Phase 2d's fast loop
-    # makes the race reachable WITHIN a single tick (previously only reachable ACROSS two
-    # separate ticks, which this scenario's temperature curve was deliberately tuned to
-    # avoid). No comfort impact (indoor's physical trajectory is identical either way);
-    # bounded to exactly one extra fan-on/fan-off pair, not unbounded thrash. Now formally
-    # tracked as GitHub issue #699 ("Nat-vent same-tick reactivation race after a
-    # proactive/away-ceiling exit") rather than only this scenario's own precedent note.
+    # Resolved by Issue #696: this used to be a genuine (bounded) behavior difference —
+    # check_natural_vent_conditions()'s idle-open gate never consulted the reactivation
+    # lockout, so when it re-ran later in the same tick as a PROACTIVE_FLOOR exit (which
+    # DOES arm _nat_vent_outdoor_exit_time, Issue #641) with _actively_paused False
+    # (exit paused with _paused_with_hvac_already_off=True), the gate saw indoor
+    # unchanged since the exit and re-armed instantly, producing one extra
+    # activate/deactivate cycle. #696 wired is_reactivation_locked_out() into that same
+    # idle-open gate (both FSM and legacy branches) — the lockout now blocks this
+    # same-tick re-check the same way it already blocked the separate
+    # paused-by-door-reactivation call site. Bounded, no-occupant-impact race is now
+    # eliminated rather than merely bounded. Also resolves this scenario's manifestation
+    # of GitHub issue #699 (the AWAY_CEILING variant above remains open — that exit
+    # reason still never arms the lockout, #696 did not touch it).
     "issue-411-natvent-floor-exit-consistency": _KnownDivergence(
         description=(
-            "5 event divergences, 3 action divergences: payload gains source=temp_check "
-            "(cosmetic, 1 event) plus one extra fan activate/deactivate pair — "
-            "whf_hvac_suppressed, fan_activated, sensor_opened, and a second (deferred) "
-            "nat_vent_predicted_floor_exit event (4 events), and set_hvac_mode off + fan "
-            "turn_on + fan turn_off (3 actions) — not present in the baseline run. See the "
-            "long-form root-cause comment above this dict for the full mechanism; tracked as "
-            "GitHub issue #699."
+            "1 event divergence, 0 action divergences: payload gains source=temp_check "
+            "(cosmetic) on the PROACTIVE_FLOOR exit event. No extra fan activate/deactivate "
+            "pair — Issue #696 closed the same-tick reactivation race this entry previously "
+            "documented."
         ),
-        event_count=5,
-        action_count=3,
+        event_count=1,
+        action_count=0,
     ),
 }
 

--- a/tests/test_nat_vent_fsm_phase2b_wiring.py
+++ b/tests/test_nat_vent_fsm_phase2b_wiring.py
@@ -256,14 +256,19 @@ class TestSite2IdleOpenReentry:
             asyncio.run(engine.check_natural_vent_conditions())
             assert engine._natural_vent_active is False, f"authoritative={authoritative}"
 
-    def test_authoritative_ignores_stale_paused_by_door_lockout(self):
-        """Real production incident (see issue-641-whf-proactive-exit-reactivation-
-        flip-flop.json): this site only ever runs when _actively_paused is False,
-        which can coincide with _paused_by_door=True (HVAC was already off, nothing
-        to interrupt). Legacy never consults the reactivation lockout at this call
-        site (only the paused-reactivation site, tested below, does) -- the FSM
-        path must reproduce that exact scope, not apply a lockout legacy never has
-        here."""
+    def test_authoritative_now_respects_lockout(self):
+        """Issue #696 (supersedes the pre-fix test this replaces, which was named
+        test_authoritative_ignores_stale_paused_by_door_lockout and asserted the bug
+        itself as correct behavior): a real production incident (2026-08-23, see
+        tools/simulations/pending/issue_696_idle_open_reactivation_bypasses_lockout.json)
+        showed this site DOES need the lockout -- _paused_with_hvac_already_off=True
+        (HVAC already off, nothing to interrupt) makes _actively_paused False even
+        though _paused_by_door is True, which is exactly what a COMFORT_FLOOR exit
+        with an open sensor produces. Both the FSM branch (no longer overriding
+        paused_by_door=False when building FSM inputs) and the legacy branch (new
+        explicit is_reactivation_locked_out() guard) must now block reactivation here
+        while within the lockout window, matching the paused-reactivation site's
+        existing behavior (TestSite3PausedReactivation below)."""
         for authoritative in (True, False):
             engine = _make_engine(comfort_heat=68.0, comfort_cool=74.0, indoor_f=69.0, authoritative=authoritative)
             self._arm_idle_open(engine, outdoor=58.6)
@@ -272,9 +277,9 @@ class TestSite2IdleOpenReentry:
             engine._nat_vent_outdoor_exit_time = _NOW - timedelta(seconds=5)  # well within the 300s lockout
             with patch(_DT_NOW_PATH, return_value=_NOW):
                 asyncio.run(engine.check_natural_vent_conditions())
-            assert engine._natural_vent_active is True, (
-                f"authoritative={authoritative}: idle-open re-entry must not be blocked by a "
-                "lockout this call site has never enforced"
+            assert engine._natural_vent_active is False, (
+                f"authoritative={authoritative}: idle-open re-entry must be blocked by the "
+                "reactivation lockout within its window (Issue #696)"
             )
 
     def test_authoritative_preserves_paused_by_door_flag(self):
@@ -283,13 +288,18 @@ class TestSite2IdleOpenReentry:
         site (`self._natural_vent_active = True`) never touched it. Entering with
         _paused_by_door=True + _paused_with_hvac_already_off=True must leave
         _paused_by_door=True afterward -- otherwise the pair becomes incoherent
-        (_paused_by_door=False while _paused_with_hvac_already_off=True)."""
+        (_paused_by_door=False while _paused_with_hvac_already_off=True).
+
+        Issue #696: exit_time moved outside the (now-enforced) 300s lockout window so
+        reactivation actually proceeds here -- this test is specifically about what
+        happens to _paused_by_door once a genuine post-lockout reactivation succeeds,
+        not about the lockout gate itself (covered separately above)."""
         for authoritative in (True, False):
             engine = _make_engine(comfort_heat=68.0, comfort_cool=74.0, indoor_f=69.0, authoritative=authoritative)
             self._arm_idle_open(engine, outdoor=58.6)
             engine._paused_by_door = True
             engine._paused_with_hvac_already_off = True
-            engine._nat_vent_outdoor_exit_time = _NOW - timedelta(seconds=5)  # well within the 300s lockout
+            engine._nat_vent_outdoor_exit_time = _NOW - timedelta(seconds=400)  # past the 300s lockout
             with patch(_DT_NOW_PATH, return_value=_NOW):
                 asyncio.run(engine.check_natural_vent_conditions())
             assert engine._natural_vent_active is True, f"authoritative={authoritative}"

--- a/tests/test_nat_vent_lifecycle_state.py
+++ b/tests/test_nat_vent_lifecycle_state.py
@@ -219,16 +219,25 @@ class TestGroundTruthScenarios:
         scenario = _load_scenario(_GOLDEN_DIR / "mild_all_day_nat_vent_only.json")
         assert _derive_state_for_scenario(scenario) == NatVentLifecycleState.ACTIVE_FULL_GATE
 
-    def test_comfort_floor_exit_ends_inactive_not_paused(self) -> None:
-        """Issue #99 golden: comfort-floor exit inside check_natural_vent_conditions()
-        is a hand-rolled inline exit (confirmed by reading automation.py directly —
-        it does NOT route through _exit_nat_vent(), unlike most other exits) that
-        clears only _natural_vent_active and never touches _paused_by_door or
-        _nat_vent_outdoor_exit_time. The scenario's own verdict states this
-        explicitly: 'fan stops, heat restores, paused_by_door stays False.'
-        Expect INACTIVE, not PAUSED_REACTIVATION_LOCKOUT."""
+    def test_comfort_floor_exit_ends_locked_out_while_sensor_open(self) -> None:
+        """Issue #99 golden, re-verified for Issue #696: this test previously expected
+        INACTIVE on the premise that the comfort-floor exit "never touches
+        _paused_by_door" — checked directly against the real engine output while
+        investigating #696, that premise was already wrong (this scenario's sensor
+        opens and is never closed, so `_exit_nat_vent()`'s own sensors-still-open
+        branch sets `_paused_by_door=True` here regardless of HVAC restoring to
+        heat — the scenario JSON's own `verdict.observed_behavior` field claiming
+        `paused_by_door=False` was stale). The test passed before #696 only because
+        `_nat_vent_outdoor_exit_time` was never armed for a COMFORT_FLOOR exit, so
+        `derive_nat_vent_lifecycle_state()` had no lockout window to apply even
+        though `_paused_by_door` was already True. Issue #696 arms it (see
+        nat_vent_temperature_check()'s COMFORT_FLOOR branch); at this scenario's
+        final event (the exit itself, elapsed=0s into the 300s lockout), the correct
+        state is PAUSED_REACTIVATION_LOCKOUT — the same state
+        test_outdoor_rise_exit_with_sensor_still_open_ends_locked_out below already
+        expects for the analogous outdoor-rise exit."""
         scenario = _load_scenario(_GOLDEN_DIR / "nat-vent-comfort-floor-exit-restores-heat.json")
-        assert _derive_state_for_scenario(scenario) == NatVentLifecycleState.INACTIVE
+        assert _derive_state_for_scenario(scenario) == NatVentLifecycleState.PAUSED_REACTIVATION_LOCKOUT
 
     def test_outdoor_rise_exit_with_sensor_still_open_ends_locked_out(self) -> None:
         """Issue #115 golden: nat-vent activates at 18:00, the door/window sensor

--- a/tests/test_shadow_fsm_harness_event_coverage.py
+++ b/tests/test_shadow_fsm_harness_event_coverage.py
@@ -110,16 +110,23 @@ class TestHardFloorExitWithSensorOpen:
             "exit with the sensor open — this is the exact live incident (Issue #666)"
         )
 
-    def test_nat_vent_fsm_reaches_inactive(self) -> None:
+    def test_nat_vent_fsm_reaches_paused_reactivation_lockout(self) -> None:
+        """Issue #696: this test previously expected 'inactive' because the
+        COMFORT_FLOOR/hard-floor exit never armed `_nat_vent_outdoor_exit_time`, so
+        derive_nat_vent_lifecycle_state() had no lockout window to apply even though
+        `_paused_by_door` was already True with the sensor open. #696 arms it (the
+        same fix that closed the idle-open reactivation gap this incident's own
+        replay exposed) — the sensor is still open here, so the correct state
+        immediately after the exit is PAUSED_REACTIVATION_LOCKOUT, not INACTIVE."""
         coordinator, _fake_hass, scheduler, _event_log, ae = _build_incident_coordinator()
 
         with scheduler.installed():
             run_coro(ae.nat_vent_temperature_check(67.0, outdoor=58.5))
 
         assert ae._natural_vent_active is False
-        assert coordinator._nat_vent_fsm_state.value == "inactive", (
+        assert coordinator._nat_vent_fsm_state.value == "paused_reactivation_lockout", (
             f"shadow nat-vent FSM ({coordinator._nat_vent_fsm_state}) disagreed with production's "
-            "real _natural_vent_active=False after a hard-floor exit — matches the live "
+            "real state after a hard-floor exit with the sensor still open — matches the live "
             "'Nat-vent FSM disagreement (Issue #633)' warning"
         )
 

--- a/tools/simulations/pending/issue_696_idle_open_reactivation_bypasses_lockout.json
+++ b/tools/simulations/pending/issue_696_idle_open_reactivation_bypasses_lockout.json
@@ -1,0 +1,75 @@
+{
+  "name": "issue_696_idle_open_reactivation_bypasses_lockout",
+  "description": "Reproduces the reported WHF brief-reactivation incident (2026-08-23, 06:30-06:40): a comfort-floor exit fires while a monitored window is still open and HVAC was already idle, and the next re-evaluation tick -- with indoor drifted only 1F above the floor -- must NOT reactivate nat-vent before the 300s lockout expires. Before the Issue #696 fix, the idle-open re-entry path inside check_natural_vent_conditions() never consulted the reactivation lockout at all (regardless of whether any exit had armed it), so a COMFORT_FLOOR exit followed by a small indoor uptick reactivated the WHF below the daytime cycling band's off-threshold.",
+  "source": "production_incident",
+  "issue": 696,
+  "notes": [
+    "Distinct bug from Issue #641: #641's gap was a missing set_outdoor_exit_time=True on 3 exit reasons, all consumed by the paused-by-door reactivation block. #696's gap was that the idle-open re-entry block (a separate code path, reached when _paused_with_hvac_already_off=True makes _actively_paused False even though _paused_by_door is True -- the Issue #523 widening) never called is_reactivation_locked_out() at all, in either its FSM or legacy branch.",
+    "hvac_mode=off in the classification is load-bearing: it is what makes _paused_with_hvac_already_off=True when the window-open pause fires, which is what routes reactivation through the idle-open path instead of the (already-protected) strict paused-by-door path.",
+    "No thermal_model block on purpose -- omitting it means no PROACTIVE_FLOOR prediction is available, so the 68F reading triggers the hard COMFORT_FLOOR exit specifically, matching the real incident's log line (\"Nat-vent hard exit [daytime] via temp-check (comfort_floor)\").",
+    "The second temp_update lands 250s after the exit -- comfortably inside the 300s default lockout window, unlike the real incident's ~300.02s edge case (that timing-margin question is tracked separately, out of scope for this fix per the #696 plan).",
+    "Occupant framing: before the fix, the WHF would have been commanded on again at 69F -- pulling in cool outside air for several minutes while indoor was still below the 70-72F daytime comfort band -- purely because it ticked 1F above the hard floor, not because conditions actually called for it. After the fix, it stays off until the lockout clears."
+  ],
+  "config": {
+    "comfort_heat": 68,
+    "comfort_cool": 74,
+    "setback_heat": 60,
+    "setback_cool": 80,
+    "natural_vent_delta": 3.0,
+    "fan_mode": "whole_house_fan",
+    "fan_entity": "fan.whole_house"
+  },
+  "events": [
+    {
+      "time": "2026-08-23T06:00:00",
+      "type": "temp_update",
+      "indoor_f": 70.0,
+      "outdoor_f": 60.0,
+      "note": "Baseline: indoor 70F, outdoor 60F -- favorable for nat-vent, well above the 68F floor."
+    },
+    {
+      "time": "2026-08-23T06:00:01",
+      "type": "classification",
+      "day_type": "hot",
+      "hvac_mode": "off",
+      "windows_recommended": true,
+      "note": "Hot-day classification with HVAC off -- matches the real incident's daytime classification. HVAC already off is what produces _paused_with_hvac_already_off=True when the pause below fires."
+    },
+    {
+      "time": "2026-08-23T06:00:02",
+      "type": "sensor_open",
+      "entity": "binary_sensor.bedroom_window",
+      "note": "Window open (matches the real incident's open-sensor precondition). outdoor(60) < indoor(70) - hysteresis(1), indoor > comfort_heat(68), outdoor < threshold -- nat-vent activates, WHF turns on, HVAC suppressed."
+    },
+    {
+      "time": "2026-08-23T06:30:00",
+      "type": "temp_update",
+      "indoor_f": 68.0,
+      "outdoor_f": 59.0,
+      "note": "Indoor has drifted down to exactly the 68F comfort floor -- COMFORT_FLOOR hard-floor exit fires. Window still open -> _exit_nat_vent() pauses rather than restoring HVAC. HVAC was already off (idle), so _paused_with_hvac_already_off=True and _actively_paused becomes False -- the idle-open re-entry path (not the strict paused-by-door path) governs the next re-evaluation. (Issue #696 fix) this exit now also arms the 300s reactivation lockout."
+    },
+    {
+      "time": "2026-08-23T06:34:10",
+      "type": "temp_update",
+      "indoor_f": 69.0,
+      "outdoor_f": 59.0,
+      "note": "Next re-evaluation tick, 250s later (inside the 300s lockout): indoor has drifted up 1F, clearing the raw comfort_heat floor (68) and the idle-open gate's outdoor/hysteresis check -- but still below the 70-72F daytime cycling band. Before the fix: the idle-open path never checked the lockout at all, so this reactivates the WHF regardless of timing. After the fix: the lockout armed at 06:30:00 blocks reactivation here."
+    }
+  ],
+  "assertions": [
+    {
+      "at": "2026-08-23T06:34:10",
+      "expect": "paused_by_door",
+      "reason": "The reactivation lockout armed by the comfort-floor exit at 06:30:00 must still be blocking reactivation 250s later -- reactivating here reproduces the reported brief below-band WHF run."
+    },
+    {
+      "at": "2026-08-23T06:34:10",
+      "expect": "fan_not_active",
+      "reason": "The WHF must still be physically off at this tick -- before the fix it would have been commanded back on via the idle-open path, which never consulted the lockout."
+    }
+  ],
+  "verdict": {
+    "type": "positive",
+    "summary": "A comfort-floor exit with a window still open and HVAC already idle correctly stays paused through the next re-evaluation tick instead of reactivating on a 1F uptick, closing the idle-open re-entry path's lockout gap."
+  }
+}


### PR DESCRIPTION
## Summary
- Live incident (2026-08-23): the WHF reactivated ~5 minutes after a comfort-floor exit, below the 70-72F daytime cycling band, because the idle-open re-entry path in `check_natural_vent_conditions()` never consulted the reactivation lockout at all — reachable via `_paused_with_hvac_already_off=True` (Issue #523), a case the lockout module's own docstring had (incorrectly) scoped out.
- Arms the 300s lockout on `COMFORT_FLOOR` exits and wires `is_reactivation_locked_out()` into both branches (FSM + legacy) of the idle-open block.
- Side effect: also collapses a previously-tracked same-tick reactivation race (#699) for `PROACTIVE_FLOOR`/`OUTDOOR_RISE` down to a cosmetic-only diff. `AWAY_CEILING`'s variant of #699 remains open.
- Filed #755 separately for a related-but-distinct gap (`fan_thermostat_check()`'s `STOP_COOLED_TO_FLOOR`) found during the blast-radius check — not fixed here, out of scope.
- Updated 5 pre-existing tests that had encoded the old buggy behavior as correct, plus the AST-enforced lockout coverage registry.
- New pending simulation scenario reproduces the incident; confirmed it fails pre-fix and passes post-fix.

## Test plan
- [x] `ruff check` / `ruff format` clean
- [x] `pytest tests/ -W error::pytest.PytestUnraisableExceptionWarning -W error::RuntimeWarning` — 5835 passed, 6 skipped
- [x] `python tools/simulate.py` — 91/91 golden scenarios pass
- [x] `python tools/simulate.py --pending -v` — new scenario passes; confirmed fails against pre-fix code
- [x] Version bump (0.6.65), RELEASE_NOTES, KNOWN_FIXES, CHANGELOG entries added